### PR TITLE
Create spans from transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 target
 dependency-reduced-pom.xml
+/.metadata/
+/.recommenders/
+.classpath
+.project
+.settings

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/ElasticApm.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/ElasticApm.java
@@ -66,7 +66,7 @@ public class ElasticApm {
      * }
      * </pre>
      *
-     * @return the started transaction
+     * @return the started transaction.  
      */
     @Nonnull
     public static Transaction startTransaction() {
@@ -76,6 +76,22 @@ public class ElasticApm {
 
     private static Object doStartTransaction() {
         // co.elastic.apm.api.ElasticApmInstrumentation.StartTransactionInstrumentation.doStartTransaction
+        return null;
+    }
+    
+    
+    /**
+     * The same as {@link ElasticApm#startTransaction()} but doesn't bind created transaction to the current thread
+     * @return the started transaction.  
+     */
+    @Nonnull
+    public static Transaction startAsyncTransaction() {
+        Object transaction = doStartAsyncTransaction();
+        return transaction != null ? new TransactionImpl(transaction) : NoopTransaction.INSTANCE;
+    }
+    
+    private static Object doStartAsyncTransaction() {
+        // co.elastic.apm.api.ElasticApmInstrumentation.StartTransactionInstrumentation.doStartAsyncTransaction
         return null;
     }
 
@@ -158,7 +174,7 @@ public class ElasticApm {
      *
      * @param e the exception to record
      */
-    public static void captureException(@Nullable Exception e) {
+    public static void captureException(@Nullable Throwable e) {
         // co.elastic.apm.api.ElasticApmInstrumentation.CaptureExceptionInstrumentation.captureException
     }
 

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/NoopSpan.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/NoopSpan.java
@@ -37,4 +37,8 @@ enum NoopSpan implements Span {
         // noop
     }
 
+    @Override
+    public Span createSpan() {
+        return INSTANCE;
+    }
 }

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/NoopTransaction.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/NoopTransaction.java
@@ -48,4 +48,8 @@ enum NoopTransaction implements Transaction {
         // noop
     }
 
+    @Override
+    public Span createSpan() {
+        return NoopSpan.INSTANCE;
+    }
 }

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/Span.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/Span.java
@@ -56,6 +56,13 @@ public interface Span {
     void setType(String type);
 
     /**
+     * Creates child span for this span.
+     * 
+     * @return new span or noop span (never {@code null}).
+     */
+    Span createSpan();
+    
+    /**
      * Ends the span.
      * If the span has already ended, nothing happens.
      */

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/SpanImpl.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/SpanImpl.java
@@ -47,6 +47,17 @@ class SpanImpl implements Span {
     }
 
     @Override
+    public Span createSpan() {
+        Object span = doCreateSpan();
+        return span != null ? new SpanImpl(span) : NoopSpan.INSTANCE;
+    }
+    
+    private Object doCreateSpan() {
+        // co.elastic.apm.plugin.api.SpanInstrumentation$DoCreateSpanInstrumentation.doCreateSpan
+        return null;
+    }
+    
+    @Override
     public void end() {
         // co.elastic.apm.plugin.api.SpanInstrumentation$EndInstrumentation.end
     }

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/Transaction.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/Transaction.java
@@ -92,5 +92,11 @@ public interface Transaction {
      * </p>
      */
     void end();
+    
+    /**
+     * Creates span bound to the current transaction
+     * @return {@link Span}
+     */
+    Span createSpan();
 
 }

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/TransactionImpl.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/TransactionImpl.java
@@ -61,4 +61,14 @@ class TransactionImpl implements Transaction {
         // co.elastic.apm.plugin.api.TransactionInstrumentation$EndInstrumentation.end
     }
 
+    @Override
+    public Span createSpan() {
+        Object span = doCreateSpan();
+        return span != null ? new SpanImpl(span) : NoopSpan.INSTANCE;
+    }
+    
+    private Object doCreateSpan() {
+        // co.elastic.apm.plugin.api.TransactionInstrumentation$DoCreateSpanInstrumentation.doCreateSpan
+        return null;
+    }
 }

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/objectpool/ObjectPoolBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/objectpool/ObjectPoolBenchmark.java
@@ -24,6 +24,7 @@ import co.elastic.apm.impl.transaction.Transaction;
 import co.elastic.apm.objectpool.impl.MixedObjectPool;
 import co.elastic.apm.objectpool.impl.QueueBasedObjectPool;
 import co.elastic.apm.objectpool.impl.ThreadLocalObjectPool;
+
 import org.agrona.concurrent.ManyToManyConcurrentArrayQueue;
 import org.jctools.queues.MpmcArrayQueue;
 import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
@@ -75,7 +76,7 @@ public class ObjectPoolBenchmark extends AbstractBenchmark {
     //    @Benchmark
     @Threads(8)
     public Transaction testNewOperator() {
-        return new Transaction();
+        return new Transaction(null);
     }
 
     @Benchmark

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/objectpool/ObjectPoolBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/objectpool/ObjectPoolBenchmark.java
@@ -57,14 +57,14 @@ public class ObjectPoolBenchmark extends AbstractBenchmark {
 
     @Setup
     public void setUp() {
-        blockingQueueObjectPool = new QueueBasedObjectPool<>(new ArrayBlockingQueue<>(256), true, () -> new Transaction(null));
-        jctoolsQueueObjectPool = new QueueBasedObjectPool<>(new MpmcArrayQueue<>(256), true, () -> new Transaction(null));
-        jctoolsAtomicQueueObjectPool = new QueueBasedObjectPool<>(new MpmcAtomicArrayQueue<>(256), true, () -> new Transaction(null));
-        agronaQueueObjectPool = new QueueBasedObjectPool<>(new ManyToManyConcurrentArrayQueue<>(256), true, () -> new Transaction(null));
-        mixedObjectPool = new MixedObjectPool<>(() -> new Transaction(null),
-            new ThreadLocalObjectPool<>(256, true, () -> new Transaction(null)),
-            new QueueBasedObjectPool<>(new ManyToManyConcurrentArrayQueue<>(256), true, () -> new Transaction(null)));
-        threadLocalObjectPool = new ThreadLocalObjectPool<>(64, true, () -> new Transaction(null));
+        blockingQueueObjectPool = new QueueBasedObjectPool<>(new ArrayBlockingQueue<>(256), true, Transaction::new);
+        jctoolsQueueObjectPool = new QueueBasedObjectPool<>(new MpmcArrayQueue<>(256), true, Transaction::new);
+        jctoolsAtomicQueueObjectPool = new QueueBasedObjectPool<>(new MpmcAtomicArrayQueue<>(256), true, Transaction::new);
+        agronaQueueObjectPool = new QueueBasedObjectPool<>(new ManyToManyConcurrentArrayQueue<>(256), true, Transaction::new);
+        mixedObjectPool = new MixedObjectPool<>(Transaction::new,
+            new ThreadLocalObjectPool<>(256, true, Transaction::new),
+            new QueueBasedObjectPool<>(new ManyToManyConcurrentArrayQueue<>(256), true, Transaction::new));
+        threadLocalObjectPool = new ThreadLocalObjectPool<>(64, true, Transaction::new);
     }
 
     @TearDown
@@ -76,7 +76,7 @@ public class ObjectPoolBenchmark extends AbstractBenchmark {
     //    @Benchmark
     @Threads(8)
     public Transaction testNewOperator() {
-        return new Transaction(null);
+        return new Transaction();
     }
 
     @Benchmark

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/objectpool/ObjectPoolBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/objectpool/ObjectPoolBenchmark.java
@@ -57,14 +57,14 @@ public class ObjectPoolBenchmark extends AbstractBenchmark {
 
     @Setup
     public void setUp() {
-        blockingQueueObjectPool = new QueueBasedObjectPool<>(new ArrayBlockingQueue<>(256), true, Transaction::new);
-        jctoolsQueueObjectPool = new QueueBasedObjectPool<>(new MpmcArrayQueue<>(256), true, Transaction::new);
-        jctoolsAtomicQueueObjectPool = new QueueBasedObjectPool<>(new MpmcAtomicArrayQueue<>(256), true, Transaction::new);
-        agronaQueueObjectPool = new QueueBasedObjectPool<>(new ManyToManyConcurrentArrayQueue<>(256), true, Transaction::new);
-        mixedObjectPool = new MixedObjectPool<>(Transaction::new,
-            new ThreadLocalObjectPool<>(256, true, Transaction::new),
-            new QueueBasedObjectPool<>(new ManyToManyConcurrentArrayQueue<>(256), true, Transaction::new));
-        threadLocalObjectPool = new ThreadLocalObjectPool<>(64, true, Transaction::new);
+        blockingQueueObjectPool = new QueueBasedObjectPool<>(new ArrayBlockingQueue<>(256), true, () -> new Transaction(null));
+        jctoolsQueueObjectPool = new QueueBasedObjectPool<>(new MpmcArrayQueue<>(256), true, () -> new Transaction(null));
+        jctoolsAtomicQueueObjectPool = new QueueBasedObjectPool<>(new MpmcAtomicArrayQueue<>(256), true, () -> new Transaction(null));
+        agronaQueueObjectPool = new QueueBasedObjectPool<>(new ManyToManyConcurrentArrayQueue<>(256), true, () -> new Transaction(null));
+        mixedObjectPool = new MixedObjectPool<>(() -> new Transaction(null),
+            new ThreadLocalObjectPool<>(256, true, () -> new Transaction(null)),
+            new QueueBasedObjectPool<>(new ManyToManyConcurrentArrayQueue<>(256), true, () -> new Transaction(null)));
+        threadLocalObjectPool = new ThreadLocalObjectPool<>(64, true, () -> new Transaction(null));
     }
 
     @TearDown

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/AbstractReporterBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/AbstractReporterBenchmark.java
@@ -42,6 +42,7 @@ import co.elastic.apm.report.PayloadSender;
 import co.elastic.apm.report.Reporter;
 import co.elastic.apm.report.ReporterConfiguration;
 import co.elastic.apm.report.processor.ProcessorEventHandler;
+
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.TearDown;
@@ -99,7 +100,7 @@ public abstract class AbstractReporterBenchmark extends AbstractBenchmark {
             ProcessorEventHandler.loadProcessors(tracer.getConfigurationRegistry()), coreConfiguration);
         payload = new TransactionPayload(process, service, system);
         for (int i = 0; i < reporterConfiguration.getMaxQueueSize(); i++) {
-            Transaction t = new Transaction();
+            Transaction t = new Transaction(coreConfiguration);
             fillTransaction(t);
             payload.getTransactions().add(t);
         }

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/AbstractReporterBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/benchmark/reporter/AbstractReporterBenchmark.java
@@ -100,7 +100,7 @@ public abstract class AbstractReporterBenchmark extends AbstractBenchmark {
             ProcessorEventHandler.loadProcessors(tracer.getConfigurationRegistry()), coreConfiguration);
         payload = new TransactionPayload(process, service, system);
         for (int i = 0; i < reporterConfiguration.getMaxQueueSize(); i++) {
-            Transaction t = new Transaction(coreConfiguration);
+            Transaction t = new Transaction();
             fillTransaction(t);
             payload.getTransactions().add(t);
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanCount.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanCount.java
@@ -22,26 +22,28 @@ package co.elastic.apm.impl.transaction;
 
 import co.elastic.apm.objectpool.Recyclable;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class SpanCount implements Recyclable {
 
     private final Dropped dropped = new Dropped();
-    private int total = 0;
+    private final AtomicInteger total = new AtomicInteger(0);
 
     public Dropped getDropped() {
         return dropped;
     }
 
     public void increment() {
-        total++;
+        total.incrementAndGet();
     }
 
     public int getTotal() {
-        return total;
+        return total.get();
     }
 
     @Override
     public void resetState() {
         dropped.resetState();
-        total = 0;
+        total.set(0);
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
@@ -238,6 +238,7 @@ public class Transaction extends AbstractSpan implements AutoCloseable {
         spanCount.increment();
         span.start(tracer, this, currentSpan, System.nanoTime(), dropped);
         currentSpan = span;
+        tracer.activate(span);
         return span;
     }
     
@@ -250,9 +251,6 @@ public class Transaction extends AbstractSpan implements AutoCloseable {
     }
 
     public void end(long nanoTime, boolean releaseActiveTransaction) {
-        while (this.currentSpan != null) {
-            this.currentSpan.close();
-        }
         this.duration = (nanoTime - duration) / ElasticApmTracer.MS_IN_NANOS;
         if (!isSampled()) {
             context.resetState();

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ApmServerHttpPayloadSender.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ApmServerHttpPayloadSender.java
@@ -23,12 +23,13 @@ import co.elastic.apm.impl.error.ErrorPayload;
 import co.elastic.apm.impl.payload.Agent;
 import co.elastic.apm.impl.payload.Payload;
 import co.elastic.apm.report.serialize.PayloadSerializer;
+
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import okio.BufferedSink;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,13 +41,13 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.zip.Deflater;
-import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPOutputStream;
+
+import okio.BufferedSink;
 
 public class ApmServerHttpPayloadSender implements PayloadSender {
     private static final Logger logger = LoggerFactory.getLogger(ApmServerHttpPayloadSender.class);
     private static final MediaType MEDIA_TYPE_JSON = Objects.requireNonNull(MediaType.parse("application/json"));
-    private static final int GZIP_COMPRESSION_LEVEL = 3;
 
     private final OkHttpClient httpClient;
     private final ReporterConfiguration reporterConfiguration;
@@ -102,8 +103,7 @@ public class ApmServerHttpPayloadSender implements PayloadSender {
                 public void writeTo(BufferedSink sink) throws IOException {
                     OutputStream os = sink.outputStream();
                     if (useGzip(payload)) {
-                        final Deflater def = new Deflater(GZIP_COMPRESSION_LEVEL);
-                        os = new DeflaterOutputStream(os, def);
+                        os = new GZIPOutputStream(os);
                     }
                     try {
                         payloadSerializer.serializePayload(os, payload);

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/TransactionPayloadJsonSchemaTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/TransactionPayloadJsonSchemaTest.java
@@ -26,10 +26,12 @@ import co.elastic.apm.impl.sampling.ConstantSampler;
 import co.elastic.apm.impl.transaction.Span;
 import co.elastic.apm.impl.transaction.Transaction;
 import co.elastic.apm.report.serialize.DslJsonSerializer;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.ValidationMessage;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +65,7 @@ class TransactionPayloadJsonSchemaTest {
     }
 
     private Transaction createTransactionWithRequiredValues() {
-        Transaction t = new Transaction();
+        Transaction t = new Transaction(null);
         t.start(mock(ElasticApmTracer.class), null, 0, ConstantSampler.of(true));
         t.setType("type");
         t.getContext().getRequest().withMethod("GET");
@@ -77,7 +79,7 @@ class TransactionPayloadJsonSchemaTest {
     }
 
     private TransactionPayload createPayloadWithAllValues() {
-        final Transaction transaction = new Transaction();
+        final Transaction transaction = new Transaction(null);
         TransactionUtils.fillTransaction(transaction);
         final TransactionPayload payload = createPayload();
         payload.getTransactions().add(transaction);
@@ -96,7 +98,7 @@ class TransactionPayloadJsonSchemaTest {
     @Test
     void testJsonSchemaDslJsonEmptyValues() throws IOException {
         final TransactionPayload payload = createPayload();
-        payload.getTransactions().add(new Transaction());
+        payload.getTransactions().add(new Transaction(null));
         final String content = new DslJsonSerializer(coreConfiguration).toJsonString(payload);
         System.out.println(content);
         objectMapper.readTree(content);

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/TransactionPayloadJsonSchemaTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/TransactionPayloadJsonSchemaTest.java
@@ -65,7 +65,7 @@ class TransactionPayloadJsonSchemaTest {
     }
 
     private Transaction createTransactionWithRequiredValues() {
-        Transaction t = new Transaction(null);
+        Transaction t = new Transaction();
         t.start(mock(ElasticApmTracer.class), null, 0, ConstantSampler.of(true));
         t.setType("type");
         t.getContext().getRequest().withMethod("GET");
@@ -79,7 +79,7 @@ class TransactionPayloadJsonSchemaTest {
     }
 
     private TransactionPayload createPayloadWithAllValues() {
-        final Transaction transaction = new Transaction(null);
+        final Transaction transaction = new Transaction();
         TransactionUtils.fillTransaction(transaction);
         final TransactionPayload payload = createPayload();
         payload.getTransactions().add(transaction);
@@ -98,7 +98,7 @@ class TransactionPayloadJsonSchemaTest {
     @Test
     void testJsonSchemaDslJsonEmptyValues() throws IOException {
         final TransactionPayload payload = createPayload();
-        payload.getTransactions().add(new Transaction(null));
+        payload.getTransactions().add(new Transaction());
         final String content = new DslJsonSerializer(coreConfiguration).toJsonString(payload);
         System.out.println(content);
         objectMapper.readTree(content);

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/TransactionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/TransactionTest.java
@@ -20,18 +20,20 @@
 package co.elastic.apm.impl.transaction;
 
 import co.elastic.apm.TransactionUtils;
+
 import org.junit.jupiter.api.Test;
 
 import static co.elastic.apm.JsonUtils.toJson;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TransactionTest {
 
     @Test
     void resetState() {
-        final Transaction transaction = new Transaction();
+        final Transaction transaction = new Transaction(null);
         TransactionUtils.fillTransaction(transaction);
         transaction.resetState();
-        assertThat(toJson(transaction)).isEqualTo(toJson(new Transaction()));
+        assertThat(toJson(transaction)).isEqualTo(toJson(new Transaction(null)));
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/TransactionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/TransactionTest.java
@@ -31,9 +31,9 @@ class TransactionTest {
 
     @Test
     void resetState() {
-        final Transaction transaction = new Transaction(null);
+        final Transaction transaction = new Transaction();
         TransactionUtils.fillTransaction(transaction);
         transaction.resetState();
-        assertThat(toJson(transaction)).isEqualTo(toJson(new Transaction(null)));
+        assertThat(toJson(transaction)).isEqualTo(toJson(new Transaction()));
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterIntegrationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterIntegrationTest.java
@@ -44,7 +44,7 @@ import java.net.InetSocketAddress;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.Mockito.when;
 
 class ApmServerReporterIntegrationTest {
@@ -98,7 +98,7 @@ class ApmServerReporterIntegrationTest {
 
     @Test
     void testReportTransaction() throws ExecutionException, InterruptedException {
-        reporter.report(new Transaction(null));
+        reporter.report(new Transaction());
         reporter.flush().get();
         assertThat(reporter.getDropped()).isEqualTo(0);
         assertThat(receivedHttpRequests.get()).isEqualTo(1);
@@ -112,7 +112,7 @@ class ApmServerReporterIntegrationTest {
             receivedHttpRequests.incrementAndGet();
             exchange.setStatusCode(200).endExchange();
         };
-        reporter.report(new Transaction(null));
+        reporter.report(new Transaction());
         reporter.flush().get();
         assertThat(reporter.getDropped()).isEqualTo(0);
         assertThat(receivedHttpRequests.get()).isEqualTo(1);

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterIntegrationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterIntegrationTest.java
@@ -28,9 +28,12 @@ import co.elastic.apm.impl.payload.SystemInfo;
 import co.elastic.apm.impl.transaction.Transaction;
 import co.elastic.apm.report.processor.ProcessorEventHandler;
 import co.elastic.apm.report.serialize.DslJsonSerializer;
+
 import io.undertow.Undertow;
 import io.undertow.server.HttpHandler;
+
 import okhttp3.OkHttpClient;
+
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -95,7 +98,7 @@ class ApmServerReporterIntegrationTest {
 
     @Test
     void testReportTransaction() throws ExecutionException, InterruptedException {
-        reporter.report(new Transaction());
+        reporter.report(new Transaction(null));
         reporter.flush().get();
         assertThat(reporter.getDropped()).isEqualTo(0);
         assertThat(receivedHttpRequests.get()).isEqualTo(1);
@@ -109,7 +112,7 @@ class ApmServerReporterIntegrationTest {
             receivedHttpRequests.incrementAndGet();
             exchange.setStatusCode(200).endExchange();
         };
-        reporter.report(new Transaction());
+        reporter.report(new Transaction(null));
         reporter.flush().get();
         assertThat(reporter.getDropped()).isEqualTo(0);
         assertThat(receivedHttpRequests.get()).isEqualTo(1);

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterTest.java
@@ -27,6 +27,7 @@ import co.elastic.apm.impl.payload.Service;
 import co.elastic.apm.impl.payload.SystemInfo;
 import co.elastic.apm.impl.transaction.Transaction;
 import co.elastic.apm.report.processor.ProcessorEventHandler;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.stagemonitor.configuration.ConfigurationRegistry;
@@ -58,7 +59,7 @@ class ApmServerReporterTest {
     @Test
     void testTransactionProcessor() throws ExecutionException, InterruptedException {
         final int transactionCount = TestProcessor.getTransactionCount();
-        reporter.report(new Transaction());
+        reporter.report(new Transaction(null));
         reporter.flush().get();
 
         assertThat(reporter.getDropped()).isEqualTo(0);

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/ApmServerReporterTest.java
@@ -59,7 +59,7 @@ class ApmServerReporterTest {
     @Test
     void testTransactionProcessor() throws ExecutionException, InterruptedException {
         final int transactionCount = TestProcessor.getTransactionCount();
-        reporter.report(new Transaction(null));
+        reporter.report(new Transaction());
         reporter.flush().get();
 
         assertThat(reporter.getDropped()).isEqualTo(0);

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/ElasticApmApiInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/ElasticApmApiInstrumentation.java
@@ -21,6 +21,7 @@ package co.elastic.apm.plugin.api;
 
 import co.elastic.apm.bci.ElasticApmInstrumentation;
 import co.elastic.apm.bci.VisibleForAdvice;
+
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -75,6 +76,20 @@ public class ElasticApmApiInstrumentation extends ElasticApmInstrumentation {
             }
         }
     }
+    
+    public static class StartAsyncTransactionInstrumentation extends ElasticApmApiInstrumentation {
+        public StartAsyncTransactionInstrumentation() {
+            super(named("doStartAsyncTransaction"));
+        }
+        
+        @VisibleForAdvice
+        @Advice.OnMethodExit
+        private static void doStartAsyncTransaction(@Advice.Return(readOnly = false) Object transaction) {
+            if (tracer != null) {
+                transaction = tracer.startAsyncTransaction();
+            }
+        }
+    }
 
     public static class CurrentTransactionInstrumentation extends ElasticApmApiInstrumentation {
         public CurrentTransactionInstrumentation() {
@@ -125,7 +140,7 @@ public class ElasticApmApiInstrumentation extends ElasticApmInstrumentation {
 
         @VisibleForAdvice
         @Advice.OnMethodEnter
-        private static void captureException(@Advice.Argument(0) @Nullable Exception e) {
+        private static void captureException(@Advice.Argument(0) @Nullable Throwable e) {
             if (tracer != null) {
                 tracer.captureException(e);
             }

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/SpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/SpanInstrumentation.java
@@ -22,6 +22,7 @@ package co.elastic.apm.plugin.api;
 import co.elastic.apm.bci.ElasticApmInstrumentation;
 import co.elastic.apm.bci.VisibleForAdvice;
 import co.elastic.apm.impl.transaction.Span;
+
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -29,6 +30,7 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 
 import static co.elastic.apm.plugin.api.ElasticApmApiInstrumentation.PUBLIC_API_INSTRUMENTATION_GROUP;
+
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/SpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/SpanInstrumentation.java
@@ -89,6 +89,21 @@ public class SpanInstrumentation extends ElasticApmInstrumentation {
             span.setType(type);
         }
     }
+    
+    public static class DoCreateSpanInstrumentation extends SpanInstrumentation {
+        public DoCreateSpanInstrumentation() {
+            super(named("doCreateSpan"));
+        }
+        
+        @VisibleForAdvice
+        @Advice.OnMethodExit
+        public static void doCreateSpan(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Span span,
+                @Advice.Return(readOnly = false) Object result) {
+            if (span != null) {
+                result = span.createSpan();
+            }
+        }
+    }
 
     public static class EndInstrumentation extends SpanInstrumentation {
         public EndInstrumentation() {

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/TransactionInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/TransactionInstrumentation.java
@@ -19,6 +19,9 @@
  */
 package co.elastic.apm.plugin.api;
 
+import static co.elastic.apm.plugin.api.ElasticApmApiInstrumentation.PUBLIC_API_INSTRUMENTATION_GROUP;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
 import co.elastic.apm.bci.ElasticApmInstrumentation;
 import co.elastic.apm.bci.VisibleForAdvice;
 import co.elastic.apm.impl.transaction.Transaction;
@@ -27,9 +30,6 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
-
-import static co.elastic.apm.plugin.api.ElasticApmApiInstrumentation.PUBLIC_API_INSTRUMENTATION_GROUP;
-import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**
  * Injects the actual implementation of the public API class co.elastic.apm.api.TransactionImpl.
@@ -123,6 +123,21 @@ public class TransactionInstrumentation extends ElasticApmInstrumentation {
         @Advice.OnMethodEnter
         public static void end(@Advice.FieldValue(value = "transaction", typing = Assigner.Typing.DYNAMIC) Transaction transaction) {
             transaction.end();
+        }
+    }
+    
+    public static class DoCreateSpanInstrumentation extends TransactionInstrumentation {
+        public DoCreateSpanInstrumentation() {
+            super(named("doCreateSpan"));
+        }
+        
+        @VisibleForAdvice
+        @Advice.OnMethodExit
+        public static void doCreateSpan(@Advice.FieldValue(value = "transaction", typing = Assigner.Typing.DYNAMIC) Transaction transaction,
+                @Advice.Return(readOnly = false) Object span) {
+            if (transaction != null) {
+                span = transaction.createSpan();
+            }
         }
     }
 }

--- a/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.bci.ElasticApmInstrumentation
@@ -8,6 +8,7 @@ co.elastic.apm.plugin.api.TransactionInstrumentation$SetTypeInstrumentation
 co.elastic.apm.plugin.api.TransactionInstrumentation$AddTagInstrumentation
 co.elastic.apm.plugin.api.TransactionInstrumentation$SetUserInstrumentation
 co.elastic.apm.plugin.api.TransactionInstrumentation$EndInstrumentation
+co.elastic.apm.plugin.api.TransactionInstrumentation$DoCreateSpanInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$SetNameInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$SetTypeInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$EndInstrumentation

--- a/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.bci.ElasticApmInstrumentation
@@ -1,4 +1,5 @@
 co.elastic.apm.plugin.api.ElasticApmApiInstrumentation$StartTransactionInstrumentation
+co.elastic.apm.plugin.api.ElasticApmApiInstrumentation$StartAsyncTransactionInstrumentation
 co.elastic.apm.plugin.api.ElasticApmApiInstrumentation$CurrentTransactionInstrumentation
 co.elastic.apm.plugin.api.ElasticApmApiInstrumentation$StartSpanInstrumentation
 co.elastic.apm.plugin.api.ElasticApmApiInstrumentation$CurrentSpanInstrumentation
@@ -11,4 +12,5 @@ co.elastic.apm.plugin.api.TransactionInstrumentation$EndInstrumentation
 co.elastic.apm.plugin.api.TransactionInstrumentation$DoCreateSpanInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$SetNameInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$SetTypeInstrumentation
+co.elastic.apm.plugin.api.SpanInstrumentation$DoCreateSpanInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$EndInstrumentation

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/ElasticApmApiInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/ElasticApmApiInstrumentationTest.java
@@ -20,6 +20,7 @@
 package co.elastic.apm.api;
 
 import co.elastic.apm.AbstractInstrumentationTest;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,6 +31,12 @@ class ElasticApmApiInstrumentationTest extends AbstractInstrumentationTest {
     void testCreateTransaction() {
         assertThat(ElasticApm.startTransaction()).isNotSameAs(NoopTransaction.INSTANCE);
         assertThat(ElasticApm.currentTransaction()).isNotSameAs(NoopTransaction.INSTANCE);
+    }
+
+    @Test
+    void testCreateAsyncTransaction() {
+        assertThat(ElasticApm.startAsyncTransaction()).isNotSameAs(NoopTransaction.INSTANCE);
+        assertThat(ElasticApm.currentTransaction()).isSameAs(NoopTransaction.INSTANCE);
     }
 
     @Test

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/plugin/api/TransactionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/plugin/api/TransactionInstrumentationTest.java
@@ -75,17 +75,24 @@ class TransactionInstrumentationTest extends AbstractInstrumentationTest {
         Span span = transaction.createSpan();
         span.setType("foo");
         span.setName("bar");
-        Span child = transaction.createSpan();
+        Span child = span.createSpan();
         child.setType("foo2");
         child.setName("bar2");
+        Span span3 = transaction.createSpan();
+        span3.setType("foo3");
+        span3.setName("bar3");
+        span3.end();
         child.end();
         span.end();
         endTransaction();
-        assertThat(reporter.getSpans()).hasSize(2);
+        assertThat(reporter.getSpans()).hasSize(3);
         assertThat(reporter.getTransactions()).hasSize(1);
-        assertThat(reporter.getFirstSpan().getType()).isEqualTo("foo2");
-        assertThat(reporter.getFirstSpan().getName().toString()).isEqualTo("bar2");
-        assertThat(reporter.getFirstSpan().getTraceContext().getParentId()).isEqualTo(reporter.getSpans().get(1).getTraceContext().getId());
+        assertThat(reporter.getFirstSpan().getType()).isEqualTo("foo3");
+        assertThat(reporter.getFirstSpan().getName().toString()).isEqualTo("bar3");
+        assertThat(reporter.getSpans().get(1).getType()).isEqualTo("foo2");
+        assertThat(reporter.getSpans().get(1).getName().toString()).isEqualTo("bar2");
+        assertThat(reporter.getSpans().get(1).getTraceContext().getParentId()).isEqualTo(reporter.getSpans().get(2).getTraceContext().getId());
+        assertThat(reporter.getFirstSpan().getTraceContext().getParentId()).isEqualTo(reporter.getFirstTransaction().getTraceContext().getId());
     }
     
     private void endTransaction() {

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/plugin/api/TransactionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/plugin/api/TransactionInstrumentationTest.java
@@ -19,15 +19,15 @@
  */
 package co.elastic.apm.plugin.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-
 import co.elastic.apm.AbstractInstrumentationTest;
 import co.elastic.apm.api.ElasticApm;
 import co.elastic.apm.api.Span;
 import co.elastic.apm.api.Transaction;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 class TransactionInstrumentationTest extends AbstractInstrumentationTest {
 

--- a/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/web/BodyProcessorTest.java
+++ b/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/web/BodyProcessorTest.java
@@ -22,6 +22,7 @@ package co.elastic.apm.web;
 import co.elastic.apm.configuration.SpyConfiguration;
 import co.elastic.apm.impl.error.ErrorCapture;
 import co.elastic.apm.impl.transaction.Transaction;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.stagemonitor.configuration.ConfigurationRegistry;
@@ -115,7 +116,7 @@ class BodyProcessorTest {
     }
 
     private Transaction processTransaction() {
-        final Transaction transaction = new Transaction();
+        final Transaction transaction = new Transaction(null);
         transaction.getContext().getRequest().withRawBody("foo");
         bodyProcessor.processBeforeReport(transaction);
         return transaction;

--- a/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/web/BodyProcessorTest.java
+++ b/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/web/BodyProcessorTest.java
@@ -116,7 +116,7 @@ class BodyProcessorTest {
     }
 
     private Transaction processTransaction() {
-        final Transaction transaction = new Transaction(null);
+        final Transaction transaction = new Transaction();
         transaction.getContext().getRequest().withRawBody("foo");
         bodyProcessor.processBeforeReport(transaction);
         return transaction;

--- a/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/web/SanitizingWebProcessorTest.java
+++ b/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/web/SanitizingWebProcessorTest.java
@@ -41,7 +41,7 @@ class SanitizingWebProcessorTest {
 
     @Test
     void processTransactions() {
-        Transaction transaction = new Transaction(null);
+        Transaction transaction = new Transaction();
         fillContext(transaction.getContext());
 
         processor.processBeforeReport(transaction);

--- a/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/web/SanitizingWebProcessorTest.java
+++ b/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/web/SanitizingWebProcessorTest.java
@@ -23,6 +23,7 @@ import co.elastic.apm.configuration.SpyConfiguration;
 import co.elastic.apm.impl.context.Context;
 import co.elastic.apm.impl.error.ErrorCapture;
 import co.elastic.apm.impl.transaction.Transaction;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +41,7 @@ class SanitizingWebProcessorTest {
 
     @Test
     void processTransactions() {
-        Transaction transaction = new Transaction();
+        Transaction transaction = new Transaction(null);
         fillContext(transaction.getContext());
 
         processor.processBeforeReport(transaction);


### PR DESCRIPTION
This is convenient feature to use in reactive environment where it is not possible to use thread locals across the transaction lifecycle.