### PR TITLE
Reduce usages of guava map

### DIFF
--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/jdbc/ConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/jdbc/ConnectionInstrumentation.java
@@ -21,7 +21,6 @@ package co.elastic.apm.jdbc;
 
 import co.elastic.apm.bci.ElasticApmInstrumentation;
 import co.elastic.apm.bci.VisibleForAdvice;
-import com.google.common.collect.MapMaker;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
@@ -34,6 +33,7 @@ import java.sql.PreparedStatement;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.WeakHashMap;
 
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
@@ -52,7 +52,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 public class ConnectionInstrumentation extends ElasticApmInstrumentation {
 
     @VisibleForAdvice
-    public static final Map<Object, String> statementSqlMap = new MapMaker().concurrencyLevel(16).weakKeys().makeMap();
+    public static final Map<Object, String> statementSqlMap = Collections.synchronizedMap(new WeakHashMap<>());
     static final String JDBC_INSTRUMENTATION_GROUP = "jdbc";
 
     @VisibleForAdvice

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/jdbc/ConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/jdbc/ConnectionInstrumentation.java
@@ -52,7 +52,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 public class ConnectionInstrumentation extends ElasticApmInstrumentation {
 
     @VisibleForAdvice
-    public static final Map<Object, String> statementSqlMap = Collections.synchronizedMap(new WeakHashMap<>());
+    public static final Map<Object, String> statementSqlMap = Collections.synchronizedMap(new WeakHashMap<Object, String>());
     static final String JDBC_INSTRUMENTATION_GROUP = "jdbc";
 
     @VisibleForAdvice


### PR DESCRIPTION
Turned out that in multi-threaded benchmark,s a simple synchronized map significantly outperforms the guava map.

The benchmarks were executed locally on my MBP and were configured to run with 8 threads.

`Collections.synchronizedMap(new WeakHashMap())`:
```
Benchmark   Mode      Cnt        Score         Error       Units
          sample  2431418        5.153 ±       0.159       us/op
p0.00     sample                 1.206                     us/op
p0.50     sample                 3.320                     us/op
p0.90     sample                 3.624                     us/op
p0.95     sample                 3.764                     us/op
p0.99     sample                 4.736                     us/op
p0.999    sample               207.104                     us/op
p0.9999   sample              3767.739                     us/op
p1.00     sample             13320.192                     us/op
```

<img width="1990" alt="screen shot 2018-11-19 at 09 11 53" src="https://user-images.githubusercontent.com/2163464/48694980-1dcc5e80-ebde-11e8-9691-58720ffcc800.png">

`new MapMaker().concurrencyLevel(16).weakKeys().makeMap()`
```
Benchmark   Mode      Cnt        Score         Error       Units
          sample  2149363        9.935 ±       0.074       us/op
p0.00     sample                 1.276                     us/op
p0.50     sample                 2.972                     us/op
p0.90     sample                38.592                     us/op
p0.95     sample                56.128                     us/op
p0.99     sample               100.736                     us/op
p0.999    sample               212.224                     us/op
p0.9999   sample               434.688                     us/op
p1.00     sample             15859.712                     us/op
```
<img width="1990" alt="screen shot 2018-11-19 at 09 12 07" src="https://user-images.githubusercontent.com/2163464/48694981-1dcc5e80-ebde-11e8-82b3-5d246479f571.png">

[flamegraphs.zip](https://github.com/elastic/apm-agent-java/files/2594372/flamegraphs.zip)

---

I'll leave the guava map in JdbcHelperImpl for the field `Map<Connection, ConnectionMetaData> metaDataMap` for now as writes are a lot less common there (which guava seemingly can't handle well) and reads don't seem to be synchronized (in contrast to Collections.synchronizedMap).

We should continue our search for a performant, concurrent and garbage free map with weak keys.