### PR TITLE
Cache docker containers on CI worker image

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-JAVA_HOME=$HOME/.java/java10 ./mvnw compile
+JAVA_HOME=$HOME/.java/java10 ./mvnw verify


### PR DESCRIPTION
This requires docker to be available while building the worker image. Not sure if that is the case. It will take longer to build the image but CI builds will be faster.