### PR TITLE
Remove incubating label from Apache HttpClient instrumentation

### DIFF
--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/httpclient/ApacheHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/httpclient/ApacheHttpClientInstrumentation.java
@@ -100,6 +100,6 @@ public class ApacheHttpClientInstrumentation extends ElasticApmInstrumentation {
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        return Arrays.asList("incubating", "http-client", "apache-httpclient");
+        return Arrays.asList("http-client", "apache-httpclient");
     }
 }


### PR DESCRIPTION
making it active by default