### PR TITLE
Store active transaction in its own ThreadLocal

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/ElasticApmTracer.java
@@ -62,6 +62,7 @@ public class ElasticApmTracer {
     private final ObjectPool<Span> spanPool;
     private final ObjectPool<ErrorCapture> errorPool;
     private final Reporter reporter;
+    private final ThreadLocal<Transaction> activeTransaction = new ThreadLocal<>();
     private final ThreadLocal<AbstractSpan> active = new ThreadLocal<>();
     private final CoreConfiguration coreConfiguration;
     private final List<SpanListener> spanListeners;
@@ -143,11 +144,7 @@ public class ElasticApmTracer {
 
     @Nullable
     public Transaction currentTransaction() {
-        final AbstractSpan<?> activeSpan = active.get();
-        if (activeSpan != null) {
-            return activeSpan.getTransaction();
-        }
-        return null;
+        return activeTransaction.get();
     }
 
     @Nullable
@@ -163,10 +160,6 @@ public class ElasticApmTracer {
      * Starts a span with a given parent context.
      * <p>
      * This method makes it possible to start a span after the parent has already ended.
-     * </p>
-     * <p>
-     * Note: both, {@link Span#getTransaction()} and {@link #currentTransaction()},
-     * will return {@code null} when starting the span this way.
      * </p>
      *
      * @param parentContext the trace context of the parent
@@ -360,5 +353,13 @@ public class ElasticApmTracer {
 
     public List<SpanListener> getSpanListeners() {
         return spanListeners;
+    }
+
+    public void activateTransaction(Transaction transaction) {
+        activeTransaction.set(transaction);
+    }
+
+    public void deactivateTransaction() {
+        activeTransaction.set(null);
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/AbstractSpan.java
@@ -45,8 +45,6 @@ public abstract class AbstractSpan<T extends AbstractSpan> implements Recyclable
      * (Required)
      */
     protected double duration;
-    @Nullable
-    private volatile AbstractSpan<?> previouslyActive;
     /**
      * Keyword of specific relevance in the service's domain
      * (eg:  'request', 'backgroundjob' for transactions and
@@ -152,8 +150,7 @@ public abstract class AbstractSpan<T extends AbstractSpan> implements Recyclable
     public abstract Transaction getTransaction();
 
     public T activate() {
-        previouslyActive = tracer.getActive();
-        tracer.setActive(this);
+        tracer.activate(this);
         List<SpanListener> spanListeners = tracer.getSpanListeners();
         for (int i = 0; i < spanListeners.size(); i++) {
             try {
@@ -168,7 +165,7 @@ public abstract class AbstractSpan<T extends AbstractSpan> implements Recyclable
     }
 
     public T deactivate() {
-        tracer.setActive(previouslyActive);
+        tracer.deactivate(this);
         List<SpanListener> spanListeners = tracer.getSpanListeners();
         for (int i = 0; i < spanListeners.size(); i++) {
             try {
@@ -184,7 +181,7 @@ public abstract class AbstractSpan<T extends AbstractSpan> implements Recyclable
 
     public Scope activateInScope() {
         // already in scope
-        if (tracer.currentTransaction() == this) {
+        if (tracer.getActive() == this) {
             return Scope.NoopScope.INSTANCE;
         }
         activate();

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
@@ -176,19 +176,4 @@ public class Transaction extends AbstractSpan<Transaction> {
     public String toString() {
         return String.format("'%s' %s", name, traceContext);
     }
-
-    @Override
-    public Transaction activate() {
-        tracer.activateTransaction(this);
-        return super.activate();
-    }
-
-    @Override
-    public Transaction deactivate() {
-        try {
-            return super.deactivate();
-        } finally {
-            tracer.deactivateTransaction();
-        }
-    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/Transaction.java
@@ -176,4 +176,19 @@ public class Transaction extends AbstractSpan<Transaction> {
     public String toString() {
         return String.format("'%s' %s", name, traceContext);
     }
+
+    @Override
+    public Transaction activate() {
+        tracer.activateTransaction(this);
+        return super.activate();
+    }
+
+    @Override
+    public Transaction deactivate() {
+        try {
+            return super.deactivate();
+        } finally {
+            tracer.deactivateTransaction();
+        }
+    }
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletTransactionHelper.java
@@ -136,7 +136,12 @@ public class ServletTransactionHelper {
             // in case we screwed up, don't bring down the monitored application with us
             logger.warn("Exception while capturing Elastic APM transaction", e);
         }
-        transaction.deactivate().end();
+        if (tracer.getActive() == transaction) {
+            // when calling javax.servlet.AsyncContext#start, the transaction is not activated,
+            // as neither javax.servlet.Filter.doFilter nor javax.servlet.AsyncListener.onStartAsync will be invoked
+            transaction.deactivate();
+        }
+        transaction.end();
     }
 
     void applyDefaultTransactionName(String method, String servletPath, @Nullable String pathInfo, StringBuilder transactionName) {


### PR DESCRIPTION
Deprecate Span#getTransaction (see javadoc)
This change reduces the usage of Span#getTransaction