### PR TITLE
Avoid setting request attributes to reduce allocations

### DIFF
--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/FilterChainInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/FilterChainInstrumentation.java
@@ -20,7 +20,6 @@
 package co.elastic.apm.servlet;
 
 import co.elastic.apm.bci.ElasticApmInstrumentation;
-import co.elastic.apm.bci.VisibleForAdvice;
 import co.elastic.apm.impl.ElasticApmTracer;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
@@ -42,9 +41,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
  * Instruments {@link javax.servlet.FilterChain}s to create transactions.
  */
 public class FilterChainInstrumentation extends ElasticApmInstrumentation {
-
-    @VisibleForAdvice
-    public static final String EXCLUDE_REQUEST = "elastic.apm.servlet.request.exclude";
 
     @Override
     public void init(ElasticApmTracer tracer) {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletApiAdvice.java
@@ -55,6 +55,13 @@ public class ServletApiAdvice {
     @Nullable
     @VisibleForAdvice
     public static ElasticApmTracer tracer;
+    @VisibleForAdvice
+    public static ThreadLocal<Boolean> excluded = new ThreadLocal<>() {
+        @Override
+        protected Boolean initialValue() {
+            return Boolean.FALSE;
+        }
+    };
 
     static void init(ElasticApmTracer tracer) {
         ServletApiAdvice.tracer = tracer;
@@ -77,7 +84,7 @@ public class ServletApiAdvice {
         if (servletTransactionHelper != null &&
             servletRequest instanceof HttpServletRequest &&
             servletRequest.getDispatcherType() == DispatcherType.REQUEST &&
-            !Boolean.TRUE.equals(servletRequest.getAttribute(FilterChainInstrumentation.EXCLUDE_REQUEST))) {
+            !Boolean.TRUE.equals(excluded.get())) {
 
             final HttpServletRequest request = (HttpServletRequest) servletRequest;
             transaction = servletTransactionHelper.onBefore(
@@ -86,10 +93,8 @@ public class ServletApiAdvice {
                 request.getHeader(TraceContext.TRACE_PARENT_HEADER));
             if (transaction == null) {
                 // if the request is excluded, avoid matching all exclude patterns again on each filter invocation
-                request.setAttribute(FilterChainInstrumentation.EXCLUDE_REQUEST, Boolean.TRUE);
+                excluded.set(Boolean.TRUE);
                 return;
-            } else {
-                request.setAttribute(TRANSACTION_ATTRIBUTE, transaction);
             }
             final Request req = transaction.getContext().getRequest();
             if (transaction.isSampled() && request.getCookies() != null) {
@@ -121,6 +126,7 @@ public class ServletApiAdvice {
         if (tracer == null) {
             return;
         }
+        excluded.set(Boolean.FALSE);
         if (scope != null) {
             scope.close();
         }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletApiAdvice.java
@@ -56,7 +56,7 @@ public class ServletApiAdvice {
     @VisibleForAdvice
     public static ElasticApmTracer tracer;
     @VisibleForAdvice
-    public static ThreadLocal<Boolean> excluded = new ThreadLocal<>() {
+    public static ThreadLocal<Boolean> excluded = new ThreadLocal<Boolean>() {
         @Override
         protected Boolean initialValue() {
             return Boolean.FALSE;

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/servlet/ServletTransactionHelper.java
@@ -39,6 +39,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -185,15 +186,17 @@ public class ServletTransactionHelper {
     }
 
     private boolean isExcluded(String servletPath, String pathInfo, String requestURI, @Nullable String userAgentHeader) {
-        boolean excludeUrl = WildcardMatcher.anyMatch(webConfiguration.getIgnoreUrls(), servletPath, pathInfo) != null;
+        final List<WildcardMatcher> ignoreUrls = webConfiguration.getIgnoreUrls();
+        boolean excludeUrl = WildcardMatcher.anyMatch(ignoreUrls, servletPath, pathInfo) != null;
         if (excludeUrl) {
             logger.debug("Not tracing this request as the URL {} is ignored by one of the matchers",
-                requestURI, webConfiguration.getIgnoreUrls());
+                requestURI, ignoreUrls);
         }
-        boolean excludeAgent = userAgentHeader != null && WildcardMatcher.anyMatch(webConfiguration.getIgnoreUserAgents(), userAgentHeader) != null;
+        final List<WildcardMatcher> ignoreUserAgents = webConfiguration.getIgnoreUserAgents();
+        boolean excludeAgent = userAgentHeader != null && WildcardMatcher.anyMatch(ignoreUserAgents, userAgentHeader) != null;
         if (excludeAgent) {
             logger.debug("Not tracing this request as the User-Agent {} is ignored by one of the matchers",
-                userAgentHeader, webConfiguration.getIgnoreUserAgents());
+                userAgentHeader, ignoreUserAgents);
         }
         return excludeUrl || excludeAgent;
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/servlet/ApmFilterTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/servlet/ApmFilterTest.java
@@ -49,6 +49,8 @@ import java.util.Objects;
 
 import static org.assertj.core.api.Java6Assertions.assertThat;
 import static org.assertj.core.api.Java6Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class ApmFilterTest extends AbstractInstrumentationTest {
@@ -145,11 +147,14 @@ class ApmFilterTest extends AbstractInstrumentationTest {
 
     @Test
     void testIgnoreUrlEndWith() throws IOException, ServletException {
+        filterChain = new MockFilterChain(new HttpServlet() {
+        });
         when(webConfiguration.getIgnoreUrls()).thenReturn(Collections.singletonList(WildcardMatcher.valueOf("*.js")));
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.setServletPath("/resources");
         request.setPathInfo("test.js");
         filterChain.doFilter(request, new MockHttpServletResponse());
+        verify(webConfiguration, times(1)).getIgnoreUrls();
         assertThat(reporter.getTransactions()).hasSize(0);
     }
 


### PR DESCRIPTION
Adding a request attribute creates a new HashMap$Node which allocates 32b
- Only set transaction request attribute when startAsync is called
- Set excluded as ThreadLocal as opposed to request attribute