### PR TITLE
Elasticsearch REST client instrumentation: adding support for sync ops and IT

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
@@ -259,6 +259,10 @@ public class ElasticApmTracer {
                     // That's why we have to ensure the visibility of the transaction properties
                     error.getContext().copyFrom(transaction.getContextEnsureVisibility());
                 }
+                else if (active instanceof Span) {
+                    Span span = (Span) active;
+                    error.getContext().getTags().putAll(span.getContext().getTags());
+                }
                 error.asChildOf(active);
             } else {
                 error.getTraceContext().getId().setToRandomValue();

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/context/AbstractContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/context/AbstractContext.java
@@ -45,4 +45,8 @@ public abstract class AbstractContext implements Recyclable {
     public boolean hasContent() {
         return !tags.isEmpty();
     }
+
+    public void copyFrom(AbstractContext other) {
+        tags.putAll(other.tags);
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Http.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Http.java
@@ -32,11 +32,31 @@ public class Http implements Recyclable {
     private String url;
 
     /**
+     * HTTP method used by this HTTP outgoing span
+     */
+    @Nullable
+    private String method;
+
+    /**
+     * Status code of the response
+     */
+    private int statusCode;
+
+    /**
      * URL used for the outgoing HTTP call
      */
     @Nullable
     public String getUrl() {
         return url;
+    }
+
+    @Nullable
+    public String getMethod() {
+        return method;
+    }
+
+    public int getStatusCode() {
+        return statusCode;
     }
 
     /**
@@ -47,16 +67,32 @@ public class Http implements Recyclable {
         return this;
     }
 
+    public Http withMethod(String method) {
+        this.method = method;
+        return this;
+    }
+
+    public Http withStatusCode(int statusCode) {
+        this.statusCode = statusCode;
+        return this;
+    }
+
     @Override
     public void resetState() {
         url = null;
+        method = null;
+        statusCode = 0;
     }
 
     public boolean hasContent() {
-        return url != null;
+        return url != null ||
+            method != null ||
+            statusCode > 0;
     }
 
     public void copyFrom(Http other) {
         url = other.url;
+        method = other.method;
+        statusCode = other.statusCode;
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/serialize/DslJsonSerializer.java
@@ -81,7 +81,7 @@ public class DslJsonSerializer implements PayloadSerializer {
      */
     public static final int BUFFER_SIZE = 16384;
     static final int MAX_VALUE_LENGTH = 1024;
-    static final int MAX_LONG_STRING_VALUE_LENGTH = 10000;
+    public static final int MAX_LONG_STRING_VALUE_LENGTH = 10000;
     private static final byte NEW_LINE = (byte) '\n';
     private static final Logger logger = LoggerFactory.getLogger(DslJsonSerializer.class);
     private static final String[] DISALLOWED_IN_TAG_KEY = new String[]{".", "*", "\""};

--- a/apm-agent-core/src/test/java/co/elastic/apm/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/MockReporter.java
@@ -20,6 +20,9 @@
 package co.elastic.apm;
 
 import co.elastic.apm.impl.error.ErrorCapture;
+import co.elastic.apm.impl.error.ErrorPayload;
+import co.elastic.apm.impl.payload.PayloadUtils;
+import co.elastic.apm.impl.payload.TransactionPayload;
 import co.elastic.apm.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.impl.transaction.Span;
 import co.elastic.apm.impl.transaction.Transaction;
@@ -152,6 +155,19 @@ public class MockReporter implements Reporter {
 
     public ErrorCapture getFirstError() {
         return errors.iterator().next();
+    }
+
+    public String generateTransactionPayloadJson() {
+        TransactionPayload payload = PayloadUtils.createTransactionPayload();
+        payload.getTransactions().addAll(transactions);
+        payload.getSpans().addAll(spans);
+        return dslJsonSerializer.toJsonString(payload);
+    }
+
+    public String generateErrorPayloadJson() {
+        ErrorPayload errorPayload = PayloadUtils.createErrorPayload();
+        errorPayload.getErrors().addAll(errors);
+        return dslJsonSerializer.toJsonString(errorPayload);
     }
 
     @Override

--- a/apm-agent-core/src/test/java/co/elastic/apm/TransactionUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/TransactionUtils.java
@@ -115,7 +115,10 @@ public class TransactionUtils {
             .appendToName("GET ")
             .appendToName("test.elastic.co")
             .withType("ext.http.apache-httpclient");
-        span.getContext().getHttp().withUrl("http://test.elastic.co/test-service");
+        span.getContext().getHttp()
+            .withUrl("http://test.elastic.co/test-service")
+            .withMethod("POST")
+            .withStatusCode(201);
         spans.add(span);
         return spans;
     }

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/PayloadUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/PayloadUtils.java
@@ -1,0 +1,57 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.impl.payload;
+
+import co.elastic.apm.TransactionUtils;
+import co.elastic.apm.impl.ElasticApmTracer;
+import co.elastic.apm.impl.error.ErrorPayload;
+import co.elastic.apm.impl.transaction.Transaction;
+
+import static org.mockito.Mockito.mock;
+
+public class PayloadUtils {
+
+    private static final Service SERVICE;
+    private static final SystemInfo SYSTEM;
+    private static final ProcessInfo PROCESS_INFO;
+
+    static {
+        SERVICE = new Service().withAgent(new Agent("name", "version")).withName("name");
+        SYSTEM = new SystemInfo("", "", "");
+        PROCESS_INFO = new ProcessInfo("title");
+        PROCESS_INFO.getArgv().add("test");
+    }
+
+    public static TransactionPayload createTransactionPayloadWithAllValues() {
+        final Transaction transaction = new Transaction(mock(ElasticApmTracer.class));
+        TransactionUtils.fillTransaction(transaction);
+        final TransactionPayload payload = createTransactionPayload();
+        payload.getTransactions().add(transaction);
+        return payload;
+    }
+
+    public static TransactionPayload createTransactionPayload() {
+        return new TransactionPayload(PROCESS_INFO, SERVICE, SYSTEM);
+    }
+
+    public static ErrorPayload createErrorPayload() {
+        return new ErrorPayload(PROCESS_INFO, SERVICE, SYSTEM);
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/TransactionPayloadJsonSchemaTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/payload/TransactionPayloadJsonSchemaTest.java
@@ -130,6 +130,7 @@ class TransactionPayloadJsonSchemaTest {
     private JsonNode getSerializedSpans(TransactionPayload payload) throws IOException {
         DslJsonSerializer serializer = new DslJsonSerializer(mock(StacktraceConfiguration.class));
         final String content = serializer.toJsonString(payload);
+        System.out.println(content);
         JsonNode node = objectMapper.readTree(content);
 
         assertThat(node.get("transactions").get(0).get("spans")).isNull();
@@ -169,11 +170,12 @@ class TransactionPayloadJsonSchemaTest {
             if(child.get("type").textValue().startsWith("ext.http.")) {
                 assertThat(child.get("name").textValue()).isEqualTo("GET test.elastic.co");
                 JsonNode context = child.get("context");
-                assertThat(context.get("db")).isNull();
                 contextOfHttpSpanFound = true;
                 JsonNode http = context.get("http");
                 assertThat(http).isNotNull();
                 assertThat(http.get("url").textValue()).isEqualTo("http://test.elastic.co/test-service");
+                assertThat(http.get("method").textValue()).isEqualTo("POST");
+                assertThat(http.get("status_code").intValue()).isEqualTo(201);
             }
         }
         assertThat(contextOfHttpSpanFound).isTrue();

--- a/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
@@ -13,7 +13,7 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <elasticsearch.version>6.4.1</elasticsearch.version>
+        <version.elasticsearch>6.4.1</version.elasticsearch>
     </properties>
 
     <dependencies>
@@ -21,12 +21,14 @@
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-client</artifactId>
-            <version>${elasticsearch.version}</version>
+            <version>${version.elasticsearch}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>${elasticsearch.version}</version>
+            <version>${version.elasticsearch}</version>
+            <scope>provided</scope>
         </dependency>
 
         <!-- Elasticsearch testcontainer -->
@@ -34,6 +36,7 @@
             <groupId>fr.pilato.elasticsearch.testcontainers</groupId>
             <artifactId>testcontainers-elasticsearch</artifactId>
             <version>0.1</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>0.8.0-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apm-agent-plugins</artifactId>
+        <groupId>co.elastic.apm</groupId>
+        <version>0.8.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-es-restclient-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <elasticsearch.version>6.4.1</elasticsearch.version>
+    </properties>
+
+    <dependencies>
+        <!-- Elasticsearch rest client -->
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+            <version>${elasticsearch.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+            <version>${elasticsearch.version}</version>
+        </dependency>
+
+        <!-- Elasticsearch testcontainer -->
+        <dependency>
+            <groupId>fr.pilato.elasticsearch.testcontainers</groupId>
+            <artifactId>testcontainers-elasticsearch</artifactId>
+            <version>0.1</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ESRestClientInstrumentationHelper.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ESRestClientInstrumentationHelper.java
@@ -41,8 +41,10 @@ public class ESRestClientInstrumentationHelper {
         try {
             byte[] data = bodyReadBuffer.get();
             if (data == null) {
-                bodyReadBuffer.set(new byte[DslJsonSerializer.MAX_LONG_STRING_VALUE_LENGTH]);
-                data = bodyReadBuffer.get();
+                // The DslJsonSerializer.MAX_LONG_STRING_VALUE_LENGTH is actually used to count chars and not bytes, but that's not
+                // that important, the most important is that we limit the payload size we read and decode
+                data = new byte[DslJsonSerializer.MAX_LONG_STRING_VALUE_LENGTH];
+                bodyReadBuffer.set(data);
             }
             int length = bodyIS.read(data, 0, data.length);
 

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ESRestClientInstrumentationHelper.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ESRestClientInstrumentationHelper.java
@@ -1,0 +1,59 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.es.restclient;
+
+import co.elastic.apm.bci.VisibleForAdvice;
+import co.elastic.apm.report.serialize.DslJsonSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+
+@VisibleForAdvice
+public class ESRestClientInstrumentationHelper {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ESRestClientInstrumentationHelper.class);
+
+    private static ThreadLocal<byte[]> bodyReadBuffer = new ThreadLocal<>();
+
+    @Nullable
+    @VisibleForAdvice
+    public static String readRequestBody(InputStream bodyIS, String endpoint) throws IOException {
+        String body = null;
+        try {
+            byte[] data = bodyReadBuffer.get();
+            if (data == null) {
+                bodyReadBuffer.set(new byte[DslJsonSerializer.MAX_LONG_STRING_VALUE_LENGTH]);
+                data = bodyReadBuffer.get();
+            }
+            int length = bodyIS.read(data, 0, data.length);
+
+            // Using platform's default charset for decoding
+            body = new String(data, 0, length);
+        } catch (IOException e) {
+            LOGGER.info("Failed to read request body for " + endpoint);
+        } finally {
+            bodyIS.close();
+        }
+
+        return body;
+    }
+}

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ESRestClientInstrumentationHelper.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ESRestClientInstrumentationHelper.java
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets;
 
 @VisibleForAdvice
 public class ESRestClientInstrumentationHelper {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ESRestClientInstrumentationHelper.class);
+    private static final Logger logger = LoggerFactory.getLogger(ESRestClientInstrumentationHelper.class);
 
     private static ThreadLocal<byte[]> bodyReadBuffer = new ThreadLocal<>();
     private static final byte CURLY_BRACKET_UTF8 = '{';
@@ -55,7 +55,7 @@ public class ESRestClientInstrumentationHelper {
                 body = new String(data, 0, length, StandardCharsets.UTF_8);
             }
         } catch (IOException e) {
-            LOGGER.info("Failed to read request body for " + endpoint);
+            logger.info("Failed to read request body for " + endpoint);
         } finally {
             bodyIS.close();
         }

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ESRestClientInstrumentationHelper.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ESRestClientInstrumentationHelper.java
@@ -21,23 +21,24 @@ package co.elastic.apm.es.restclient;
 
 import co.elastic.apm.bci.VisibleForAdvice;
 import co.elastic.apm.report.serialize.DslJsonSerializer;
-import org.elasticsearch.common.io.stream.InputStreamStreamInput;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 
 @VisibleForAdvice
 public class ESRestClientInstrumentationHelper {
     private static final Logger LOGGER = LoggerFactory.getLogger(ESRestClientInstrumentationHelper.class);
 
     private static ThreadLocal<byte[]> bodyReadBuffer = new ThreadLocal<>();
+    private static final byte CURLY_BRACKET_UTF8 = '{';
 
     @Nullable
     @VisibleForAdvice
-    public static String readRequestBody(InputStream bodyIS, long contentLength, String endpoint) throws IOException {
+    public static String readRequestBody(InputStream bodyIS, String endpoint) throws IOException {
         String body = null;
         try {
             byte[] data = bodyReadBuffer.get();
@@ -47,47 +48,18 @@ public class ESRestClientInstrumentationHelper {
                 data = new byte[DslJsonSerializer.MAX_LONG_STRING_VALUE_LENGTH];
                 bodyReadBuffer.set(data);
             }
+            int length = bodyIS.read(data, 0, data.length);
 
-            try {
-                body = new InputStreamStreamInputWrapper(bodyIS, contentLength).readString();
-            } catch (Exception e) {
-                LOGGER.info("Failed to read request body for " + endpoint);
+            // read only if UTF8-encoded (based on the first byte being UTF8 of curly bracket char)
+            if(data[0] == CURLY_BRACKET_UTF8) {
+                body = new String(data, 0, length, StandardCharsets.UTF_8);
             }
-
-        }
-        finally {
+        } catch (IOException e) {
+            LOGGER.info("Failed to read request body for " + endpoint);
+        } finally {
             bodyIS.close();
         }
 
         return body;
-    }
-
-    private static class InputStreamStreamInputWrapper extends InputStreamStreamInput {
-        private byte[] contentLengthBytes = new byte[5];
-        private int contentLengthValidReadIndex = 0;
-        private int contentLengthByteReadIndex;
-
-        InputStreamStreamInputWrapper(InputStream is, long contentLength) {
-            super(is);
-            // Encoding the content length into bytes. This size must be returned from the InputStream before the content is returned.
-            for (int i=0; i<contentLengthBytes.length; i++) {
-                contentLengthValidReadIndex++;
-                contentLengthBytes[i] = (byte)(contentLength & 0x7F);
-                contentLength >>>= 7;
-                if (contentLength == 0) {
-                    break;
-                }
-                contentLengthBytes[i] |= 0x80;
-            }
-            contentLengthByteReadIndex = 0;
-        }
-
-        @Override
-        public byte readByte() throws IOException {
-            if(contentLengthByteReadIndex < contentLengthValidReadIndex) {
-                return contentLengthBytes[contentLengthByteReadIndex++];
-            }
-            return super.readByte();
-        }
     }
 }

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentation.java
@@ -1,0 +1,121 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.es.restclient;
+
+import co.elastic.apm.bci.ElasticApmInstrumentation;
+import co.elastic.apm.impl.transaction.Span;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.http.Header;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+/**
+ * Instrumentation for Elasticsearch RestClient, currently supporting only synchronized queries.
+ * All sync operations go through org.elasticsearch.client.RestClient#performRequest(org.elasticsearch.client.Request)
+ */
+public class ElasticsearchRestClientInstrumentation extends ElasticApmInstrumentation {
+    private static final String ES_REST_CLIENT_INSTRUMENTATION_GROUP = "elasticsearch-restclient";
+    private static final String SPAN_TYPE = "es-restclient";
+
+    private static final String REST_CLIENT_CLASS_NAME = "org.elasticsearch.client.RestClient";
+    private static final String REQUEST_CLASS_NAME = "org.elasticsearch.client.Request";
+    private static final String PERFORM_REQUEST_METHOD_NAME = "performRequest";
+
+    static final String ELASTICSEARCH_NODE_KEY = "Elasticsearch-node";
+    static final String QUERY_STATUS_CODE_KEY = "Query-status-code";
+    static final String ERROR_REASON_KEY = "Error-reason";
+
+    @Advice.OnMethodEnter
+    private static void onBeforeExecute(@Advice.Argument(0) Request request,
+                                        @Advice.Local("span") Span span,
+                                        @Advice.Local("esre") ResponseException esre) {
+        if (tracer == null || tracer.getActive() == null) {
+            return;
+        }
+        span = tracer.getActive().createSpan()
+            .withType(SPAN_TYPE)
+            .appendToName(request.getEndpoint()).appendToName(" ").appendToName(request.getMethod())
+            .activate();
+
+
+        // Add request parameters to query info
+        for (Map.Entry<String, String> param: request.getParameters().entrySet()) {
+            span.addTag(param.getKey(), param.getValue());
+        }
+
+        // Add request options to query info
+        for (Header header: request.getOptions().getHeaders()) {
+            span.addTag(header.getName(), header.getValue());
+        }
+    }
+
+    @Advice.OnMethodExit(onThrowable = Throwable.class)
+    public static void onAfterExecute(@Advice.Return @Nullable Response response,
+                                      @Advice.Local("span") @Nullable Span span,
+                                      @Advice.Local("esre") ResponseException esre,
+                                      @Advice.Thrown @Nullable Throwable t) {
+        if (span != null) {
+            if(response != null) {
+                span.addTag(ELASTICSEARCH_NODE_KEY, response.getHost().toHostString());
+                span.addTag(QUERY_STATUS_CODE_KEY, Integer.toString(response.getStatusLine().getStatusCode()));
+            }
+            else if(t instanceof ResponseException)
+            {
+                esre = (ResponseException) t;
+                span.addTag(QUERY_STATUS_CODE_KEY, Integer.toString(esre.getResponse().getStatusLine().getStatusCode()));
+                span.addTag(ERROR_REASON_KEY, esre.getResponse().getStatusLine().getReasonPhrase());
+                span.addTag(ELASTICSEARCH_NODE_KEY, esre.getResponse().getHost().toHostString());
+                span.captureException(t);
+            }
+
+            span.deactivate().end();
+        }
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named(REST_CLIENT_CLASS_NAME);
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named(PERFORM_REQUEST_METHOD_NAME)
+            .and(takesArguments(1)
+            .and(takesArgument(0, named(REQUEST_CLASS_NAME))));
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        return Collections.singleton(ES_REST_CLIENT_INSTRUMENTATION_GROUP);
+    }
+}

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentation.java
@@ -68,8 +68,9 @@ public class ElasticsearchRestClientInstrumentation extends ElasticApmInstrument
         }
         span = tracer.getActive().createSpan()
             .withType(SPAN_TYPE)
-            .appendToName("Elasticsearch: ").appendToName(request.getMethod()).appendToName(" ").appendToName(request.getEndpoint())
-            .activate();
+            .appendToName("Elasticsearch: ").appendToName(request.getMethod()).appendToName(" ").appendToName(request.getEndpoint());
+        span.getContext().getDb().withType(DB_CONTEXT_TYPE);
+        span.activate();
 
         if (span.isSampled()) {
             span.getContext().getHttp().withMethod(request.getMethod());
@@ -79,9 +80,7 @@ public class ElasticsearchRestClientInstrumentation extends ElasticApmInstrument
                     try {
                         String body = ESRestClientInstrumentationHelper.readRequestBody(entity.getContent(), request.getEndpoint());
                         if (body != null && !body.isEmpty()) {
-                            span.getContext().getDb()
-                                .withType(DB_CONTEXT_TYPE)
-                                .withStatement(body);
+                            span.getContext().getDb().withStatement(body);
                         }
                     } catch (IOException e) {
                         // We can't log from here

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentation.java
@@ -107,10 +107,12 @@ public class ElasticsearchRestClientInstrumentation extends ElasticApmInstrument
                         url = esre.getResponse().getHost().toURI().toString();
                         statusCode = esre.getResponse().getStatusLine().getStatusCode();
 
+                        /*
                         // Add tags so that they will be copied to error capture
                         span.addTag(QUERY_STATUS_CODE_KEY, Integer.toString(statusCode));
                         span.addTag(ELASTICSEARCH_NODE_URL_KEY, url);
                         span.addTag(ERROR_REASON_KEY, esre.getResponse().getStatusLine().getReasonPhrase());
+                        */
                     }
                     span.captureException(t);
                 }

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentation.java
@@ -75,7 +75,7 @@ public class ElasticsearchRestClientInstrumentation extends ElasticApmInstrument
             HttpEntity entity = request.getEntity();
             if (entity != null && entity.isRepeatable()) {
                 try {
-                    String body = ESRestClientInstrumentationHelper.readRequestBody(entity.getContent(), request.getEndpoint());
+                    String body = ESRestClientInstrumentationHelper.readRequestBody(entity.getContent(), entity.getContentLength(), request.getEndpoint());
                     if (body != null && !body.isEmpty()) {
                         span.getContext().getDb()
                             .withType(DB_CONTEXT_TYPE)

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/package-info.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/java/co/elastic/apm/es/restclient/package-info.java
@@ -1,0 +1,23 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+@NonnullApi
+package co.elastic.apm.es.restclient;
+
+import co.elastic.apm.annotation.NonnullApi;

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/main/resources/META-INF/services/co.elastic.apm.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/main/resources/META-INF/services/co.elastic.apm.bci.ElasticApmInstrumentation
@@ -1,0 +1,1 @@
+co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
@@ -121,7 +121,7 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
     @Before
     public void startTransaction() {
         Transaction transaction = tracer.startTransaction().activate();
-        transaction.setName("transaction");
+        transaction.setName("ES Transaction");
         transaction.withType("request");
         transaction.withResult("success");
     }
@@ -130,7 +130,7 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
     public void endTransaction() {
         Transaction currentTransaction = tracer.currentTransaction();
         if (currentTransaction != null) {
-            tracer.endTransaction(currentTransaction);
+            currentTransaction.end();
         }
         reporter.reset();
     }
@@ -165,10 +165,10 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
         assertThat(span.getName().toString()).isEqualTo(expectedName);
         validateHttpContextContent(span.getContext().getHttp(), statusCode, method);
 
+        assertThat(span.getContext().getDb().getType()).isEqualTo(DB_CONTEXT_TYPE);
+
         if (expectedName.contains(SEARCH_QUERY_PATH_SUFFIX)) {
             assertThat(span.getContext().getDb().hasContent()).isTrue();
-        } else {
-            assertThat(span.getContext().getDb().hasContent()).isFalse();
         }
     }
 

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
@@ -93,7 +93,9 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
     @BeforeClass
     public static void startElasticsearchContainerAndClient() throws IOException {
         // Start the container
-        container = new ElasticsearchContainer();
+        // TODO: the env setting is to pass the bootstrap check of "vm.max_map_count" which fails on the CI env.
+        // TODO: Can be removed after changing to the official testcontainer
+        container = (ElasticsearchContainer) new ElasticsearchContainer().withEnv("discovery.type", "single-node");
         container.start();
 
         // Create the client

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
@@ -152,12 +152,14 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
         assertThat(errorCaptures).hasSize(1);
         ErrorCapture errorCapture = errorCaptures.get(0);
         assertThat(errorCapture.getException()).isNotNull();
+/*
         Map<String, String> tags = errorCapture.getContext().getTags();
         assertThat(tags).containsKey(QUERY_STATUS_CODE_KEY);
         assertThat(tags.get(QUERY_STATUS_CODE_KEY)).isEqualTo("404");
         assertThat(tags).containsKey(ERROR_REASON_KEY);
         assertThat(tags).containsKey(ELASTICSEARCH_NODE_URL_KEY);
         assertThat(tags.get(ELASTICSEARCH_NODE_URL_KEY)).isEqualTo(container.getHost().toURI().toString());
+*/
     }
 
     private void validateSpanContent(Span span, String expectedName, int statusCode, String method) {

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
@@ -21,6 +21,7 @@ package co.elastic.apm.es.restclient;
 
 import co.elastic.apm.AbstractInstrumentationTest;
 import co.elastic.apm.impl.error.ErrorCapture;
+import co.elastic.apm.impl.transaction.Db;
 import co.elastic.apm.impl.transaction.Span;
 import co.elastic.apm.impl.transaction.Transaction;
 import fr.pilato.elasticsearch.containers.ElasticsearchContainer;
@@ -32,6 +33,8 @@ import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
@@ -43,26 +46,27 @@ import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.FixMethodOrder;
 import org.junit.Test;
-import org.junit.runners.MethodSorters;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.SPAN_TYPE;
+import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.DB_CONTEXT_TYPE;
 import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.ELASTICSEARCH_NODE_KEY;
 import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.ERROR_REASON_KEY;
 import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.QUERY_STATUS_CODE_KEY;
 import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrumentationTest {
     private static final String USER_NAME = "elastic-user";
     private static final String PASSWORD = "elastic-pass";
@@ -73,7 +77,8 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
     private static RestHighLevelClient client;
 
     private static final String INDEX = "my-index";
-    private static final String DOC_ID = "1";
+    private static final String SECOND_INDEX = "my-second-index";
+    private static final String DOC_ID = "38uhjds8s4g";
     private static final String DOC_TYPE = "_doc";
     private static final String FOO = "foo";
     private static final String BAR = "bar";
@@ -85,7 +90,7 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
      * <a href="https://github.com/testcontainers/testcontainers-java">testcontainers repo</a>)
      */
     @BeforeClass
-    public static void startElasticsearchContainerAndClient() {
+    public static void startElasticsearchContainerAndClient() throws IOException {
         // Start the container
         container = new ElasticsearchContainer();
         container.start();
@@ -97,10 +102,14 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
         RestClientBuilder builder =  RestClient.builder(container.getHost())
             .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
         client = new RestHighLevelClient(builder);
+
+        client.indices().create(new CreateIndexRequest(INDEX), RequestOptions.DEFAULT);
+        reporter.reset();
     }
 
     @AfterClass
     public static void stopElasticsearchContainerAndClient() throws IOException {
+        client.indices().delete(new DeleteIndexRequest(INDEX), RequestOptions.DEFAULT);
         container.stop();
         client.close();
     }
@@ -123,10 +132,10 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
     }
 
     @Test
-    public void testATryToDeleteNonExistingIndex() throws IOException {
+    public void testTryToDeleteNonExistingIndex() throws IOException {
         ElasticsearchStatusException ese = null;
         try {
-            client.indices().delete(new DeleteIndexRequest(INDEX), RequestOptions.DEFAULT);
+            client.indices().delete(new DeleteIndexRequest(SECOND_INDEX), RequestOptions.DEFAULT);
         } catch (ElasticsearchStatusException e) {
             ese = e;
         }
@@ -148,25 +157,45 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
     }
 
     private void validateSpanContent(Span span, String expectedName, String expectedStatus) {
+        assertThat(span.getType()).isEqualTo(SPAN_TYPE);
         assertThat(span.getName().toString()).isEqualTo(expectedName);
         Map<String, String> tags = span.getContext().getTags();
         assertThat(tags).containsKey(QUERY_STATUS_CODE_KEY);
         assertThat(tags.get(QUERY_STATUS_CODE_KEY)).isEqualTo(expectedStatus);
     }
 
+    private void validateDbContextContent(Span span, String statement) {
+        Db db = span.getContext().getDb();
+        assertThat(db.getType()).isEqualTo(DB_CONTEXT_TYPE);
+        assertThat(db.getStatement()).isEqualTo(statement);
+    }
+
     @Test
-    public void testBCreateIndex() throws IOException {
-        client.indices().create(new CreateIndexRequest(INDEX), RequestOptions.DEFAULT);
+    public void testCreateAndDeleteIndex() throws IOException {
+        // Create an Index
+        client.indices().create(new CreateIndexRequest(SECOND_INDEX), RequestOptions.DEFAULT);
 
         System.out.println(reporter.generateTransactionPayloadJson());
 
         List<Span> spans = reporter.getSpans();
         assertThat(spans).hasSize(1);
-        validateSpanContent(spans.get(0), String.format("/%s PUT", INDEX), "200");
+        validateSpanContent(spans.get(0), String.format("Elasticsearch: PUT /%s", SECOND_INDEX), "200");
+
+        // Delete the index
+        reporter.reset();
+
+        client.indices().delete(new DeleteIndexRequest(SECOND_INDEX), RequestOptions.DEFAULT);
+
+        System.out.println(reporter.generateTransactionPayloadJson());
+
+        spans = reporter.getSpans();
+        assertThat(spans).hasSize(1);
+        validateSpanContent(spans.get(0), String.format("Elasticsearch: DELETE /%s", SECOND_INDEX), "200");
     }
 
     @Test
-    public void testCIndexADocument() throws IOException {
+    public void testDocumentScenario() throws IOException {
+        // Index a document
         IndexResponse ir = client.index(new IndexRequest(INDEX, DOC_TYPE, DOC_ID).source(
             jsonBuilder()
                 .startObject()
@@ -179,35 +208,43 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
 
         List<Span> spans = reporter.getSpans();
         assertThat(spans).hasSize(1);
-        validateSpanContent(spans.get(0), String.format("/%s/%s/%s PUT", INDEX, DOC_TYPE, DOC_ID), "201");
-    }
+        validateSpanContent(spans.get(0), String.format("Elasticsearch: PUT /%s/%s/%s", INDEX, DOC_TYPE, DOC_ID), "201");
 
-    @Test
-    public void testDSearchTheIndex() throws IOException {
-        SearchResponse sr = client.search(new SearchRequest(INDEX), RequestOptions.DEFAULT);
+        // Search the index
+        reporter.reset();
+
+        SearchRequest searchRequest = new SearchRequest(INDEX);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(QueryBuilders.termQuery(FOO, BAR));
+        sourceBuilder.from(0);
+        sourceBuilder.size(5);
+        searchRequest.source(sourceBuilder);
+        SearchResponse sr = client.search(searchRequest, RequestOptions.DEFAULT);
         assertThat(sr.getHits().totalHits).isEqualTo(1L);
         assertThat(sr.getHits().getAt(0).getSourceAsMap().get(FOO)).isEqualTo(BAR);
 
         System.out.println(reporter.generateTransactionPayloadJson());
 
-        List<Span> spans = reporter.getSpans();
+        spans = reporter.getSpans();
         assertThat(spans).hasSize(1);
-        validateSpanContent(spans.get(0), String.format("/%s/_search POST", INDEX), "200");
-    }
+        Span searchSpan = spans.get(0);
+        validateSpanContent(searchSpan, String.format("Elasticsearch: POST /%s/_search", INDEX), "200");
+        validateDbContextContent(searchSpan, "{\"from\":0,\"size\":5,\"query\":{\"term\":{\"foo\":{\"value\":\"bar\",\"boost\":1.0}}}}");
 
-    @Test
-    public void testEUpdateTheDocument() throws IOException {
+        // Now update and re-search
+        reporter.reset();
+
         Map<String, Object> jsonMap = new HashMap<>();
         jsonMap.put(FOO, BAZ);
         UpdateResponse ur = client.update(new UpdateRequest(INDEX, DOC_TYPE, DOC_ID).doc(jsonMap)
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), RequestOptions.DEFAULT);
         assertThat(ur.status().getStatus()).isEqualTo(200);
-        SearchResponse sr = client.search(new SearchRequest(INDEX), RequestOptions.DEFAULT);
+        sr = client.search(new SearchRequest(INDEX), RequestOptions.DEFAULT);
         assertThat(sr.getHits().getAt(0).getSourceAsMap().get(FOO)).isEqualTo(BAZ);
 
         System.out.println(reporter.generateTransactionPayloadJson());
 
-        List<Span> spans = reporter.getSpans();
+        spans = reporter.getSpans();
         assertThat(spans).hasSize(2);
         boolean updateSpanFound = false;
         for(Span span: spans) {
@@ -217,10 +254,18 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
             }
         }
         assertThat(updateSpanFound).isTrue();
+
+        // Finally - delete the document
+        reporter.reset();
+        DeleteResponse dr = client.delete(new DeleteRequest(INDEX, DOC_TYPE, DOC_ID), RequestOptions.DEFAULT);
+        assertThat(dr.status().getStatus()).isEqualTo(200);
+        validateSpanContent(spans.get(0), String.format("Elasticsearch: DELETE /%s/%s/%s", INDEX, DOC_TYPE, DOC_ID), "200");
+
+        System.out.println(reporter.generateTransactionPayloadJson());
     }
 
     @Test
-    public void testFScenarioAsBulkRequest() throws IOException {
+    public void testScenarioAsBulkRequest() throws IOException {
         client.bulk(new BulkRequest()
             .add(new IndexRequest(INDEX, DOC_TYPE, "2").source(
                 jsonBuilder()
@@ -240,18 +285,6 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
 
         List<Span> spans = reporter.getSpans();
         assertThat(spans).hasSize(1);
-        assertThat(spans.get(0).getName().toString()).isEqualTo("/_bulk POST");
-    }
-
-    @Test
-    public void testGDeleteExistingIndex() throws IOException {
-        // Remove any existing index
-        client.indices().delete(new DeleteIndexRequest(INDEX), RequestOptions.DEFAULT);
-
-        System.out.println(reporter.generateTransactionPayloadJson());
-
-        List<Span> spans = reporter.getSpans();
-        assertThat(spans).hasSize(1);
-        validateSpanContent(spans.get(0), String.format("/%s DELETE", INDEX), "200");
+        assertThat(spans.get(0).getName().toString()).isEqualTo("Elasticsearch: POST /_bulk");
     }
 }

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
@@ -59,6 +59,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.SEARCH_QUERY_PATH_SUFFIX;
 import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.SPAN_TYPE;
 import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.DB_CONTEXT_TYPE;
 import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.ELASTICSEARCH_NODE_KEY;
@@ -162,6 +163,11 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
         Map<String, String> tags = span.getContext().getTags();
         assertThat(tags).containsKey(QUERY_STATUS_CODE_KEY);
         assertThat(tags.get(QUERY_STATUS_CODE_KEY)).isEqualTo(expectedStatus);
+        if (expectedName.contains(SEARCH_QUERY_PATH_SUFFIX)) {
+            assertThat(span.getContext().getDb().hasContent()).isTrue();
+        } else {
+            assertThat(span.getContext().getDb().hasContent()).isFalse();
+        }
     }
 
     private void validateDbContextContent(Span span, String statement) {

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
@@ -1,0 +1,257 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.es.restclient;
+
+import co.elastic.apm.AbstractInstrumentationTest;
+import co.elastic.apm.impl.error.ErrorCapture;
+import co.elastic.apm.impl.transaction.Span;
+import co.elastic.apm.impl.transaction.Transaction;
+import fr.pilato.elasticsearch.containers.ElasticsearchContainer;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runners.MethodSorters;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.ELASTICSEARCH_NODE_KEY;
+import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.ERROR_REASON_KEY;
+import static co.elastic.apm.es.restclient.ElasticsearchRestClientInstrumentation.QUERY_STATUS_CODE_KEY;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrumentationTest {
+    private static final String USER_NAME = "elastic-user";
+    private static final String PASSWORD = "elastic-pass";
+
+    @SuppressWarnings("NullableProblems")
+    private static ElasticsearchContainer container;
+    @SuppressWarnings("NullableProblems")
+    private static RestHighLevelClient client;
+
+    private static final String INDEX = "my-index";
+    private static final String DOC_ID = "1";
+    private static final String DOC_TYPE = "_doc";
+    private static final String FOO = "foo";
+    private static final String BAR = "bar";
+    private static final String BAZ = "baz";
+
+    /**
+     * This Integration testing relies on <a href="https://github.com/dadoonet/testcontainers-java-module-elasticsearch">this
+     * ES testcontainer module</a> (will be replaced with an official version once merged into the
+     * <a href="https://github.com/testcontainers/testcontainers-java">testcontainers repo</a>)
+     */
+    @BeforeClass
+    public static void startElasticsearchContainerAndClient() {
+        // Start the container
+        container = new ElasticsearchContainer();
+        container.start();
+
+        // Create the client
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(USER_NAME, PASSWORD));
+
+        RestClientBuilder builder =  RestClient.builder(container.getHost())
+            .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+        client = new RestHighLevelClient(builder);
+    }
+
+    @AfterClass
+    public static void stopElasticsearchContainerAndClient() throws IOException {
+        container.stop();
+        client.close();
+    }
+
+    @Before
+    public void startTransaction() {
+        Transaction transaction = tracer.startTransaction().activate();
+        transaction.setName("transaction");
+        transaction.withType("request");
+        transaction.withResult("success");
+    }
+
+    @After
+    public void endTransaction() {
+        Transaction currentTransaction = tracer.currentTransaction();
+        if (currentTransaction != null) {
+            tracer.endTransaction(currentTransaction);
+        }
+        reporter.reset();
+    }
+
+    @Test
+    public void testATryToDeleteNonExistingIndex() throws IOException {
+        ElasticsearchStatusException ese = null;
+        try {
+            client.indices().delete(new DeleteIndexRequest(INDEX), RequestOptions.DEFAULT);
+        } catch (ElasticsearchStatusException e) {
+            ese = e;
+        }
+        assertThat(ese).isNotNull();
+        assertThat(ese.status().getStatus()).isEqualTo(404);
+
+        System.out.println(reporter.generateErrorPayloadJson());
+
+        List<ErrorCapture> errorCaptures = reporter.getErrors();
+        assertThat(errorCaptures).hasSize(1);
+        ErrorCapture errorCapture = errorCaptures.get(0);
+        assertThat(errorCapture.getException()).isNotNull();
+        Map<String, String> tags = errorCapture.getContext().getTags();
+        assertThat(tags).containsKey(QUERY_STATUS_CODE_KEY);
+        assertThat(tags.get(QUERY_STATUS_CODE_KEY)).isEqualTo("404");
+        assertThat(tags).containsKey(ERROR_REASON_KEY);
+        assertThat(tags).containsKey(ELASTICSEARCH_NODE_KEY);
+        assertThat(tags.get(ELASTICSEARCH_NODE_KEY)).isEqualTo(container.getHost().toHostString());
+    }
+
+    private void validateSpanContent(Span span, String expectedName, String expectedStatus) {
+        assertThat(span.getName().toString()).isEqualTo(expectedName);
+        Map<String, String> tags = span.getContext().getTags();
+        assertThat(tags).containsKey(QUERY_STATUS_CODE_KEY);
+        assertThat(tags.get(QUERY_STATUS_CODE_KEY)).isEqualTo(expectedStatus);
+    }
+
+    @Test
+    public void testBCreateIndex() throws IOException {
+        client.indices().create(new CreateIndexRequest(INDEX), RequestOptions.DEFAULT);
+
+        System.out.println(reporter.generateTransactionPayloadJson());
+
+        List<Span> spans = reporter.getSpans();
+        assertThat(spans).hasSize(1);
+        validateSpanContent(spans.get(0), String.format("/%s PUT", INDEX), "200");
+    }
+
+    @Test
+    public void testCIndexADocument() throws IOException {
+        IndexResponse ir = client.index(new IndexRequest(INDEX, DOC_TYPE, DOC_ID).source(
+            jsonBuilder()
+                .startObject()
+                .field(FOO, BAR)
+                .endObject()
+        ).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), RequestOptions.DEFAULT);
+        assertThat(ir.status().getStatus()).isEqualTo(201);
+
+        System.out.println(reporter.generateTransactionPayloadJson());
+
+        List<Span> spans = reporter.getSpans();
+        assertThat(spans).hasSize(1);
+        validateSpanContent(spans.get(0), String.format("/%s/%s/%s PUT", INDEX, DOC_TYPE, DOC_ID), "201");
+    }
+
+    @Test
+    public void testDSearchTheIndex() throws IOException {
+        SearchResponse sr = client.search(new SearchRequest(INDEX), RequestOptions.DEFAULT);
+        assertThat(sr.getHits().totalHits).isEqualTo(1L);
+        assertThat(sr.getHits().getAt(0).getSourceAsMap().get(FOO)).isEqualTo(BAR);
+
+        System.out.println(reporter.generateTransactionPayloadJson());
+
+        List<Span> spans = reporter.getSpans();
+        assertThat(spans).hasSize(1);
+        validateSpanContent(spans.get(0), String.format("/%s/_search POST", INDEX), "200");
+    }
+
+    @Test
+    public void testEUpdateTheDocument() throws IOException {
+        Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put(FOO, BAZ);
+        UpdateResponse ur = client.update(new UpdateRequest(INDEX, DOC_TYPE, DOC_ID).doc(jsonMap)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), RequestOptions.DEFAULT);
+        assertThat(ur.status().getStatus()).isEqualTo(200);
+        SearchResponse sr = client.search(new SearchRequest(INDEX), RequestOptions.DEFAULT);
+        assertThat(sr.getHits().getAt(0).getSourceAsMap().get(FOO)).isEqualTo(BAZ);
+
+        System.out.println(reporter.generateTransactionPayloadJson());
+
+        List<Span> spans = reporter.getSpans();
+        assertThat(spans).hasSize(2);
+        boolean updateSpanFound = false;
+        for(Span span: spans) {
+            if(span.getName().toString().contains("_update")) {
+                updateSpanFound = true;
+                break;
+            }
+        }
+        assertThat(updateSpanFound).isTrue();
+    }
+
+    @Test
+    public void testFScenarioAsBulkRequest() throws IOException {
+        client.bulk(new BulkRequest()
+            .add(new IndexRequest(INDEX, DOC_TYPE, "2").source(
+                jsonBuilder()
+                    .startObject()
+                    .field(FOO, BAR)
+                    .endObject()
+            ))
+            .add(new IndexRequest(INDEX, DOC_TYPE, "3").source(
+                jsonBuilder()
+                    .startObject()
+                    .field(FOO, BAR)
+                    .endObject()
+            ))
+        , RequestOptions.DEFAULT);
+
+        System.out.println(reporter.generateTransactionPayloadJson());
+
+        List<Span> spans = reporter.getSpans();
+        assertThat(spans).hasSize(1);
+        assertThat(spans.get(0).getName().toString()).isEqualTo("/_bulk POST");
+    }
+
+    @Test
+    public void testGDeleteExistingIndex() throws IOException {
+        // Remove any existing index
+        client.indices().delete(new DeleteIndexRequest(INDEX), RequestOptions.DEFAULT);
+
+        System.out.println(reporter.generateTransactionPayloadJson());
+
+        List<Span> spans = reporter.getSpans();
+        assertThat(spans).hasSize(1);
+        validateSpanContent(spans.get(0), String.format("/%s DELETE", INDEX), "200");
+    }
+}

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT.java
@@ -169,8 +169,8 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractInstrument
 
         assertThat(span.getContext().getDb().getType()).isEqualTo(DB_CONTEXT_TYPE);
 
-        if (expectedName.contains(SEARCH_QUERY_PATH_SUFFIX)) {
-            assertThat(span.getContext().getDb().hasContent()).isTrue();
+        if (!expectedName.contains(SEARCH_QUERY_PATH_SUFFIX)) {
+            assertThat(span.getContext().getDb().getStatement()).isNull();
         }
     }
 

--- a/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT_RealReporter.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/src/test/java/co/elastic/apm/es/restclient/ElasticsearchRestClientInstrumentationIT_RealReporter.java
@@ -1,0 +1,248 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.es.restclient;
+
+import co.elastic.apm.bci.ElasticApmAgent;
+import co.elastic.apm.configuration.SpyConfiguration;
+import co.elastic.apm.configuration.converter.TimeDuration;
+import co.elastic.apm.impl.ElasticApmTracer;
+import co.elastic.apm.impl.ElasticApmTracerBuilder;
+import co.elastic.apm.impl.payload.Agent;
+import co.elastic.apm.impl.payload.ProcessInfo;
+import co.elastic.apm.impl.payload.Service;
+import co.elastic.apm.impl.payload.SystemInfo;
+import co.elastic.apm.impl.stacktrace.StacktraceConfiguration;
+import co.elastic.apm.impl.transaction.Transaction;
+import co.elastic.apm.report.ApmServerReporter;
+import co.elastic.apm.report.IntakeV2ReportingEventHandler;
+import co.elastic.apm.report.Reporter;
+import co.elastic.apm.report.ReporterConfiguration;
+import co.elastic.apm.report.processor.ProcessorEventHandler;
+import co.elastic.apm.report.serialize.DslJsonSerializer;
+import fr.pilato.elasticsearch.containers.ElasticsearchContainer;
+import net.bytebuddy.agent.ByteBuddyAgent;
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.ElasticsearchStatusException;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.update.UpdateRequest;
+import org.elasticsearch.action.update.UpdateResponse;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.stagemonitor.configuration.ConfigurationRegistry;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Ignore
+public class ElasticsearchRestClientInstrumentationIT_RealReporter {
+    private static final String USER_NAME = "elastic-user";
+    private static final String PASSWORD = "elastic-pass";
+
+    @SuppressWarnings("NullableProblems")
+    private static ElasticsearchContainer container;
+    @SuppressWarnings("NullableProblems")
+    private static RestHighLevelClient client;
+
+    private static final String INDEX = "my-index";
+    private static final String SECOND_INDEX = "my-second-index";
+    private static final String DOC_ID = "38uhjds8s4g";
+    private static final String DOC_TYPE = "_doc";
+    private static final String FOO = "foo";
+    private static final String BAR = "bar";
+    private static final String BAZ = "baz";
+
+    private static ElasticApmTracer tracer;
+    private static Reporter realReporter;
+
+    /**
+     * A version of ElasticsearchRestClientInstrumentationIT that can be used to test E2E the ES client instrumentation with the IT stack
+     */
+    @BeforeClass
+    public static void startElasticsearchContainerAndClient() throws IOException {
+        // Start the container
+        // TODO: the env setting is to pass the bootstrap check of "vm.max_map_count" which fails on the CI env.
+        // TODO: Can be removed after changing to the official testcontainer
+        container = (ElasticsearchContainer) new ElasticsearchContainer().withEnv("discovery.type", "single-node");
+
+        // There is currently no way to change the ES port on the testcontainer, so it will conflict with the IT ES. So we just use the IT ES
+        // container.start();
+
+        // Create the client
+        CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(USER_NAME, PASSWORD));
+
+        RestClientBuilder builder =  RestClient.builder(new HttpHost("localhost", 9200))
+            .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
+        client = new RestHighLevelClient(builder);
+
+        client.indices().create(new CreateIndexRequest(INDEX), RequestOptions.DEFAULT);
+
+        final ConfigurationRegistry configurationRegistry = SpyConfiguration.createSpyConfig();
+        ReporterConfiguration reporterConfiguration = configurationRegistry.getConfig(ReporterConfiguration.class);
+        when(reporterConfiguration.getFlushInterval()).thenReturn(TimeDuration.of("1ms"));
+        when(reporterConfiguration.getMaxQueueSize()).thenReturn(0);
+        StacktraceConfiguration stacktraceConfiguration = configurationRegistry.getConfig(StacktraceConfiguration.class);
+        when(stacktraceConfiguration.getStackTraceLimit()).thenReturn(30);
+        SystemInfo system = new SystemInfo("x64", "localhost", "platform");
+        final Service service = new Service().withName("Eyal-ES-client-test").withAgent(new Agent("java", "Test"));
+        final ProcessInfo title = new ProcessInfo("title");
+        final ProcessorEventHandler processorEventHandler = ProcessorEventHandler.loadProcessors(configurationRegistry);
+        final IntakeV2ReportingEventHandler v2handler = new IntakeV2ReportingEventHandler(service, title, system, reporterConfiguration,
+            processorEventHandler, new DslJsonSerializer(mock(StacktraceConfiguration.class)));
+        realReporter = new ApmServerReporter(true, reporterConfiguration, v2handler);
+
+        tracer = new ElasticApmTracerBuilder()
+            .configurationRegistry(configurationRegistry)
+            .reporter(realReporter)
+            .build();
+        ElasticApmAgent.initInstrumentation(tracer, ByteBuddyAgent.install());
+    }
+
+    @AfterClass
+    public static void stopElasticsearchContainerAndClient() throws IOException {
+        client.indices().delete(new DeleteIndexRequest(INDEX), RequestOptions.DEFAULT);
+        container.stop();
+        client.close();
+
+        try {
+            realReporter.flush().get();
+        } catch (InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Before
+    public void startTransaction() {
+        Transaction transaction = tracer.startTransaction().activate();
+        transaction.setName("transaction");
+        transaction.withType("request");
+        transaction.withResult("success");
+    }
+
+    @After
+    public void endTransaction() {
+        Transaction currentTransaction = tracer.currentTransaction();
+        if (currentTransaction != null) {
+            currentTransaction.end();
+        }
+    }
+
+    @Test
+    public void testTryToDeleteNonExistingIndex() throws IOException {
+        ElasticsearchStatusException ese = null;
+        try {
+            client.indices().delete(new DeleteIndexRequest(SECOND_INDEX), RequestOptions.DEFAULT);
+        } catch (ElasticsearchStatusException e) {
+            ese = e;
+        }
+        assertThat(ese).isNotNull();
+        assertThat(ese.status().getStatus()).isEqualTo(404);
+    }
+
+    @Test
+    public void testCreateAndDeleteIndex() throws IOException {
+        // Create an Index
+        client.indices().create(new CreateIndexRequest(SECOND_INDEX), RequestOptions.DEFAULT);
+        client.indices().delete(new DeleteIndexRequest(SECOND_INDEX), RequestOptions.DEFAULT);
+    }
+
+    @Test
+    public void testDocumentScenario() throws IOException {
+        // Index a document
+        IndexResponse ir = client.index(new IndexRequest(INDEX, DOC_TYPE, DOC_ID).source(
+            jsonBuilder()
+                .startObject()
+                .field(FOO, BAR)
+                .endObject()
+        ).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), RequestOptions.DEFAULT);
+        assertThat(ir.status().getStatus()).isEqualTo(201);
+
+        SearchRequest searchRequest = new SearchRequest(INDEX);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        sourceBuilder.query(QueryBuilders.termQuery(FOO, BAR));
+        sourceBuilder.from(0);
+        sourceBuilder.size(5);
+        searchRequest.source(sourceBuilder);
+        SearchResponse sr = client.search(searchRequest, RequestOptions.DEFAULT);
+        assertThat(sr.getHits().totalHits).isEqualTo(1L);
+        assertThat(sr.getHits().getAt(0).getSourceAsMap().get(FOO)).isEqualTo(BAR);
+
+        // Now update and re-search
+        Map<String, Object> jsonMap = new HashMap<>();
+        jsonMap.put(FOO, BAZ);
+        UpdateResponse ur = client.update(new UpdateRequest(INDEX, DOC_TYPE, DOC_ID).doc(jsonMap)
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE), RequestOptions.DEFAULT);
+        assertThat(ur.status().getStatus()).isEqualTo(200);
+        sr = client.search(new SearchRequest(INDEX), RequestOptions.DEFAULT);
+        assertThat(sr.getHits().getAt(0).getSourceAsMap().get(FOO)).isEqualTo(BAZ);
+
+        // Finally - delete the document
+        DeleteResponse dr = client.delete(new DeleteRequest(INDEX, DOC_TYPE, DOC_ID), RequestOptions.DEFAULT);
+        assertThat(dr.status().getStatus()).isEqualTo(200);
+    }
+
+    @Test
+    public void testScenarioAsBulkRequest() throws IOException {
+        client.bulk(new BulkRequest()
+            .add(new IndexRequest(INDEX, DOC_TYPE, "2").source(
+                jsonBuilder()
+                    .startObject()
+                    .field(FOO, BAR)
+                    .endObject()
+            ))
+            .add(new IndexRequest(INDEX, DOC_TYPE, "3").source(
+                jsonBuilder()
+                    .startObject()
+                    .field(FOO, BAR)
+                    .endObject()
+            ))
+        , RequestOptions.DEFAULT);
+    }
+}

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -19,6 +19,7 @@
         <module>apm-spring-resttemplate-plugin</module>
         <module>apm-httpclient-core</module>
         <module>apm-slf4j-plugin</module>
+        <module>apm-es-restclient-plugin</module>
     </modules>
 
     <properties>

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -250,7 +250,7 @@ you should add an additional entry to this list (make sure to also include the d
 ==== `disable_instrumentations`
 
 A list of instrumentations which should be disabled.
-Valid options are `apache-httpclient`, `http-client`, `incubating`, `jax-rs`, `jax-rs-annotations`, `jdbc`, `opentracing`, `public-api`, `servlet-api`, `servlet-api-async`, `spring-mvc`, `spring-resttemplate`.
+Valid options are `apache-httpclient`, `elasticsearch-restclient`, `http-client`, `incubating`, `jax-rs`, `jax-rs-annotations`, `jdbc`, `opentracing`, `public-api`, `servlet-api`, `servlet-api-async`, `spring-mvc`, `spring-resttemplate`.
 If you want to try out incubating features,
 set the value to an empty string.
 
@@ -875,7 +875,7 @@ The default unit for this option is `ms`
 # sanitize_field_names=password,passwd,pwd,secret,*key,*token*,*session*,*credit*,*card*,authorization,set-cookie
 
 # A list of instrumentations which should be disabled.
-# Valid options are `apache-httpclient`, `http-client`, `incubating`, `jax-rs`, `jax-rs-annotations`, `jdbc`, `opentracing`, `public-api`, `servlet-api`, `servlet-api-async`, `spring-mvc`, `spring-resttemplate`.
+# Valid options are `apache-httpclient`, `elasticsearch-restclient`, `http-client`, `incubating`, `jax-rs`, `jax-rs-annotations`, `jdbc`, `opentracing`, `public-api`, `servlet-api`, `servlet-api-async`, `spring-mvc`, `spring-resttemplate`.
 # If you want to try out incubating features,
 # set the value to an empty string.
 #

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -173,6 +173,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>apm-es-restclient-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>apm-opentracing-plugin</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
This is still WIP, but it's a good point to review.
Several notes:

- The discussion about what to do with tags is still in progress, so I just decided to copy `Span` tags to `ErrorCapture` tags at the moment, just so you can see what info we have. Once decided, I can either put the relevant info on `Span` tags in case of error, or add the tags directly to the `ErrorCapture` when creating it (without relying on copying from parent span)

- I add the query options and parameters as tags as well. I assume that won't be the default behaviour. If you think this may valuable info for some users, we can add a configuration property that enables adding those and is off by default, or we can just overlook those.

- The `onMethodEnter` advice currently introduces variable due to iteration (starting [here](https://github.com/elastic/apm-agent-java/pull/228/files#diff-a50aafc4c23195a6df81ed2942542584R72)), if we decide to keep options and parameter, I will replace them with inlined code or external method, e.g:
```
        // Add request parameters to query info
        span.getContext().getTags().putAll(request.getParameters());

        // Add request options to query info
        request.getOptions().getHeaders().forEach(header -> span.addTag(header.getName(), header.getValue()));
```

- Feel free to suggest different names for span type, tag names etc. 