### PR TITLE
fix doc build errors take 2

### DIFF
--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -12,9 +12,9 @@ In other words,
 it translates the calls to the OpenTracing API to Elastic APM and thus allows for reusing existing instrumentation.
 
 The first span of a service will be converted to an Elastic APM
-link:{apm-server-ref}/transactions.html[`Transaction`],
+https://www.elastic.co/guide/en/apm/get-started/master/transactions.html[`Transaction`],
 subsequent spans are mapped to Elastic APM
-link:{apm-server-ref}/transactions.html#transaction-spans[`Span`]s.
+https://www.elastic.co/guide/en/apm/get-started/master/transaction-span.html[`Span`].
 
 [float]
 [[operation-modes]]
@@ -120,7 +120,7 @@ Baggage items are silently dropped.
 ==== Logs
 Only exception logging is supported.
 Logging an Exception on the OpenTracing span will create an Elastic APM
-link:{apm-server-ref}/errors.html[`Error`].
+https://www.elastic.co/guide/en/apm/get-started/master/errors.html[`Error`].
 Example:
 
 [source,java]


### PR DESCRIPTION
Take 2 on fixing doc build errors. There are discrepancies in what current is. Changing these to hard-coded links for now. Will need to chat about this when I'm back from X School. 