### PR TITLE
Add support for WildFly 8-13

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/logging/JulBridgeLogger.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/logging/JulBridgeLogger.java
@@ -1,0 +1,270 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ResourceBundle;
+import java.util.logging.Filter;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+
+import static java.util.logging.Level.CONFIG;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINER;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
+
+/**
+ * <p>
+ * Some dependencies of the agent like okhttp use {@link java.util.logging.Logger}.
+ * This is problematic,
+ * as calling {@link java.util.logging.Logger#getLogger(String)} initializes the default {@link java.util.logging.LogManager}.
+ * WildFly expects the {@link java.util.logging.LogManager} implementation to be {@code org.jboss.logmanager.LogManager} and refuses to
+ * start otherwise.
+ * There are workarounds (https://docs.tcell.io/docs/jboss-issue-with-external-java-agent)
+ * but it would require users of the agent to configure some obscure stuff.
+ * </p>
+ * <p>
+ * The approach we take is to mimic the public interface of {@link java.util.logging.Logger} and use the maven shadow plugin to replace the
+ * usage of {@link java.util.logging.Logger} in our dependencies with this class.
+ * This class then forwards the logger calls to a slf4j {@link org.slf4j.Logger}.
+ * </p>
+ */
+public class JulBridgeLogger {
+
+    public static final String GLOBAL_LOGGER_NAME = "global";
+    public static final JulBridgeLogger global = new JulBridgeLogger(LoggerFactory.getLogger(GLOBAL_LOGGER_NAME));
+    private final Logger logger;
+
+    private JulBridgeLogger(Logger logger) {
+        this.logger = logger;
+    }
+
+    public static final JulBridgeLogger getGlobal() {
+        return global;
+    }
+
+    public static JulBridgeLogger getLogger(String name) {
+        return new JulBridgeLogger(LoggerFactory.getLogger(name));
+    }
+
+    public static JulBridgeLogger getLogger(String name, String resourceBundleName) {
+        return getLogger(name);
+    }
+
+    public static JulBridgeLogger getAnonymousLogger() {
+        return global;
+    }
+
+    public static JulBridgeLogger getAnonymousLogger(String resourceBundleName) {
+        return global;
+    }
+
+    public String getName() {
+        return logger.getName();
+    }
+
+    public void severe(String msg) {
+        logger.error(msg);
+    }
+
+    public void warning(String msg) {
+        logger.warn(msg);
+    }
+
+    public void info(String msg) {
+        logger.info(msg);
+    }
+
+    public void config(String msg) {
+        logger.info(msg);
+    }
+
+    public void fine(String msg) {
+        logger.debug(msg);
+    }
+
+    public void finer(String msg) {
+        logger.debug(msg);
+    }
+
+    public void finest(String msg) {
+        logger.trace(msg);
+    }
+
+    public void log(Level level, String msg) {
+        log(level, msg, (Object) null);
+    }
+
+    public void log(LogRecord record) {
+        log(record.getLevel(), record.getMessage(), record.getParameters());
+    }
+
+    public void log(Level level, String msg, Object param1) {
+        if (level == SEVERE) {
+            logger.error(msg, param1);
+        } else if (level == WARNING) {
+            logger.warn(msg, param1);
+        } else if (level == INFO) {
+            logger.info(msg, param1);
+        } else if (level == CONFIG) {
+            logger.info(msg, param1);
+        } else if (level == FINE) {
+            logger.debug(msg, param1);
+        } else if (level == FINER) {
+            logger.debug(msg, param1);
+        } else if (level == FINEST) {
+            logger.trace(msg, param1);
+        }
+    }
+
+    public void log(Level level, String msg, Object params[]) {
+        log(level, msg, (Object) params);
+    }
+
+    public void log(Level level, String msg, Throwable thrown) {
+        log(level, msg, (Object) thrown);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, String msg) {
+        log(level, msg);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, String msg, Object param1) {
+        log(level, msg, param1);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, String msg, Object params[]) {
+        log(level, msg, params);
+    }
+
+    public void logp(Level level, String sourceClass, String sourceMethod, String msg, Throwable thrown) {
+        log(level, msg, thrown);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg) {
+        log(level, msg);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg, Object param1) {
+        log(level, msg, param1);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg, Object params[]) {
+        log(level, msg, params);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, ResourceBundle bundle, String msg, Object... params) {
+        log(level, msg, params);
+    }
+
+    public void logrb(Level level, ResourceBundle bundle, String msg, Object... params) {
+        log(level, msg, params);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg, Throwable thrown) {
+        log(level, msg, thrown);
+    }
+
+    public void logrb(Level level, String sourceClass, String sourceMethod, ResourceBundle bundle, String msg, Throwable thrown) {
+        log(level, msg, thrown);
+    }
+
+    public void logrb(Level level, ResourceBundle bundle, String msg, Throwable thrown) {
+        log(level, msg, thrown);
+    }
+
+    public void entering(String sourceClass, String sourceMethod) {
+    }
+
+    public void entering(String sourceClass, String sourceMethod, Object param1) {
+    }
+
+    public void entering(String sourceClass, String sourceMethod, Object params[]) {
+    }
+
+    public void exiting(String sourceClass, String sourceMethod) {
+    }
+
+    public void exiting(String sourceClass, String sourceMethod, Object result) {
+    }
+
+    public void throwing(String sourceClass, String sourceMethod, Throwable thrown) {
+    }
+
+    public ResourceBundle getResourceBundle() {
+        return null;
+    }
+
+    public void setResourceBundle(ResourceBundle bundle) {
+    }
+
+    public String getResourceBundleName() {
+        return null;
+    }
+
+    public Filter getFilter() {
+        return null;
+    }
+
+    public void setFilter(Filter newFilter) throws SecurityException {
+    }
+
+    public Level getLevel() {
+        return null;
+    }
+
+    public void setLevel(Level newLevel) throws SecurityException {
+    }
+
+    public boolean isLoggable(Level level) {
+        return false;
+    }
+
+    public void addHandler(Handler handler) throws SecurityException {
+    }
+
+    public void removeHandler(Handler handler) throws SecurityException {
+    }
+
+    public Handler[] getHandlers() {
+        return null;
+    }
+
+    public boolean getUseParentHandlers() {
+        return false;
+    }
+
+    public void setUseParentHandlers(boolean useParentHandlers) {
+    }
+
+    public JulBridgeLogger getParent() {
+        return null;
+    }
+
+    public void setParent(JulBridgeLogger parent) {
+    }
+}
+

