### PR TITLE
Test public API in app server integration test

### DIFF
--- a/integration-tests/simple-webapp/pom.xml
+++ b/integration-tests/simple-webapp/pom.xml
@@ -29,6 +29,11 @@
             <artifactId>h2</artifactId>
             <version>${version.h2}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
     </dependencies>
 
 </project>

--- a/integration-tests/simple-webapp/src/main/java/co/elastic/webapp/TestServlet.java
+++ b/integration-tests/simple-webapp/src/main/java/co/elastic/webapp/TestServlet.java
@@ -19,6 +19,8 @@
  */
 package co.elastic.webapp;
 
+import co.elastic.apm.api.ElasticApm;
+
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
@@ -46,6 +48,9 @@ public class TestServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        if (!ElasticApm.currentTransaction().isSampled()) {
+            throw new IllegalStateException("Current transaction is not sampled: " + ElasticApm.currentTransaction());
+        }
         try {
             PreparedStatement preparedStatement = connection.prepareStatement("SELECT * FROM ELASTIC_APM WHERE FOO=$1");
             preparedStatement.setInt(1, 1);


### PR DESCRIPTION
This currently fails for WildFly, probably because of the bootdelegation