### PR TITLE
docs: use shared attributes

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,4 +1,6 @@
 = APM Java Agent Reference (Alpha)
+:branch: current
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]
 NOTE: For the best reading experience,

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -25,8 +25,8 @@ see the <<public-api,public api documentation>>.
 The agent is only one of multiple components you need to get started with APM.
 Please also have a look at the documentation for
 
-* https://www.elastic.co/guide/en/apm/server/current/index.html[APM Server]
-* https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html[Elasticsearch]
+* {apm-server-ref}/index.html[APM Server]
+* {ref}/index.html[Elasticsearch]
 
 [float]
 [[get-started]]

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -12,9 +12,9 @@ In other words,
 it translates the calls to the OpenTracing API to Elastic APM and thus allows for reusing existing instrumentation.
 
 The first span of a service will be converted to an Elastic APM
-link:https://www.elastic.co/guide/en/apm/server/current/transactions.html[`Transaction`],
+link:{apm-server-ref}/transactions.html[`Transaction`],
 subsequent spans are mapped to Elastic APM
-link:https://www.elastic.co/guide/en/apm/server/current/spans.html[`Span`]s.
+link:{apm-server-ref}/spans.html[`Span`]s.
 
 [float]
 [[operation-modes]]
@@ -120,7 +120,7 @@ Baggage items are silently dropped.
 ==== Logs
 Only exception logging is supported.
 Logging an Exception on the OpenTracing span will create an Elastic APM
-link:https://www.elastic.co/guide/en/apm/server/current/errors.html[`Error`].
+link:{apm-server-ref}/errors.html[`Error`].
 Example:
 
 [source,java]


### PR DESCRIPTION
Use the shared attributes provided
by elastic/docs for linking to other
product docs, forums, etc.