--- a/apm-agent-core/src/main/java/co/elastic/apm/logging/JulBridgeLogger.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/logging/JulBridgeLogger.java
@@ -33,6 +33,7 @@ import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
 import static java.util.logging.Level.FINEST;
 import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.OFF;
 import static java.util.logging.Level.SEVERE;
 import static java.util.logging.Level.WARNING;
 
@@ -58,11 +59,11 @@ public class JulBridgeLogger {
     public static final JulBridgeLogger global = new JulBridgeLogger(LoggerFactory.getLogger(GLOBAL_LOGGER_NAME));
     private final Logger logger;
 
-    private JulBridgeLogger(Logger logger) {
+    JulBridgeLogger(Logger logger) {
         this.logger = logger;
     }
 
-    public static final JulBridgeLogger getGlobal() {
+    public static JulBridgeLogger getGlobal() {
         return global;
     }
 
@@ -115,37 +116,90 @@ public class JulBridgeLogger {
     }
 
     public void log(Level level, String msg) {
-        log(level, msg, (Object) null);
-    }
-
-    public void log(LogRecord record) {
-        log(record.getLevel(), record.getMessage(), record.getParameters());
-    }
-
-    public void log(Level level, String msg, Object param1) {
         if (level == SEVERE) {
-            logger.error(msg, param1);
+            logger.error(msg);
         } else if (level == WARNING) {
-            logger.warn(msg, param1);
+            logger.warn(msg);
         } else if (level == INFO) {
-            logger.info(msg, param1);
+            logger.info(msg);
         } else if (level == CONFIG) {
-            logger.info(msg, param1);
+            logger.info(msg);
         } else if (level == FINE) {
-            logger.debug(msg, param1);
+            logger.debug(msg);
         } else if (level == FINER) {
-            logger.debug(msg, param1);
+            logger.debug(msg);
         } else if (level == FINEST) {
-            logger.trace(msg, param1);
+            logger.trace(msg);
         }
     }
 
-    public void log(Level level, String msg, Object params[]) {
-        log(level, msg, (Object) params);
+    public void log(Level level, String msg, Throwable thrown) {
+        if (level == SEVERE) {
+            logger.error(msg, thrown);
+        } else if (level == WARNING) {
+            logger.warn(msg, thrown);
+        } else if (level == INFO) {
+            logger.info(msg, thrown);
+        } else if (level == CONFIG) {
+            logger.info(msg, thrown);
+        } else if (level == FINE) {
+            logger.debug(msg, thrown);
+        } else if (level == FINER) {
+            logger.debug(msg, thrown);
+        } else if (level == FINEST) {
+            logger.trace(msg, thrown);
+        }
     }
 
-    public void log(Level level, String msg, Throwable thrown) {
-        log(level, msg, (Object) thrown);
+    public Level getLevel() {
+        if (logger.isTraceEnabled()) {
+            return FINEST;
+        } else if (logger.isDebugEnabled()) {
+            return FINE;
+        } else if (logger.isInfoEnabled()) {
+            return INFO;
+        } else if (logger.isWarnEnabled()) {
+            return WARNING;
+        } else if (logger.isErrorEnabled()) {
+            return SEVERE;
+        }
+        return OFF;
+    }
+
+    public void setLevel(Level newLevel) throws SecurityException {
+        // noop
+    }
+
+    public boolean isLoggable(Level level) {
+        if (level == SEVERE) {
+            return logger.isErrorEnabled();
+        } else if (level == WARNING) {
+            return logger.isWarnEnabled();
+        } else if (level == INFO) {
+            return logger.isInfoEnabled();
+        } else if (level == CONFIG) {
+            return logger.isInfoEnabled();
+        } else if (level == FINE) {
+            return logger.isDebugEnabled();
+        } else if (level == FINER) {
+            return logger.isDebugEnabled();
+        } else if (level == FINEST) {
+            return logger.isTraceEnabled();
+        } else {
+            return false;
+        }
+    }
+
+    public void log(LogRecord record) {
+        log(record.getLevel(), record.getMessage());
+    }
+
+    public void log(Level level, String msg, Object param1) {
+        log(level, msg);
+    }
+
+    public void log(Level level, String msg, Object params[]) {
+        log(level, msg);
     }
 
     public void logp(Level level, String sourceClass, String sourceMethod, String msg) {
@@ -153,11 +207,11 @@ public class JulBridgeLogger {
     }
 
     public void logp(Level level, String sourceClass, String sourceMethod, String msg, Object param1) {
-        log(level, msg, param1);
+        log(level, msg);
     }
 
     public void logp(Level level, String sourceClass, String sourceMethod, String msg, Object params[]) {
-        log(level, msg, params);
+        log(level, msg);
     }
 
     public void logp(Level level, String sourceClass, String sourceMethod, String msg, Throwable thrown) {
@@ -169,19 +223,19 @@ public class JulBridgeLogger {
     }
 
     public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg, Object param1) {
-        log(level, msg, param1);
+        log(level, msg);
     }
 
     public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg, Object params[]) {
-        log(level, msg, params);
+        log(level, msg);
     }
 
     public void logrb(Level level, String sourceClass, String sourceMethod, ResourceBundle bundle, String msg, Object... params) {
-        log(level, msg, params);
+        log(level, msg);
     }
 
     public void logrb(Level level, ResourceBundle bundle, String msg, Object... params) {
-        log(level, msg, params);
+        log(level, msg);
     }
 
     public void logrb(Level level, String sourceClass, String sourceMethod, String bundleName, String msg, Throwable thrown) {
@@ -197,21 +251,27 @@ public class JulBridgeLogger {
     }
 
     public void entering(String sourceClass, String sourceMethod) {
+        // noop
     }
 
     public void entering(String sourceClass, String sourceMethod, Object param1) {
+        // noop
     }
 
     public void entering(String sourceClass, String sourceMethod, Object params[]) {
+        // noop
     }
 
     public void exiting(String sourceClass, String sourceMethod) {
+        // noop
     }
 
     public void exiting(String sourceClass, String sourceMethod, Object result) {
+        // noop
     }
 
     public void throwing(String sourceClass, String sourceMethod, Throwable thrown) {
+        // noop
     }
 
     public ResourceBundle getResourceBundle() {
@@ -219,6 +279,7 @@ public class JulBridgeLogger {
     }
 
     public void setResourceBundle(ResourceBundle bundle) {
+        // noop
     }
 
     public String getResourceBundleName() {
@@ -230,23 +291,15 @@ public class JulBridgeLogger {
     }
 
     public void setFilter(Filter newFilter) throws SecurityException {
-    }
-
-    public Level getLevel() {
-        return null;
-    }
-
-    public void setLevel(Level newLevel) throws SecurityException {
-    }
-
-    public boolean isLoggable(Level level) {
-        return false;
+        // noop
     }
 
     public void addHandler(Handler handler) throws SecurityException {
+        // noop
     }
 
     public void removeHandler(Handler handler) throws SecurityException {
+        // noop
     }
 
     public Handler[] getHandlers() {
@@ -258,6 +311,7 @@ public class JulBridgeLogger {
     }
 
     public void setUseParentHandlers(boolean useParentHandlers) {
+        // noop
     }
 
     public JulBridgeLogger getParent() {
@@ -265,6 +319,6 @@ public class JulBridgeLogger {
     }
 
     public void setParent(JulBridgeLogger parent) {
+        // noop
     }
 }
-

--- a/apm-agent-core/src/test/java/co/elastic/apm/logging/JulBridgeLoggerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/logging/JulBridgeLoggerTest.java
@@ -1,0 +1,146 @@
+package co.elastic.apm.logging;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+
+import static java.util.logging.Level.CONFIG;
+import static java.util.logging.Level.FINE;
+import static java.util.logging.Level.FINER;
+import static java.util.logging.Level.FINEST;
+import static java.util.logging.Level.INFO;
+import static java.util.logging.Level.SEVERE;
+import static java.util.logging.Level.WARNING;
+import static org.assertj.core.api.Java6Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class JulBridgeLoggerTest {
+
+    private JulBridgeLogger julLogger;
+    private Exception e;
+    private Logger slf4jLogger;
+
+    @BeforeEach
+    void setUp() {
+        slf4jLogger = mock(Logger.class);
+        julLogger = new JulBridgeLogger(slf4jLogger);
+        e = new Exception("This exception is used to test exception logging");
+    }
+
+    @Test
+    void testLogException() {
+        julLogger.log(SEVERE, "test", e);
+        verify(slf4jLogger).error("test", e);
+
+        julLogger.log(WARNING, "test", e);
+        verify(slf4jLogger).warn("test", e);
+
+        julLogger.log(INFO, "test", e);
+        julLogger.log(CONFIG, "test", e);
+        verify(slf4jLogger, times(2)).info("test", e);
+
+        julLogger.log(FINE, "test", e);
+        julLogger.log(FINER, "test", e);
+        verify(slf4jLogger, times(2)).debug("test", e);
+
+        julLogger.log(FINEST, "test", e);
+        verify(slf4jLogger).trace("test", e);
+    }
+
+    @Test
+    void testLog() {
+        julLogger.log(SEVERE, "test");
+        verify(slf4jLogger).error("test");
+
+        julLogger.log(WARNING, "test");
+        verify(slf4jLogger).warn("test");
+
+        julLogger.log(INFO, "test");
+        julLogger.log(CONFIG, "test");
+        verify(slf4jLogger, times(2)).info("test");
+
+        julLogger.log(FINE, "test");
+        julLogger.log(FINER, "test");
+        verify(slf4jLogger, times(2)).debug("test");
+
+        julLogger.log(FINEST, "test");
+        verify(slf4jLogger).trace("test");
+    }
+
+    @Test
+    void testLog2() {
+        julLogger.severe("test");
+        verify(slf4jLogger).error("test");
+
+        julLogger.warning("test");
+        verify(slf4jLogger).warn("test");
+
+        julLogger.info("test");
+        julLogger.config("test");
+        verify(slf4jLogger, times(2)).info("test");
+
+        julLogger.fine("test");
+        julLogger.finer("test");
+        verify(slf4jLogger, times(2)).debug("test");
+
+        julLogger.finest("test");
+        verify(slf4jLogger).trace("test");
+    }
+
+    // The bridge does not support parameter placeholders,
+    // but who is perfect?
+    @Test
+    void testLogWithParameter() {
+        julLogger.log(SEVERE, "test {0}", new Object());
+        verify(slf4jLogger).error("test {0}");
+
+        julLogger.log(WARNING, "test {0}", new Object());
+        verify(slf4jLogger).warn("test {0}");
+
+        julLogger.log(INFO, "test {0}", new Object());
+        julLogger.log(CONFIG, "test {0}", new Object());
+        verify(slf4jLogger, times(2)).info("test {0}");
+
+        julLogger.log(FINE, "test {0}", new Object());
+        julLogger.log(FINER, "test {0}", new Object());
+        verify(slf4jLogger, times(2)).debug("test {0}");
+
+        julLogger.log(FINEST, "test {0}", new Object());
+        verify(slf4jLogger).trace("test {0}");
+    }
+
+    @Test
+    void testLogWithParameters() {
+        julLogger.log(SEVERE, "test {0}", new Object[]{new Object()});
+        verify(slf4jLogger).error("test {0}");
+
+        julLogger.log(WARNING, "test {0}", new Object[]{new Object()});
+        verify(slf4jLogger).warn("test {0}");
+
+        julLogger.log(INFO, "test {0}", new Object[]{new Object()});
+        julLogger.log(CONFIG, "test {0}", new Object[]{new Object()});
+        verify(slf4jLogger, times(2)).info("test {0}");
+
+        julLogger.log(FINE, "test {0}", new Object[]{new Object()});
+        julLogger.log(FINER, "test {0}", new Object[]{new Object()});
+        verify(slf4jLogger, times(2)).debug("test {0}");
+
+        julLogger.log(FINEST, "test {0}", new Object[]{new Object()});
+        verify(slf4jLogger).trace("test {0}");
+    }
+
+    @Test
+    void testIsLoggable() {
+        final JulBridgeLogger logger = JulBridgeLogger.getLogger(getClass().getName());
+        assertThat(logger.isLoggable(SEVERE)).isTrue();
+        assertThat(logger.isLoggable(WARNING)).isTrue();
+        assertThat(logger.isLoggable(INFO)).isTrue();
+        assertThat(logger.isLoggable(CONFIG)).isTrue();
+        assertThat(logger.isLoggable(FINE)).isTrue();
+        assertThat(logger.isLoggable(FINER)).isTrue();
+        assertThat(logger.isLoggable(FINEST)).isFalse();
+        assertThat(logger.getLevel()).isSameAs(FINE);
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/logging/JulBridgeLoggerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/logging/JulBridgeLoggerTest.java
@@ -4,6 +4,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 
+import java.util.ResourceBundle;
+import java.util.logging.LogRecord;
+
 import static java.util.logging.Level.CONFIG;
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.FINER;
@@ -15,6 +18,7 @@ import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 
 class JulBridgeLoggerTest {
 
@@ -132,6 +136,36 @@ class JulBridgeLoggerTest {
     }
 
     @Test
+    void testLogRecord() {
+        julLogger.log(new LogRecord(INFO, "test"));
+        verify(slf4jLogger).info("test");
+    }
+
+    @Test
+    void testLogp() {
+        julLogger.logp(INFO, null, null, "test");
+        julLogger.logp(INFO, null, null, "test", new Object());
+        julLogger.logp(INFO, null, null, "test", new Object[]{});
+        julLogger.logp(INFO, null, null, "test", e);
+        verify(slf4jLogger, times(3)).info("test");
+        verify(slf4jLogger, times(1)).info("test", e);
+    }
+
+    @Test
+    void testLogrb() {
+        julLogger.logrb(INFO, "", "", "", "test");
+        julLogger.logrb(INFO, "", "", "", "test", new Object());
+        julLogger.logrb(INFO, "", "", "", "test", new Object[]{});
+        julLogger.logrb(INFO, "", "", (ResourceBundle) null, "test");
+        julLogger.logrb(INFO, null, "test");
+        julLogger.logrb(INFO, "", "", "", "test", e);
+        julLogger.logrb(INFO, "", "", (ResourceBundle) null, "test", e);
+        julLogger.logrb(INFO, null, "test", e);
+        verify(slf4jLogger, times(5)).info("test");
+        verify(slf4jLogger, times(3)).info("test", e);
+    }
+
+    @Test
     void testIsLoggable() {
         final JulBridgeLogger logger = JulBridgeLogger.getLogger(getClass().getName());
         assertThat(logger.isLoggable(SEVERE)).isTrue();
@@ -142,5 +176,24 @@ class JulBridgeLoggerTest {
         assertThat(logger.isLoggable(FINER)).isTrue();
         assertThat(logger.isLoggable(FINEST)).isFalse();
         assertThat(logger.getLevel()).isSameAs(FINE);
+    }
+
+    @Test
+    void testNoops() {
+        julLogger.setLevel(FINEST);
+        julLogger.setLevel(null);
+        julLogger.entering(null, null);
+        julLogger.entering(null, null, new Object());
+        julLogger.entering(null, null, new Object[]{});
+        julLogger.exiting(null, null);
+        julLogger.exiting(null, null, null);
+        julLogger.throwing(null, null, e);
+        julLogger.setResourceBundle(null);
+        julLogger.setFilter(null);
+        julLogger.addHandler(null);
+        julLogger.removeHandler(null);
+        julLogger.setUseParentHandlers(true);
+        julLogger.setParent(null);
+        verifyZeroInteractions(slf4jLogger);
     }
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/wildfly/WildFlyLifecycleListener.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/wildfly/WildFlyLifecycleListener.java
@@ -1,0 +1,47 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.servlet.wildfly;
+
+import co.elastic.apm.context.LifecycleListener;
+import co.elastic.apm.impl.ElasticApmTracer;
+
+/**
+ * Makes the {@code co.elastic.apm} package visible from all modules
+ */
+public class WildFlyLifecycleListener implements LifecycleListener {
+
+    private static final String JBOSS_MODULES_SYSTEM_PKGS = "jboss.modules.system.pkgs";
+    private static final String APM_BASE_PACKAGE = "co.elastic.apm";
+
+    @Override
+    public void start(ElasticApmTracer tracer) {
+        final String systemPackages = System.getProperty(JBOSS_MODULES_SYSTEM_PKGS);
+        if (systemPackages != null) {
+            System.setProperty(JBOSS_MODULES_SYSTEM_PKGS, systemPackages + "," + APM_BASE_PACKAGE);
+        } else {
+            System.setProperty(JBOSS_MODULES_SYSTEM_PKGS, APM_BASE_PACKAGE);
+        }
+    }
+
+    @Override
+    public void stop() {
+        // noop
+    }
+}

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/resources/META-INF/services/co.elastic.apm.context.LifecycleListener
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/resources/META-INF/services/co.elastic.apm.context.LifecycleListener
@@ -1,0 +1,1 @@
+co.elastic.apm.servlet.wildfly.WildFlyLifecycleListener

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -64,6 +64,19 @@
                                     <pattern>org.jctools</pattern>
                                     <shadedPattern>co.elastic.apm.shaded.jctools</shadedPattern>
                                 </relocation>
+                                <!--
+                                Makes sure that the relocated slf4j simple does not look for a simplelogger.properties
+                                Although this is not a package but a string constant, it does work
+                                -->
+                                <relocation>
+                                    <pattern>simplelogger.properties</pattern>
+                                    <shadedPattern>elasticapmlogger.properties</shadedPattern>
+                                </relocation>
+                                <!-- See javadoc of co.elastic.apm.logging.JulBridgeLogger -->
+                                <relocation>
+                                    <pattern>java.util.logging.Logger</pattern>
+                                    <shadedPattern>co.elastic.apm.logging.JulBridgeLogger</shadedPattern>
+                                </relocation>
                             </relocations>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
@@ -110,7 +123,12 @@
     <dependencies>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${version.slf4j}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
             <version>${version.slf4j}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
* Includes integration tests
* Replace usage of java.util.logging with slf4j simplelogger,
  as WildFly does not like JUL
* Adds co.elastic.apm as system packages to work around
  module class loader issues

closes #99