### PR TITLE
Exclude process.argv by default

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ApmServerReporter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ApmServerReporter.java
@@ -105,6 +105,9 @@ public class ApmServerReporter implements Reporter {
         }, ProducerType.MULTI, PhasedBackoffWaitStrategy.withLock(1, 10, TimeUnit.MILLISECONDS));
         this.coreConfiguration = coreConfiguration;
         reportingEventHandler = new ReportingEventHandler(service, process, system, payloadSender, reporterConfiguration, processorEventHandler);
+        if (!reporterConfiguration.isIncludeProcessArguments()) {
+            process.getArgv().clear();
+        }
         disruptor.handleEventsWith(reportingEventHandler);
         disruptor.start();
         if (reporterConfiguration.getFlushInterval() > 0) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterConfiguration.java
@@ -94,7 +94,8 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
     private final ConfigurationOption<Boolean> includeProcessArguments = ConfigurationOption.booleanOption()
         .key("include_process_args")
         .configurationCategory(REPORTER_CATEGORY)
-        .description("Whether each transaction should have the process arguments attached. Disabled by default to save disk space.")
+        .description("Whether each transaction should have the process arguments attached.\n" +
+            "Disabled by default to save disk space.")
         .buildWithDefault(false);
 
     @Nullable

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterConfiguration.java
@@ -91,6 +91,12 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
             "Blocks the requests until the transaction has been reported to the APM server.")
         .buildWithDefault(false);
 
+    private final ConfigurationOption<Boolean> includeProcessArguments = ConfigurationOption.booleanOption()
+        .key("include_process_args")
+        .configurationCategory(REPORTER_CATEGORY)
+        .description("Whether each transaction should have the process arguments attached. Disabled by default to save disk space.")
+        .buildWithDefault(false);
+
     @Nullable
     public String getSecretToken() {
         return secretToken.get();
@@ -118,5 +124,9 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
 
     public boolean isReportSynchronously() {
         return reportSynchronously.get();
+    }
+
+    public boolean isIncludeProcessArguments() {
+        return includeProcessArguments.get();
     }
 }

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -517,6 +517,27 @@ This setting is useful to limit memory consumption if you experience a sudden sp
 | `elastic.apm.max_queue_size` | `ELASTIC_APM_MAX_QUEUE_SIZE`
 |============
 
+[float]
+[[config-include-process-args]]
+==== `include_process_args`
+
+Whether each transaction should have the process arguments attached.
+Disabled by default to save disk space.
+
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `false` | Boolean | false
+|============
+
+
+[options="header"]
+|============
+| Java System Properties      | Environment
+| `elastic.apm.include_process_args` | `ELASTIC_APM_INCLUDE_PROCESS_ARGS`
+|============
+
 [[config-stacktrace]]
 === Stacktrace configuration options
 [float]


### PR DESCRIPTION
It can take quite a lot of space, as it's added to each transaction, and stored even for non-sampled transactions