### PR TITLE
Use LiteBlockingWaitStrategy

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/report/ApmServerReporter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/report/ApmServerReporter.java
@@ -89,7 +89,7 @@ public class ApmServerReporter implements Reporter {
                 thread.setName("apm-reporter");
                 return thread;
             }
-        }, ProducerType.MULTI, PhasedBackoffWaitStrategy.withLock(1, 10, TimeUnit.MILLISECONDS));
+        }, ProducerType.MULTI, PhasedBackoffWaitStrategy.withLiteLock(1, 10, TimeUnit.MILLISECONDS));
         this.reportingEventHandler = reportingEventHandler;
         disruptor.setDefaultExceptionHandler(new IgnoreExceptionHandler());
         disruptor.handleEventsWith(this.reportingEventHandler);


### PR DESCRIPTION
With multiple threads involved, the disruptor's BlockingWaitStrategy causes quite some contention when signalling the publish of a new sequence (aka waking up producer threads).

That contention completely disappears with this `LiteBlockingWaitStrategy`.

<img width="1990" alt="screen shot 2018-11-19 at 11 21 02" src="https://user-images.githubusercontent.com/2163464/48703509-38a9cd80-ebf4-11e8-9316-26b3b7af5f74.png">

[flamegraph.zip](https://github.com/elastic/apm-agent-java/files/2595002/flamegraph.zip)

We could also evaluate other strategies like the `SleepingWaitStrategy` but judging from the last evaluation I did (where I didn't store the results 🤦‍♂️ ), the `BlockingWaitStrategy` was the only one with negligable CPU overhead in quiet periods. An agent which increases CPU usage even if there are no requests served is not what we want.