### PR TITLE
Make sure the error context is always set

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
@@ -232,6 +232,7 @@ public class ElasticApmTracer {
             Transaction transaction = currentTransaction();
             if (transaction != null) {
                 error.asChildOf(transaction);
+                error.getTransaction().getTransactionId().copyFrom(transaction.getId());
                 error.getContext().copyFrom(transaction.getContext());
             }
             reporter.report(error);

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
@@ -231,11 +231,11 @@ public class ElasticApmTracer {
             stacktraceFactory.fillStackTrace(error.getException().getStacktrace(), e.getStackTrace());
             Transaction transaction = currentTransaction();
             if (transaction != null) {
-                // TODO add memory fence to make sure its fields are visible
-                // as the transaction might be created in a different thread
+                // The error might have occurred in a different thread than the one the transaction was recorded
+                // That's why we have to ensure the visibility of the transaction properties
+                error.getContext().copyFrom(transaction.getContextEnsureVisibility());
                 error.asChildOf(transaction);
                 error.getTransaction().getTransactionId().copyFrom(transaction.getId());
-                error.getContext().copyFrom(transaction.getContext());
             }
             reporter.report(error);
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
@@ -231,6 +231,8 @@ public class ElasticApmTracer {
             stacktraceFactory.fillStackTrace(error.getException().getStacktrace(), e.getStackTrace());
             Transaction transaction = currentTransaction();
             if (transaction != null) {
+                // TODO add memory fence to make sure its fields are visible
+                // as the transaction might be created in a different thread
                 error.asChildOf(transaction);
                 error.getTransaction().getTransactionId().copyFrom(transaction.getId());
                 error.getContext().copyFrom(transaction.getContext());

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
@@ -110,6 +110,18 @@ public class Transaction extends AbstractSpan implements AutoCloseable {
     }
 
     /**
+     * Returns the context and ensures visibility when accessed from a different thread.
+     *
+     * @return the transaction context
+     * @see #getContext()
+     */
+    public Context getContextEnsureVisibility() {
+        synchronized (this) {
+            return context;
+        }
+    }
+
+    /**
      * UUID for the transaction, referred by its spans
      * (Required)
      */

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
@@ -146,7 +146,7 @@ public class DslJsonSerializer implements PayloadSerializer {
     }
 
     private void serializeTransactionReference(ErrorCapture errorCapture) {
-        if (!errorCapture.getTransaction().hasContent()) {
+        if (errorCapture.getTransaction().hasContent()) {
             writeFieldName("transaction");
             jw.writeByte(JsonWriter.OBJECT_START);
             TransactionId transactionId = errorCapture.getTransaction().getTransactionId();

--- a/apm-agent-core/src/test/java/co/elastic/apm/AbstractInstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/AbstractInstrumentationTest.java
@@ -27,16 +27,19 @@ import net.bytebuddy.agent.ByteBuddyAgent;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.stagemonitor.configuration.ConfigurationRegistry;
 
 public abstract class AbstractInstrumentationTest {
     protected static ElasticApmTracer tracer;
     protected static MockReporter reporter;
+    protected static ConfigurationRegistry config;
 
     @BeforeAll
     static void beforeAll() {
         reporter = new MockReporter();
+        config = SpyConfiguration.createSpyConfig();
         tracer = new ElasticApmTracerBuilder()
-            .configurationRegistry(SpyConfiguration.createSpyConfig())
+            .configurationRegistry(config)
             .reporter(reporter)
             .build();
         ElasticApmAgent.initInstrumentation(tracer, ByteBuddyAgent.install());
@@ -49,6 +52,7 @@ public abstract class AbstractInstrumentationTest {
 
     @BeforeEach
     final void resetReporter() {
+        SpyConfiguration.reset(config);
         reporter.reset();
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/configuration/SpyConfiguration.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/configuration/SpyConfiguration.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +19,7 @@
  */
 package co.elastic.apm.configuration;
 
+import org.mockito.Mockito;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 import org.stagemonitor.configuration.source.SimpleSource;
@@ -47,5 +48,11 @@ public class SpyConfiguration {
         return builder
             .addConfigSource(new SimpleSource(CONFIG_SOURCE_NAME).add("service_name", "elastic-apm-test"))
             .build();
+    }
+
+    public static void reset(ConfigurationRegistry config) {
+        for (ConfigurationOptionProvider provider : config.getConfigurationOptionProviders()) {
+            Mockito.reset(provider);
+        }
     }
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletTransactionHelper.java
@@ -75,7 +75,7 @@ public class ServletTransactionHelper {
      * because the creating the context is handled in one central place.
      *
      * Furthermore, it is not trivial to create an error context at an arbitrary location
-     * (when the user calls ElasticApm.captureError()),
+     * (when the user calls ElasticApm.captureException()),
      * as we don't necessarily have access to the framework's request and response objects.
      *
      * Additionally, we only have access to the classes of the instrumented classes inside advice methods.


### PR DESCRIPTION
Previously, most of the transaction context was set after the execution of a request.
When capturing an exception, the transaction context is copied over at it's current state.
That means when the user captures an exception, the the transaction context is not yet
populated and therefore, the Error context is empty.

This changes the initialization of the transaction context so that it is set
before the request starts.

That way, we can be sure that the Error context is always set