### PR TITLE
docs: version cross doc links

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,5 +1,6 @@
 = APM Java Agent Reference
 :branch: current
+:server-branch: 6.5
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
 ifdef::env-github[]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -28,8 +28,8 @@ NOTE: The minimum required version of the APM Server is 6.5.0
 [[additional-components]]
 === Additional Components
 
-APM Agents work in conjunction with the {apm-server-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-Please view the {apm-get-started-ref}/index.html[APM Overview] for details on how these components work together. 
+APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how these components work together. 
 
 [float]
 [[get-started]]

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -12,9 +12,9 @@ In other words,
 it translates the calls to the OpenTracing API to Elastic APM and thus allows for reusing existing instrumentation.
 
 The first span of a service will be converted to an Elastic APM
-{apm-get-started-ref}/transactions.html[`Transaction`],
+{apm-overview-ref-v}/transactions.html[`Transaction`],
 subsequent spans are mapped to Elastic APM
-{apm-get-started-ref}/transaction-spans.html[`Span`].
+{apm-overview-ref-v}/transaction-spans.html[`Span`].
 
 [float]
 [[operation-modes]]
@@ -120,7 +120,7 @@ Baggage items are silently dropped.
 ==== Logs
 Only exception logging is supported.
 Logging an Exception on the OpenTracing span will create an Elastic APM
-{apm-get-started-ref}/errors.html[`Error`].
+{apm-overview-ref-v}/errors.html[`Error`].
 Example:
 
 [source,java]


### PR DESCRIPTION
versions cross doc links in master to APM Server 6.5 per https://github.com/elastic/apm/issues/19