### PR TITLE
Enable complex wildcard patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 # next version
 
 ## Breaking changes
+ * Wildcard patterns are case insensitive by default. Prepend `(?-i)` to make the matching case sensitive.
 
 ## Features
+ * Wildcard patterns are now not limited to only one wildcard in the middle and can be arbitrarily complex now.
+   Example: `*foo*bar*baz`.
 
 ## Bug Fixes
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/configuration/CoreConfiguration.java
@@ -148,20 +148,19 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .dynamic(true)
         .tags("security")
         .buildWithDefault(Arrays.asList(
-            WildcardMatcher.valueOf("(?i)password"),
-            WildcardMatcher.valueOf("(?i)passwd"),
-            WildcardMatcher.valueOf("(?i)pwd"),
-            WildcardMatcher.valueOf("(?i)secret"),
-            WildcardMatcher.valueOf("(?i)token"),
-            WildcardMatcher.valueOf("(?i)*key"),
-            WildcardMatcher.valueOf("(?i)*token"),
-            WildcardMatcher.valueOf("(?i)*session*"),
-            WildcardMatcher.valueOf("(?i)*credit*"),
-            WildcardMatcher.valueOf("(?i)*card*"),
+            WildcardMatcher.valueOf("password"),
+            WildcardMatcher.valueOf("passwd"),
+            WildcardMatcher.valueOf("pwd"),
+            WildcardMatcher.valueOf("secret"),
+            WildcardMatcher.valueOf("*key"),
+            WildcardMatcher.valueOf("*token*"),
+            WildcardMatcher.valueOf("*session*"),
+            WildcardMatcher.valueOf("*credit*"),
+            WildcardMatcher.valueOf("*card*"),
             // HTTP request header for basic auth, contains passwords
-            WildcardMatcher.valueOf("(?i)authorization"),
+            WildcardMatcher.valueOf("authorization"),
             // HTTP response header which can contain session ids
-            WildcardMatcher.valueOf("(?i)set-cookie")
+            WildcardMatcher.valueOf("set-cookie")
         ));
 
     private final ConfigurationOption<Boolean> distributedTracing = ConfigurationOption.booleanOption()

--- a/apm-agent-core/src/test/java/co/elastic/apm/matcher/WildcardMatcherTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/matcher/WildcardMatcherTest.java
@@ -22,7 +22,9 @@ package co.elastic.apm.matcher;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
+import java.util.List;
 
