### PR TITLE
Fix noop handling for Transactions and Spans

### DIFF
--- a/apm-agent-api/src/main/java/co/elastic/apm/api/ElasticApm.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/ElasticApm.java
@@ -135,7 +135,8 @@ public class ElasticApm implements Tracer {
     @Override
     @Nonnull
     public Span startSpan() {
-        return tracer.startSpan();
+        final Span span = tracer.startSpan();
+        return span != null ? span : NoopTracer.NoopSpan.INSTANCE;
     }
 
     @Override

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/Tracer.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/Tracer.java
@@ -83,9 +83,9 @@ public interface Tracer {
      * }
      * </pre>
      *
-     * @return the started span
+     * @return the started span, or {@code null} if there is no current transaction
      */
-    @Nonnull
+    @Nullable
     Span startSpan();
 
     /**

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
@@ -91,6 +91,7 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
      * Transactions that are 'sampled' will include all available information. Transactions that are not sampled will not have 'spans' or 'context'. Defaults to true.
      */
     private boolean sampled;
+    private boolean noop;
 
     public Transaction start(ElasticApmTracer tracer, long startTimestampNanos, Sampler sampler) {
         this.tracer = tracer;
@@ -98,6 +99,14 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
         this.timestamp.setTime(System.currentTimeMillis());
         this.id.setToRandomValue();
         this.sampled = sampler.isSampled(id);
+        this.noop = false;
+        return this;
+    }
+
+    public Transaction startNoop(ElasticApmTracer tracer) {
+        this.tracer = tracer;
+        this.sampled = false;
+        this.noop = true;
         return this;
     }
 
@@ -304,6 +313,7 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
         spanCount.resetState();
         tracer = null;
         spanIdCounter.set(0);
+        noop = false;
     }
 
     public void recycle() {
@@ -312,4 +322,7 @@ public class Transaction implements Recyclable, co.elastic.apm.api.Transaction {
         }
     }
 
+    public boolean isNoop() {
+        return noop;
+    }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/ElasticApmTracerTest.java
@@ -204,7 +204,7 @@ class ElasticApmTracerTest {
             try (Span span = tracerImpl.startSpan()) {
                 assertThat(tracerImpl.currentSpan()).isSameAs(span);
                 assertThat(transaction.getSpans()).isEmpty();
-                assertThat(span.isSampled()).isFalse();
+                assertThat(span).isNull();
             }
             assertThat(tracerImpl.currentSpan()).isNull();
         }
@@ -281,7 +281,7 @@ class ElasticApmTracerTest {
     @Test
     void testSpanWithoutTransaction() {
         try (Span span = tracerImpl.startSpan()) {
-            assertThat(span.isSampled()).isFalse();
+            assertThat(span).isNull();
         }
 
     }

--- a/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmScope.java
+++ b/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmScope.java
@@ -39,9 +39,9 @@ class ApmScope implements Scope {
         if (finishSpanOnClose) {
             apmSpan.finish();
         }
-        if (apmSpan.isTransaction()) {
+        if (apmSpan.getTransaction() != null) {
             tracer.releaseActiveTransaction();
-        } else {
+        } else if (apmSpan.getSpan() != null) {
             tracer.releaseActiveSpan();
         }
     }

--- a/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmScopeManager.java
+++ b/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmScopeManager.java
@@ -37,9 +37,9 @@ class ApmScopeManager implements ScopeManager {
     @Override
     public ApmScope activate(Span span, boolean finishSpanOnClose) {
         final ApmSpan apmSpan = (ApmSpan) span;
-        if (apmSpan.isTransaction()) {
+        if (apmSpan.getTransaction() != null) {
             tracer.activate(apmSpan.getTransaction());
-        } else {
+        } else if (apmSpan.getSpan() != null) {
             tracer.activate(apmSpan.getSpan());
         }
         return new ApmScope(finishSpanOnClose, apmSpan, tracer);

--- a/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmSpan.java
+++ b/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmSpan.java
@@ -44,18 +44,8 @@ class ApmSpan implements Span, SpanContext {
 
     ApmSpan(@Nullable Transaction transaction, @Nullable co.elastic.apm.impl.transaction.Span span, ElasticApmTracer tracer) {
         this.tracer = tracer;
-        if (transaction == null && span == null) {
-            throw new IllegalArgumentException();
-        } else if (transaction != null && span != null) {
-            throw new IllegalArgumentException();
-        }
-
         this.transaction = transaction;
         this.span = span;
-    }
-
-    boolean isTransaction() {
-        return transaction != null;
     }
 
     @Override
@@ -85,8 +75,7 @@ class ApmSpan implements Span, SpanContext {
     public ApmSpan setOperationName(String operationName) {
         if (transaction != null) {
             transaction.setName(operationName);
-        } else {
-            assert span != null;
+        } else if (span != null) {
             span.setName(operationName);
         }
         return this;
@@ -190,7 +179,7 @@ class ApmSpan implements Span, SpanContext {
         }
         if (transaction != null) {
             handleTransactionTag(key, value);
-        } else {
+        } else if (span != null) {
             handleSpanTag(key, value);
         }
     }

--- a/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmSpanBuilder.java
+++ b/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmSpanBuilder.java
@@ -30,7 +30,6 @@ import io.opentracing.tag.Tags;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.Map;
@@ -125,7 +124,6 @@ class ApmSpanBuilder implements Tracer.SpanBuilder {
         return start();
     }
 
-    @Nonnull
     private ApmSpan startApmSpan() {
         final ApmScope active = scopeManager.active();
         if (!ignoreActiveSpan && active != null) {

--- a/apm-opentracing/src/test/java/co/elastic/apm/opentracing/ApmTracerTest.java
+++ b/apm-opentracing/src/test/java/co/elastic/apm/opentracing/ApmTracerTest.java
@@ -149,6 +149,8 @@ class ApmTracerTest {
     void testCreatingClientTransactionCreatesNoopSpan() {
         try (Scope transaction = apmTracer.buildSpan("transaction").withTag("span.kind", "client").startActive(true)) {
             try (Scope span = apmTracer.buildSpan("span").startActive(true)) {
+                try (Scope nestedSpan = apmTracer.buildSpan("nestedSpan").startActive(true)) {
+                }
             }
         }
         assertThat(reporter.getTransactions()).isEmpty();
@@ -159,7 +161,7 @@ class ApmTracerTest {
         Span span = apmTracer.buildSpan("someWork").start();
         try (Scope scope = apmTracer.scopeManager().activate(span, false)) {
             throw new RuntimeException("Catch me if you can");
-        } catch(Exception ex) {
+        } catch (Exception ex) {
             Tags.ERROR.set(span, true);
             span.log(Map.of(Fields.EVENT, "error", Fields.ERROR_OBJECT, ex, Fields.MESSAGE, ex.getMessage()));
         } finally {


### PR DESCRIPTION
- Adds Transaction.noop flag
- noop Transactions don't get reported
- noop Transactions are not a singleton, as this leads or threading issues
- startSpan returns null if current transaction is null or noop
- public api never returns null span but returns noop span

fixes #71

Signed-off-by: Felix Barnsteiner <felix.barnsteiner@elastic.co>