### PR TITLE
Error id adjustments for intake v2

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
@@ -229,6 +229,8 @@ public class ElasticApmTracer {
                     error.getTransaction().getTransactionId().copyFrom(transaction.getId());
                 }
                 error.asChildOf(active);
+            } else {
+                error.getTraceContext().getId().setToRandomValue();
             }
             reporter.report(error);
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/error/ErrorCapture.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/error/ErrorCapture.java
@@ -37,7 +37,7 @@ import java.util.Collection;
  */
 public class ErrorCapture implements Recyclable {
 
-    private final TraceContext traceContext = new TraceContext();
+    private final TraceContext traceContext = TraceContext.with128BitId();
 
     /**
      * Context

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/ConstantSampler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/ConstantSampler.java
@@ -19,7 +19,7 @@
  */
 package co.elastic.apm.impl.sampling;
 
-import co.elastic.apm.impl.transaction.TraceId;
+import co.elastic.apm.impl.transaction.Id;
 
 /**
  * This is a implementation of {@link Sampler} which always returns the same sampling decision.
@@ -44,7 +44,7 @@ public class ConstantSampler implements Sampler {
     }
 
     @Override
-    public boolean isSampled(TraceId traceId) {
+    public boolean isSampled(Id traceId) {
         return decision;
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/Sampler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/sampling/Sampler.java
@@ -20,7 +20,7 @@
 package co.elastic.apm.impl.sampling;
 
 import co.elastic.apm.impl.transaction.Span;
-import co.elastic.apm.impl.transaction.TraceId;
+import co.elastic.apm.impl.transaction.Id;
 import co.elastic.apm.impl.transaction.Transaction;
 
 /**
@@ -45,5 +45,5 @@ public interface Sampler {
      * @param traceId The id of the transaction.
      * @return The sampling decision.
      */
-    boolean isSampled(TraceId traceId);
+    boolean isSampled(Id traceId);
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/AbstractSpan.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 public abstract class AbstractSpan<T extends AbstractSpan> implements Recyclable {
     private static final Logger logger = LoggerFactory.getLogger(AbstractSpan.class);
-    protected final TraceContext traceContext = new TraceContext();
+    protected final TraceContext traceContext = TraceContext.with64BitId();
     /**
      * Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')
      */

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanId.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SpanId.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ThreadLocalRandom;
 /**
  * A 64 bit random id which is used as a unique id for {@link Span}s within a {@link Transaction}
  */
+@Deprecated
 public class SpanId implements Recyclable {
 
     private static final int LENGTH = 8;

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/sampling/ProbabilitySamplerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/sampling/ProbabilitySamplerTest.java
@@ -19,7 +19,7 @@
  */
 package co.elastic.apm.impl.sampling;
 
-import co.elastic.apm.impl.transaction.TraceId;
+import co.elastic.apm.impl.transaction.Id;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,7 +40,7 @@ class ProbabilitySamplerTest {
     @Test
     void isSampledEmpiricalTest() {
         int sampledTransactions = 0;
-        TraceId id = new TraceId();
+        Id id = Id.new128BitId();
         for (int i = 0; i < ITERATIONS; i++) {
             id.setToRandomValue();
             if (sampler.isSampled(id)) {
@@ -53,30 +53,30 @@ class ProbabilitySamplerTest {
     @Test
     void testSamplingUpperBoundary() {
         long upperBound = Long.MAX_VALUE / 2;
-        final TraceId transactionId = new TraceId();
+        final Id transactionId = Id.new128BitId();
 
-        transactionId.setValue(upperBound - 1, 0);
+        transactionId.fromLongs((long) 0, upperBound - 1);
         assertThat(ProbabilitySampler.of(0.5).isSampled(transactionId)).isTrue();
 
-        transactionId.setValue(upperBound, 0);
+        transactionId.fromLongs((long) 0, upperBound);
         assertThat(ProbabilitySampler.of(0.5).isSampled(transactionId)).isTrue();
 
-        transactionId.setValue(upperBound + 1, 0);
+        transactionId.fromLongs((long) 0, upperBound + 1);
         assertThat(ProbabilitySampler.of(0.5).isSampled(transactionId)).isFalse();
     }
 
     @Test
     void testSamplingLowerBoundary() {
         long lowerBound = -Long.MAX_VALUE / 2;
-        final TraceId transactionId = new TraceId();
+        final Id transactionId = Id.new128BitId();
 
-        transactionId.setValue(lowerBound + 1, 0);
+        transactionId.fromLongs((long) 0, lowerBound + 1);
         assertThat(ProbabilitySampler.of(0.5).isSampled(transactionId)).isTrue();
 
-        transactionId.setValue(lowerBound, 0);
+        transactionId.fromLongs((long) 0, lowerBound);
         assertThat(ProbabilitySampler.of(0.5).isSampled(transactionId)).isTrue();
 
-        transactionId.setValue(lowerBound - 1, 0);
+        transactionId.fromLongs((long) 0, lowerBound - 1);
         assertThat(ProbabilitySampler.of(0.5).isSampled(transactionId)).isFalse();
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/IdTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/IdTest.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.impl.transaction;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IdTest {
+
+    @Test
+    void testReInit() {
+        final Id id = Id.new64BitId();
+
+        id.fromHexString("0000000000000001", 0);
+        assertThat(id.toString()).isEqualTo("0000000000000001");
+        assertThat(id.isEmpty()).isFalse();
+
+        id.fromHexString("0000000000000002", 0);
+        assertThat(id.toString()).isEqualTo("0000000000000002");
+        assertThat(id.isEmpty()).isFalse();
+    }
+
+    @Test
+    void testReset() {
+        final Id id = Id.new64BitId();
+
+        id.fromHexString("0000000000000001", 0);
+        assertThat(id.toString()).isEqualTo("0000000000000001");
+        assertThat(id.isEmpty()).isFalse();
+
+        id.resetState();
+        assertThat(id.toString()).isEqualTo("0000000000000000");
+        assertThat(id.isEmpty()).isTrue();
+    }
+
+    @Test
+    void testInitEmpty() {
+        final Id id = Id.new64BitId();
+        assertThat(id.toString()).isEqualTo("0000000000000000");
+        assertThat(id.isEmpty()).isTrue();
+
+        id.fromHexString("0000000000000000", 0);
+        assertThat(id.toString()).isEqualTo("0000000000000000");
+        assertThat(id.isEmpty()).isTrue();
+
+        id.fromLongs(0);
+        assertThat(id.toString()).isEqualTo("0000000000000000");
+        assertThat(id.isEmpty()).isTrue();
+    }
+
+    @Test
+    void testFromAndToLong() {
+        final Id id = Id.new128BitId();
+
+        id.fromLongs(21, 42);
+        assertThat(id.isEmpty()).isFalse();
+        assertThat(id.readLong(0)).isEqualTo(21);
+        assertThat(id.readLong(8)).isEqualTo(42);
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/TraceContextTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/TraceContextTest.java
@@ -38,7 +38,7 @@ class TraceContextTest {
 
     @Test
     void parseFromTraceParentHeader_notRecorded_notRequested() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         final String header = "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-00";
         assertThat(traceContext.asChildOf(header)).isTrue();
         assertThat(traceContext.isSampled()).isFalse();
@@ -51,7 +51,7 @@ class TraceContextTest {
 
     @Test
     void parseFromTraceParentHeader_recorded_notRequested() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         final String header = "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-02";
         assertThat(traceContext.asChildOf(header)).isTrue();
         assertThat(traceContext.isSampled()).isTrue();
@@ -64,7 +64,7 @@ class TraceContextTest {
 
     @Test
     void parseFromTraceParentHeader_notRecorded_requested() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         final String header = "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01";
         assertThat(traceContext.asChildOf(header)).isTrue();
         assertThat(traceContext.isSampled()).isTrue();
@@ -78,7 +78,7 @@ class TraceContextTest {
 
     @Test
     void parseFromTraceParentHeader_recorded_requested() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         final String header = "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-03";
         assertThat(traceContext.asChildOf(header)).isTrue();
         assertThat(traceContext.isSampled()).isTrue();
@@ -91,7 +91,7 @@ class TraceContextTest {
 
     @Test
     void outgoingHeader() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         final String header = "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-03";
         assertThat(traceContext.asChildOf(header)).isTrue();
         assertThat(traceContext.getOutgoingTraceParentHeader().toString())
@@ -100,7 +100,7 @@ class TraceContextTest {
 
     @Test
     void outgoingHeaderRootSpan() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         traceContext.asRootSpan(ConstantSampler.of(true));
         assertThat(traceContext.getOutgoingTraceParentHeader().toString()).hasSize(55);
         assertThat(traceContext.getOutgoingTraceParentHeader().toString()).startsWith("00-");
@@ -109,7 +109,7 @@ class TraceContextTest {
 
     @Test
     void parseFromTraceParentHeader_notSampled() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         final String header = "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-00";
         assertThat(traceContext.asChildOf(header)).isTrue();
         assertThat(traceContext.isSampled()).isFalse();
@@ -126,14 +126,16 @@ class TraceContextTest {
 
     @Test
     void testRandomValue() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         traceContext.asRootSpan(ConstantSampler.of(true));
-        assertIsRoot(traceContext);
+        assertThat(traceContext.getTraceId().isEmpty()).isFalse();
+        assertThat(traceContext.getParentId().isEmpty()).isTrue();
+        assertThat(traceContext.getId().isEmpty()).isFalse();
     }
 
     @Test
     void testSetSampled() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         traceContext.asRootSpan(ConstantSampler.of(false));
         assertThat(traceContext.isSampled()).isFalse();
         traceContext.setRecorded(true);
@@ -182,11 +184,5 @@ class TraceContextTest {
     private void assertInvalid(String s) {
         final TraceContext traceContext = new TraceContext();
         assertThat(traceContext.asChildOf(s)).isFalse();
-    }
-
-    private void assertIsRoot(TraceContext traceContext) {
-        assertThat(traceContext.getTraceId().isEmpty()).isFalse();
-        assertThat(traceContext.getParentId().asLong()).isZero();
-        assertThat(traceContext.getId().asLong()).isNotZero();
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/TraceContextTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/TraceContextTest.java
@@ -118,7 +118,7 @@ class TraceContextTest {
 
     @Test
     void testResetState() {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         traceContext.asChildOf("00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-00");
         traceContext.resetState();
         assertThat(traceContext.getIncomingTraceParentHeader()).isEqualTo("00-00000000000000000000000000000000-0000000000000000-00");
@@ -182,7 +182,7 @@ class TraceContextTest {
     }
 
     private void assertInvalid(String s) {
-        final TraceContext traceContext = new TraceContext();
+        final TraceContext traceContext = TraceContext.with64BitId();
         assertThat(traceContext.asChildOf(s)).isFalse();
     }
 }

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/SpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/plugin/api/SpanInstrumentation.java
@@ -25,7 +25,6 @@ import co.elastic.apm.configuration.CoreConfiguration;
 import co.elastic.apm.impl.transaction.AbstractSpan;
 import co.elastic.apm.impl.transaction.Span;
 import co.elastic.apm.impl.transaction.Transaction;
-import co.elastic.apm.impl.transaction.TransactionId;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -34,7 +33,6 @@ import net.bytebuddy.matcher.ElementMatcher;
 
 import java.util.Collection;
 import java.util.Collections;
-import java.util.UUID;
 
 import static co.elastic.apm.plugin.api.ElasticApmApiInstrumentation.PUBLIC_API_INSTRUMENTATION_GROUP;
 import static net.bytebuddy.matcher.ElementMatchers.named;

--- a/apm-opentracing/src/test/java/co/elastic/apm/opentracing/OpenTracingBridgeTest.java
+++ b/apm-opentracing/src/test/java/co/elastic/apm/opentracing/OpenTracingBridgeTest.java
@@ -246,7 +246,7 @@ class OpenTracingBridgeTest extends AbstractInstrumentationTest {
 
         final HashMap<String, String> map = new HashMap<>();
         apmTracer.inject(scope.span().context(), Format.Builtin.TEXT_MAP, new TextMapInjectAdapter(map));
-        final TraceContext injectedContext = new TraceContext();
+        final TraceContext injectedContext = TraceContext.with64BitId();
         assertThat(injectedContext.asChildOf(map.get(TraceContext.TRACE_PARENT_HEADER))).isTrue();
         assertThat(injectedContext.getTraceId().toString()).isEqualTo(traceId);
         assertThat(injectedContext.getParentId()).isEqualTo(tracer.currentTransaction().getTraceContext().getId());


### PR DESCRIPTION
- add transactionId to TraceContext
- Error.id is required in intake v2
- Error.id is 128 bits long

closes elastic/apm-agent-java#213