### PR TITLE
Replace Agrona with JCTools as it's Java 7 compatible

### DIFF
--- a/apm-agent-benchmarks/pom.xml
+++ b/apm-agent-benchmarks/pom.xml
@@ -101,6 +101,11 @@
             <artifactId>byte-buddy-agent</artifactId>
             <version>${version.byte-buddy}</version>
         </dependency>
+        <dependency>
+            <groupId>org.agrona</groupId>
+            <artifactId>agrona</artifactId>
+            <version>0.9.18</version>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -70,9 +70,9 @@
             <version>3.3.7</version>
         </dependency>
         <dependency>
-            <groupId>org.agrona</groupId>
-            <artifactId>agrona</artifactId>
-            <version>0.9.18</version>
+            <groupId>org.jctools</groupId>
+            <artifactId>jctools-core</artifactId>
+            <version>2.1.2</version>
         </dependency>
 
         <dependency>

--- a/apm-agent-core/src/test/java/co/elastic/apm/objectpool/ObjectPoolTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/objectpool/ObjectPoolTest.java
@@ -20,7 +20,7 @@
 package co.elastic.apm.objectpool;
 
 import co.elastic.apm.objectpool.impl.QueueBasedObjectPool;
-import org.agrona.concurrent.ManyToManyConcurrentArrayQueue;
+import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +35,7 @@ public class ObjectPoolTest {
     @BeforeEach
     void setUp() {
 //        objectPool = new ThreadLocalObjectPool<>(10, false, TestRecyclable::new);
-        objectPool = new QueueBasedObjectPool<>(new ManyToManyConcurrentArrayQueue<>(MAX_SIZE), true, TestRecyclable::new);
+        objectPool = new QueueBasedObjectPool<>(new MpmcAtomicArrayQueue<>(MAX_SIZE), true, TestRecyclable::new);
     }
 
     @Test

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -61,8 +61,8 @@
                                     <shadedPattern>co.elastic.apm.shaded.stagemonitor</shadedPattern>
                                 </relocation>
                                 <relocation>
-                                    <pattern>org.agrona</pattern>
-                                    <shadedPattern>co.elastic.apm.shaded.agrona</shadedPattern>
+                                    <pattern>org.jctools</pattern>
+                                    <shadedPattern>co.elastic.apm.shaded.jctools</shadedPattern>
                                 </relocation>
                             </relocations>
                             <transformers>


### PR DESCRIPTION
As an additional benefit the `Atomic` variants of JCTools' queues don't depend on `sun.misc.Unsafe`, making it Java 11 proof.