+import static co.elastic.apm.matcher.WildcardMatcher.indexOfIgnoreCase;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class WildcardMatcherTest {
@@ -53,10 +55,114 @@ class WildcardMatcherTest {
     }
 
     @Test
-    void testInvalidExpressions() {
+    void testCompoundWildcardMatcher() {
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("*foo*foo*");
         assertSoftly(softly -> {
-            softly.assertThatThrownBy(() -> WildcardMatcher.valueOf("/foo/*/baz*")).isInstanceOf(IllegalArgumentException.class);
-            softly.assertThatThrownBy(() -> WildcardMatcher.valueOf("/foo/*/bar/*/baz")).isInstanceOf(IllegalArgumentException.class);
+            softly.assertThat(matcher.toString()).isEqualTo("*foo*foo*");
+            softly.assertThat(matcher.matches("foofoo")).isTrue();
+            softly.assertThat(matcher.matches("foo/bar/foo")).isTrue();
+            softly.assertThat(matcher.matches("/foo/bar/foo/bar")).isTrue();
+            softly.assertThat(matcher.matches("foo")).isFalse();
+        });
+    }
+
+    @Test
+    void testCompoundWildcardMatcher3() {
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("*foo*oo*");
+        assertSoftly(softly -> {
+            softly.assertThat(matcher.toString()).isEqualTo("*foo*oo*");
+            softly.assertThat(matcher.matches("foooo")).isTrue();
+            softly.assertThat(matcher.matches("foofoo")).isTrue();
+            softly.assertThat(matcher.matches("foo/bar/foo")).isTrue();
+            softly.assertThat(matcher.matches("/foo/bar/foo/bar")).isTrue();
+            softly.assertThat(matcher.matches("foo")).isFalse();
+            softly.assertThat(matcher.matches("fooo")).isFalse();
+        });
+    }
+
+    @Test
+    void testCompoundWildcardMatcher2() {
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("*foo*bar*");
+        assertSoftly(softly -> {
+            softly.assertThat(matcher.toString()).isEqualTo("*foo*bar*");
+            softly.assertThat(matcher.matches("foobar")).isTrue();
+            softly.assertThat(matcher.matches("foo/bar/foo/baz")).isTrue();
+            softly.assertThat(matcher.matches("/foo/bar/baz")).isTrue();
+            softly.assertThat(matcher.matches("bar/foo")).isFalse();
+            softly.assertThat(matcher.matches("barfoo")).isFalse();
+        });
+    }
+
+    @Test
+    void testCompoundWildcardMatcher4() {
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("*foo*far*");
+        assertSoftly(softly -> {
+            softly.assertThat(matcher.toString()).isEqualTo("*foo*far*");
+            softly.assertThat(matcher.matches("foofar")).isTrue();
+            softly.assertThat(matcher.matches("foo/far/foo/baz")).isTrue();
+            softly.assertThat(matcher.matches("/foo/far/baz")).isTrue();
+            softly.assertThat(matcher.matches("/far/foo")).isFalse();
+            softly.assertThat(matcher.matches("farfoo")).isFalse();
+        });
+    }
+
+    @Test
+    void testMatchBetween() {
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("*foo*foo*");
+        assertSoftly(softly -> {
+            softly.assertThat(matcher.toString()).isEqualTo("*foo*foo*");
+            softly.assertThat(matcher.matches("foofoo")).isTrue();
+            softly.assertThat(matcher.matches("foofo", "o")).isTrue();
+            softly.assertThat(matcher.matches("foof", "oo")).isTrue();
+            softly.assertThat(matcher.matches("foo", "foo")).isTrue();
+            softly.assertThat(matcher.matches("fo", "ofoo")).isTrue();
+            softly.assertThat(matcher.matches("f", "oofoo")).isTrue();
+            softly.assertThat(matcher.matches("foo/foo/foo/baz")).isTrue();
+            softly.assertThat(matcher.matches("/foo/foo/baz")).isTrue();
+            softly.assertThat(matcher.matches("/foo/foo")).isTrue();
+            softly.assertThat(matcher.matches("foobar")).isFalse();
+        });
+    }
+
+    @Test
+    void testCharAt() {
+        assertSoftly(softly -> {
+            softly.assertThat(WildcardMatcher.SimpleWildcardMatcher.charAt(0, "foo", "bar", "foo".length())).isEqualTo('f');
+            softly.assertThat(WildcardMatcher.SimpleWildcardMatcher.charAt(1, "foo", "bar", "foo".length())).isEqualTo('o');
+            softly.assertThat(WildcardMatcher.SimpleWildcardMatcher.charAt(2, "foo", "bar", "foo".length())).isEqualTo('o');
+            softly.assertThat(WildcardMatcher.SimpleWildcardMatcher.charAt(3, "foo", "bar", "foo".length())).isEqualTo('b');
+            softly.assertThat(WildcardMatcher.SimpleWildcardMatcher.charAt(4, "foo", "bar", "foo".length())).isEqualTo('a');
+            softly.assertThat(WildcardMatcher.SimpleWildcardMatcher.charAt(5, "foo", "bar", "foo".length())).isEqualTo('r');
+        });
+    }
+
+    @Test
+    void testIndexOfIgnoreCase() {
+        assertSoftly(softly -> {
+            softly.assertThat(indexOfIgnoreCase( "foo", "foo", "foo", false, 0, 6)).isEqualTo(0);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "foo", false, 0, 6)).isEqualTo(0);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "oob", false, 0, 6)).isEqualTo(1);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "oba", false, 0, 6)).isEqualTo(2);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "bar", false, 0, 6)).isEqualTo(3);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "o", false, 0, 6)).isEqualTo(1);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "ob", false, 0, 6)).isEqualTo(2);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "ooba", false, 0, 6)).isEqualTo(1);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "oobar", false, 0, 6)).isEqualTo(1);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "fooba", false, 0, 6)).isEqualTo(0);
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "foobar", false, 0, 6)).isEqualTo(0);
+            softly.assertThat(indexOfIgnoreCase( "afoo", "bar", "oba", false, 0, 7)).isEqualTo(3);
+            softly.assertThat(indexOfIgnoreCase( "afoo", "bara", "oba", false, 0, 8)).isEqualTo(3);
+            softly.assertThat(indexOfIgnoreCase( "aafoo", "baraa", "oba", false, 0, 10)).isEqualTo(4);
+
+            softly.assertThat(indexOfIgnoreCase( "foo", "bar", "ara", false, 0, 6)).isEqualTo(-1);
+        });
+    }
+
+    @Test
+    void testComplexExpressions() {
+        assertSoftly(softly -> {
+            softly.assertThat(WildcardMatcher.valueOf("/foo/*/baz*").matches("/foo/a/bar/b/baz")).isTrue();
+            softly.assertThat(WildcardMatcher.valueOf("/foo/*/bar/*/baz").matches("/foo/a/bar/b/baz")).isTrue();
         });
     }
 
