### PR TITLE
Fix bug in intake v2 when log level is DEBUG

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/PayloadSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/PayloadSerializer.java
@@ -51,7 +51,7 @@ public interface PayloadSerializer {
      * Flushes the {@link OutputStream} which has been set via {@link #setOutputStream(OutputStream)}
      * and detaches that {@link OutputStream} from the serializer.
      */
-    void flush();
+    void flush() throws IOException;
 
     /**
      * Gets the number of bytes which are currently buffered


### PR DESCRIPTION
When DEBUG logs are active the agent logs the JSON of the Transaction objects it serializes.
When serializing the transaction to a String, which is only done when it should be logged, it resets the JsonWriter which detaches the request body's OutputStream form the JsonWriter.

The solution is to buffer the serialized bytes when the payload should be logged. When the request is about to end, log the buffered bytes as a String and write the bytes to the underlying OutputStream.