### PR TITLE
docs: fix spelling

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ReporterConfiguration.java
@@ -94,11 +94,11 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
             "Events like transactions and spans are buffered when the agent can't keep up with sending them to the APM Server " +
             "or if the APM server is down.\n" +
             "\n" +
-            "If the queue is full, events are rejected which means you will loose transactions and spans in that case.\n" +
+            "If the queue is full, events are rejected which means you will lose transactions and spans in that case.\n" +
             "This guards the application from crashing in case the APM server is unavailable for a longer period of time.\n" +
             "\n" +
             "A lower value will decrease the heap overhead of the agent,\n" +
-            "while a higher value makes it less likely to loose events in case of a temporary spike in throughput.")
+            "while a higher value makes it less likely to lose events in case of a temporary spike in throughput.")
         .dynamic(true)
         .buildWithDefault(512);
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -655,11 +655,11 @@ The maximum size of buffered events.
 
 Events like transactions and spans are buffered when the agent can't keep up with sending them to the APM Server or if the APM server is down.
 
-If the queue is full, events are rejected which means you will loose transactions and spans in that case.
+If the queue is full, events are rejected which means you will lose transactions and spans in that case.
 This guards the application from crashing in case the APM server is unavailable for a longer period of time.
 
 A lower value will decrease the heap overhead of the agent,
-while a higher value makes it less likely to loose events in case of a temporary spike in throughput.
+while a higher value makes it less likely to lose events in case of a temporary spike in throughput.
 
 
 [options="header"]
@@ -1109,11 +1109,11 @@ The default unit for this option is `ms`
 # 
 # Events like transactions and spans are buffered when the agent can't keep up with sending them to the APM Server or if the APM server is down.
 # 
-# If the queue is full, events are rejected which means you will loose transactions and spans in that case.
+# If the queue is full, events are rejected which means you will  transactions and spans in that case.
 # This guards the application from crashing in case the APM server is unavailable for a longer period of time.
 # 
 # A lower value will decrease the heap overhead of the agent,
-# while a higher value makes it less likely to loose events in case of a temporary spike in throughput.
+# while a higher value makes it less likely to lose events in case of a temporary spike in throughput.
 #
 # This setting can be changed at runtime
 # Type: Integer


### PR DESCRIPTION
Ammend #273 spelling: `loose` -> `lose`