### PR TITLE
Replace Jackson with DSL-JSON

### DIFF
--- a/apm-agent-benchmarks/pom.xml
+++ b/apm-agent-benchmarks/pom.xml
@@ -77,6 +77,16 @@
             <version>1.5.0</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-afterburner</artifactId>
+            <version>${jackson.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
             <version>${jackson.version}</version>

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/AbstractHttpJacksonReporterBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/AbstractHttpJacksonReporterBenchmark.java
@@ -20,7 +20,7 @@
 package co.elastic.apm.benchmark.reporter;
 
 import co.elastic.apm.benchmark.profiler.CpuProfiler;
-import co.elastic.apm.report.serialize.JacksonPayloadSerializer;
+import co.elastic.apm.benchmark.serializer.JacksonPayloadSerializer;
 import co.elastic.apm.report.serialize.PayloadSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/AbstractHttpReporterBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/AbstractHttpReporterBenchmark.java
@@ -80,7 +80,7 @@ public abstract class AbstractHttpReporterBenchmark extends AbstractReporterBenc
     @Benchmark
     @Threads(1)
     public void testSerialization() throws IOException {
-       payloadSerializer.serializePayload(noopBufferedSink, payload);
+        payloadSerializer.serializePayload(noopBufferedSink, payload);
     }
 
     @SuppressWarnings("ConstantConditions")

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/HttpDslJsonReporterContinuousBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/HttpDslJsonReporterContinuousBenchmark.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 the original author or authors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.benchmark.reporter;
+
+import co.elastic.apm.report.serialize.DslJsonSerializer;
+import co.elastic.apm.report.serialize.PayloadSerializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openjdk.jmh.runner.RunnerException;
+
+/**
+ * Measures the performance of the actually used reporter implementation
+ * including JSON serialization and reporting payloads over HTTP
+ */
+public class HttpDslJsonReporterContinuousBenchmark extends AbstractHttpReporterBenchmark {
+
+    /**
+     * Convenience benchmark run method
+     * <p>
+     * For more accurate results, execute {@code mvn clean package} and run the benchmark via
+     * {@code java -jar apm-agent-benchmarks/target/benchmarks.jar -prof gc}
+     */
+    public static void main(String[] args) throws RunnerException {
+        run(HttpDslJsonReporterContinuousBenchmark.class);
+    }
+
+    @Override
+    protected PayloadSerializer getPayloadSerializer() {
+        return new DslJsonSerializer();
+    }
+}

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/HttpJacksonReporterBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/HttpJacksonReporterBenchmark.java
@@ -26,7 +26,7 @@ import org.openjdk.jmh.runner.RunnerException;
  * Measures the performance of the actually used reporter implementation
  * including JSON serialization and reporting payloads over HTTP
  */
-public class HttpJacksonReporterContinuousBenchmark extends AbstractHttpJacksonReporterBenchmark {
+public class HttpJacksonReporterBenchmark extends AbstractHttpJacksonReporterBenchmark {
 
     /**
      * Convenience benchmark run method
@@ -35,7 +35,7 @@ public class HttpJacksonReporterContinuousBenchmark extends AbstractHttpJacksonR
      * {@code java -jar apm-agent-benchmarks/target/benchmarks.jar -prof gc}
      */
     public static void main(String[] args) throws RunnerException {
-        run(HttpJacksonReporterContinuousBenchmark.class);
+        run(HttpJacksonReporterBenchmark.class);
     }
 
     protected ObjectMapper getObjectMapper() {

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/serializer/JacksonPayloadSerializer.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/serializer/JacksonPayloadSerializer.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,9 +17,10 @@
  * limitations under the License.
  * #L%
  */
-package co.elastic.apm.report.serialize;
+package co.elastic.apm.benchmark.serializer;
 
 import co.elastic.apm.impl.payload.Payload;
+import co.elastic.apm.report.serialize.PayloadSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import okio.BufferedSink;
 import org.slf4j.Logger;

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -61,16 +61,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-afterburner</artifactId>
-            <version>${jackson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${okhttp.version}</version>

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -121,10 +121,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.networknt</groupId>
-            <artifactId>json-schema-validator</artifactId>
-            <version>0.1.16</version>
-            <scope>test</scope>
+            <groupId>com.dslplatform</groupId>
+            <artifactId>dsl-json</artifactId>
+            <version>1.7.4</version>
         </dependency>
     </dependencies>
 </project>

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
@@ -73,6 +73,7 @@ public class ElasticApmTracer implements Tracer {
     private final DetachedThreadLocal<Transaction> currentTransaction = new DetachedThreadLocal<>(DetachedThreadLocal.Cleaner.INLINE);
     private final DetachedThreadLocal<Span> currentSpan = new DetachedThreadLocal<>(DetachedThreadLocal.Cleaner.INLINE);
     private final CoreConfiguration coreConfiguration;
+    // TODO make really noop, otherwise content grows -> OOME
     private final Transaction noopTransaction;
     private final Span noopSpan;
     private Sampler sampler;

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
@@ -46,7 +46,6 @@ import org.stagemonitor.configuration.ConfigurationOption;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.concurrent.TimeUnit;
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracerBuilder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracerBuilder.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Context.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Context.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,6 @@
 package co.elastic.apm.impl.context;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -32,34 +30,28 @@ import java.util.concurrent.ConcurrentHashMap;
  * <p>
  * Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Context implements Recyclable {
 
     /**
      * An arbitrary mapping of additional metadata to store with the event.
      */
-    @JsonProperty("custom")
     private final Map<String, Object> custom = new ConcurrentHashMap<>();
-    @JsonProperty("response")
     private final Response response = new Response();
     /**
      * Request
      * <p>
      * If a log record was generated as a result of a http request, the http interface can be used to collect this information.
      */
-    @JsonProperty("request")
     private final Request request = new Request();
     /**
      * A flat mapping of user-defined tags with string values.
      */
-    @JsonProperty("tags")
     private final Map<String, String> tags = new ConcurrentHashMap<>();
     /**
      * User
      * <p>
      * Describes the authenticated User for a request.
      */
-    @JsonProperty("user")
     private final User user = new User();
 
 
@@ -72,12 +64,10 @@ public class Context implements Recyclable {
     /**
      * An arbitrary mapping of additional metadata to store with the event.
      */
-    @JsonProperty("custom")
     public Map<String, Object> getCustom() {
         return custom;
     }
 
-    @JsonProperty("response")
     public Response getResponse() {
         return response;
     }
@@ -87,7 +77,6 @@ public class Context implements Recyclable {
      * <p>
      * If a log record was generated as a result of a http request, the http interface can be used to collect this information.
      */
-    @JsonProperty("request")
     public Request getRequest() {
         return request;
     }
@@ -95,7 +84,6 @@ public class Context implements Recyclable {
     /**
      * A flat mapping of user-defined tags with string values.
      */
-    @JsonProperty("tags")
     public Map<String, String> getTags() {
         return tags;
     }
@@ -105,7 +93,6 @@ public class Context implements Recyclable {
      * <p>
      * Describes the authenticated User for a request.
      */
-    @JsonProperty("user")
     public User getUser() {
         return user;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Request.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Request.java
@@ -90,6 +90,12 @@ public class Request implements Recyclable {
         }
     }
 
+    @Nullable
+    @JsonIgnore
+    public String getRawBody() {
+        return rawBody;
+    }
+
     public void redactBody() {
         postParams.clear();
         rawBody = "[REDACTED]";
@@ -190,7 +196,7 @@ public class Request implements Recyclable {
      * A parsed key-value object of cookies
      */
     @JsonProperty("cookies")
-    public Map<String, Object> getCookies() {
+    public PotentiallyMultiValuedMap<String, String> getCookies() {
         return cookies;
     }
 
@@ -215,5 +221,16 @@ public class Request implements Recyclable {
         this.socket.copyFrom(other.socket);
         this.url.copyFrom(other.url);
         this.cookies.putAll(other.cookies);
+    }
+
+    public boolean hasContent() {
+        return method != null ||
+            headers.size() > 0 ||
+            httpVersion != null ||
+            cookies.size() > 0 ||
+            rawBody != null ||
+            postParams.size() > 0 ||
+            socket.hasContent() ||
+            url.hasContent();
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Request.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Request.java
@@ -21,12 +21,8 @@ package co.elastic.apm.impl.context;
 
 import co.elastic.apm.objectpool.Recyclable;
 import co.elastic.apm.util.PotentiallyMultiValuedMap;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
-import java.util.Map;
 
 
 /**
@@ -34,53 +30,43 @@ import java.util.Map;
  * <p>
  * If a log record was generated as a result of a http request, the http interface can be used to collect this information.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Request implements Recyclable {
 
-    @JsonIgnore
     private final PotentiallyMultiValuedMap<String, String> postParams = new PotentiallyMultiValuedMap<>();
     /**
      * Should include any headers sent by the requester. Map<String, String> </String,>will be taken by headers if supplied.
      */
-    @JsonProperty("headers")
     private final PotentiallyMultiValuedMap<String, String> headers = new PotentiallyMultiValuedMap<>();
-    @JsonProperty("socket")
     private final Socket socket = new Socket();
     /**
      * A complete Url, with scheme, host and path.
      * (Required)
      */
-    @JsonProperty("url")
     private final Url url = new Url();
     /**
      * A parsed key-value object of cookies
      */
-    @JsonProperty("cookies")
     private final PotentiallyMultiValuedMap<String, String> cookies = new PotentiallyMultiValuedMap<>();
     /**
      * Data should only contain the request body (not the query string). It can either be a dictionary (for standard HTTP requests) or a raw request body.
      */
     @Nullable
-    @JsonIgnore
     private String rawBody;
     /**
      * HTTP version.
      */
     @Nullable
-    @JsonProperty("http_version")
     private String httpVersion;
     /**
      * HTTP method.
      * (Required)
      */
     @Nullable
-    @JsonProperty("method")
     private String method;
 
     /**
      * Data should only contain the request body (not the query string). It can either be a dictionary (for standard HTTP requests) or a raw request body.
      */
-    @JsonProperty("body")
     @Nullable
     public Object getBody() {
         if (!postParams.isEmpty()) {
@@ -91,7 +77,6 @@ public class Request implements Recyclable {
     }
 
     @Nullable
-    @JsonIgnore
     public String getRawBody() {
         return rawBody;
     }
@@ -118,7 +103,6 @@ public class Request implements Recyclable {
         return this;
     }
 
-    @JsonIgnore
     public PotentiallyMultiValuedMap<String, String> getFormUrlEncodedParameters() {
         return postParams;
     }
@@ -138,7 +122,6 @@ public class Request implements Recyclable {
     /**
      * Should include any headers sent by the requester.
      */
-    @JsonProperty("headers")
     public PotentiallyMultiValuedMap<String, String> getHeaders() {
         return headers;
     }
@@ -147,7 +130,6 @@ public class Request implements Recyclable {
      * HTTP version.
      */
     @Nullable
-    @JsonProperty("http_version")
     public String getHttpVersion() {
         return httpVersion;
     }
@@ -162,7 +144,6 @@ public class Request implements Recyclable {
      * (Required)
      */
     @Nullable
-    @JsonProperty("method")
     public String getMethod() {
         return method;
     }
@@ -172,7 +153,6 @@ public class Request implements Recyclable {
         return this;
     }
 
-    @JsonProperty("socket")
     public Socket getSocket() {
         return socket;
     }
@@ -181,7 +161,6 @@ public class Request implements Recyclable {
      * A complete Url, with scheme, host and path.
      * (Required)
      */
-    @JsonProperty("url")
     public Url getUrl() {
         return url;
     }
@@ -195,7 +174,6 @@ public class Request implements Recyclable {
     /**
      * A parsed key-value object of cookies
      */
-    @JsonProperty("cookies")
     public PotentiallyMultiValuedMap<String, String> getCookies() {
         return cookies;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Response.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Response.java
@@ -79,7 +79,7 @@ public class Response implements Recyclable {
      * A mapping of HTTP headers of the response object
      */
     @JsonProperty("headers")
-    public Map<String, Object> getHeaders() {
+    public PotentiallyMultiValuedMap<String, String> getHeaders() {
         return headers;
     }
 
@@ -123,5 +123,9 @@ public class Response implements Recyclable {
         this.headers.putAll(other.headers);
         this.headersSent = other.headersSent;
         this.statusCode = other.statusCode;
+    }
+
+    public boolean hasContent() {
+        return statusCode > 0 || headers.size() > 0;
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Response.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Response.java
@@ -21,36 +21,26 @@ package co.elastic.apm.impl.context;
 
 import co.elastic.apm.objectpool.Recyclable;
 import co.elastic.apm.util.PotentiallyMultiValuedMap;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
-import java.util.Map;
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Response implements Recyclable {
 
     /**
      * A mapping of HTTP headers of the response object
      */
-    @JsonProperty("headers")
     private final PotentiallyMultiValuedMap<String, String> headers = new PotentiallyMultiValuedMap<>();
     /**
      * A boolean indicating whether the response was finished or not
      */
-    @JsonProperty("finished")
     private boolean finished;
-    @JsonProperty("headers_sent")
     private boolean headersSent;
     /**
      * The HTTP status code of the response.
      */
-    @JsonProperty("status_code")
     private long statusCode;
 
     /**
      * A boolean indicating whether the response was finished or not
      */
-    @JsonProperty("finished")
     public boolean isFinished() {
         return finished;
     }
@@ -78,13 +68,11 @@ public class Response implements Recyclable {
     /**
      * A mapping of HTTP headers of the response object
      */
-    @JsonProperty("headers")
     public PotentiallyMultiValuedMap<String, String> getHeaders() {
         return headers;
     }
 
 
-    @JsonProperty("headers_sent")
     public boolean isHeadersSent() {
         return headersSent;
     }
@@ -97,7 +85,6 @@ public class Response implements Recyclable {
     /**
      * The HTTP status code of the response.
      */
-    @JsonProperty("status_code")
     public long getStatusCode() {
         return statusCode;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Socket.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Socket.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -74,5 +74,9 @@ public class Socket implements Recyclable {
     public void copyFrom(Socket other) {
         this.encrypted = other.encrypted;
         this.remoteAddress = other.remoteAddress;
+    }
+
+    public boolean hasContent() {
+        return remoteAddress != null;
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Socket.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Socket.java
@@ -21,27 +21,21 @@
 package co.elastic.apm.impl.context;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Socket implements Recyclable {
 
     /**
      * Indicates whether request was sent as SSL/HTTPS request.
      */
-    @JsonProperty("encrypted")
     private boolean encrypted;
-    @JsonProperty("remote_address")
     @Nullable
     private String remoteAddress;
 
     /**
      * Indicates whether request was sent as SSL/HTTPS request.
      */
-    @JsonProperty("encrypted")
     public boolean isEncrypted() {
         return encrypted;
     }
@@ -55,7 +49,6 @@ public class Socket implements Recyclable {
     }
 
     @Nullable
-    @JsonProperty("remote_address")
     public String getRemoteAddress() {
         return remoteAddress;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Url.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Url.java
@@ -20,8 +20,6 @@
 package co.elastic.apm.impl.context;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 
@@ -29,49 +27,41 @@ import javax.annotation.Nullable;
 /**
  * A complete Url, with scheme, host and path.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Url implements Recyclable {
 
     /**
      * The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.
      */
-    @JsonProperty("full")
     private final StringBuilder full = new StringBuilder();
     /**
      * The protocol of the request, e.g. 'https:'.
      */
     @Nullable
-    @JsonProperty("protocol")
     private String protocol;
     /**
      * The hostname of the request, e.g. 'example.com'.
      */
     @Nullable
-    @JsonProperty("hostname")
     private String hostname;
     /**
      * The port of the request, e.g. '443'
      */
-    @JsonProperty("port")
     private final StringBuilder port = new StringBuilder();
     /**
      * The path of the request, e.g. '/search'
      */
     @Nullable
-    @JsonProperty("pathname")
     private String pathname;
     /**
      * The search describes the query string of the request. It is expected to have values delimited by ampersands.
      */
     @Nullable
-    @JsonProperty("search")
     private String search;
 
     /**
      * The protocol of the request, e.g. 'https:'.
      */
     @Nullable
-    @JsonProperty("protocol")
     public String getProtocol() {
         return protocol;
     }
@@ -87,7 +77,6 @@ public class Url implements Recyclable {
     /**
      * The full, possibly agent-assembled URL of the request, e.g https://example.com:443/search?q=elasticsearch#top.
      */
-    @JsonProperty("full")
     public StringBuilder getFull() {
         return full;
     }
@@ -101,7 +90,6 @@ public class Url implements Recyclable {
      * The hostname of the request, e.g. 'example.com'.
      */
     @Nullable
-    @JsonProperty("hostname")
     public String getHostname() {
         return hostname;
     }
@@ -117,7 +105,6 @@ public class Url implements Recyclable {
     /**
      * The port of the request, e.g. '443'
      */
-    @JsonProperty("port")
     public StringBuilder getPort() {
         return port;
     }
@@ -134,7 +121,6 @@ public class Url implements Recyclable {
      * The path of the request, e.g. '/search'
      */
     @Nullable
-    @JsonProperty("pathname")
     public String getPathname() {
         return pathname;
     }
@@ -151,7 +137,6 @@ public class Url implements Recyclable {
      * The search describes the query string of the request. It is expected to have values delimited by ampersands.
      */
     @Nullable
-    @JsonProperty("search")
     public String getSearch() {
         return search;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Url.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/Url.java
@@ -182,4 +182,13 @@ public class Url implements Recyclable {
         this.pathname = other.pathname;
         this.search = other.search;
     }
+
+    public boolean hasContent() {
+        return protocol != null ||
+            full.length() > 0 ||
+            hostname != null ||
+            port.length() > 0 ||
+            pathname != null ||
+            search != null;
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/User.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/User.java
@@ -21,8 +21,6 @@
 package co.elastic.apm.impl.context;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 
@@ -32,33 +30,28 @@ import javax.annotation.Nullable;
  * <p>
  * Describes the authenticated User for a request.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class User implements Recyclable {
 
     /**
      * Identifier of the logged in user, e.g. the primary key of the user
      */
     @Nullable
-    @JsonProperty("id")
     private String id;
     /**
      * Email of the logged in user
      */
     @Nullable
-    @JsonProperty("email")
     private String email;
     /**
      * The username of the logged in user
      */
     @Nullable
-    @JsonProperty("username")
     private String username;
 
     /**
      * Identifier of the logged in user, e.g. the primary key of the user
      */
     @Nullable
-    @JsonProperty("id")
     public String getId() {
         return id;
     }
@@ -75,7 +68,6 @@ public class User implements Recyclable {
      * Email of the logged in user
      */
     @Nullable
-    @JsonProperty("email")
     public String getEmail() {
         return email;
     }
@@ -92,7 +84,6 @@ public class User implements Recyclable {
      * The username of the logged in user
      */
     @Nullable
-    @JsonProperty("username")
     public String getUsername() {
         return username;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/User.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/User.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -116,5 +116,9 @@ public class User implements Recyclable {
         this.email = other.email;
         this.id = other.id;
         this.username = other.username;
+    }
+
+    public boolean hasContent() {
+        return id != null || email != null || username != null;
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/package-info.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/package-info.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/error/ErrorCapture.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/error/ErrorCapture.java
@@ -23,9 +23,6 @@ import co.elastic.apm.impl.ElasticApmTracer;
 import co.elastic.apm.impl.context.Context;
 import co.elastic.apm.impl.transaction.TransactionId;
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 import java.util.Date;
@@ -34,7 +31,6 @@ import java.util.Date;
 /**
  * Data captured by an agent representing an event occurring in a monitored service
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorCapture implements Recyclable {
 
     /**
@@ -42,31 +38,25 @@ public class ErrorCapture implements Recyclable {
      * <p>
      * Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user
      */
-    @JsonProperty("context")
     private final Context context = new Context();
     /**
      * Information about the originally thrown error.
      */
-    @JsonProperty("exception")
     private final ExceptionInfo exception = new ExceptionInfo();
     /**
      * Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ
      * (Required)
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
-    @JsonProperty("timestamp")
     private final Date timestamp = new Date();
     /**
      * Data for correlating errors with transactions
      */
-    @JsonProperty("transaction")
     private final TransactionReference transaction = new TransactionReference();
     @Nullable
     private transient ElasticApmTracer tracer;
     /**
      * ID for the error
      */
-    @JsonProperty("id")
     private final TransactionId id = new TransactionId();
 
     /**
@@ -74,7 +64,6 @@ public class ErrorCapture implements Recyclable {
      * <p>
      * Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user
      */
-    @JsonProperty("context")
     public Context getContext() {
         return context;
     }
@@ -82,7 +71,6 @@ public class ErrorCapture implements Recyclable {
     /**
      * Information about the originally thrown error.
      */
-    @JsonProperty("exception")
     public ExceptionInfo getException() {
         return exception;
     }
@@ -90,7 +78,6 @@ public class ErrorCapture implements Recyclable {
     /**
      * UUID for the error
      */
-    @JsonProperty("id")
     public TransactionId getId() {
         return id;
     }
@@ -99,7 +86,6 @@ public class ErrorCapture implements Recyclable {
      * Recorded time of the error, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ
      * (Required)
      */
-    @JsonProperty("timestamp")
     public Date getTimestamp() {
         return timestamp;
     }
@@ -112,7 +98,6 @@ public class ErrorCapture implements Recyclable {
     /**
      * Data for correlating errors with transactions
      */
-    @JsonProperty("transaction")
     public TransactionReference getTransaction() {
         return transaction;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/error/ErrorPayload.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/error/ErrorPayload.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,8 +25,6 @@ import co.elastic.apm.impl.payload.ProcessInfo;
 import co.elastic.apm.impl.payload.Service;
 import co.elastic.apm.impl.payload.SystemInfo;
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,13 +35,11 @@ import java.util.List;
  * <p>
  * List of errors wrapped in an object containing some other attributes normalized away from the errors themselves
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ErrorPayload extends Payload {
 
     /**
      * (Required)
      */
-    @JsonProperty("errors")
     private final List<ErrorCapture> errors = new ArrayList<ErrorCapture>();
 
     public ErrorPayload(ProcessInfo process, Service service, SystemInfo system) {
@@ -53,7 +49,6 @@ public class ErrorPayload extends Payload {
     /**
      * (Required)
      */
-    @JsonProperty("errors")
     public List<ErrorCapture> getErrors() {
         return errors;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/error/ExceptionInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/error/ExceptionInfo.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,8 +21,6 @@ package co.elastic.apm.impl.error;
 
 import co.elastic.apm.impl.stacktrace.Stacktrace;
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -31,36 +29,30 @@ import java.util.List;
 /**
  * Information about the originally thrown error.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ExceptionInfo implements Recyclable {
 
-    @JsonProperty("stacktrace")
     private final List<Stacktrace> stacktrace = new ArrayList<>();
     /**
      * The error code set when the error happened, e.g. database error code.
      */
     @Nullable
-    @JsonProperty("code")
     private String code;
     /**
      * The original error message.
      * (Required)
      */
     @Nullable
-    @JsonProperty("message")
     private String message;
     /**
      * Describes the exception type's module namespace.
      */
     @Nullable
-    @JsonProperty("type")
     private String type;
 
     /**
      * The error code set when the error happened, e.g. database error code.
      */
     @Nullable
-    @JsonProperty("code")
     public String getCode() {
         return code;
     }
@@ -78,7 +70,6 @@ public class ExceptionInfo implements Recyclable {
      * (Required)
      */
     @Nullable
-    @JsonProperty("message")
     public String getMessage() {
         return message;
     }
@@ -92,13 +83,11 @@ public class ExceptionInfo implements Recyclable {
         return this;
     }
 
-    @JsonProperty("stacktrace")
     public List<Stacktrace> getStacktrace() {
         return stacktrace;
     }
 
     @Nullable
-    @JsonProperty("type")
     public String getType() {
         return type;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/error/Log.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/error/Log.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,8 +21,6 @@ package co.elastic.apm.impl.error;
 
 import co.elastic.apm.impl.stacktrace.Stacktrace;
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -31,42 +29,35 @@ import java.util.List;
 /**
  * Additional information added when logging the error.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Log implements Recyclable {
 
     private static final String DEFAULT_LOGGER_NAME = "default";
     private static final String DEFAULT_LEVEL = "error";
 
-    @JsonProperty("stacktrace")
     private final List<Stacktrace> stacktrace = new ArrayList<>();
     /**
      * The severity of the record.
      */
-    @JsonProperty("level")
     private String level = DEFAULT_LEVEL;
     /**
      * The name of the logger instance used.
      */
-    @JsonProperty("logger_name")
     private String loggerName = DEFAULT_LOGGER_NAME;
     /**
      * The additionally logged error message.
      * (Required)
      */
     @Nullable
-    @JsonProperty("message")
     private String message;
     /**
      * A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together. The string is not interpreted, so feel free to use whichever placeholders makes sense in the client languange.
      */
     @Nullable
-    @JsonProperty("param_message")
     private String paramMessage;
 
     /**
      * The severity of the record.
      */
-    @JsonProperty("level")
     public String getLevel() {
         return level;
     }
@@ -82,7 +73,6 @@ public class Log implements Recyclable {
     /**
      * The name of the logger instance used.
      */
-    @JsonProperty("logger_name")
     public String getLoggerName() {
         return loggerName;
     }
@@ -100,7 +90,6 @@ public class Log implements Recyclable {
      * (Required)
      */
     @Nullable
-    @JsonProperty("message")
     public String getMessage() {
         return message;
     }
@@ -118,7 +107,6 @@ public class Log implements Recyclable {
      * A parametrized message. E.g. 'Could not connect to %s'. The property message is still required, and should be equal to the param_message, but with placeholders replaced. In some situations the param_message is used to group errors together. The string is not interpreted, so feel free to use whichever placeholders makes sense in the client languange.
      */
     @Nullable
-    @JsonProperty("param_message")
     public String getParamMessage() {
         return paramMessage;
     }
@@ -131,7 +119,6 @@ public class Log implements Recyclable {
         return this;
     }
 
-    @JsonProperty("stacktrace")
     public List<Stacktrace> getStacktrace() {
         return stacktrace;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/error/TransactionReference.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/error/TransactionReference.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,26 +22,21 @@ package co.elastic.apm.impl.error;
 
 import co.elastic.apm.impl.transaction.TransactionId;
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 /**
  * Data for correlating errors with transactions
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionReference implements Recyclable {
 
     /**
      * ID for the transaction
      */
-    @JsonProperty("id")
     private final TransactionId id = new TransactionId();
 
     /**
      * UUID for the transaction
      */
-    @JsonProperty("id")
     public TransactionId getId() {
         return id;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/error/package-info.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/error/package-info.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/package-info.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/package-info.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Agent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Agent.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,27 +20,21 @@
 
 package co.elastic.apm.impl.payload;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 
 /**
  * Name and version of the Elastic APM agent
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Agent {
 
     /**
      * Name of the Elastic APM agent, e.g. "Python"
      * (Required)
      */
-    @JsonProperty("name")
     private final String name;
     /**
      * Version of the Elastic APM agent, e.g."1.0.0"
      * (Required)
      */
-    @JsonProperty("version")
     private final String version;
 
     public Agent(String name, String version) {
@@ -52,7 +46,6 @@ public class Agent {
      * Name of the Elastic APM agent, e.g. "Python"
      * (Required)
      */
-    @JsonProperty("name")
     public String getName() {
         return name;
     }
@@ -61,7 +54,6 @@ public class Agent {
      * Version of the Elastic APM agent, e.g."1.0.0"
      * (Required)
      */
-    @JsonProperty("version")
     public String getVersion() {
         return version;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Framework.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Framework.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,25 +20,19 @@
 
 package co.elastic.apm.impl.payload;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 
 /**
  * Name and version of the web framework used
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Framework {
 
     /**
      * (Required)
      */
-    @JsonProperty("name")
     private final String name;
     /**
      * (Required)
      */
-    @JsonProperty("version")
     private final String version;
 
     public Framework(String name, String version) {
@@ -49,7 +43,6 @@ public class Framework {
     /**
      * (Required)
      */
-    @JsonProperty("name")
     public String getName() {
         return name;
     }
@@ -57,7 +50,6 @@ public class Framework {
     /**
      * (Required)
      */
-    @JsonProperty("version")
     public String getVersion() {
         return version;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Language.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Language.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,22 +20,16 @@
 
 package co.elastic.apm.impl.payload;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 
 /**
  * Name and version of the programming language used
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Language {
 
     /**
      * (Required)
      */
-    @JsonProperty("name")
     private final String name;
-    @JsonProperty("version")
     private final String version;
 
     public Language(String name, String version) {
@@ -46,12 +40,10 @@ public class Language {
     /**
      * (Required)
      */
-    @JsonProperty("name")
     public String getName() {
         return name;
     }
 
-    @JsonProperty("version")
     public String getVersion() {
         return version;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Payload.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Payload.java
@@ -20,8 +20,6 @@
 package co.elastic.apm.impl.payload;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.List;
 
@@ -30,17 +28,14 @@ public abstract class Payload implements Recyclable {
      * Service
      * (Required)
      */
-    @JsonProperty("service")
     protected final Service service;
     /**
      * Process
      */
-    @JsonProperty("process")
     protected final ProcessInfo process;
     /**
      * System
      */
-    @JsonProperty("system")
     protected final SystemInfo system;
 
     public Payload(ProcessInfo process, Service service, SystemInfo system) {
@@ -55,7 +50,6 @@ public abstract class Payload implements Recyclable {
      *
      * @return the service name
      */
-    @JsonProperty("service")
     public Service getService() {
         return service;
     }
@@ -65,7 +59,6 @@ public abstract class Payload implements Recyclable {
      *
      * @return the process name
      */
-    @JsonProperty("process")
     public ProcessInfo getProcess() {
         return process;
     }
@@ -75,12 +68,10 @@ public abstract class Payload implements Recyclable {
      *
      * @return the system name
      */
-    @JsonProperty("system")
     public SystemInfo getSystem() {
         return system;
     }
 
-    @JsonIgnore
     public abstract List<? extends Recyclable> getPayloadObjects();
 
     public abstract void recycle();

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/ProcessInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/ProcessInfo.java
@@ -20,8 +20,6 @@
 
 package co.elastic.apm.impl.payload;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -31,27 +29,22 @@ import java.util.List;
 /**
  * Process
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class ProcessInfo {
 
     /**
      * Process ID of the service
      * (Required)
      */
-    @JsonProperty("pid")
     private long pid;
     /**
      * Parent process ID of the service
      */
     @Nullable
-    @JsonProperty("ppid")
     private Long ppid;
-    @JsonProperty("title")
     private final String title;
     /**
      * Command line arguments used to start this process
      */
-    @JsonProperty("argv")
     private List<String> argv = new ArrayList<String>();
 
     public ProcessInfo(String title) {
@@ -62,7 +55,6 @@ public class ProcessInfo {
      * Process ID of the service
      * (Required)
      */
-    @JsonProperty("pid")
     public long getPid() {
         return pid;
     }
@@ -79,7 +71,6 @@ public class ProcessInfo {
      * Parent process ID of the service
      */
     @Nullable
-    @JsonProperty("ppid")
     public Long getPpid() {
         return ppid;
     }
@@ -92,7 +83,6 @@ public class ProcessInfo {
         return this;
     }
 
-    @JsonProperty("title")
     public String getTitle() {
         return title;
     }
@@ -100,7 +90,6 @@ public class ProcessInfo {
     /**
      * Command line arguments used to start this process
      */
-    @JsonProperty("argv")
     public List<String> getArgv() {
         return argv;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/RuntimeInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/RuntimeInfo.java
@@ -20,19 +20,13 @@
 
 package co.elastic.apm.impl.payload;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 
 /**
  * Name and version of the language runtime running this service
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class RuntimeInfo {
 
-    @JsonProperty("name")
     private final String name;
-    @JsonProperty("version")
     private final String version;
 
     public RuntimeInfo(String name, String version) {
@@ -40,12 +34,10 @@ public class RuntimeInfo {
         this.version = version;
     }
 
-    @JsonProperty("name")
     public String getName() {
         return name;
     }
 
-    @JsonProperty("version")
     public String getVersion() {
         return version;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Service.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/Service.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,8 +19,6 @@
  */
 package co.elastic.apm.impl.payload;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 
@@ -28,7 +26,6 @@ import javax.annotation.Nullable;
 /**
  * Information about the instrumented Service
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Service {
 
     /**
@@ -36,44 +33,37 @@ public class Service {
      * (Required)
      */
     @Nullable
-    @JsonProperty("agent")
     private Agent agent;
     /**
      * Name and version of the web framework used
      */
     @Nullable
-    @JsonProperty("framework")
     private Framework framework;
     /**
      * Name and version of the programming language used
      */
     @Nullable
-    @JsonProperty("language")
     private Language language;
     /**
      * Immutable name of the service emitting this event
      * (Required)
      */
     @Nullable
-    @JsonProperty("name")
     private String name;
     /**
      * Environment name of the service, e.g. "production" or "staging"
      */
     @Nullable
-    @JsonProperty("environment")
     private String environment;
     /**
      * Name and version of the language runtime running this service
      */
     @Nullable
-    @JsonProperty("runtime")
     private RuntimeInfo runtime;
     /**
      * Version of the service emitting this event
      */
     @Nullable
-    @JsonProperty("version")
     private String version;
 
     /**
@@ -81,7 +71,6 @@ public class Service {
      * (Required)
      */
     @Nullable
-    @JsonProperty("agent")
     public Agent getAgent() {
         return agent;
     }
@@ -99,7 +88,6 @@ public class Service {
      * Name and version of the web framework used
      */
     @Nullable
-    @JsonProperty("framework")
     public Framework getFramework() {
         return framework;
     }
@@ -116,7 +104,6 @@ public class Service {
      * Name and version of the programming language used
      */
     @Nullable
-    @JsonProperty("language")
     public Language getLanguage() {
         return language;
     }
@@ -134,7 +121,6 @@ public class Service {
      * (Required)
      */
     @Nullable
-    @JsonProperty("name")
     public String getName() {
         return name;
     }
@@ -152,7 +138,6 @@ public class Service {
      * Environment name of the service, e.g. "production" or "staging"
      */
     @Nullable
-    @JsonProperty("environment")
     public String getEnvironment() {
         return environment;
     }
@@ -169,7 +154,6 @@ public class Service {
      * Name and version of the language runtime running this service
      */
     @Nullable
-    @JsonProperty("runtime")
     public RuntimeInfo getRuntime() {
         return runtime;
     }
@@ -186,7 +170,6 @@ public class Service {
      * Version of the service emitting this event
      */
     @Nullable
-    @JsonProperty("version")
     public String getVersion() {
         return version;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/ServiceFactory.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/ServiceFactory.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/SystemInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/SystemInfo.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,31 +19,25 @@
  */
 package co.elastic.apm.impl.payload;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.net.InetAddress;
 
 /**
  * Information about the system the agent is running on.
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SystemInfo {
 
     /**
      * Architecture of the system the agent is running on.
      */
-    @JsonProperty("architecture")
     private final String architecture;
     /**
      * Hostname of the system the agent is running on.
      */
-    @JsonProperty("hostname")
     private final String hostname;
     /**
      * Name of the system platform the agent is running on.
      */
-    @JsonProperty("platform")
     private final String platform;
 
     public SystemInfo(String architecture, String hostname, String platform) {
@@ -79,7 +73,6 @@ public class SystemInfo {
     /**
      * Architecture of the system the agent is running on.
      */
-    @JsonProperty("architecture")
     public String getArchitecture() {
         return architecture;
     }
@@ -87,7 +80,6 @@ public class SystemInfo {
     /**
      * Hostname of the system the agent is running on.
      */
-    @JsonProperty("hostname")
     public String getHostname() {
         return hostname;
     }
@@ -95,7 +87,6 @@ public class SystemInfo {
     /**
      * Name of the system platform the agent is running on.
      */
-    @JsonProperty("platform")
     public String getPlatform() {
         return platform;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/TransactionPayload.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/TransactionPayload.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/TransactionPayload.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/TransactionPayload.java
@@ -22,8 +22,6 @@ package co.elastic.apm.impl.payload;
 
 import co.elastic.apm.impl.transaction.Transaction;
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,13 +32,11 @@ import java.util.List;
  * <p>
  * List of transactions wrapped in an object containing some other attributes normalized away from the transactions themselves
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class TransactionPayload extends Payload {
 
     /**
      * (Required)
      */
-    @JsonProperty("transactions")
     private final List<Transaction> transactions = new ArrayList<Transaction>();
 
     public TransactionPayload(ProcessInfo process, Service service, SystemInfo system) {
@@ -50,7 +46,6 @@ public class TransactionPayload extends Payload {
     /**
      * (Required)
      */
-    @JsonProperty("transactions")
     public List<Transaction> getTransactions() {
         return transactions;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/package-info.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/payload/package-info.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/ConstantSampler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/ConstantSampler.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/Sampler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/Sampler.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/package-info.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/package-info.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/stacktrace/Stacktrace.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/stacktrace/Stacktrace.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,8 +21,6 @@
 package co.elastic.apm.impl.stacktrace;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 
@@ -32,51 +30,43 @@ import javax.annotation.Nullable;
  * <p>
  * A stacktrace frame, contains various bits (most optional) describing the context of the frame
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Stacktrace implements Recyclable {
 
     /**
      * The absolute path of the file involved in the stack frame
      */
     @Nullable
-    @JsonProperty("abs_path")
     private String absPath;
     /**
      * The relative filename of the code involved in the stack frame, used e.g. to do error checksumming
      * (Required)
      */
     @Nullable
-    @JsonProperty("filename")
     private String filename;
     /**
      * The function involved in the stack frame
      */
     @Nullable
-    @JsonProperty("function")
     private String function;
     /**
      * A boolean, indicating if this frame is from a library or user code
      */
-    @JsonProperty("library_frame")
     private boolean libraryFrame;
     /**
      * The line number of code part of the stack frame, used e.g. to do error checksumming
      * (Required)
      */
-    @JsonProperty("lineno")
     private long lineno;
     /**
      * The module to which frame belongs to
      */
     @Nullable
-    @JsonProperty("module")
     private String module;
 
     /**
      * The absolute path of the file involved in the stack frame
      */
     @Nullable
-    @JsonProperty("abs_path")
     public String getAbsPath() {
         return absPath;
     }
@@ -94,7 +84,6 @@ public class Stacktrace implements Recyclable {
      * (Required)
      */
     @Nullable
-    @JsonProperty("filename")
     public String getFilename() {
         return filename;
     }
@@ -112,7 +101,6 @@ public class Stacktrace implements Recyclable {
      * The function involved in the stack frame
      */
     @Nullable
-    @JsonProperty("function")
     public String getFunction() {
         return function;
     }
@@ -128,7 +116,6 @@ public class Stacktrace implements Recyclable {
     /**
      * A boolean, indicating if this frame is from a library or user code
      */
-    @JsonProperty("library_frame")
     public boolean isLibraryFrame() {
         return libraryFrame;
     }
@@ -145,7 +132,6 @@ public class Stacktrace implements Recyclable {
      * The line number of code part of the stack frame, used e.g. to do error checksumming
      * (Required)
      */
-    @JsonProperty("lineno")
     public long getLineno() {
         return lineno;
     }
@@ -163,7 +149,6 @@ public class Stacktrace implements Recyclable {
      * The module to which frame belongs to
      */
     @Nullable
-    @JsonProperty("module")
     public String getModule() {
         return module;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/stacktrace/StacktraceConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/stacktrace/StacktraceConfiguration.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/stacktrace/StacktraceFactory.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/stacktrace/StacktraceFactory.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/stacktrace/package-info.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/stacktrace/package-info.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Db.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Db.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -132,5 +132,12 @@ public class Db implements Recyclable {
         statement = null;
         type = null;
         user = null;
+    }
+
+    public boolean hasContent() {
+        return instance != null ||
+            statement != null ||
+            type != null ||
+            user != null;
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Db.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Db.java
@@ -21,8 +21,6 @@
 package co.elastic.apm.impl.transaction;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 
@@ -30,39 +28,33 @@ import javax.annotation.Nullable;
 /**
  * An object containing contextual data for database spans
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Db implements Recyclable {
 
     /**
      * Database instance name
      */
     @Nullable
-    @JsonProperty("instance")
     private String instance;
     /**
      * A database statement (e.g. query) for the given database type
      */
     @Nullable
-    @JsonProperty("statement")
     private String statement;
     /**
      * Database type. For any SQL database, "sql". For others, the lower-case database category, e.g. "cassandra", "hbase", or "redis"
      */
     @Nullable
-    @JsonProperty("type")
     private String type;
     /**
      * Username for accessing database
      */
     @Nullable
-    @JsonProperty("user")
     private String user;
 
     /**
      * Database instance name
      */
     @Nullable
-    @JsonProperty("instance")
     public String getInstance() {
         return instance;
     }
@@ -79,7 +71,6 @@ public class Db implements Recyclable {
      * A database statement (e.g. query) for the given database type
      */
     @Nullable
-    @JsonProperty("statement")
     public String getStatement() {
         return statement;
     }
@@ -96,7 +87,6 @@ public class Db implements Recyclable {
      * Database type. For any SQL database, "sql". For others, the lower-case database category, e.g. "cassandra", "hbase", or "redis"
      */
     @Nullable
-    @JsonProperty("type")
     public String getType() {
         return type;
     }
@@ -113,7 +103,6 @@ public class Db implements Recyclable {
      * Username for accessing database
      */
     @Nullable
-    @JsonProperty("user")
     public String getUser() {
         return user;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Dropped.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Dropped.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,24 +20,19 @@
 package co.elastic.apm.impl.transaction;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Dropped implements Recyclable {
 
     /**
      * Number of spans that have been dropped by the agent recording the transaction.
      */
-    @JsonProperty("total")
     private final AtomicInteger total = new AtomicInteger();
 
     /**
      * Number of spans that have been dropped by the agent recording the transaction.
      */
-    @JsonProperty("total")
     public int getTotal() {
         return total.get();
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Span.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,9 +22,6 @@ package co.elastic.apm.impl.transaction;
 import co.elastic.apm.impl.ElasticApmTracer;
 import co.elastic.apm.impl.stacktrace.Stacktrace;
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -32,23 +29,19 @@ import java.util.List;
 
 import static co.elastic.apm.impl.ElasticApmTracer.MS_IN_NANOS;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Span implements Recyclable, co.elastic.apm.api.Span {
 
     /**
      * Any other arbitrary data captured by the agent, optionally provided by the user
      */
-    @JsonProperty("context")
     private final SpanContext context = new SpanContext();
     /**
      * List of stack frames with variable attributes (eg: lineno, filename, etc)
      */
-    @JsonProperty("stacktrace")
     private final List<Stacktrace> stacktrace = new ArrayList<Stacktrace>();
     /**
      * The locally unique ID of the span.
      */
-    @JsonProperty("id")
     private final SpanId id = new SpanId();
     @Nullable
     private transient ElasticApmTracer tracer;
@@ -57,32 +50,27 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
      * Duration of the span in milliseconds
      * (Required)
      */
-    @JsonProperty("duration")
     private double duration;
     /**
      * Generic designation of a span in the scope of a transaction
      * (Required)
      */
     @Nullable
-    @JsonProperty("name")
     private String name;
     /**
      * The locally unique ID of the parent of the span.
      */
-    @JsonProperty("parent")
     private SpanId parent = new SpanId();
     /**
      * Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds
      * (Required)
      */
-    @JsonProperty("start")
     private double start;
     /**
      * Keyword of specific relevance in the service's domain (eg: 'db.postgresql.query', 'template.erb', etc)
      * (Required)
      */
     @Nullable
-    @JsonProperty("type")
     private String type;
 
     public Span start(ElasticApmTracer tracer, Transaction transaction, @Nullable Span span, long nanoTime, boolean dropped) {
@@ -103,7 +91,6 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
     /**
      * The locally unique ID of the span.
      */
-    @JsonProperty("id")
     public SpanId getId() {
         return id;
     }
@@ -111,7 +98,6 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
     /**
      * Any other arbitrary data captured by the agent, optionally provided by the user
      */
-    @JsonProperty("context")
     public SpanContext getContext() {
         return context;
     }
@@ -120,7 +106,6 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
      * Duration of the span in milliseconds
      * (Required)
      */
-    @JsonProperty("duration")
     public double getDuration() {
         return duration;
     }
@@ -130,7 +115,6 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
      * (Required)
      */
     @Nullable
-    @JsonProperty("name")
     public String getName() {
         return name;
     }
@@ -155,7 +139,6 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
     /**
      * The locally unique ID of the parent of the span.
      */
-    @JsonProperty("parent")
     public SpanId getParent() {
         return parent;
     }
@@ -163,7 +146,6 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
     /**
      * List of stack frames with variable attributes (eg: lineno, filename, etc)
      */
-    @JsonProperty("stacktrace")
     public List<Stacktrace> getStacktrace() {
         return stacktrace;
     }
@@ -172,7 +154,6 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
      * Offset relative to the transaction's timestamp identifying the start of the span, in milliseconds
      * (Required)
      */
-    @JsonProperty("start")
     public double getStart() {
         return start;
     }
@@ -182,7 +163,6 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
      * (Required)
      */
     @Nullable
-    @JsonProperty("type")
     public String getType() {
         return type;
     }
@@ -223,7 +203,6 @@ public class Span implements Recyclable, co.elastic.apm.api.Span {
         return this;
     }
 
-    @JsonIgnore
     public boolean isSampled() {
         return sampled;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanContext.java
@@ -21,26 +21,21 @@
 package co.elastic.apm.impl.transaction;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 
 /**
  * Any other arbitrary data captured by the agent, optionally provided by the user
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SpanContext implements Recyclable {
 
     /**
      * An object containing contextual data for database spans
      */
-    @JsonProperty("db")
     private final Db db = new Db();
 
     /**
      * An object containing contextual data for database spans
      */
-    @JsonProperty("db")
     public Db getDb() {
         return db;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanContext.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -48,5 +48,9 @@ public class SpanContext implements Recyclable {
     @Override
     public void resetState() {
         db.resetState();
+    }
+
+    public boolean hasContent() {
+        return db.hasContent();
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanCount.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanCount.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,16 +21,11 @@
 package co.elastic.apm.impl.transaction;
 
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class SpanCount implements Recyclable {
 
-    @JsonProperty("dropped")
     private final Dropped dropped = new Dropped();
 
-    @JsonProperty("dropped")
     public Dropped getDropped() {
         return dropped;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanId.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanId.java
@@ -21,7 +21,6 @@ package co.elastic.apm.impl.transaction;
 
 import co.elastic.apm.objectpool.Recyclable;
 import co.elastic.apm.util.HexUtils;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -64,7 +63,6 @@ public class SpanId implements Recyclable {
      *
      * @return the span id as a {@code long}
      */
-    @JsonValue
     public long asLong() {
         long l = 0;
         for (int i = 0; i < 8; i++) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
@@ -23,10 +23,6 @@ import co.elastic.apm.impl.ElasticApmTracer;
 import co.elastic.apm.impl.context.Context;
 import co.elastic.apm.impl.sampling.Sampler;
 import co.elastic.apm.objectpool.Recyclable;
-import com.fasterxml.jackson.annotation.JsonFormat;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 import javax.annotation.Nullable;
 import java.util.ArrayList;
@@ -40,7 +36,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 /**
  * Data captured by an agent representing an event occurring in a monitored service
  */
-@JsonInclude(JsonInclude.Include.NON_NULL)
 public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
 
     /**
@@ -53,29 +48,22 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * <p>
      * Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user
      */
-    @JsonProperty("context")
     private final Context context = new Context();
     /**
      * Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ
      * (Required)
      */
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX", timezone = "UTC")
-    @JsonProperty("timestamp")
     private final Date timestamp = new Date(0);
-    @JsonProperty("spans")
     private final List<Span> spans = new ArrayList<Span>();
     /**
      * A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.
      */
-    @JsonProperty("marks")
     private final Map<String, Object> marks = new HashMap<>();
-    @JsonProperty("span_count")
     private final SpanCount spanCount = new SpanCount();
     /**
      * UUID for the transaction, referred by its spans
      * (Required)
      */
-    @JsonProperty("id")
     private final TransactionId id = new TransactionId();
     @Nullable
     private transient ElasticApmTracer tracer;
@@ -83,30 +71,25 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * How long the transaction took to complete, in ms with 3 decimal points
      * (Required)
      */
-    @JsonProperty("duration")
     private double duration;
     /**
      * Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')
      */
-    @JsonProperty("name")
     private final StringBuilder name = new StringBuilder();
     /**
      * The result of the transaction. HTTP status code for HTTP-related transactions.
      */
     @Nullable
-    @JsonProperty("result")
     private String result;
     /**
      * Keyword of specific relevance in the service's domain (eg: 'request', 'backgroundjob', etc)
      * (Required)
      */
     @Nullable
-    @JsonProperty("type")
     private String type;
     /**
      * Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true.
      */
-    @JsonProperty("sampled")
     private boolean sampled;
 
     public Transaction start(ElasticApmTracer tracer, long startTimestampNanos, Sampler sampler) {
@@ -123,7 +106,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * <p>
      * Any arbitrary contextual information regarding the event, captured by the agent, optionally provided by the user
      */
-    @JsonProperty("context")
     public Context getContext() {
         return context;
     }
@@ -132,7 +114,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * How long the transaction took to complete, in ms with 3 decimal points
      * (Required)
      */
-    @JsonProperty("duration")
     public double getDuration() {
         return duration;
     }
@@ -141,7 +122,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * UUID for the transaction, referred by its spans
      * (Required)
      */
-    @JsonProperty("id")
     public TransactionId getId() {
         return id;
     }
@@ -149,7 +129,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
     /**
      * Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')
      */
-    @JsonProperty("name")
     public StringBuilder getName() {
         return name;
     }
@@ -178,7 +157,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * The result of the transaction. HTTP status code for HTTP-related transactions.
      */
     @Nullable
-    @JsonProperty("result")
     public String getResult() {
         return result;
     }
@@ -198,7 +176,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * Recorded time of the transaction, UTC based and formatted as YYYY-MM-DDTHH:mm:ss.sssZ
      * (Required)
      */
-    @JsonProperty("timestamp")
     public Date getTimestamp() {
         return timestamp;
     }
@@ -211,7 +188,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
         return this;
     }
 
-    @JsonProperty("spans")
     public List<Span> getSpans() {
         return spans;
     }
@@ -231,7 +207,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * (Required)
      */
     @Nullable
-    @JsonProperty("type")
     public String getType() {
         return type;
     }
@@ -241,7 +216,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * (Required)
      */
     @Override
-    @JsonProperty("type")
     public void setType(@Nullable String type) {
         if (!sampled) {
             return;
@@ -289,7 +263,6 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
     /**
      * A mark captures the timing of a significant event during the lifetime of a transaction. Marks are organized into groups and can be set by the user or the agent.
      */
-    @JsonProperty("marks")
     public Map<String, Object> getMarks() {
         return marks;
     }
@@ -299,18 +272,15 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * Transactions that are not sampled will not have 'spans' or 'context'.
      * Defaults to true.
      */
-    @JsonProperty("sampled")
     public boolean isSampled() {
         return sampled;
     }
 
-    @JsonProperty("span_count")
     public SpanCount getSpanCount() {
         return spanCount;
     }
 
 
-    @JsonIgnore
     int getNextSpanId() {
         return spanIdCounter.incrementAndGet();
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/TransactionId.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/TransactionId.java
@@ -21,7 +21,6 @@ package co.elastic.apm.impl.transaction;
 
 import co.elastic.apm.objectpool.Recyclable;
 import co.elastic.apm.util.HexUtils;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -81,7 +80,6 @@ public class TransactionId implements Recyclable {
         return lsb;
     }
 
-    @JsonValue
     public UUID toUuid() {
         return new UUID(getMostSignificantBits(), getLeastSignificantBits());
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/package-info.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/package-info.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ApmServerReporter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ApmServerReporter.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterFactory.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterFactory.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,9 +23,7 @@ import co.elastic.apm.configuration.CoreConfiguration;
 import co.elastic.apm.impl.payload.ProcessFactory;
 import co.elastic.apm.impl.payload.ServiceFactory;
 import co.elastic.apm.impl.payload.SystemInfo;
-import co.elastic.apm.report.serialize.JacksonPayloadSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import co.elastic.apm.report.serialize.DslJsonSerializer;
 import okhttp3.OkHttpClient;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.slf4j.Logger;
@@ -51,14 +49,13 @@ public class ReporterFactory {
 
     public Reporter createReporter(ConfigurationRegistry configurationRegistry, @Nullable String frameworkName,
                                    @Nullable String frameworkVersion) {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new AfterburnerModule());
         final ReporterConfiguration reporterConfiguration = configurationRegistry.getConfig(ReporterConfiguration.class);
         return new ApmServerReporter(configurationRegistry,
             new ServiceFactory().createService(configurationRegistry.getConfig(CoreConfiguration.class), frameworkName, frameworkVersion),
             ProcessFactory.ForCurrentVM.INSTANCE.getProcessInformation(),
             SystemInfo.create(),
-            new ApmServerHttpPayloadSender(getOkHttpClient(reporterConfiguration), new JacksonPayloadSerializer(objectMapper), reporterConfiguration), true, reporterConfiguration);
+            new ApmServerHttpPayloadSender(getOkHttpClient(reporterConfiguration), new DslJsonSerializer(), reporterConfiguration),
+            true, reporterConfiguration);
     }
 
     @Nonnull

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
@@ -53,6 +53,8 @@ import com.dslplatform.json.NumberConverter;
 import com.dslplatform.json.StringConverter;
 import com.dslplatform.json.UUIDConverter;
 import okio.BufferedSink;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.text.DateFormat;
@@ -70,9 +72,10 @@ import static com.dslplatform.json.JsonWriter.OBJECT_START;
 
 public class DslJsonSerializer implements PayloadSerializer {
 
+    private static final Logger logger = LoggerFactory.getLogger(DslJsonSerializer.class);
+
     private final JsonWriter jw;
     private final DateFormat dateFormat;
-
 
     public DslJsonSerializer() {
         jw = new DslJson<>().newWriter();
@@ -82,6 +85,9 @@ public class DslJsonSerializer implements PayloadSerializer {
 
     @Override
     public void serializePayload(final BufferedSink sink, final Payload payload) {
+        if (logger.isTraceEnabled()) {
+            logger.trace(toJsonString(payload));
+        }
         jw.reset(sink.outputStream());
         if (payload instanceof TransactionPayload) {
             serializeTransactionPayload((TransactionPayload) payload);
@@ -160,6 +166,8 @@ public class DslJsonSerializer implements PayloadSerializer {
         jw.reset();
         if (payload instanceof TransactionPayload) {
             serializeTransactionPayload((TransactionPayload) payload);
+        } else if (payload instanceof ErrorPayload) {
+            serializeErrorPayload((ErrorPayload) payload);
         }
         final String s = jw.toString();
         jw.reset();
@@ -598,6 +606,7 @@ public class DslJsonSerializer implements PayloadSerializer {
                 jw.writeString(values.get(i));
             }
             jw.writeByte(ARRAY_END);
+            jw.writeByte(COMMA);
         }
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
@@ -302,7 +302,7 @@ public class DslJsonSerializer implements PayloadSerializer {
     }
 
     private void serializeTransaction(final Transaction transaction) {
-        writeObjectStart();
+        jw.writeByte(OBJECT_START);
         // TODO date formatting allocates objects
         // writeField("timestamp", transaction.getTimestamp().getTime());
         writeField("timestamp", dateFormat.format(transaction.getTimestamp()));
@@ -336,7 +336,7 @@ public class DslJsonSerializer implements PayloadSerializer {
     }
 
     private void serializeSpan(final Span span) {
-        writeObjectStart();
+        jw.writeByte(OBJECT_START);
         writeField("name", span.getName());
         writeField("id", span.getId().asLong());
         final long parent = span.getParent().asLong();
@@ -383,9 +383,9 @@ public class DslJsonSerializer implements PayloadSerializer {
 
     private void serializeSpanContext(SpanContext context) {
         writeFieldName("context");
-        writeObjectStart();
+        jw.writeByte(OBJECT_START);
         writeFieldName("db");
-        writeObjectStart();
+        jw.writeByte(OBJECT_START);
         final Db db = context.getDb();
         writeField("instance", db.getInstance());
         writeField("statement", db.getStatement());
@@ -398,9 +398,9 @@ public class DslJsonSerializer implements PayloadSerializer {
 
     private void serializeSpanCount(final SpanCount spanCount) {
         writeFieldName("span_count");
-        writeObjectStart();
+        jw.writeByte(OBJECT_START);
         writeFieldName("dropped");
-        writeObjectStart();
+        jw.writeByte(OBJECT_START);
         writeFieldName("total");
         NumberConverter.serialize(spanCount.getDropped().getTotal(), jw);
         jw.writeByte(OBJECT_END);
@@ -428,7 +428,7 @@ public class DslJsonSerializer implements PayloadSerializer {
     private void serializeResponse(final Response response) {
         if (response.hasContent()) {
             writeFieldName("response");
-            writeObjectStart();
+            jw.writeByte(OBJECT_START);
             writeField("headers", response.getHeaders());
             writeField("finished", response.isFinished());
             writeField("headers_sent", response.isHeadersSent());
@@ -442,7 +442,7 @@ public class DslJsonSerializer implements PayloadSerializer {
     private void serializeRequest(final Request request) {
         if (request.hasContent()) {
             writeFieldName("request");
-            writeObjectStart();
+            jw.writeByte(OBJECT_START);
             writeField("method", request.getMethod());
             writeField("headers", request.getHeaders());
             writeField("cookies", request.getCookies());
@@ -463,7 +463,7 @@ public class DslJsonSerializer implements PayloadSerializer {
 
     private void serializeUrl(final Url url) {
         writeFieldName("url");
-        writeObjectStart();
+        jw.writeByte(OBJECT_START);
         writeField("full", url.getFull());
         writeField("protocol", url.getProtocol());
         writeField("hostname", url.getHostname());
@@ -477,7 +477,7 @@ public class DslJsonSerializer implements PayloadSerializer {
 
     private void serializeSocket(final Socket socket) {
         writeFieldName("socket");
-        writeObjectStart();
+        jw.writeByte(OBJECT_START);
         writeField("encrypted", socket.isEncrypted());
         writeLastField("remote_address", socket.getRemoteAddress());
         jw.writeByte(OBJECT_END);
@@ -487,7 +487,7 @@ public class DslJsonSerializer implements PayloadSerializer {
     private void writeField(final String fieldName, final PotentiallyMultiValuedMap<String, String> map) {
         if (map.size() > 0) {
             writeFieldName(fieldName);
-            writeObjectStart();
+            jw.writeByte(OBJECT_START);
             final int size = map.size();
             if (size > 0) {
                 final Iterator<Map.Entry<String, Object>> iterator = map.entrySet().iterator();
@@ -524,15 +524,11 @@ public class DslJsonSerializer implements PayloadSerializer {
 
     private void serializeUser(final User user) {
         writeFieldName("user");
-        writeObjectStart();
+        jw.writeByte(OBJECT_START);
         writeField("id", user.getId());
         writeField("email", user.getEmail());
         writeLastField("username", user.getUsername());
         jw.writeByte(OBJECT_END);
-    }
-
-    private void writeObjectStart() {
-        jw.writeByte(OBJECT_START);
     }
 
     private void writeField(final String fieldName, final StringBuilder value) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
@@ -1,0 +1,613 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 the original author or authors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.report.serialize;
+
+import co.elastic.apm.impl.context.Context;
+import co.elastic.apm.impl.context.Request;
+import co.elastic.apm.impl.context.Response;
+import co.elastic.apm.impl.context.Socket;
+import co.elastic.apm.impl.context.Url;
+import co.elastic.apm.impl.context.User;
+import co.elastic.apm.impl.error.ErrorCapture;
+import co.elastic.apm.impl.error.ErrorPayload;
+import co.elastic.apm.impl.error.ExceptionInfo;
+import co.elastic.apm.impl.payload.Agent;
+import co.elastic.apm.impl.payload.Framework;
+import co.elastic.apm.impl.payload.Language;
+import co.elastic.apm.impl.payload.Payload;
+import co.elastic.apm.impl.payload.ProcessInfo;
+import co.elastic.apm.impl.payload.RuntimeInfo;
+import co.elastic.apm.impl.payload.Service;
+import co.elastic.apm.impl.payload.SystemInfo;
+import co.elastic.apm.impl.payload.TransactionPayload;
+import co.elastic.apm.impl.stacktrace.Stacktrace;
+import co.elastic.apm.impl.transaction.Db;
+import co.elastic.apm.impl.transaction.Span;
+import co.elastic.apm.impl.transaction.SpanContext;
+import co.elastic.apm.impl.transaction.SpanCount;
+import co.elastic.apm.impl.transaction.Transaction;
+import co.elastic.apm.impl.transaction.TransactionId;
+import co.elastic.apm.util.PotentiallyMultiValuedMap;
+import com.dslplatform.json.BoolConverter;
+import com.dslplatform.json.DslJson;
+import com.dslplatform.json.JsonWriter;
+import com.dslplatform.json.MapConverter;
+import com.dslplatform.json.NumberConverter;
+import com.dslplatform.json.StringConverter;
+import com.dslplatform.json.UUIDConverter;
+import okio.BufferedSink;
+
+import javax.annotation.Nullable;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
+
+import static com.dslplatform.json.JsonWriter.ARRAY_END;
+import static com.dslplatform.json.JsonWriter.ARRAY_START;
+import static com.dslplatform.json.JsonWriter.COMMA;
+import static com.dslplatform.json.JsonWriter.OBJECT_END;
+import static com.dslplatform.json.JsonWriter.OBJECT_START;
+
+public class DslJsonSerializer implements PayloadSerializer {
+
+    private final JsonWriter jw;
+    private final DateFormat dateFormat;
+
+
+    public DslJsonSerializer() {
+        jw = new DslJson<>().newWriter();
+        dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    @Override
+    public void serializePayload(final BufferedSink sink, final Payload payload) {
+        jw.reset(sink.outputStream());
+        if (payload instanceof TransactionPayload) {
+            serializeTransactionPayload((TransactionPayload) payload);
+        } else if (payload instanceof ErrorPayload) {
+            serializeErrorPayload((ErrorPayload) payload);
+        }
+        jw.flush();
+        jw.reset();
+    }
+
+    private void serializeErrorPayload(ErrorPayload payload) {
+        jw.writeByte(JsonWriter.OBJECT_START);
+        serializeService(payload.getService());
+        serializeProcess(payload.getProcess());
+        serializeSystem(payload.getSystem());
+        serializeErrors(payload.getErrors());
+        jw.writeByte(JsonWriter.OBJECT_END);
+
+    }
+
+    private void serializeErrors(List<ErrorCapture> errors) {
+        writeFieldName("errors");
+        jw.writeByte(ARRAY_START);
+        if (errors.size() > 0) {
+            serializeError(errors.get(0));
+            for (int i = 1; i < errors.size(); i++) {
+                jw.writeByte(COMMA);
+                serializeError(errors.get(i));
+            }
+        }
+        jw.writeByte(ARRAY_END);
+
+    }
+
+    private void serializeError(ErrorCapture errorCapture) {
+        jw.writeByte(JsonWriter.OBJECT_START);
+
+        final TransactionId id = errorCapture.getId();
+        final String fieldName = "id";
+        writeField(fieldName, id);
+
+        serializeTransactionReference(errorCapture);
+        serializeContext(errorCapture.getContext());
+        serializeException(errorCapture.getException());
+
+        // TODO date formatting allocates objects
+        // writeLastField("timestamp", errorCapture.getTimestamp().getTime());
+        writeLastField("timestamp", dateFormat.format(errorCapture.getTimestamp()));
+        jw.writeByte(JsonWriter.OBJECT_END);
+    }
+
+    private void serializeTransactionReference(ErrorCapture errorCapture) {
+        final TransactionId transactionId = errorCapture.getTransaction().getId();
+        if (!transactionId.isEmpty()) {
+            writeFieldName("transaction");
+            jw.writeByte(JsonWriter.OBJECT_START);
+            writeFieldName("id");
+            UUIDConverter.serialize(transactionId.getMostSignificantBits(), transactionId.getLeastSignificantBits(), jw);
+            jw.writeByte(JsonWriter.OBJECT_END);
+            jw.writeByte(COMMA);
+        }
+    }
+
+    private void serializeException(ExceptionInfo exception) {
+        writeFieldName("exception");
+        jw.writeByte(JsonWriter.OBJECT_START);
+        writeField("code", exception.getCode());
+        writeField("message", exception.getMessage());
+        serializeStacktrace(exception.getStacktrace());
+        writeLastField("type", exception.getType());
+        jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    public String toJsonString(final Payload payload) {
+        jw.reset();
+        if (payload instanceof TransactionPayload) {
+            serializeTransactionPayload((TransactionPayload) payload);
+        }
+        final String s = jw.toString();
+        jw.reset();
+        return s;
+    }
+
+    public String toJsonString(final Transaction transaction) {
+        jw.reset();
+        serializeTransaction(transaction);
+        final String s = jw.toString();
+        jw.reset();
+        return s;
+    }
+
+    public String toJsonString(final ErrorCapture error) {
+        jw.reset();
+        serializeError(error);
+        final String s = jw.toString();
+        jw.reset();
+        return s;
+    }
+
+    private void serializeTransactionPayload(final TransactionPayload payload) {
+        jw.writeByte(JsonWriter.OBJECT_START);
+        serializeService(payload.getService());
+        serializeProcess(payload.getProcess());
+        serializeSystem(payload.getSystem());
+        serializeTransactions(payload);
+        jw.writeByte(JsonWriter.OBJECT_END);
+    }
+
+    private void serializeTransactions(final TransactionPayload payload) {
+        writeFieldName("transactions");
+        jw.writeByte(ARRAY_START);
+        if (payload.getTransactions().size() > 0) {
+            serializeTransactions(payload.getTransactions());
+        }
+        jw.writeByte(ARRAY_END);
+    }
+
+    private void serializeService(final Service service) {
+        writeFieldName("service");
+        jw.writeByte(JsonWriter.OBJECT_START);
+
+        writeField("name", service.getName());
+        writeField("environment", service.getEnvironment());
+
+        final Agent agent = service.getAgent();
+        if (agent != null) {
+            serializeAgent(agent);
+        }
+
+        final Framework framework = service.getFramework();
+        if (framework != null) {
+            serializeFramework(framework);
+        }
+
+        final Language language = service.getLanguage();
+        if (language != null) {
+            serializeLanguage(language);
+        }
+
+        final RuntimeInfo runtime = service.getRuntime();
+        if (runtime != null) {
+            serializeRuntime(runtime);
+        }
+
+        writeLastField("version", service.getVersion());
+        jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeAgent(final Agent agent) {
+        writeFieldName("agent");
+        jw.writeByte(JsonWriter.OBJECT_START);
+        writeField("name", agent.getName());
+        writeLastField("version", agent.getVersion());
+        jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeFramework(final Framework framework) {
+        writeFieldName("framework");
+        jw.writeByte(JsonWriter.OBJECT_START);
+        writeField("name", framework.getName());
+        writeLastField("version", framework.getVersion());
+        jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeLanguage(final Language language) {
+        writeFieldName("language");
+        jw.writeByte(JsonWriter.OBJECT_START);
+        writeField("name", language.getName());
+        writeLastField("version", language.getVersion());
+        jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeRuntime(final RuntimeInfo runtime) {
+        writeFieldName("runtime");
+        jw.writeByte(JsonWriter.OBJECT_START);
+        writeField("name", runtime.getName());
+        writeLastField("version", runtime.getVersion());
+        jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeProcess(final ProcessInfo process) {
+        writeFieldName("process");
+        jw.writeByte(JsonWriter.OBJECT_START);
+        writeField("pid", process.getPid());
+        if (process.getPpid() != null) {
+            writeField("ppid", process.getPpid());
+        }
+
+        List<String> argv = process.getArgv();
+        writeField("argv", argv);
+        writeLastField("title", process.getTitle());
+        jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeSystem(final SystemInfo system) {
+        writeFieldName("system");
+        jw.writeByte(JsonWriter.OBJECT_START);
+        writeField("architecture", system.getArchitecture());
+        writeField("hostname", system.getHostname());
+        writeLastField("platform", system.getPlatform());
+        jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeTransactions(final List<Transaction> transactions) {
+        serializeTransaction(transactions.get(0));
+        for (int i = 1; i < transactions.size(); i++) {
+            jw.writeByte(COMMA);
+            serializeTransaction(transactions.get(i));
+        }
+    }
+
+    private void serializeTransaction(final Transaction transaction) {
+        writeObjectStart();
+        // TODO date formatting allocates objects
+        // writeField("timestamp", transaction.getTimestamp().getTime());
+        writeField("timestamp", dateFormat.format(transaction.getTimestamp()));
+        writeField("name", transaction.getName());
+        writeField("id", transaction.getId());
+        writeField("type", transaction.getType());
+        writeField("duration", transaction.getDuration());
+        writeField("result", transaction.getResult());
+        serializeContext(transaction.getContext());
+        if (transaction.getSpanCount().getDropped().getTotal() > 0) {
+            serializeSpanCount(transaction.getSpanCount());
+        }
+        if (transaction.getSpans().size() > 0) {
+            serializeSpans(transaction.getSpans());
+        }
+        // TODO marks
+        writeLastField("sampled", transaction.isSampled());
+        jw.writeByte(OBJECT_END);
+    }
+
+    private void serializeSpans(final List<Span> spans) {
+        writeFieldName("spans");
+        jw.writeByte(ARRAY_START);
+        serializeSpan(spans.get(0));
+        for (int i = 1; i < spans.size(); i++) {
+            jw.writeByte(COMMA);
+            serializeSpan(spans.get(i));
+        }
+        jw.writeByte(ARRAY_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeSpan(final Span span) {
+        writeObjectStart();
+        writeField("name", span.getName());
+        writeField("id", span.getId().asLong());
+        final long parent = span.getParent().asLong();
+        if (parent != 0) {
+            writeField("parent", parent);
+        }
+        writeField("duration", span.getDuration());
+        writeField("start", span.getStart());
+        writeField("type", span.getType());
+        if (span.getStacktrace().size() > 0) {
+            serializeStacktrace(span.getStacktrace());
+        }
+        if (span.getContext().hasContent()) {
+            serializeSpanContext(span.getContext());
+        }
+        writeLastField("sampled", span.isSampled());
+        jw.writeByte(OBJECT_END);
+    }
+
+    private void serializeStacktrace(List<Stacktrace> stacktrace) {
+        if (stacktrace.size() > 0) {
+            writeFieldName("stacktrace");
+            jw.writeByte(ARRAY_START);
+            serializeStackTraceElement(stacktrace.get(0));
+            for (int i = 1; i < stacktrace.size(); i++) {
+                jw.writeByte(COMMA);
+                serializeStackTraceElement(stacktrace.get(i));
+            }
+            jw.writeByte(ARRAY_END);
+            jw.writeByte(COMMA);
+        }
+    }
+
+    private void serializeStackTraceElement(Stacktrace stacktrace) {
+        jw.writeByte(OBJECT_START);
+        writeField("filename", stacktrace.getFilename());
+        writeField("function", stacktrace.getFunction());
+        writeField("library_frame", stacktrace.isLibraryFrame());
+        writeField("lineno", stacktrace.getLineno());
+        writeField("module", stacktrace.getModule());
+        writeLastField("abs_path", stacktrace.getAbsPath());
+        jw.writeByte(OBJECT_END);
+    }
+
+    private void serializeSpanContext(SpanContext context) {
+        writeFieldName("context");
+        writeObjectStart();
+        writeFieldName("db");
+        writeObjectStart();
+        final Db db = context.getDb();
+        writeField("instance", db.getInstance());
+        writeField("statement", db.getStatement());
+        writeField("type", db.getType());
+        writeLastField("user", db.getUser());
+        jw.writeByte(OBJECT_END);
+        jw.writeByte(OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeSpanCount(final SpanCount spanCount) {
+        writeFieldName("span_count");
+        writeObjectStart();
+        writeFieldName("dropped");
+        writeObjectStart();
+        writeFieldName("total");
+        NumberConverter.serialize(spanCount.getDropped().getTotal(), jw);
+        jw.writeByte(OBJECT_END);
+        jw.writeByte(OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeContext(final Context context) {
+        writeFieldName("context");
+        jw.writeByte(OBJECT_START);
+
+        if (context.getUser().hasContent()) {
+            serializeUser(context.getUser());
+            jw.writeByte(COMMA);
+        }
+        serializeRequest(context.getRequest());
+        serializeResponse(context.getResponse());
+        // TODO custom context
+        writeFieldName("tags");
+        MapConverter.serialize(context.getTags(), jw);
+        jw.writeByte(OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeResponse(final Response response) {
+        if (response.hasContent()) {
+            writeFieldName("response");
+            writeObjectStart();
+            writeField("headers", response.getHeaders());
+            writeField("finished", response.isFinished());
+            writeField("headers_sent", response.isHeadersSent());
+            writeFieldName("status_code");
+            NumberConverter.serialize(response.getStatusCode(), jw);
+            jw.writeByte(OBJECT_END);
+            jw.writeByte(COMMA);
+        }
+    }
+
+    private void serializeRequest(final Request request) {
+        if (request.hasContent()) {
+            writeFieldName("request");
+            writeObjectStart();
+            writeField("method", request.getMethod());
+            writeField("headers", request.getHeaders());
+            writeField("cookies", request.getCookies());
+            // only one of those can be non-empty
+            writeField("body", request.getFormUrlEncodedParameters());
+            writeField("body", request.getRawBody());
+            if (request.getUrl().hasContent()) {
+                serializeUrl(request.getUrl());
+            }
+            if (request.getSocket().hasContent()) {
+                serializeSocket(request.getSocket());
+            }
+            writeLastField("http_version", request.getHttpVersion());
+            jw.writeByte(OBJECT_END);
+            jw.writeByte(COMMA);
+        }
+    }
+
+    private void serializeUrl(final Url url) {
+        writeFieldName("url");
+        writeObjectStart();
+        writeField("full", url.getFull());
+        writeField("protocol", url.getProtocol());
+        writeField("hostname", url.getHostname());
+        writeField("port", url.getPort());
+        writeField("pathname", url.getPathname());
+        writeField("search", url.getSearch());
+        writeLastField("protocol", url.getProtocol());
+        jw.writeByte(OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeSocket(final Socket socket) {
+        writeFieldName("socket");
+        writeObjectStart();
+        writeField("encrypted", socket.isEncrypted());
+        writeLastField("remote_address", socket.getRemoteAddress());
+        jw.writeByte(OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void writeField(final String fieldName, final PotentiallyMultiValuedMap<String, String> map) {
+        if (map.size() > 0) {
+            writeFieldName(fieldName);
+            writeObjectStart();
+            final int size = map.size();
+            if (size > 0) {
+                final Iterator<Map.Entry<String, Object>> iterator = map.entrySet().iterator();
+                Map.Entry<String, Object> kv = iterator.next();
+                serializePotentiallyMultiValuedEntry(kv);
+                for (int i = 1; i < size; i++) {
+                    jw.writeByte(COMMA);
+                    kv = iterator.next();
+                    serializePotentiallyMultiValuedEntry(kv);
+                }
+            }
+            jw.writeByte(OBJECT_END);
+            jw.writeByte(COMMA);
+        }
+    }
+
+    private void serializePotentiallyMultiValuedEntry(final Map.Entry<String, Object> entry) {
+        jw.writeString(entry.getKey());
+        jw.writeByte(JsonWriter.SEMI);
+        final Object value = entry.getValue();
+        if (value instanceof String) {
+            StringConverter.serializeNullable((String) value, jw);
+        } else if (value instanceof List) {
+            jw.writeByte(ARRAY_START);
+            final List<String> values = (List<String>) value;
+            jw.writeString(values.get(0));
+            for (int i = 1; i < values.size(); i++) {
+                jw.writeByte(COMMA);
+                jw.writeString(values.get(i));
+            }
+            jw.writeByte(ARRAY_END);
+        }
+    }
+
+    private void serializeUser(final User user) {
+        writeFieldName("user");
+        writeObjectStart();
+        writeField("id", user.getId());
+        writeField("email", user.getEmail());
+        writeLastField("username", user.getUsername());
+        jw.writeByte(OBJECT_END);
+    }
+
+    private void writeObjectStart() {
+        jw.writeByte(OBJECT_START);
+    }
+
+    private void writeField(final String fieldName, final StringBuilder value) {
+        // TODO limit size of value to 1024
+        if (value.length() > 0) {
+            writeFieldName(fieldName);
+            jw.writeString(value);
+            jw.writeByte(COMMA);
+        }
+    }
+
+    private void writeField(final String fieldName, @Nullable final String value) {
+        // TODO limit size of value to 1024
+        if (value != null) {
+            writeFieldName(fieldName);
+            jw.writeString(value);
+            jw.writeByte(COMMA);
+        }
+    }
+
+    private void writeField(final String fieldName, final long value) {
+        writeFieldName(fieldName);
+        NumberConverter.serialize(value, jw);
+        jw.writeByte(COMMA);
+    }
+
+    private void writeField(final String fieldName, final boolean value) {
+        writeFieldName(fieldName);
+        BoolConverter.serialize(value, jw);
+        jw.writeByte(COMMA);
+    }
+
+    private void writeLastField(final String fieldName, final boolean value) {
+        writeFieldName(fieldName);
+        BoolConverter.serialize(value, jw);
+    }
+
+    private void writeField(final String fieldName, final double value) {
+        writeFieldName(fieldName);
+        NumberConverter.serialize(value, jw);
+        jw.writeByte(COMMA);
+    }
+
+    private void writeLastField(final String fieldName, @Nullable final String value) {
+        writeFieldName(fieldName);
+        if (value != null) {
+            jw.writeString(value);
+        } else {
+            jw.writeNull();
+        }
+    }
+
+    private void writeFieldName(final String fieldName) {
+        jw.writeByte(JsonWriter.QUOTE);
+        jw.writeAscii(fieldName);
+        jw.writeByte(JsonWriter.QUOTE);
+        jw.writeByte(JsonWriter.SEMI);
+    }
+
+    private void writeField(final String fieldName, final List<String> values) {
+        if (values.size() > 0) {
+            writeFieldName(fieldName);
+            jw.writeByte(ARRAY_START);
+            jw.writeString(values.get(0));
+            for (int i = 1; i < values.size(); i++) {
+                jw.writeByte(COMMA);
+                jw.writeString(values.get(i));
+            }
+            jw.writeByte(ARRAY_END);
+        }
+    }
+
+    private void writeField(String fieldName, TransactionId id) {
+        writeFieldName(fieldName);
+        UUIDConverter.serialize(id.getMostSignificantBits(), id.getLeastSignificantBits(), jw);
+        jw.writeByte(COMMA);
+    }
+}

--- a/apm-agent-core/src/main/resources/schema/errors/error.json
+++ b/apm-agent-core/src/main/resources/schema/errors/error.json
@@ -5,7 +5,7 @@
     "description": "Data captured by an agent representing an event occurring in a monitored service",
     "properties": {
         "context": {
-            "$ref": "./../context.json"
+            "$ref": "../context.json"
         },
         "culprit": {
             "description": "Function call which was the primary perpetrator of this event.",
@@ -35,7 +35,7 @@
                 "stacktrace": {
                     "type": ["array", "null"],
                     "items": {
-                        "$ref": "./../stacktrace_frame.json"
+                        "$ref": "../stacktrace_frame.json"
                     },
                     "minItems": 0
                 },
@@ -85,7 +85,7 @@
                 "stacktrace": {
                     "type": ["array", "null"],
                     "items": {
-                        "$ref": "./../stacktrace_frame.json"
+                        "$ref": "../stacktrace_frame.json"
                     },
                     "minItems": 0
                 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/MockReporter.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,22 +22,77 @@ package co.elastic.apm;
 import co.elastic.apm.impl.error.ErrorCapture;
 import co.elastic.apm.impl.transaction.Transaction;
 import co.elastic.apm.report.Reporter;
+import co.elastic.apm.report.serialize.DslJsonSerializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.networknt.schema.JsonSchema;
+import com.networknt.schema.JsonSchemaFactory;
+import com.networknt.schema.ValidationMessage;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class MockReporter implements Reporter {
     private final List<Transaction> transactions = new ArrayList<>();
     private final List<ErrorCapture> errors = new ArrayList<>();
+    private final JsonSchema transactionSchema;
+    private final JsonSchema errorSchema;
+    private final DslJsonSerializer dslJsonSerializer;
+    private final ObjectMapper objectMapper;
+    private final boolean verifyJsonSchema;
+
+    public MockReporter() {
+        this(true);
+    }
+
+    public MockReporter(boolean verifyJsonSchema) {
+        this.verifyJsonSchema = verifyJsonSchema;
+        transactionSchema = getSchema("/schema/transactions/transaction.json");
+        errorSchema = getSchema("/schema/errors/error.json");
+        dslJsonSerializer = new DslJsonSerializer();
+        objectMapper = new ObjectMapper();
+    }
+
+    private JsonSchema getSchema(String resource) {
+        return JsonSchemaFactory.getInstance().getSchema(getClass().getResourceAsStream(resource));
+    }
 
     @Override
     public void report(Transaction transaction) {
+        verifyJsonSchema(transaction);
         transactions.add(transaction);
+    }
+
+    private void verifyJsonSchema(Transaction transaction) {
+        final String content = dslJsonSerializer.toJsonString(transaction);
+        verifyJsonSchema(content, transactionSchema);
+    }
+
+    private void verifyJsonSchema(ErrorCapture error) {
+        final String content = dslJsonSerializer.toJsonString(error);
+        verifyJsonSchema(content, errorSchema);
+    }
+
+    private void verifyJsonSchema(String jsonContent, JsonSchema transactionSchema) {
+        try {
+            final JsonNode node = objectMapper.readTree(jsonContent);
+            if (verifyJsonSchema) {
+                Set<ValidationMessage> errors = transactionSchema.validate(node);
+                assertThat(errors).isEmpty();
+            }
+        } catch (IOException e) {
+            System.out.println(jsonContent);
+            throw new RuntimeException(e);
+        }
     }
 
     public List<Transaction> getTransactions() {
@@ -50,6 +105,7 @@ public class MockReporter implements Reporter {
 
     @Override
     public void report(ErrorCapture error) {
+        verifyJsonSchema(error);
         errors.add(error);
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/TransactionUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/TransactionUtils.java
@@ -21,6 +21,7 @@ package co.elastic.apm;
 
 import co.elastic.apm.impl.context.Context;
 import co.elastic.apm.impl.context.Request;
+import co.elastic.apm.impl.sampling.ConstantSampler;
 import co.elastic.apm.impl.transaction.Span;
 import co.elastic.apm.impl.transaction.Transaction;
 
@@ -32,6 +33,7 @@ public class TransactionUtils {
     private static final List<String> STRINGS = Arrays.asList("bar", "baz");
 
     public static void fillTransaction(Transaction t) {
+        t.start(null, 0, ConstantSampler.of(true));
         t.setName("GET /api/types");
         t.setType("request");
         t.withResult("success");
@@ -76,6 +78,7 @@ public class TransactionUtils {
         context.getCustom().put("and_objects", STRINGS);
 
         Span span = new Span()
+            .start(null, t, null, 0, false)
             .withName("SELECT FROM product_types")
             .withType("db.postgresql.query");
         span.getContext().getDb()
@@ -85,12 +88,15 @@ public class TransactionUtils {
             .withUser("readonly_user");
         t.getSpans().add(span);
         t.getSpans().add(new Span()
+            .start(null, t, null, 0, false)
             .withName("GET /api/types")
             .withType("request"));
         t.getSpans().add(new Span()
+            .start(null, t, null, 0, false)
             .withName("GET /api/types")
             .withType("request"));
         t.getSpans().add(new Span()
+            .start(null, t, null, 0, false)
             .withName("GET /api/types")
             .withType("request"));
     }

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/ElasticApmTracerTest.java
@@ -49,7 +49,7 @@ class ElasticApmTracerTest {
 
     @BeforeEach
     void setUp() {
-        reporter = new MockReporter();
+        reporter = new MockReporter(false);
         config = SpyConfiguration.createSpyConfig();
         tracerImpl = ElasticApmTracer.builder()
             .configurationRegistry(config)

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/context/ContextTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/context/ContextTest.java
@@ -40,7 +40,7 @@ class ContextTest {
         context.getTags().put("foo", "bar");
         Context copyOfContext = new Context();
         copyOfContext.copyFrom(context);
-        assertThat(toJson(context)).isNotEqualTo(toJson(copyOfContext));
+        assertThat(copyOfContext.getTags()).isEmpty();
     }
 
     @Test
@@ -49,7 +49,7 @@ class ContextTest {
         context.getCustom().put("foo", "bar");
         Context copyOfContext = new Context();
         copyOfContext.copyFrom(context);
-        assertThat(toJson(context)).isNotEqualTo(toJson(copyOfContext));
+        assertThat(copyOfContext.getCustom()).isEmpty();
     }
 
     private Context createContext() {

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/TransactionPayloadJsonSchemaTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/TransactionPayloadJsonSchemaTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,10 +19,12 @@
  */
 package co.elastic.apm.impl.payload;
 
+import co.elastic.apm.TransactionUtils;
 import co.elastic.apm.impl.ElasticApmTracer;
 import co.elastic.apm.impl.sampling.ConstantSampler;
 import co.elastic.apm.impl.transaction.Span;
 import co.elastic.apm.impl.transaction.Transaction;
+import co.elastic.apm.report.serialize.DslJsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
@@ -30,6 +32,7 @@ import com.networknt.schema.ValidationMessage;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,20 +40,22 @@ import static org.mockito.Mockito.mock;
 
 class TransactionPayloadJsonSchemaTest {
 
-    private TransactionPayload payload;
     private JsonSchema schema;
+    private DslJsonSerializer dslJsonSerializer;
+    private ObjectMapper objectMapper;
 
     @BeforeEach
     void setUp() {
-        payload = createPayloadWithRequiredValues();
-        payload.getTransactions().add(createTransactionWithRequiredValues());
         schema = JsonSchemaFactory.getInstance().getSchema(getClass().getResourceAsStream("/schema/transactions/payload.json"));
+        dslJsonSerializer = new DslJsonSerializer();
+
+        objectMapper = new ObjectMapper();
     }
 
     private TransactionPayload createPayloadWithRequiredValues() {
-        Service service = new Service().withAgent(new Agent("name", "version")).withName("name");
-        SystemInfo system = new SystemInfo("", "", "");
-        return new TransactionPayload(new ProcessInfo("title"), service, system);
+        final TransactionPayload payload = createPayload();
+        payload.getTransactions().add(createTransactionWithRequiredValues());
+        return payload;
     }
 
     private Transaction createTransactionWithRequiredValues() {
@@ -58,6 +63,7 @@ class TransactionPayloadJsonSchemaTest {
         t.start(mock(ElasticApmTracer.class), 0, ConstantSampler.of(true));
         t.setType("type");
         t.getContext().getRequest().withMethod("GET");
+        t.getContext().getRequest().getUrl().appendToFull("http://localhost:8080/foo/bar");
         Span s = new Span();
         s.start(mock(ElasticApmTracer.class), t, null, 0, false)
             .withType("type")
@@ -66,9 +72,42 @@ class TransactionPayloadJsonSchemaTest {
         return t;
     }
 
+    private TransactionPayload createPayloadWithAllValues() {
+        final Transaction transaction = new Transaction();
+        TransactionUtils.fillTransaction(transaction);
+        final TransactionPayload payload = createPayload();
+        payload.getTransactions().add(transaction);
+        return payload;
+    }
+
+    private TransactionPayload createPayload() {
+        Service service = new Service().withAgent(new Agent("name", "version")).withName("name");
+        SystemInfo system = new SystemInfo("", "", "");
+        return new TransactionPayload(new ProcessInfo("title"), service, system);
+    }
+
     @Test
-    void testJsonSchema() {
-        Set<ValidationMessage> errors = schema.validate(new ObjectMapper().valueToTree(payload));
+    void testJsonSchemaDslJsonEmptyValues() throws IOException {
+        final TransactionPayload payload = createPayload();
+        payload.getTransactions().add(new Transaction());
+        final String content = dslJsonSerializer.toJsonString(payload);
+        System.out.println(content);
+        objectMapper.readTree(content);
+    }
+
+    @Test
+    void testJsonSchemaDslJsonMinimalValues() throws IOException {
+        final String content = dslJsonSerializer.toJsonString(createPayloadWithRequiredValues());
+        System.out.println(content);
+        Set<ValidationMessage> errors = schema.validate(objectMapper.readTree(content));
+        assertThat(errors).isEmpty();
+    }
+
+    @Test
+    void testJsonSchemaDslJsonAllValues() throws IOException {
+        final String content = dslJsonSerializer.toJsonString(createPayloadWithAllValues());
+        System.out.println(content);
+        Set<ValidationMessage> errors = schema.validate(objectMapper.readTree(content));
         assertThat(errors).isEmpty();
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/SpanTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/SpanTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,6 @@ package co.elastic.apm.impl.transaction;
 
 import org.junit.jupiter.api.Test;
 
-import static co.elastic.apm.JsonUtils.toJson;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SpanTest {
@@ -37,6 +36,8 @@ class SpanTest {
             .withType("sql")
             .withUser("readonly_user");
         span.resetState();
-        assertThat(toJson(span)).isEqualTo(toJson(new Span()));
+        assertThat(span.getContext().hasContent()).isFalse();
+        assertThat(span.getName()).isNullOrEmpty();
+        assertThat(span.getType()).isNullOrEmpty();
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterIntegrationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterIntegrationTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,9 +25,7 @@ import co.elastic.apm.impl.payload.ProcessInfo;
 import co.elastic.apm.impl.payload.Service;
 import co.elastic.apm.impl.payload.SystemInfo;
 import co.elastic.apm.impl.transaction.Transaction;
-import co.elastic.apm.report.serialize.JacksonPayloadSerializer;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
+import co.elastic.apm.report.serialize.DslJsonSerializer;
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
 import okhttp3.OkHttpClient;
@@ -79,13 +77,11 @@ class ApmServerReporterIntegrationTest {
             exchange.setStatusCode(200).endExchange();
         };
         receivedHttpRequests.set(0);
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new AfterburnerModule());
         final ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
         reporterConfiguration = config.getConfig(ReporterConfiguration.class);
         when(reporterConfiguration.getFlushInterval()).thenReturn(-1);
         when(reporterConfiguration.getServerUrl()).thenReturn("http://localhost:" + port);
-        payloadSender = new ApmServerHttpPayloadSender(new OkHttpClient(), new JacksonPayloadSerializer(objectMapper), reporterConfiguration);
+        payloadSender = new ApmServerHttpPayloadSender(new OkHttpClient(), new DslJsonSerializer(), reporterConfiguration);
         SystemInfo system = new SystemInfo("x64", "localhost", "platform");
         reporter = new ApmServerReporter(config, new Service(), new ProcessInfo("title"), system, payloadSender, false,
             reporterConfiguration);

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/serialize/DslJsonSerializerTest.java
@@ -1,12 +1,16 @@
 package co.elastic.apm.report.serialize;
 
+import com.dslplatform.json.JsonWriter;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 
@@ -30,6 +34,24 @@ class DslJsonSerializerTest {
             softly.assertThat(serializeTags(Map.of("foo*bar*baz", "qux"))).isEqualTo(toJson(Map.of("foo_bar_baz", "qux")));
             softly.assertThat(serializeTags(Map.of("foo\"bar\"baz", "qux"))).isEqualTo(toJson(Map.of("foo_bar_baz", "qux")));
         });
+    }
+
+    @Test
+    void testLimitStringValueLength() throws IOException {
+        StringBuilder longValue = new StringBuilder(DslJsonSerializer.MAX_VALUE_LENGTH + 1);
+        for (int i = 0; i < DslJsonSerializer.MAX_VALUE_LENGTH + 1; i++) {
+            longValue.append('0');
+        }
+
+        serializer.jw.writeByte(JsonWriter.OBJECT_START);
+        serializer.writeField("stringBuilder", longValue);
+        serializer.writeField("string", longValue.toString());
+        serializer.writeLastField("lastString", longValue.toString());
+        serializer.jw.writeByte(JsonWriter.OBJECT_END);
+        final JsonNode jsonNode = objectMapper.readTree(serializer.jw.toString());
+        assertThat(jsonNode.get("stringBuilder").textValue()).hasSize(DslJsonSerializer.MAX_VALUE_LENGTH).endsWith("…");
+        assertThat(jsonNode.get("string").textValue()).hasSize(DslJsonSerializer.MAX_VALUE_LENGTH).endsWith("…");
+        assertThat(jsonNode.get("lastString").textValue()).hasSize(DslJsonSerializer.MAX_VALUE_LENGTH).endsWith("…");
     }
 
     private String toJson(Map<String, String> map) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/serialize/DslJsonSerializerTest.java
@@ -1,0 +1,49 @@
+package co.elastic.apm.report.serialize;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
+
+
+class DslJsonSerializerTest {
+
+    private DslJsonSerializer serializer;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        serializer = new DslJsonSerializer();
+        objectMapper = new ObjectMapper();
+    }
+
+    @Test
+    void serializeTags() {
+        assertSoftly(softly -> {
+            softly.assertThat(serializeTags(Map.of(".**", "foo.bar"))).isEqualTo(toJson(Map.of("___", "foo.bar")));
+            softly.assertThat(serializeTags(Map.of("foo.bar", "baz"))).isEqualTo(toJson(Map.of("foo_bar", "baz")));
+            softly.assertThat(serializeTags(Map.of("foo.bar.baz", "qux"))).isEqualTo(toJson(Map.of("foo_bar_baz", "qux")));
+            softly.assertThat(serializeTags(Map.of("foo*bar*baz", "qux"))).isEqualTo(toJson(Map.of("foo_bar_baz", "qux")));
+            softly.assertThat(serializeTags(Map.of("foo\"bar\"baz", "qux"))).isEqualTo(toJson(Map.of("foo_bar_baz", "qux")));
+        });
+    }
+
+    private String toJson(Map<String, String> map) {
+        try {
+            return objectMapper.writeValueAsString(map);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private String serializeTags(Map<String, String> tags) {
+        serializer.serializeTags(tags);
+        final String jsonString = serializer.jw.toString();
+        serializer.jw.reset();
+        return jsonString;
+    }
+}

--- a/apm-agent-java/pom.xml
+++ b/apm-agent-java/pom.xml
@@ -30,8 +30,8 @@
                             <shadedArtifactAttached>false</shadedArtifactAttached>
                             <relocations>
                                 <relocation>
-                                    <pattern>com.fasterxml.jackson</pattern>
-                                    <shadedPattern>co.elastic.apm.shaded.jackson</shadedPattern>
+                                    <pattern>com.dslplatform</pattern>
+                                    <shadedPattern>co.elastic.apm.shaded.dslplatform</shadedPattern>
                                 </relocation>
                                 <relocation>
                                     <pattern>com.lmax</pattern>

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/jdbc/ApmJdbcEventListenerTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/jdbc/ApmJdbcEventListenerTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -54,6 +54,9 @@ class ApmJdbcEventListenerTest {
         connection.createStatement().execute("CREATE TABLE IF NOT EXISTS ELASTIC_APM (FOO INT, BAR VARCHAR(255))");
         connection.createStatement().execute("INSERT INTO ELASTIC_APM (FOO, BAR) VALUES (1, 'APM')");
         transaction = tracer.startTransaction();
+        transaction.setName("transaction");
+        transaction.setType("request");
+        transaction.withResult("success");
     }
 
     @AfterEach

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>co.elastic.apm</groupId>
@@ -27,8 +28,8 @@
         <connection>scm:git:git@github.com:elastic/apm-agent-java.git</connection>
         <developerConnection>scm:git:git@github.com:elastic/apm-agent-java.git</developerConnection>
         <url>https://github.com/elastic/apm-agent-java</url>
-      <tag>HEAD</tag>
-  </scm>
+        <tag>HEAD</tag>
+    </scm>
 
     <developers>
         <developer>
@@ -432,6 +433,12 @@
             <groupId>com.networknt</groupId>
             <artifactId>json-schema-validator</artifactId>
             <version>0.1.16</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -428,5 +428,11 @@
             <version>${slf4j.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.networknt</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>0.1.16</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
Benchmarking shows that serializing payloads with dsl-json is x2.4 faster and requires -86% less allocations.

DSL-JSON is a nice library which focuses on fast and garbage free JSON serialization. It only has a small byte[] buffer, which is reused and otherwise directly writes into a `OutputStream`, so there are no temporary objects created. It also has a mode where it can automatically serialize annotated POJOs. I opted for a more manual approach to have more control about the resulting JSON (see `hasContent()` checks and explicitly serializing `TransactionId` with `UUIDConverter.serialize(id.getMostSignificantBits(), id.getLeastSignificantBits(), jw);`)

My recent additions to dsl-json https://github.com/ngs-doo/dsl-json/pull/48 and https://github.com/ngs-doo/dsl-json/pull/49 make it possible to also serialize `StringBuilders` and transaction ids in the UUID format in a garbage free way. The only thing which requires allocations now is creating a ISO date formatted string for the `Transaction.timestamp` and creating `Map.entrySet().iterator()`s for iterating over custom `Context.tag`s. I'm not quite sure why JIT can't replace the iterator heap allocations with stack allocations, but maybe JMH's GC profiler also reports stack allocations in `gc.alloc.rate.norm`. Regarding the timestamp serialization, there is an open issue about adding support for epoch timestamps: https://github.com/elastic/apm-server/issues/850. That would make the JSON serialization essentially completely garbage free.

As an additional benefit, the total size of the agent jar drops from 2.8 to 1.2 mb as the replaced Jackson library is much heavier.

This PR is currently blocked until dsl-json 1.7.4 is released.