### PR TITLE
Remove field limit for SQL queries

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
@@ -564,10 +564,10 @@ public class DslJsonSerializer implements PayloadSerializer {
         writeFieldName("db");
         jw.writeByte(OBJECT_START);
         final Db db = context.getDb();
-        writeField("instance", db.getInstance());
-        writeField("statement", db.getStatement());
-        writeField("type", db.getType());
-        writeField("user", db.getUser());
+        writeFieldUnlimited("instance", db.getInstance());
+        writeFieldUnlimited("statement", db.getStatement());
+        writeFieldUnlimited("type", db.getType());
+        writeFieldUnlimited("user", db.getUser());
         writeFieldName("tags");
         serializeTags(context.getTags());
         jw.writeByte(OBJECT_END);
@@ -770,6 +770,14 @@ public class DslJsonSerializer implements PayloadSerializer {
         }
     }
 
+    void writeFieldUnlimited(final String fieldName, @Nullable final String value) {
+        if (value != null) {
+            writeFieldName(fieldName);
+            writeStringValueUnlimited(value);
+            jw.writeByte(COMMA);
+        }
+    }
+
     private void writeStringBuilderValue(StringBuilder value) {
         if (value.length() > MAX_VALUE_LENGTH) {
             value.setLength(MAX_VALUE_LENGTH - 1);
@@ -786,6 +794,10 @@ public class DslJsonSerializer implements PayloadSerializer {
         } else {
             jw.writeString(value);
         }
+    }
+	/*Write the string value with no limit applied on the string length. Enabled for Span context*/
+    private void writeStringValueUnlimited(String value) {
+          jw.writeString(value);
     }
 
     private void writeField(final String fieldName, final long value) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/report/serialize/DslJsonSerializerTest.java
@@ -71,11 +71,13 @@ class DslJsonSerializerTest {
         serializer.jw.writeByte(JsonWriter.OBJECT_START);
         serializer.writeField("stringBuilder", longValue);
         serializer.writeField("string", longValue.toString());
+        serializer.writeFieldUnlimited("stringUnlimited", longValue.toString());
         serializer.writeLastField("lastString", longValue.toString());
         serializer.jw.writeByte(JsonWriter.OBJECT_END);
         final JsonNode jsonNode = objectMapper.readTree(serializer.jw.toString());
         assertThat(jsonNode.get("stringBuilder").textValue()).hasSize(DslJsonSerializer.MAX_VALUE_LENGTH).endsWith("…");
         assertThat(jsonNode.get("string").textValue()).hasSize(DslJsonSerializer.MAX_VALUE_LENGTH).endsWith("…");
+        assertThat(jsonNode.get("stringUnlimited").textValue()).hasSize(DslJsonSerializer.MAX_VALUE_LENGTH+1).endsWith("0");
         assertThat(jsonNode.get("lastString").textValue()).hasSize(DslJsonSerializer.MAX_VALUE_LENGTH).endsWith("…");
     }
 


### PR DESCRIPTION
Fix for issue #176. 

(1) The fix was done on DslJsonSerializer.java to add 2 new methods and modified serializeSpanContext method specifically.

(2) Modified testLimitStringValueLength method in DslJsonSerializerTest.java for testing the string length values for newly added method