### PR TITLE
Omit instrumenting classes version pre Java 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Bug Fixes
+ * Avoid `VerifyError`s by non instrumenting classes compiled for Java 4 or earlier
 
 # 1.0.1
 

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -132,5 +132,12 @@
             <artifactId>guava</artifactId>
             <version>27.0-android</version>
         </dependency>
+        <!--Used to test excluding old class file versions-->
+        <dependency>
+            <groupId>commons-math</groupId>
+            <artifactId>commons-math</artifactId>
+            <version>1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/apm-agent-core/src/main/java/co/elastic/apm/bci/bytebuddy/ErrorLoggingListener.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/bci/bytebuddy/ErrorLoggingListener.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -26,10 +26,15 @@ import org.slf4j.LoggerFactory;
 
 public class ErrorLoggingListener extends AgentBuilder.Listener.Adapter {
 
-	private static final Logger logger = LoggerFactory.getLogger(ErrorLoggingListener.class);
+    private static final Logger logger = LoggerFactory.getLogger(ErrorLoggingListener.class);
 
-	@Override
-	public void onError(String typeName, ClassLoader classLoader, JavaModule module, boolean loaded, Throwable throwable) {
-		logger.warn("ERROR on transformation " + typeName, throwable);
-	}
+    @Override
+    public void onError(String typeName, ClassLoader classLoader, JavaModule module, boolean loaded, Throwable throwable) {
+        if (throwable instanceof MinimumClassFileVersionValidator.UnsupportedClassFileVersionException) {
+            logger.warn("{} uses an unsupported class file version (pre Java 5) and can't be instrumented. " +
+                "Consider updating to a newer version of that library.", typeName);
+        } else {
+            logger.warn("ERROR on transformation " + typeName, throwable);
+        }
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/bci/bytebuddy/MinimumClassFileVersionValidator.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/bci/bytebuddy/MinimumClassFileVersionValidator.java
@@ -1,0 +1,61 @@
+package co.elastic.apm.bci.bytebuddy;
+
+import net.bytebuddy.ClassFileVersion;
+import net.bytebuddy.asm.AsmVisitorWrapper;
+import net.bytebuddy.description.field.FieldDescription;
+import net.bytebuddy.description.field.FieldList;
+import net.bytebuddy.description.method.MethodList;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.Implementation;
+import net.bytebuddy.jar.asm.ClassVisitor;
+import net.bytebuddy.pool.TypePool;
+import net.bytebuddy.utility.OpenedClassReader;
+
+public enum MinimumClassFileVersionValidator implements AsmVisitorWrapper {
+
+    INSTANCE;
+
+    private static final ClassFileVersion MINIMUM_CLASS_FILE_VERSION = ClassFileVersion.JAVA_V5;
+
+    @Override
+    public ClassVisitor wrap(TypeDescription instrumentedType, ClassVisitor classVisitor, Implementation.Context implementationContext,
+                             TypePool typePool, FieldList<FieldDescription.InDefinedShape> fields, MethodList<?> methods, int writerFlags, int readerFlags) {
+        return new ClassVisitor(OpenedClassReader.ASM_API, classVisitor) {
+            @Override
+            public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                final ClassFileVersion classFileVersion = ClassFileVersion.ofMinorMajor(version);
+                if (!classFileVersion.isAtLeast(MINIMUM_CLASS_FILE_VERSION)) {
+                    throw UnsupportedClassFileVersionException.INSTANCE;
+                }
+                super.visit(version, access, name, signature, superName, interfaces);
+            }
+        };
+    }
+
+    @Override
+    public int mergeWriter(int flags) {
+        return flags;
+    }
+
+    @Override
+    public int mergeReader(int flags) {
+        return flags;
+    }
+
+    public static class UnsupportedClassFileVersionException extends RuntimeException {
+        static final UnsupportedClassFileVersionException INSTANCE = new UnsupportedClassFileVersionException();
+
+        private UnsupportedClassFileVersionException() {
+            // singleton
+        }
+
+        /*
+         * avoids the expensive creation of the stack trace which is not needed
+         */
+        @Override
+        public synchronized Throwable fillInStackTrace()
+        {
+            return this;
+        }
+    }
+}

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -150,15 +150,12 @@ Also make sure to configure your firewalls so that the host the agent runs on ca
 [[trouble-shooting-old-jdbc-drivers]]
 ==== Libraries compiled against old Java versions
 
-If you are seeing exceptions like these in your application,
+If you are seeing warning like these in your application,
 it means that you are using a library which has been compiled for a very old version of Java:
 
 ----
-java.lang.VerifyError: (class: org/apache/commons/dbcp/DelegatingStatement, method: executeQuery signature: (Ljava/lang/String;)Ljava/sql/ResultSet;) Illegal type in constant pool
-----
-
-----
-java.lang.IllegalStateException: Cannot write type to constant pool for class file version Java 2
+org.apache.commons.dbcp.DelegatingStatement uses an unsupported class file version (pre Java 5) and can't be instrumented.
+Consider updating to a newer version of that library.
 ----
 
 That mostly concerns JDBC drivers.


### PR DESCRIPTION
This avoids VerifyErrors like reported [here](https://discuss.elastic.co/t/java-lang-verifyerror-with-java-agent/156882) and in #197.

An alternative would be to use the `TypeConstantAdjustment` visitor. But not instrumenting classes compiled for Java 4 or before seems to be safer.