### PR TITLE
Use java.time.Instant to get micros accurate timestamps

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/EpochTickClock.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/EpochTickClock.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,8 +20,6 @@
 package co.elastic.apm.impl.transaction;
 
 import co.elastic.apm.objectpool.Recyclable;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * This clock makes sure that each {@link Span} and {@link Transaction} uses a consistent clock
@@ -52,19 +50,19 @@ public class EpochTickClock implements Recyclable {
      * @return the epoch microsecond timestamp at initialization time
      */
     public long init() {
-        return init(System.currentTimeMillis(), System.nanoTime());
+        return init(SystemClock.ForCurrentVM.INSTANCE.getEpochMicros(), System.nanoTime());
     }
 
     /**
      * Initializes and calibrates the clock based on wall clock time
      *
-     * @param epochMillis the current timestamp in milliseconds since epoch (mostly {@link System#currentTimeMillis()})
-     * @param nanoTime    the current nanosecond precision timestamp (mostly {@link System#nanoTime()}
+     * @param epochMicrosWallClock the current timestamp in microseconds since epoch, based on wall clock time
+     * @param nanoTime             the current nanosecond ticks (mostly {@link System#nanoTime()}
      * @return the epoch microsecond timestamp at initialization time
      */
-    public long init(long epochMillis, long nanoTime) {
-        nanoTimeOffsetToEpoch = TimeUnit.MILLISECONDS.toNanos(epochMillis) - nanoTime;
-        return TimeUnit.MILLISECONDS.toMicros(epochMillis);
+    public long init(long epochMicrosWallClock, long nanoTime) {
+        nanoTimeOffsetToEpoch = epochMicrosWallClock * 1_000 - nanoTime;
+        return epochMicrosWallClock;
     }
 
     public long getEpochMicros() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SystemClock.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SystemClock.java
@@ -35,9 +35,10 @@ public interface SystemClock {
         ForCurrentVM() {
             SystemClock localDispatcher;
             try {
-                Class.forName("java.time.Instant");
-                localDispatcher = ForJava8CapableVM.INSTANCE;
-            } catch (Exception | NoClassDefFoundError e) {
+                // being cautious to not cause linking of ForJava8CapableVM in case we are not running on Java 8+
+                Class.forName("java.time.Clock");
+                localDispatcher = (SystemClock) Class.forName(SystemClock.class.getName() + "$ForJava8CapableVM").getEnumConstants()[0];
+            } catch (Exception e) {
                 localDispatcher = ForLegacyVM.INSTANCE;
             }
             dispatcher = localDispatcher;

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SystemClock.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SystemClock.java
@@ -1,0 +1,52 @@
+package co.elastic.apm.impl.transaction;
+
+import java.time.Clock;
+import java.time.Instant;
+
+public interface SystemClock {
+
+    long getEpochMicros();
+
+    enum ForCurrentVM implements SystemClock {
+        INSTANCE;
+        private final SystemClock dispatcher;
+
+        ForCurrentVM() {
+            SystemClock localDispatcher;
+            try {
+                Class.forName("java.time.Instant");
+                localDispatcher = ForJava8CapableVM.INSTANCE;
+            } catch (Exception | NoClassDefFoundError e) {
+                localDispatcher = ForLegacyVM.INSTANCE;
+            }
+            dispatcher = localDispatcher;
+        }
+
+        @Override
+        public long getEpochMicros() {
+            return dispatcher.getEpochMicros();
+        }
+    }
+
+    enum ForJava8CapableVM implements SystemClock {
+        INSTANCE;
+
+        private static final Clock clock = Clock.systemUTC();
+
+        @Override
+        public long getEpochMicros() {
+            // escape analysis, plz kick in and allocate the Instant on the stack
+            final Instant now = clock.instant();
+            return now.getEpochSecond() * 1_000_000 + now.getNano() / 1_000;
+        }
+    }
+
+    enum ForLegacyVM implements SystemClock {
+        INSTANCE;
+
+        @Override
+        public long getEpochMicros() {
+            return System.currentTimeMillis() * 1_000;
+        }
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SystemClock.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/impl/transaction/SystemClock.java
@@ -1,4 +1,25 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package co.elastic.apm.impl.transaction;
+
+import org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -28,6 +49,7 @@ public interface SystemClock {
         }
     }
 
+    @IgnoreJRERequirement
     enum ForJava8CapableVM implements SystemClock {
         INSTANCE;
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/EpochTickClockTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/EpochTickClockTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,9 +37,9 @@ class EpochTickClockTest {
 
     @Test
     void testEpochMicros() {
-        final long epochMillis = System.currentTimeMillis();
-        epochTickClock.init(epochMillis, 0);
+        final long epochMicros = SystemClock.ForJava8CapableVM.INSTANCE.getEpochMicros();
+        epochTickClock.init(epochMicros, 0);
         final int nanoTime = 1000;
-        assertThat(epochTickClock.getEpochMicros(nanoTime)).isEqualTo(epochMillis * 1000 + TimeUnit.NANOSECONDS.toMicros(nanoTime));
+        assertThat(epochTickClock.getEpochMicros(nanoTime)).isEqualTo(epochMicros + TimeUnit.NANOSECONDS.toMicros(nanoTime));
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/SystemClockTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/SystemClockTest.java
@@ -1,0 +1,17 @@
+package co.elastic.apm.impl.transaction;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Offset.offset;
+
+class SystemClockTest {
+
+    @Test
+    void testClocks() {
+        assertThat(SystemClock.ForJava8CapableVM.INSTANCE.getEpochMicros())
+            .isCloseTo(SystemClock.ForLegacyVM.INSTANCE.getEpochMicros(), offset(TimeUnit.SECONDS.toMicros(10)));
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/SystemClockTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/impl/transaction/SystemClockTest.java
@@ -11,7 +11,11 @@ class SystemClockTest {
 
     @Test
     void testClocks() {
-        assertThat(SystemClock.ForJava8CapableVM.INSTANCE.getEpochMicros())
-            .isCloseTo(SystemClock.ForLegacyVM.INSTANCE.getEpochMicros(), offset(TimeUnit.SECONDS.toMicros(10)));
+        final long currentVmEpochMicros = SystemClock.ForCurrentVM.INSTANCE.getEpochMicros();
+        final long java8EpochMicros = SystemClock.ForJava8CapableVM.INSTANCE.getEpochMicros();
+        final long java7EpochMicros = SystemClock.ForLegacyVM.INSTANCE.getEpochMicros();
+        assertThat(java8EpochMicros).isCloseTo(java7EpochMicros, offset(TimeUnit.SECONDS.toMicros(10)));
+        assertThat(java8EpochMicros).isCloseTo(currentVmEpochMicros, offset(TimeUnit.SECONDS.toMicros(10)));
+        assertThat(java7EpochMicros % 1000).isEqualTo(0);
     }
 }


### PR DESCRIPTION
fall back to System.currentTimeMillis() for Java 7