@@ -192,9 +298,9 @@ class WildcardMatcherTest {
 
     @Test
     void testMatchesStartsWith_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)foo*");
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("foo*");
         assertSoftly(softly -> {
-            softly.assertThat(matcher.toString()).isEqualTo("(?i)foo*");
+            softly.assertThat(matcher.toString()).isEqualTo("foo*");
             softly.assertThat(matcher.matches("foo")).isTrue();
             softly.assertThat(matcher.matches("foobar")).isTrue();
             softly.assertThat(matcher.matches("bar")).isFalse();
@@ -204,9 +310,9 @@ class WildcardMatcherTest {
 
     @Test
     void testInfixEmptyMatcher_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)**");
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("**");
         assertSoftly(softly -> {
-            softly.assertThat(matcher.toString()).isEqualTo("(?i)**");
+            softly.assertThat(matcher.toString()).isEqualTo("**");
             softly.assertThat(matcher.matches("")).isTrue();
             softly.assertThat(matcher.matches("foo")).isTrue();
         });
@@ -214,7 +320,7 @@ class WildcardMatcherTest {
 
     @Test
     void testMatchesPartitionedStringStartsWith_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)/foo/bar*");
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("/foo/bar*");
         assertSoftly(softly -> {
             softly.assertThat(matcher.matches("/foo/bAR/Baz", "")).isTrue();
             softly.assertThat(matcher.matches("", "/foo/bAR/baz")).isTrue();
@@ -229,9 +335,9 @@ class WildcardMatcherTest {
 
     @Test
     void testMatchesEndsWith_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)*foo");
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("*foo");
         assertSoftly(softly -> {
-            softly.assertThat(matcher.toString()).isEqualTo("(?i)*foo");
+            softly.assertThat(matcher.toString()).isEqualTo("*foo");
             softly.assertThat(matcher.matches("fOo")).isTrue();
             softly.assertThat(matcher.matches("foobar")).isFalse();
             softly.assertThat(matcher.matches("bar")).isFalse();
@@ -241,7 +347,7 @@ class WildcardMatcherTest {
 
     @Test
     void testMatchesPartitionedStringEndsWith_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)*/bar/baz");
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("*/bar/baz");
         assertSoftly(softly -> {
             softly.assertThat(matcher.matches("/foO/BAR/Baz", "")).isTrue();
             softly.assertThat(matcher.matches("", "/foO/Bar/baz")).isTrue();
@@ -255,9 +361,9 @@ class WildcardMatcherTest {
 
     @Test
     void testMatchesEquals_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)foo");
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("foo");
         assertSoftly(softly -> {
-            softly.assertThat(matcher.toString()).isEqualTo("(?i)foo");
+            softly.assertThat(matcher.toString()).isEqualTo("foo");
             softly.assertThat(matcher.matches("fOo")).isTrue();
             softly.assertThat(matcher.matches("foOBar")).isFalse();
             softly.assertThat(matcher.matches("BAR")).isFalse();
@@ -267,9 +373,9 @@ class WildcardMatcherTest {
 
     @Test
     void testMatchesInfix_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)*foo*");
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("*foo*");
         assertSoftly(softly -> {
-            softly.assertThat(matcher.toString()).isEqualTo("(?i)*foo*");
+            softly.assertThat(matcher.toString()).isEqualTo("*foo*");
             softly.assertThat(matcher.matches("FOO")).isTrue();
             softly.assertThat(matcher.matches("foOBar")).isTrue();
             softly.assertThat(matcher.matches("BAR")).isFalse();
@@ -279,41 +385,56 @@ class WildcardMatcherTest {
     }
 
     @Test
-    void testMatchesInfixPartitionedString_allocationFree_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)*foo*");
+    void testMatchesInfix_caseSensitive() {
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?-i)*foo*");
         assertSoftly(softly -> {
-            softly.assertThat(matcher.toString()).isEqualTo("(?i)*foo*");
+            softly.assertThat(matcher.toString()).isEqualTo("(?-i)*foo*");
+            softly.assertThat(matcher.matches("foo")).isTrue();
+            softly.assertThat(matcher.matches("FOO")).isFalse();
+        });
+    }
+
+    @Test
+    void testMatchesInfixPartitionedString_ignoreCase() {
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("*foo*");
+        assertSoftly(softly -> {
+            softly.assertThat(matcher.toString()).isEqualTo("*foo*");
             // no allocations necessary
             softly.assertThat(matcher.matches("foo", "BAR")).isTrue();
             softly.assertThat(matcher.matches("BAR", "foo")).isTrue();
             softly.assertThat(matcher.matches("baRFoo", "baz")).isTrue();
             softly.assertThat(matcher.matches("bA", "Rfoo")).isTrue();
-        });
-    }
-
-    @Test
-    void testMatchesInfixPartitionedString_notAllocationFree_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)*foo*");
-        assertSoftly(softly -> {
-            softly.assertThat(matcher.toString()).isEqualTo("(?i)*foo*");
-            // requires concatenating the string
             softly.assertThat(matcher.matches("fo", "O")).isTrue();
             softly.assertThat(matcher.matches("barFO", "obaz")).isTrue();
-            softly.assertThat(matcher.matches("bar", "baz")).isFalse();
-        });
+            softly.assertThat(matcher.matches("bar", "baz")).isFalse();});
     }
 
     @Test
     void testMatchesNoWildcard_ignoreCase() {
-        final WildcardMatcher matcher = WildcardMatcher.valueOf("(?i)foo");
+        final WildcardMatcher matcher = WildcardMatcher.valueOf("foo");
         assertSoftly(softly -> {
-            softly.assertThat(matcher.toString()).isEqualTo("(?i)foo");
-            // requires concatenating the string
+            softly.assertThat(matcher.toString()).isEqualTo("foo");
             softly.assertThat(matcher.matches("FO", "O")).isTrue();
             softly.assertThat(matcher.matches("FOO")).isTrue();
             softly.assertThat(matcher.matches("foO", "Bar")).isFalse();
             softly.assertThat(matcher.matches("foobar")).isFalse();
 
+        });
+    }
+
+
+    @Test
+    void testNeedleLongerThanHaystack() {
+        assertSoftly(softly -> {
+            softly.assertThat(WildcardMatcher.valueOf("*foo").matches("baz")).isFalse();
+            softly.assertThat(WildcardMatcher.valueOf("*foob").matches("baz")).isFalse();
+            softly.assertThat(WildcardMatcher.valueOf("*fooba").matches("baz")).isFalse();
+            softly.assertThat(WildcardMatcher.valueOf("*foobar").matches("baz")).isFalse();
+            softly.assertThat(WildcardMatcher.valueOf("foo*").matches("baz")).isFalse();
+            softly.assertThat(WildcardMatcher.valueOf("foob*").matches("baz")).isFalse();
+            softly.assertThat(WildcardMatcher.valueOf("fooba*").matches("baz")).isFalse();
+            softly.assertThat(WildcardMatcher.valueOf("foobar*").matches("baz")).isFalse();
+            softly.assertThat(WildcardMatcher.valueOf("*foobar*").matches("baz")).isFalse();
         });
     }
 

--- a/apm-agent-core/src/test/resources/elasticapm.properties
+++ b/apm-agent-core/src/test/resources/elasticapm.properties
@@ -1,4 +1,4 @@
 log_level=DEBUG
 log_file=System.out
 # incubating instrumentations should be active in tests
-disabled_instrumentations=
+disable_instrumentations=

--- a/apm-agent-plugins/apm-web-plugin/src/main/java/co/elastic/apm/web/WebConfiguration.java
+++ b/apm-agent-plugins/apm-web-plugin/src/main/java/co/elastic/apm/web/WebConfiguration.java
@@ -58,6 +58,7 @@ public class WebConfiguration extends ConfigurationOptionProvider {
             "\n" +
             "This property should be set to an array containing one or more strings.\n" +
             "When an incoming HTTP request is detected, its URL will be tested against each element in this list.\n" +
+            "\n" +
             WildcardMatcher.DOCUMENTATION + "\n" +
             "\n" +
             "NOTE: All errors that are captured during a request to an ignored URL are still sent to the APM Server regardless of " +
@@ -65,13 +66,14 @@ public class WebConfiguration extends ConfigurationOptionProvider {
         .dynamic(true)
         .buildWithDefault(Arrays.asList(
             WildcardMatcher.valueOf("/VAADIN/*"),
-            WildcardMatcher.valueOf("(?i)/heartbeat/*"),
+            WildcardMatcher.valueOf("/heartbeat*"),
             WildcardMatcher.valueOf("/favicon.ico"),
             WildcardMatcher.valueOf("*.js"),
             WildcardMatcher.valueOf("*.css"),
             WildcardMatcher.valueOf("*.jpg"),
             WildcardMatcher.valueOf("*.jpeg"),
             WildcardMatcher.valueOf("*.png"),
+            WildcardMatcher.valueOf("*.gif"),
             WildcardMatcher.valueOf("*.webp"),
             WildcardMatcher.valueOf("*.svg"),
             WildcardMatcher.valueOf("*.woff"),
@@ -85,7 +87,8 @@ public class WebConfiguration extends ConfigurationOptionProvider {
             "\n" +
             "When an incoming HTTP request is detected,\n" +
             "the User-Agent from the request headers will be tested against each element in this list.\n" +
-            "Example: `curl/*, (?i)*pingdom*`\n" +
+            "Example: `curl/*`, `*pingdom*`\n" +
+            "\n" +
             WildcardMatcher.DOCUMENTATION + "\n" +
             "\n" +
             "NOTE: All errors that are captured during a request by an ignored user agent are still sent to the APM Server " +
@@ -113,6 +116,7 @@ public class WebConfiguration extends ConfigurationOptionProvider {
         .description("This option is only considered, when `use_path_as_transaction_name` is active.\n" +
             "\n" +
             "With this option, you can group several URL paths together by using a wildcard expression like `/user/*`.\n" +
+            "\n" +
             WildcardMatcher.DOCUMENTATION)
         .dynamic(true)
         .buildWithDefault(Collections.<WildcardMatcher>emptyList());

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -219,8 +219,10 @@ Configure a list of wildcard patterns of field names which should be sanitized.
 These apply for example to HTTP headers and `application/x-www-form-urlencoded` data.
 
 
-NOTE: A wildcard expression may either contain a single wildcard in the middle or have wildcards at the beginning and/or the end. Legal: `*foo*`, `foo*`, `*foo`, `foo*bar*`. Illegal: `foo*bar*`, `foo*bar*baz`.
-Prepending an element with `(?i)` makes the matching case-insensitive.
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive by default.
+Prepending an element with `(?-i)` makes the matching case sensitive.
 
 NOTE: Data in the query string is considered non-sensitive,
 as sensitive information should not be sent in the query string.
@@ -234,7 +236,7 @@ you should add an additional entry to this list (make sure to also include the d
 [options="header"]
 |============
 | Default                          | Type                | Dynamic
-| `(?i)password, (?i)passwd, (?i)pwd, (?i)secret, (?i)token, (?i)*key, (?i)*token, (?i)*session*, (?i)*credit*, (?i)*card*, (?i)authorization, (?i)set-cookie` | List | true
+| `password, passwd, pwd, secret, *key, *token*, *session*, *credit*, *card*, authorization, set-cookie` | List | true
 |============
 
 
@@ -307,8 +309,10 @@ Used to restrict requests to certain URLs from being instrumented.
 This property should be set to an array containing one or more strings.
 When an incoming HTTP request is detected, its URL will be tested against each element in this list.
 
-NOTE: A wildcard expression may either contain a single wildcard in the middle or have wildcards at the beginning and/or the end. Legal: `*foo*`, `foo*`, `*foo`, `foo*bar*`. Illegal: `foo*bar*`, `foo*bar*baz`.
-Prepending an element with `(?i)` makes the matching case-insensitive.
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive by default.
+Prepending an element with `(?-i)` makes the matching case sensitive.
 
 NOTE: All errors that are captured during a request to an ignored URL are still sent to the APM Server regardless of this setting.
 
@@ -316,7 +320,7 @@ NOTE: All errors that are captured during a request to an ignored URL are still 
 [options="header"]
 |============
 | Default                          | Type                | Dynamic
-| `/VAADIN/*, (?i)/heartbeat/*, /favicon.ico, *.js, *.css, *.jpg, *.jpeg, *.png, *.webp, *.svg, *.woff, *.woff2` | List | true
+| `/VAADIN/*, /heartbeat*, /favicon.ico, *.js, *.css, *.jpg, *.jpeg, *.png, *.gif, *.webp, *.svg, *.woff, *.woff2` | List | true
 |============
 
 
@@ -334,10 +338,12 @@ Used to restrict requests from certain User-Agents from being instrumented.
 
 When an incoming HTTP request is detected,
 the User-Agent from the request headers will be tested against each element in this list.
-Example: `curl/*, (?i)*pingdom*`
+Example: `curl/*`, `*pingdom*`
 
-NOTE: A wildcard expression may either contain a single wildcard in the middle or have wildcards at the beginning and/or the end. Legal: `*foo*`, `foo*`, `*foo`, `foo*bar*`. Illegal: `foo*bar*`, `foo*bar*baz`.
-Prepending an element with `(?i)` makes the matching case-insensitive.
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive by default.
+Prepending an element with `(?-i)` makes the matching case sensitive.
 
 NOTE: All errors that are captured during a request by an ignored user agent are still sent to the APM Server regardless of this setting.
 
@@ -389,8 +395,10 @@ This option is only considered, when `use_path_as_transaction_name` is active.
 
 With this option, you can group several URL paths together by using a wildcard expression like `/user/*`.
 
-NOTE: A wildcard expression may either contain a single wildcard in the middle or have wildcards at the beginning and/or the end. Legal: `*foo*`, `foo*`, `*foo`, `foo*bar*`. Illegal: `foo*bar*`, `foo*bar*baz`.
-Prepending an element with `(?i)` makes the matching case-insensitive.
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive by default.
+Prepending an element with `(?-i)` makes the matching case sensitive.
 
 
 [options="header"]
@@ -820,8 +828,10 @@ The default unit for this option is `ms`
 # These apply for example to HTTP headers and `application/x-www-form-urlencoded` data.
 # 
 # 
-# NOTE: A wildcard expression may either contain a single wildcard in the middle or have wildcards at the beginning and/or the end. Legal: `*foo*`, `foo*`, `*foo`, `foo*bar*`. Illegal: `foo*bar*`, `foo*bar*baz`.
-# Prepending an element with `(?i)` makes the matching case-insensitive.
+# This option supports the wildcard `*`, which matches zero or more characters.
+# Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+# Matching is case insensitive by default.
+# Prepending an element with `(?-i)` makes the matching case sensitive.
 # 
 # NOTE: Data in the query string is considered non-sensitive,
 # as sensitive information should not be sent in the query string.
@@ -833,9 +843,9 @@ The default unit for this option is `ms`
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: (?i)password,(?i)passwd,(?i)pwd,(?i)secret,(?i)token,(?i)*key,(?i)*token,(?i)*session*,(?i)*credit*,(?i)*card*,(?i)authorization,(?i)set-cookie
+# Default value: password,passwd,pwd,secret,*key,*token*,*session*,*credit*,*card*,authorization,set-cookie
 #
-# sanitize_field_names=(?i)password,(?i)passwd,(?i)pwd,(?i)secret,(?i)token,(?i)*key,(?i)*token,(?i)*session*,(?i)*credit*,(?i)*card*,(?i)authorization,(?i)set-cookie
+# sanitize_field_names=password,passwd,pwd,secret,*key,*token*,*session*,*credit*,*card*,authorization,set-cookie
 
 # A list of instrumentations which should be disabled.
 # Valid options are `jdbc`, `servlet-api`, `servlet-api-async`, `spring-mvc`, `http-client`, `apache-httpclient`,`spring-resttemplate` and `incubating`.
@@ -874,25 +884,29 @@ The default unit for this option is `ms`
 # This property should be set to an array containing one or more strings.
 # When an incoming HTTP request is detected, its URL will be tested against each element in this list.
 # 
-# NOTE: A wildcard expression may either contain a single wildcard in the middle or have wildcards at the beginning and/or the end. Legal: `*foo*`, `foo*`, `*foo`, `foo*bar*`. Illegal: `foo*bar*`, `foo*bar*baz`.
-# Prepending an element with `(?i)` makes the matching case-insensitive.
+# This option supports the wildcard `*`, which matches zero or more characters.
+# Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+# Matching is case insensitive by default.
+# Prepending an element with `(?-i)` makes the matching case sensitive.
 # 
 # NOTE: All errors that are captured during a request to an ignored URL are still sent to the APM Server regardless of this setting.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: /VAADIN/*,(?i)/heartbeat/*,/favicon.ico,*.js,*.css,*.jpg,*.jpeg,*.png,*.webp,*.svg,*.woff,*.woff2
+# Default value: /VAADIN/*,/heartbeat*,/favicon.ico,*.js,*.css,*.jpg,*.jpeg,*.png,*.gif,*.webp,*.svg,*.woff,*.woff2
 #
-# ignore_urls=/VAADIN/*,(?i)/heartbeat/*,/favicon.ico,*.js,*.css,*.jpg,*.jpeg,*.png,*.webp,*.svg,*.woff,*.woff2
+# ignore_urls=/VAADIN/*,/heartbeat*,/favicon.ico,*.js,*.css,*.jpg,*.jpeg,*.png,*.gif,*.webp,*.svg,*.woff,*.woff2
 
 # Used to restrict requests from certain User-Agents from being instrumented.
 # 
 # When an incoming HTTP request is detected,
 # the User-Agent from the request headers will be tested against each element in this list.
-# Example: `curl/*, (?i)*pingdom*`
+# Example: `curl/*`, `*pingdom*`
 # 
-# NOTE: A wildcard expression may either contain a single wildcard in the middle or have wildcards at the beginning and/or the end. Legal: `*foo*`, `foo*`, `*foo`, `foo*bar*`. Illegal: `foo*bar*`, `foo*bar*baz`.
-# Prepending an element with `(?i)` makes the matching case-insensitive.
+# This option supports the wildcard `*`, which matches zero or more characters.
+# Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+# Matching is case insensitive by default.
+# Prepending an element with `(?-i)` makes the matching case sensitive.
 # 
 # NOTE: All errors that are captured during a request by an ignored user agent are still sent to the APM Server regardless of this setting.
 #
@@ -920,8 +934,10 @@ The default unit for this option is `ms`
 # 
 # With this option, you can group several URL paths together by using a wildcard expression like `/user/*`.
 # 
-# NOTE: A wildcard expression may either contain a single wildcard in the middle or have wildcards at the beginning and/or the end. Legal: `*foo*`, `foo*`, `*foo`, `foo*bar*`. Illegal: `foo*bar*`, `foo*bar*baz`.
-# Prepending an element with `(?i)` makes the matching case-insensitive.
+# This option supports the wildcard `*`, which matches zero or more characters.
+# Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+# Matching is case insensitive by default.
+# Prepending an element with `(?-i)` makes the matching case sensitive.
 #
 # This setting can be changed at runtime
 # Type: comma separated list


### PR DESCRIPTION
- match case insensitive by default
- matches are now always allocation free