### PR TITLE
Add AbstractSpan#captureException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,5 +7,7 @@
    and are thus not available via `ElasticApm.activeTransaction` and `ElasticApm.activeSpan`.
 
 ## Features
+ * Add `Span#captureException` and `Transaction#captureException` to public API.
+   `ElasticApm.captureException` is deprecated now. Use `ElasticApm.currentSpan().captureException(exception)` instead.
 
 ## Bug Fixes

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/ElasticApm.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/ElasticApm.java
@@ -59,7 +59,7 @@ public class ElasticApm {
      *     transaction.setType(Transaction.TYPE_REQUEST);
      *     // do your thing...
      * } catch (Exception e) {
-     *     ElasticApm.captureException(e);
+     *     transaction.captureException(e);
      *     throw e;
      * } finally {
      *     transaction.end();
@@ -105,6 +105,11 @@ public class ElasticApm {
      * If there is no current span, this method will return a noop span,
      * which means that you never have to check for {@code null} values.
      * </p>
+     * <p>
+     * Note that even if this method is returning a noop span,
+     * you can still {@link Span#captureException(Throwable) capture exceptions} on it.
+     * These exceptions will not have a link to a Span or a Transaction.
+     * </p>
      *
      * @return The currently active span, or transaction, or a noop span (never {@code null}).
      */
@@ -123,7 +128,9 @@ public class ElasticApm {
      * Captures an exception and reports it to the APM server.
      *
      * @param e the exception to record
+     * @deprecated use {@link #currentSpan()}.{@link Span#captureException(Throwable) captureException(Throwable)} instead
      */
+    @Deprecated
     public static void captureException(@Nullable Throwable e) {
         // co.elastic.apm.api.ElasticApmInstrumentation.CaptureExceptionInstrumentation.captureException
     }

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/NoopSpan.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/NoopSpan.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,6 +35,11 @@ enum NoopSpan implements Span {
     @Override
     public void end() {
         // noop
+    }
+
+    @Override
+    public void captureException(Throwable throwable) {
+        // co.elastic.apm.plugin.api.CaptureExceptionInstrumentation
     }
 
     @Override

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/NoopTransaction.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/NoopTransaction.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,6 +46,11 @@ enum NoopTransaction implements Transaction {
     @Override
     public void end() {
         // noop
+    }
+
+    @Override
+    public void captureException(Throwable throwable) {
+        // co.elastic.apm.plugin.api.CaptureExceptionInstrumentation
     }
 
     @Override

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/Span.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/Span.java
@@ -69,7 +69,7 @@ public interface Span {
      *     span.setType("db.mysql.query");
      *     // do your thing...
      * } catch (Exception e) {
-     *     ElasticApm.captureException(e);
+     *     span.captureException(e);
      *     throw e;
      * } finally {
      *     span.end();
@@ -85,5 +85,11 @@ public interface Span {
      * If the span has already ended, nothing happens.
      */
     void end();
+
+    /**
+     *
+     * @param throwable
+     */
+    void captureException(Throwable throwable);
 
 }

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/SpanImpl.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/SpanImpl.java
@@ -65,4 +65,9 @@ class SpanImpl implements Span {
         // co.elastic.apm.plugin.api.SpanInstrumentation$EndInstrumentation.end
     }
 
+    @Override
+    public void captureException(Throwable throwable) {
+        // co.elastic.apm.plugin.api.SpanInstrumentation.CaptureExceptionInstrumentation
+    }
+
 }

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/TransactionImpl.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/TransactionImpl.java
@@ -65,6 +65,11 @@ class TransactionImpl implements Transaction {
     }
 
     @Override
+    public void captureException(Throwable throwable) {
+        // co.elastic.apm.plugin.api.TransactionInstrumentation.CaptureExceptionInstrumentation
+    }
+
+    @Override
     public Span createSpan() {
         Object span = doCreateSpan();
         return span != null ? new SpanImpl(span) : NoopSpan.INSTANCE;

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/AbstractSpan.java
@@ -182,4 +182,12 @@ public abstract class AbstractSpan<T extends AbstractSpan> implements Recyclable
         this.type = type;
         return (T) this;
     }
+
+    public void captureException(Throwable t) {
+        captureException(System.currentTimeMillis(), t);
+    }
+
+    public void captureException(long epochTimestampMillis, Throwable t) {
+        tracer.captureException(epochTimestampMillis, t, this);
+    }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/ElasticApmTracerTest.java
@@ -171,7 +171,7 @@ class ElasticApmTracerTest {
         Transaction transaction = tracerImpl.startTransaction();
         try (Scope scope = transaction.activateInScope()) {
             transaction.getContext().getRequest().addHeader("foo", "bar");
-            tracerImpl.captureException(new Exception("test"));
+            tracerImpl.currentTransaction().captureException(new Exception("test"));
             assertThat(reporter.getErrors()).hasSize(1);
             ErrorCapture error = reporter.getFirstError();
             assertThat(error.getTraceContext().isChildOf(transaction.getTraceContext())).isTrue();

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/CaptureExceptionInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/CaptureExceptionInstrumentation.java
@@ -1,0 +1,56 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.plugin.api;
+
+import co.elastic.apm.bci.ElasticApmInstrumentation;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import static co.elastic.apm.plugin.api.ElasticApmApiInstrumentation.PUBLIC_API_INSTRUMENTATION_GROUP;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+public class CaptureExceptionInstrumentation extends ElasticApmInstrumentation {
+
+    @Advice.OnMethodEnter
+    public static void captureException(@Advice.Argument(0) Throwable t) {
+        if (tracer != null) {
+            tracer.captureException(System.currentTimeMillis(), t, null);
+        }
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named("co.elastic.apm.api.NoopTransaction").or(
+            named("co.elastic.apm.api.NoopSpan"));
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named("captureException").and(takesArguments(Throwable.class));
+    }
+
+    @Override
+    public String getInstrumentationGroupName() {
+        return PUBLIC_API_INSTRUMENTATION_GROUP;
+    }
+}

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/SpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/SpanInstrumentation.java
@@ -30,6 +30,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 import static co.elastic.apm.plugin.api.ElasticApmApiInstrumentation.PUBLIC_API_INSTRUMENTATION_GROUP;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 /**
  * Injects the actual implementation of the public API class co.elastic.apm.api.SpanImpl.
@@ -110,6 +111,20 @@ public class SpanInstrumentation extends ElasticApmInstrumentation {
         @Advice.OnMethodEnter
         public static void end(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) AbstractSpan<?> span) {
             span.end();
+        }
+    }
+
+
+    public static class CaptureExceptionInstrumentation extends SpanInstrumentation {
+        public CaptureExceptionInstrumentation() {
+            super(named("captureException").and(takesArguments(Throwable.class)));
+        }
+
+        @VisibleForAdvice
+        @Advice.OnMethodExit
+        public static void doCreateSpan(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) AbstractSpan<?> span,
+                                        @Advice.Argument(0) Throwable t) {
+            span.captureException(t);
         }
     }
 }

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/TransactionInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/TransactionInstrumentation.java
@@ -30,6 +30,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 import static co.elastic.apm.plugin.api.ElasticApmApiInstrumentation.PUBLIC_API_INSTRUMENTATION_GROUP;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
 /**
  * Injects the actual implementation of the public API class co.elastic.apm.api.TransactionImpl.
@@ -136,6 +137,19 @@ public class TransactionInstrumentation extends ElasticApmInstrumentation {
         public static void doCreateSpan(@Advice.FieldValue(value = "transaction", typing = Assigner.Typing.DYNAMIC) Transaction transaction,
                                         @Advice.Return(readOnly = false) Object span) {
             span = transaction.createSpan();
+        }
+    }
+
+    public static class CaptureExceptionInstrumentation extends TransactionInstrumentation {
+        public CaptureExceptionInstrumentation() {
+            super(named("captureException").and(takesArguments(Throwable.class)));
+        }
+
+        @VisibleForAdvice
+        @Advice.OnMethodExit
+        public static void doCreateSpan(@Advice.FieldValue(value = "transaction", typing = Assigner.Typing.DYNAMIC) Transaction transaction,
+                                        @Advice.Argument(0) Throwable t) {
+            transaction.captureException(t);
         }
     }
 }

--- a/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.bci.ElasticApmInstrumentation
@@ -8,7 +8,10 @@ co.elastic.apm.plugin.api.TransactionInstrumentation$AddTagInstrumentation
 co.elastic.apm.plugin.api.TransactionInstrumentation$SetUserInstrumentation
 co.elastic.apm.plugin.api.TransactionInstrumentation$EndInstrumentation
 co.elastic.apm.plugin.api.TransactionInstrumentation$DoCreateSpanInstrumentation
+co.elastic.apm.plugin.api.TransactionInstrumentation$CaptureExceptionInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$SetNameInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$SetTypeInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$DoCreateSpanInstrumentation
 co.elastic.apm.plugin.api.SpanInstrumentation$EndInstrumentation
+co.elastic.apm.plugin.api.SpanInstrumentation$CaptureExceptionInstrumentation
+co.elastic.apm.plugin.api.CaptureExceptionInstrumentation

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/ElasticApmApiInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/ElasticApmApiInstrumentationTest.java
@@ -55,6 +55,23 @@ class ElasticApmApiInstrumentationTest extends AbstractInstrumentationTest {
     }
 
     @Test
+    void testCaptureExceptionNoopSpan() {
+        ElasticApm.currentSpan().captureException(new RuntimeException("Bazinga"));
+        assertThat(reporter.getErrors()).hasSize(1);
+    }
+
+    @Test
+    void testTransactionWithError() {
+        final Transaction transaction = ElasticApm.startTransaction();
+        transaction.setType("request");
+        transaction.setName("transaction");
+        transaction.captureException(new RuntimeException("Bazinga"));
+        transaction.end();
+        assertThat(reporter.getTransactions()).hasSize(1);
+        assertThat(reporter.getErrors()).hasSize(1);
+    }
+
+    @Test
     void testCreateChildSpanOfCurrentTransaction() {
         final co.elastic.apm.impl.transaction.Transaction  transaction = tracer.startTransaction().withType("request").withName("transaction").activate();
         final Span span = ElasticApm.currentSpan().createSpan();

--- a/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/opentracing/impl/ApmSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/opentracing/impl/ApmSpanInstrumentation.java
@@ -121,11 +121,12 @@ public class ApmSpanInstrumentation extends ElasticApmInstrumentation {
 
         @VisibleForAdvice
         @Advice.OnMethodEnter(inline = false)
-        public static void createError(@Advice.Argument(0) long epochTimestampMillis,
+        public static void createError(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) @Nullable AbstractSpan<?> span,
+                                       @Advice.Argument(0) long epochTimestampMillis,
                                        @Advice.Argument(1) Map<String, ?> fields) {
             final Object errorObject = fields.get("error.object");
-            if (tracer != null && errorObject instanceof Exception) {
-                tracer.captureException(epochTimestampMillis, (Exception) errorObject);
+            if (span != null && errorObject instanceof Throwable) {
+                span.captureException(epochTimestampMillis, (Throwable) errorObject);
             }
         }
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletTransactionHelper.java
@@ -129,7 +129,7 @@ public class ServletTransactionHelper {
             transaction.withResult(ResultUtil.getResultByHttpStatus(status));
             transaction.withType("request");
             if (exception != null) {
-                tracer.captureException(exception);
+                transaction.captureException(exception);
             }
         } catch (RuntimeException e) {
             // in case we screwed up, don't bring down the monitored application with us

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/servlet/ApmFilterTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/servlet/ApmFilterTest.java
@@ -185,7 +185,7 @@ class ApmFilterTest extends AbstractInstrumentationTest {
         filterChain = new MockFilterChain(new HttpServlet() {
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
-                tracer.captureException(new RuntimeException("Test exception capturing"));
+                tracer.getActive().captureException(new RuntimeException("Test exception capturing"));
             }
         });
 
@@ -202,7 +202,7 @@ class ApmFilterTest extends AbstractInstrumentationTest {
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
                 tracer.currentTransaction().setUser("id", "email", "username");
-                tracer.captureException(new RuntimeException("Test exception capturing"));
+                tracer.getActive().captureException(new RuntimeException("Test exception capturing"));
             }
         });
 
@@ -219,7 +219,7 @@ class ApmFilterTest extends AbstractInstrumentationTest {
         filterChain = new MockFilterChain(new HttpServlet() {
             @Override
             protected void doGet(HttpServletRequest req, HttpServletResponse resp) {
-                tracer.captureException(new RuntimeException("Test exception capturing"));
+                tracer.getActive().captureException(new RuntimeException("Test exception capturing"));
                 tracer.currentTransaction().setUser("id", "email", "username");
             }
         });

--- a/apm-opentracing/src/test/java/co/elastic/apm/opentracing/OpenTracingBridgeTest.java
+++ b/apm-opentracing/src/test/java/co/elastic/apm/opentracing/OpenTracingBridgeTest.java
@@ -177,6 +177,25 @@ class OpenTracingBridgeTest extends AbstractInstrumentationTest {
         assertThat(reporter.getErrors()).hasSize(1);
         assertThat(reporter.getFirstError().getException().getMessage()).isEqualTo("Catch me if you can");
         assertThat(reporter.getFirstError().getException().getStacktrace()).isNotEmpty();
+        assertThat(reporter.getFirstError().getTraceContext().getParentId()).isEqualTo(reporter.getFirstTransaction().getTraceContext().getId());
+    }
+
+    @Test
+    void testErrorLoggingWithoutScope() {
+        Span span = apmTracer.buildSpan("someWork").start();
+        try {
+            throw new RuntimeException("Catch me if you can");
+        } catch (Exception ex) {
+            Tags.ERROR.set(span, true);
+            span.log(Map.of(Fields.EVENT, "error", Fields.ERROR_OBJECT, ex, Fields.MESSAGE, ex.getMessage()));
+        } finally {
+            span.finish();
+        }
+        assertThat(reporter.getTransactions()).hasSize(1);
+        assertThat(reporter.getErrors()).hasSize(1);
+        assertThat(reporter.getFirstError().getException().getMessage()).isEqualTo("Catch me if you can");
+        assertThat(reporter.getFirstError().getException().getStacktrace()).isNotEmpty();
+        assertThat(reporter.getFirstError().getTraceContext().getParentId()).isEqualTo(reporter.getFirstTransaction().getTraceContext().getId());
     }
 
     @Test

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -348,7 +348,7 @@ Sets the logging level for the agent.
 [options="header"]
 |============
 | Java System Properties      | Environment
-| `elastic.apm.logging.log_level` | `ELASTIC_APM_LOGGING.LOG_LEVEL`
+| `elastic.apm.logging.log_level` | `ELASTIC_APM_LOGGING_LOG_LEVEL`
 |============
 
 [float]
@@ -376,7 +376,7 @@ it's content is deleted when the application starts.
 [options="header"]
 |============
 | Java System Properties      | Environment
-| `elastic.apm.logging.log_file` | `ELASTIC_APM_LOGGING.LOG_FILE`
+| `elastic.apm.logging.log_file` | `ELASTIC_APM_LOGGING_LOG_FILE`
 |============
 
 [[config-reporter]]

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -68,6 +68,10 @@ If there is no current span,
 this method will return a noop span,
 which means that you never have to check for `null` values.
 
+Note that even if this method is returning a noop span,
+you can still <<api-span-capture-exception,capture exceptions>> on it.
+These exceptions will not have a link to a Span or a Transaction.
+
 [source,java]
 ----
 import co.elastic.apm.api.ElasticApm;
@@ -97,18 +101,13 @@ try {
     transaction.setType(Transaction.TYPE_REQUEST);
     // do your thing...
 } catch (Exception e) {
-    ElasticApm.captureException(e);
+    transaction.captureException(e);
     throw e;
 } finally {
     transaction.end();
 }
 ----
 
-
-[float]
-[[api-capture-exception]]
-==== `void captureException(Exception e)`
-Captures an exception and reports it to the APM server.
 
 //----------------------------
 [float]
@@ -197,6 +196,12 @@ transaction.setUser(user.getId(), user.getEmail(), user.getUsername());
 
 
 [float]
+[[api-transaction-capture-exception]]
+==== `void captureException(Exception e)`
+Captures an exception and reports it to the APM server.
+
+
+[float]
 [[api-transaction-start-span]]
 ==== `Span createSpan()`
 Start and return a new custom span as a child of this transaction.
@@ -276,6 +281,12 @@ the following are standardized across all Elastic APM agents: `app`, `db`, `cach
 * `type`: the type of the span
 
 [float]
+[[api-span-capture-exception]]
+==== `void captureException(Exception e)`
+Captures an exception and reports it to the APM server.
+
+
+[float]
 [[api-span-end]]
 ==== `void end()`
 Ends the span.
@@ -299,7 +310,7 @@ try {
     span.setType("db.mysql.query");
     // do your thing...
 } catch (Exception e) {
-    ElasticApm.captureException(e);
+    span.captureException(e);
     throw e;
 } finally {
     span.end();

--- a/elastic-apm-agent/src/test/resources/configuration.asciidoc.ftl
+++ b/elastic-apm-agent/src/test/resources/configuration.asciidoc.ftl
@@ -54,7 +54,7 @@ ${option.description}
 [options="header"]
 |============
 | Java System Properties      | Environment
-| `elastic.apm.${option.key}` | `ELASTIC_APM_${option.key?upper_case}`
+| `elastic.apm.${option.key}` | `ELASTIC_APM_${option.key?upper_case?replace(".", "_")}`
 |============
 
         </#if>


### PR DESCRIPTION
Linking an exception to a Transaction or Span should be explicit
instead of implicitly linking it to the active span.

`ElasticApm.captureException` is deprecated now.
Use `ElasticApm.currentSpan().captureException(exception)` instead.