### PR TITLE
[ci] Put everything on one line so that JAVA_HOME gets respected

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,3 +1,2 @@
 #!/usr/bin/env bash
-JAVA_HOME=$HOME/.java/java10
-./mvnw compile
+JAVA_HOME=$HOME/.java/java10 ./mvnw compile


### PR DESCRIPTION
Currently, as `JAVA_HOME` isn't being exported, it just gets ignored by `mvnw`...

Putting it all on one line means it will be set for the command being run :) 