### PR TITLE
Implement capture_body config option

### DIFF
--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/impl/AbstractReporterBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/impl/AbstractReporterBenchmark.java
@@ -66,7 +66,7 @@ public abstract class AbstractReporterBenchmark {
             .withArgv(Collections.singletonList("-javaagent:/path/to/elastic-apm-java.jar"));
         SystemInfo system = new SystemInfo("x86_64", "Felixs-MBP", "Mac OS X");
         ReporterConfiguration reporterConfiguration = new ReporterConfiguration();
-        reporter = new ApmServerReporter(service, process, system, payloadSender, false, reporterConfiguration);
+        reporter = new ApmServerReporter(tracer.getConfigurationRegistry(), service, process, system, payloadSender, false, reporterConfiguration);
         payload = new TransactionPayload(process, service, system);
         for (int i = 0; i < reporterConfiguration.getMaxQueueSize(); i++) {
             Transaction t = new Transaction();

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
@@ -204,6 +204,10 @@ public class ElasticApmTracer implements Tracer {
         reporter.report(error);
     }
 
+    public ConfigurationRegistry getConfigurationRegistry() {
+        return configurationRegistry;
+    }
+
     public <T extends ConfigurationOptionProvider> T getConfig(Class<T> pluginClass) {
         return configurationRegistry.getConfig(pluginClass);
     }
@@ -290,9 +294,7 @@ public class ElasticApmTracer implements Tracer {
                 configurationRegistry = getDefaultConfigurationRegistry();
             }
             if (reporter == null) {
-                reporter = new ReporterFactory().createReporter(configurationRegistry.getConfig(CoreConfiguration.class),
-                    configurationRegistry.getConfig(ReporterConfiguration.class),
-                    null, null);
+                reporter = new ReporterFactory().createReporter(configurationRegistry, null, null);
             }
             if (stacktraceFactory == null) {
                 StacktraceConfiguration stackConfig = configurationRegistry.getConfig(StacktraceConfiguration.class);

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Request.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Request.java
@@ -68,10 +68,14 @@ public class Request implements Recyclable {
     public Object getBody() {
         if (!postParams.isEmpty()) {
             return postParams;
-        } else if (rawBody != null) {
+        } else {
             return rawBody;
         }
-        return "[REDACTED]";
+    }
+
+    public void redactBody() {
+        postParams.clear();
+        rawBody = "[REDACTED]";
     }
 
     public Request addFormUrlEncodedParameter(String key, String value) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterFactory.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterFactory.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 import okhttp3.OkHttpClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -28,12 +29,13 @@ public class ReporterFactory {
 
     private static final Logger logger = LoggerFactory.getLogger(ReporterFactory.class);
 
-    public Reporter createReporter(CoreConfiguration coreConfiguration, ReporterConfiguration reporterConfiguration,
-                                   @Nullable String frameworkName, @Nullable String frameworkVersion) {
+    public Reporter createReporter(ConfigurationRegistry configurationRegistry, @Nullable String frameworkName,
+                                   @Nullable String frameworkVersion) {
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new AfterburnerModule());
-        return new ApmServerReporter(
-            new ServiceFactory().createService(coreConfiguration, frameworkName, frameworkVersion),
+        final ReporterConfiguration reporterConfiguration = configurationRegistry.getConfig(ReporterConfiguration.class);
+        return new ApmServerReporter(configurationRegistry,
+            new ServiceFactory().createService(configurationRegistry.getConfig(CoreConfiguration.class), frameworkName, frameworkVersion),
             ProcessFactory.ForCurrentVM.INSTANCE.getProcessInformation(),
             SystemInfo.create(),
             new ApmServerHttpPayloadSender(getOkHttpClient(reporterConfiguration), new JacksonPayloadSerializer(objectMapper), reporterConfiguration), true, reporterConfiguration);

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ReportingEvent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ReportingEvent.java
@@ -1,0 +1,59 @@
+package co.elastic.apm.report;
+
+import co.elastic.apm.impl.error.ErrorCapture;
+import co.elastic.apm.impl.transaction.Transaction;
+
+import javax.annotation.Nullable;
+
+import static co.elastic.apm.report.ReportingEvent.ReportingEventType.ERROR;
+import static co.elastic.apm.report.ReportingEvent.ReportingEventType.FLUSH;
+import static co.elastic.apm.report.ReportingEvent.ReportingEventType.TRANSACTION;
+
+
+public class ReportingEvent {
+    @Nullable
+    private Transaction transaction;
+    @Nullable
+    private ReportingEventType type;
+    @Nullable
+    private ErrorCapture error;
+
+    public void resetState() {
+        this.transaction = null;
+        this.type = null;
+        this.error = null;
+    }
+
+    @Nullable
+    public Transaction getTransaction() {
+        return transaction;
+    }
+
+    public void setTransaction(Transaction transaction) {
+        this.transaction = transaction;
+        this.type = TRANSACTION;
+    }
+
+    public void setFlushEvent() {
+        this.type = FLUSH;
+    }
+
+    @Nullable
+    public ReportingEventType getType() {
+        return type;
+    }
+
+    @Nullable
+    public ErrorCapture getError() {
+        return error;
+    }
+
+    public void setError(ErrorCapture error) {
+        this.error = error;
+        this.type = ERROR;
+    }
+
+    enum ReportingEventType {
+        FLUSH, TRANSACTION, ERROR
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ReportingEventHandler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ReportingEventHandler.java
@@ -8,11 +8,11 @@ import co.elastic.apm.impl.payload.SystemInfo;
 import co.elastic.apm.impl.payload.TransactionPayload;
 import com.lmax.disruptor.EventHandler;
 
-import static co.elastic.apm.report.ApmServerReporter.ReportingEvent.ReportingEventType.ERROR;
-import static co.elastic.apm.report.ApmServerReporter.ReportingEvent.ReportingEventType.FLUSH;
-import static co.elastic.apm.report.ApmServerReporter.ReportingEvent.ReportingEventType.TRANSACTION;
+import static co.elastic.apm.report.ReportingEvent.ReportingEventType.ERROR;
+import static co.elastic.apm.report.ReportingEvent.ReportingEventType.FLUSH;
+import static co.elastic.apm.report.ReportingEvent.ReportingEventType.TRANSACTION;
 
-class ReportingEventHandler implements EventHandler<ApmServerReporter.ReportingEvent> {
+class ReportingEventHandler implements EventHandler<ReportingEvent> {
     private final TransactionPayload transactionPayload;
     private final ErrorPayload errorPayload;
     private final PayloadSender payloadSender;
@@ -26,19 +26,19 @@ class ReportingEventHandler implements EventHandler<ApmServerReporter.ReportingE
     }
 
     @Override
-    public void onEvent(ApmServerReporter.ReportingEvent event, long sequence, boolean endOfBatch) {
-        if (event.type == FLUSH) {
+    public void onEvent(ReportingEvent event, long sequence, boolean endOfBatch) {
+        if (event.getType() == FLUSH) {
             flush(transactionPayload);
             flush(errorPayload);
         }
-        if (event.type == TRANSACTION) {
-            transactionPayload.getTransactions().add(event.transaction);
+        if (event.getType() == TRANSACTION) {
+            transactionPayload.getTransactions().add(event.getTransaction());
             if (transactionPayload.getTransactions().size() >= reporterConfiguration.getMaxQueueSize()) {
                 flush(transactionPayload);
             }
         }
-        if (event.type == ERROR) {
-            errorPayload.getErrors().add(event.error);
+        if (event.getType() == ERROR) {
+            errorPayload.getErrors().add(event.getError());
             // report errors immediately, except if there are multiple in the queue
             if (endOfBatch) {
                 flush(errorPayload);

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/processor/Processor.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/processor/Processor.java
@@ -1,0 +1,36 @@
+package co.elastic.apm.report.processor;
+
+import co.elastic.apm.impl.error.ErrorCapture;
+import co.elastic.apm.impl.transaction.Transaction;
+import org.stagemonitor.configuration.ConfigurationRegistry;
+
+/**
+ * A processor is executed right before a event (a {@link Transaction} or {@link Error}) gets reported.
+ * <p>
+ * You can use this for example to sanitize certain information.
+ * </p>
+ */
+public interface Processor {
+
+    /**
+     * This method is called so that the processor can initialize configuration before the {@link #processBeforeReport} methods are called.
+     *
+     * @param tracer A reference to the {@link ConfigurationRegistry} which can be used to get configuration options.
+     */
+    void init(ConfigurationRegistry tracer);
+
+    /**
+     * This method is executed before the provided {@link Transaction} is reported.
+     *
+     * @param transaction The transaction to process.
+     */
+    void processBeforeReport(Transaction transaction);
+
+    /**
+     * This method is executed before the provided {@link ErrorCapture} is reported.
+     *
+     * @param error The error to process.
+     */
+    void processBeforeReport(ErrorCapture error);
+
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/processor/ProcessorEventHandler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/processor/ProcessorEventHandler.java
@@ -1,0 +1,41 @@
+package co.elastic.apm.report.processor;
+
+import co.elastic.apm.report.ReportingEvent;
+import com.lmax.disruptor.EventHandler;
+import org.stagemonitor.configuration.ConfigurationRegistry;
+
+import java.util.ServiceLoader;
+
+/**
+ * Invokes all registered {@link Processor}s before a {@link ReportingEvent} is processed by
+ * the {@link co.elastic.apm.report.ReportingEventHandler}.
+ */
+public class ProcessorEventHandler implements EventHandler<ReportingEvent> {
+
+    private final Iterable<Processor> processors;
+
+    public ProcessorEventHandler(Iterable<Processor> processors) {
+        this.processors = processors;
+    }
+
+    public static ProcessorEventHandler loadProcessors(ConfigurationRegistry configurationRegistry) {
+        final ServiceLoader<Processor> processors = ServiceLoader.load(Processor.class, ProcessorEventHandler.class.getClassLoader());
+        for (Processor processor : processors) {
+            processor.init(configurationRegistry);
+        }
+        return new ProcessorEventHandler(processors);
+    }
+
+    @Override
+    public void onEvent(ReportingEvent event, long sequence, boolean endOfBatch) {
+        if (event.getTransaction() != null) {
+            for (Processor processor : processors) {
+                processor.processBeforeReport(event.getTransaction());
+            }
+        } else if (event.getError() != null) {
+            for (Processor processor : processors) {
+                processor.processBeforeReport(event.getError());
+            }
+        }
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterIntegrationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterIntegrationTest.java
@@ -1,5 +1,6 @@
 package co.elastic.apm.report;
 
+import co.elastic.apm.configuration.SpyConfiguration;
 import co.elastic.apm.impl.error.ErrorCapture;
 import co.elastic.apm.impl.payload.ProcessInfo;
 import co.elastic.apm.impl.payload.Service;
@@ -15,13 +16,13 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 class ApmServerReporterIntegrationTest {
@@ -61,12 +62,14 @@ class ApmServerReporterIntegrationTest {
         receivedHttpRequests.set(0);
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new AfterburnerModule());
-        reporterConfiguration = spy(new ReporterConfiguration());
+        final ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
+        reporterConfiguration = config.getConfig(ReporterConfiguration.class);
         when(reporterConfiguration.getFlushInterval()).thenReturn(-1);
         when(reporterConfiguration.getServerUrl()).thenReturn("http://localhost:" + port);
         payloadSender = new ApmServerHttpPayloadSender(new OkHttpClient(), new JacksonPayloadSerializer(objectMapper), reporterConfiguration);
         SystemInfo system = new SystemInfo("x64", "localhost", "platform");
-        reporter = new ApmServerReporter(new Service(), new ProcessInfo("title"), system, payloadSender, false, reporterConfiguration);
+        reporter = new ApmServerReporter(config, new Service(), new ProcessInfo("title"), system, payloadSender, false,
+            reporterConfiguration);
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterTest.java
@@ -1,48 +1,46 @@
 package co.elastic.apm.report;
 
+import co.elastic.apm.configuration.SpyConfiguration;
 import co.elastic.apm.impl.error.ErrorCapture;
 import co.elastic.apm.impl.payload.Payload;
 import co.elastic.apm.impl.payload.ProcessInfo;
 import co.elastic.apm.impl.payload.Service;
 import co.elastic.apm.impl.payload.SystemInfo;
 import co.elastic.apm.impl.transaction.Transaction;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.stagemonitor.configuration.ConfigurationRegistry;
 
-import java.util.concurrent.locks.Condition;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ApmServerReporterTest {
 
     private ApmServerReporter reporter;
-    private PayloadSender payloadSender;
     private Lock lock = new ReentrantLock();
 
     @BeforeEach
     void setUp() {
-        lock.lock();
-        ReporterConfiguration reporterConfiguration = spy(new ReporterConfiguration());
+        final ConfigurationRegistry configurationRegistry = SpyConfiguration.createSpyConfig();
+        ReporterConfiguration reporterConfiguration = configurationRegistry.getConfig(ReporterConfiguration.class);
         when(reporterConfiguration.getFlushInterval()).thenReturn(-1);
         when(reporterConfiguration.getMaxQueueSize()).thenReturn(0);
         SystemInfo system = new SystemInfo("x64", "localhost", "platform");
-        payloadSender = new PayloadSender() {
+        PayloadSender payloadSender = new PayloadSender() {
             @Override
             public void sendPayload(Payload payload) {
                 // blocks to simulate a non-responding APM server
                 lock.lock();
             }
         };
-        reporter = new ApmServerReporter(new Service(), new ProcessInfo("title"), system, payloadSender, true, reporterConfiguration);
+        reporter = new ApmServerReporter(configurationRegistry, new Service(), new ProcessInfo("title"), system, payloadSender, true, reporterConfiguration);
     }
 
     @Test
@@ -69,5 +67,25 @@ class ApmServerReporterTest {
         reporter.report(error); // queue full -> discarded
         assertThat(reporter.getDropped()).isGreaterThanOrEqualTo(1);
         verify(error, atLeastOnce()).recycle();
+    }
+
+    @Test
+    void testTransactionProcessor() throws ExecutionException, InterruptedException {
+        final int transactionCount = TestProcessor.getTransactionCount();
+        reporter.report(mock(Transaction.class));
+        reporter.flush().get();
+
+        assertThat(reporter.getDropped()).isEqualTo(0);
+        assertThat(TestProcessor.getTransactionCount()).isEqualTo(transactionCount + 1);
+    }
+
+    @Test
+    void testErrorProcessor() throws ExecutionException, InterruptedException {
+        final int errorCount = TestProcessor.getErrorCount();
+        reporter.report(mock(ErrorCapture.class));
+        reporter.flush().get();
+
+        assertThat(reporter.getDropped()).isEqualTo(0);
+        assertThat(TestProcessor.getErrorCount()).isEqualTo(errorCount + 1);
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/TestProcessor.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/TestProcessor.java
@@ -1,0 +1,37 @@
+package co.elastic.apm.report;
+
+import co.elastic.apm.impl.error.ErrorCapture;
+import co.elastic.apm.impl.transaction.Transaction;
+import co.elastic.apm.report.processor.Processor;
+import org.stagemonitor.configuration.ConfigurationRegistry;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TestProcessor implements Processor {
+
+    private static AtomicInteger transactionCounter = new AtomicInteger();
+    private static AtomicInteger errorCounter = new AtomicInteger();
+
+    @Override
+    public void init(ConfigurationRegistry tracer) {
+
+    }
+
+    @Override
+    public void processBeforeReport(Transaction transaction) {
+        transactionCounter.incrementAndGet();
+    }
+
+    @Override
+    public void processBeforeReport(ErrorCapture error) {
+        errorCounter.incrementAndGet();
+    }
+
+    public static int getTransactionCount() {
+        return transactionCounter.get();
+    }
+
+    public static int getErrorCount() {
+        return errorCounter.get();
+    }
+}

--- a/apm-agent-core/src/test/resources/META-INF/services/co.elastic.apm.report.processor.Processor
+++ b/apm-agent-core/src/test/resources/META-INF/services/co.elastic.apm.report.processor.Processor
@@ -1,0 +1,1 @@
+co.elastic.apm.report.TestProcessor

--- a/apm-agent-plugins/apm-servlet-plugin/pom.xml
+++ b/apm-agent-plugins/apm-servlet-plugin/pom.xml
@@ -13,6 +13,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-web-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.0.1</version>

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/servlet/ApmFilterTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/servlet/ApmFilterTest.java
@@ -3,6 +3,7 @@ package co.elastic.apm.servlet;
 import co.elastic.apm.MockReporter;
 import co.elastic.apm.configuration.CoreConfiguration;
 import co.elastic.apm.configuration.SpyConfiguration;
+import co.elastic.apm.configuration.WebConfiguration;
 import co.elastic.apm.impl.ElasticApmTracer;
 import co.elastic.apm.impl.context.Url;
 import co.elastic.apm.util.PotentiallyMultiValuedMap;
@@ -99,6 +100,7 @@ class ApmFilterTest {
 
     @Test
     void testTrackPostParams() throws IOException, ServletException {
+        when(config.getConfig(WebConfiguration.class).getCaptureBody()).thenReturn(WebConfiguration.EventType.ALL);
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/foo/bar");
         request.addParameter("foo", "bar");
         request.addParameter("baz", "qux", "quux");

--- a/apm-agent-plugins/apm-web-plugin/src/main/java/co/elastic/apm/body/BodyProcessor.java
+++ b/apm-agent-plugins/apm-web-plugin/src/main/java/co/elastic/apm/body/BodyProcessor.java
@@ -1,0 +1,47 @@
+package co.elastic.apm.body;
+
+import co.elastic.apm.configuration.WebConfiguration;
+import co.elastic.apm.impl.context.Context;
+import co.elastic.apm.impl.context.Request;
+import co.elastic.apm.impl.error.ErrorCapture;
+import co.elastic.apm.impl.transaction.Transaction;
+import co.elastic.apm.report.processor.Processor;
+import org.stagemonitor.configuration.ConfigurationRegistry;
+
+import static co.elastic.apm.configuration.WebConfiguration.EventType.ALL;
+import static co.elastic.apm.configuration.WebConfiguration.EventType.ERRORS;
+import static co.elastic.apm.configuration.WebConfiguration.EventType.TRANSACTIONS;
+
+/**
+ * This processor redacts the body according to the {@link WebConfiguration#captureBody} configuration option
+ */
+public class BodyProcessor implements Processor {
+
+    private WebConfiguration webConfiguration;
+
+    @Override
+    public void init(ConfigurationRegistry tracer) {
+        webConfiguration = tracer.getConfig(WebConfiguration.class);
+    }
+
+    @Override
+    public void processBeforeReport(Transaction transaction) {
+        redactBodyIfNecessary(transaction.getContext(), TRANSACTIONS);
+    }
+
+    @Override
+    public void processBeforeReport(ErrorCapture error) {
+        redactBodyIfNecessary(error.getContext(), ERRORS);
+    }
+
+    private void redactBodyIfNecessary(Context context, WebConfiguration.EventType eventType) {
+        final WebConfiguration.EventType eventTypeConfig = webConfiguration.getCaptureBody();
+        if (hasBody(context.getRequest()) && eventTypeConfig != eventType && eventTypeConfig != ALL) {
+            context.getRequest().redactBody();
+        }
+    }
+
+    private boolean hasBody(Request request) {
+        return request.getBody() != null;
+    }
+}

--- a/apm-agent-plugins/apm-web-plugin/src/main/java/co/elastic/apm/configuration/WebConfiguration.java
+++ b/apm-agent-plugins/apm-web-plugin/src/main/java/co/elastic/apm/configuration/WebConfiguration.java
@@ -8,9 +8,9 @@ import java.util.Collections;
 
 public class WebConfiguration extends ConfigurationOptionProvider {
 
-    private final ConfigurationOption<Boolean> captureBody = ConfigurationOption.booleanOption()
+    private final ConfigurationOption<EventType> captureBody = ConfigurationOption.enumOption(EventType.class)
         .key("capture_body")
-        .description("For transactions that are HTTP requests, the Python agent can optionally capture the request body (e.g. POST " +
+        .description("For transactions that are HTTP requests, the Java agent can optionally capture the request body (e.g. POST " +
             "variables).\n" +
             "\n" +
             "Possible values: errors, transactions, all, off.\n" +
@@ -23,7 +23,7 @@ public class WebConfiguration extends ConfigurationOptionProvider {
             "WARNING: request bodies often contain sensitive values like passwords, credit card numbers etc." +
             "If your service handles data like this, we advise to only enable this feature with care.")
         .dynamic(true)
-        .buildWithDefault(false);
+        .buildWithDefault(EventType.OFF);
 
     private final ConfigurationOption<Collection<String>> ignoreUrlsStartingWith = ConfigurationOption.stringsOption()
         .key("ignore_urls_starting_with")
@@ -37,4 +37,30 @@ public class WebConfiguration extends ConfigurationOptionProvider {
         .dynamic(true)
         .buildWithDefault(Collections.<String>emptyList());
 
+    public EventType getCaptureBody() {
+        return captureBody.get();
+    }
+
+    public Collection<String> getIgnoreUrlsStartingWith() {
+        return ignoreUrlsStartingWith.get();
+    }
+
+    public enum EventType {
+        /**
+         * Request bodies will never be reported
+         */
+        OFF,
+        /**
+         * Request bodies will only be reported with errors
+         */
+        ERRORS,
+        /**
+         * Request bodies will only be reported with request transactions
+         */
+        TRANSACTIONS,
+        /**
+         * Request bodies will be reported with both errors and request transactions
+         */
+        ALL
+    }
 }

--- a/apm-agent-plugins/apm-web-plugin/src/main/resources/META-INF/services/co.elastic.apm.report.processor.Processor
+++ b/apm-agent-plugins/apm-web-plugin/src/main/resources/META-INF/services/co.elastic.apm.report.processor.Processor
@@ -1,0 +1,1 @@
+co.elastic.apm.body.BodyProcessor

--- a/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/body/BodyProcessorTest.java
+++ b/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/body/BodyProcessorTest.java
@@ -1,0 +1,113 @@
+package co.elastic.apm.body;
+
+import co.elastic.apm.configuration.SpyConfiguration;
+import co.elastic.apm.configuration.WebConfiguration;
+import co.elastic.apm.impl.error.ErrorCapture;
+import co.elastic.apm.impl.transaction.Transaction;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.stagemonitor.configuration.ConfigurationRegistry;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+class BodyProcessorTest {
+
+    private BodyProcessor bodyProcessor;
+    private WebConfiguration config;
+
+    @BeforeEach
+    void setUp() {
+        bodyProcessor = new BodyProcessor();
+        ConfigurationRegistry configurationRegistry = SpyConfiguration.createSpyConfig();
+        bodyProcessor.init(configurationRegistry);
+        config = configurationRegistry.getConfig(WebConfiguration.class);
+    }
+
+    @Test
+    void processBeforeReport_Transaction_EventTypeAll() {
+        when(config.getCaptureBody()).thenReturn(WebConfiguration.EventType.ALL);
+
+        final Transaction transaction = processTransaction();
+
+        assertThat(transaction.getContext().getRequest().getBody()).isEqualTo("foo");
+    }
+
+    @Test
+    void processBeforeReport_Transaction_EventTypeTransaction() {
+        when(config.getCaptureBody()).thenReturn(WebConfiguration.EventType.TRANSACTIONS);
+
+        final Transaction transaction = processTransaction();
+
+        assertThat(transaction.getContext().getRequest().getBody()).isEqualTo("foo");
+    }
+
+    @Test
+    void processBeforeReport_Transaction_EventTypeError() {
+        when(config.getCaptureBody()).thenReturn(WebConfiguration.EventType.ERRORS);
+
+        final Transaction transaction = processTransaction();
+
+        assertThat(transaction.getContext().getRequest().getBody()).isEqualTo("[REDACTED]");
+    }
+
+    @Test
+    void processBeforeReport_Transaction_EventTypeOff() {
+        when(config.getCaptureBody()).thenReturn(WebConfiguration.EventType.OFF);
+
+        final Transaction transaction = processTransaction();
+
+        assertThat(transaction.getContext().getRequest().getBody()).isEqualTo("[REDACTED]");
+    }
+
+    @Test
+    void processBeforeReport_Error_EventTypeAll() {
+        when(config.getCaptureBody()).thenReturn(WebConfiguration.EventType.ALL);
+
+        final ErrorCapture error = processError();
+
+        assertThat(error.getContext().getRequest().getBody()).isEqualTo("foo");
+    }
+
+    @Test
+    void processBeforeReport_Error_EventTypeTransaction() {
+        when(config.getCaptureBody()).thenReturn(WebConfiguration.EventType.TRANSACTIONS);
+
+        final ErrorCapture error = processError();
+
+        assertThat(error.getContext().getRequest().getBody()).isEqualTo("[REDACTED]");
+    }
+
+    @Test
+    void processBeforeReport_Error_EventTypeError() {
+        when(config.getCaptureBody()).thenReturn(WebConfiguration.EventType.ERRORS);
+
+        final ErrorCapture error = processError();
+
+        assertThat(error.getContext().getRequest().getBody()).isEqualTo("foo");
+    }
+
+    @Test
+    void processBeforeReport_Error_EventTypeOff() {
+        when(config.getCaptureBody()).thenReturn(WebConfiguration.EventType.OFF);
+
+        final ErrorCapture error = processError();
+
+        assertThat(error.getContext().getRequest().getBody()).isEqualTo("[REDACTED]");
+    }
+
+    private Transaction processTransaction() {
+        final Transaction transaction = new Transaction();
+        transaction.getContext().getRequest().withRawBody("foo");
+        bodyProcessor.processBeforeReport(transaction);
+        return transaction;
+    }
+
+    private ErrorCapture processError() {
+        final ErrorCapture error = new ErrorCapture();
+        error.getContext().getRequest().withRawBody("foo");
+        bodyProcessor.processBeforeReport(error);
+        return error;
+    }
+
+}


### PR DESCRIPTION
Introduce Processor which processes events before they are reported
The processor is used to redact the request body based on the config