### PR TITLE
Async Servlet state management changes

### DIFF
--- a/apm-agent-api/src/main/java/co/elastic/apm/api/AbstractSpanImpl.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/AbstractSpanImpl.java
@@ -1,3 +1,22 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
 package co.elastic.apm.api;
 
 import javax.annotation.Nonnull;

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
@@ -23,7 +23,6 @@ import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
 import co.elastic.apm.agent.bci.HelperClassManager;
 import co.elastic.apm.agent.bci.VisibleForAdvice;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
-import co.elastic.apm.agent.impl.transaction.Transaction;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
@@ -38,7 +37,6 @@ import javax.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.Collection;
 
-import static co.elastic.apm.agent.servlet.ServletApiAdvice.TRANSACTION_ATTRIBUTE;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.isPublic;
@@ -126,12 +124,8 @@ public class AsyncInstrumentation extends ElasticApmInstrumentation {
         @Advice.OnMethodExit(suppress = Throwable.class)
         private static void onExitStartAsync(@Advice.This HttpServletRequest request, @Advice.Return AsyncContext asyncContext) {
             if (tracer != null) {
-                final Transaction transaction = tracer.currentTransaction();
-                if (transaction != null) {
-                    request.setAttribute(TRANSACTION_ATTRIBUTE, transaction);
-                    if (asyncHelper != null) {
-                        asyncHelper.getForClassLoaderOfClass(AsyncContext.class).onExitStartAsync(asyncContext);
-                    }
+                if (asyncHelper != null) {
+                    asyncHelper.getForClassLoaderOfClass(AsyncContext.class).onExitStartAsync(asyncContext);
                 }
             }
         }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -51,6 +51,11 @@ import static co.elastic.apm.agent.web.WebConfiguration.EventType.OFF;
 @VisibleForAdvice
 public class ServletTransactionHelper {
 
+    @VisibleForAdvice
+    public static final String TRANSACTION_ATTRIBUTE = ServletApiAdvice.class.getName() + ".transaction";
+    @VisibleForAdvice
+    public static final String ASYNC_ATTRIBUTE = ServletApiAdvice.class.getName() + ".async";
+
     private final Logger logger = LoggerFactory.getLogger(ServletTransactionHelper.class);
 
     private final Set<String> METHODS_WITH_BODY = new HashSet<>(Arrays.asList("POST", "PUT", "PATCH", "DELETE"));

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/ApmAsyncListener.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/ApmAsyncListener.java
@@ -80,7 +80,7 @@ public class ApmAsyncListener implements AsyncListener {
     // (see class-level Javadoc)
     private void endTransaction(AsyncEvent event) {
         // To ensure transaction is ended only by a single event
-        if(EVENT_COUNTER_UPDATER.getAndIncrement(this) > 0) {
+        if (EVENT_COUNTER_UPDATER.getAndIncrement(this) > 0) {
             return;
         }
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/ApmAsyncListener.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/ApmAsyncListener.java
@@ -30,6 +30,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
 
+import static co.elastic.apm.agent.servlet.ServletTransactionHelper.TRANSACTION_ATTRIBUTE;
+
 /**
  * Based on brave.servlet.ServletRuntime$TracingAsyncListener (under Apache license 2.0)
  */
@@ -83,6 +85,8 @@ public class ApmAsyncListener implements AsyncListener {
     // (see class-level Javadoc)
     private void endTransaction(AsyncEvent event) {
         HttpServletRequest request = (HttpServletRequest) event.getSuppliedRequest();
+        request.removeAttribute(TRANSACTION_ATTRIBUTE);
+
         HttpServletResponse response = (HttpServletResponse) event.getSuppliedResponse();
         final Response resp = transaction.getContext().getResponse();
         if (transaction.isSampled() && servletTransactionHelper.isCaptureHeaders()) {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/ApmAsyncListener.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/ApmAsyncListener.java
@@ -29,6 +29,7 @@ import javax.servlet.AsyncListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import static co.elastic.apm.agent.servlet.ServletTransactionHelper.TRANSACTION_ATTRIBUTE;
 
@@ -36,9 +37,12 @@ import static co.elastic.apm.agent.servlet.ServletTransactionHelper.TRANSACTION_
  * Based on brave.servlet.ServletRuntime$TracingAsyncListener (under Apache license 2.0)
  */
 public class ApmAsyncListener implements AsyncListener {
+    private static final AtomicIntegerFieldUpdater<ApmAsyncListener> EVENT_COUNTER_UPDATER =
+        AtomicIntegerFieldUpdater.newUpdater(ApmAsyncListener.class, "endEventCounter");
+
     private final ServletTransactionHelper servletTransactionHelper;
     private final Transaction transaction;
-    private volatile boolean completed = false;
+    private volatile int endEventCounter = 0;
 
     ApmAsyncListener(ServletTransactionHelper servletTransactionHelper, Transaction transaction) {
         this.servletTransactionHelper = servletTransactionHelper;
@@ -47,26 +51,17 @@ public class ApmAsyncListener implements AsyncListener {
 
     @Override
     public void onComplete(AsyncEvent event) {
-        if (!completed) {
-            endTransaction(event);
-            completed = true;
-        }
+        endTransaction(event);
     }
 
     @Override
     public void onTimeout(AsyncEvent event) {
-        if (!completed) {
-            endTransaction(event);
-            completed = true;
-        }
+        endTransaction(event);
     }
 
     @Override
     public void onError(AsyncEvent event) {
-        if (!completed) {
-            endTransaction(event);
-            completed = true;
-        }
+        endTransaction(event);
     }
 
     /**
@@ -84,6 +79,11 @@ public class ApmAsyncListener implements AsyncListener {
     // because only the onExitServletService method may contain references to the servlet API
     // (see class-level Javadoc)
     private void endTransaction(AsyncEvent event) {
+        // To ensure transaction is ended only by a single event
+        if(EVENT_COUNTER_UPDATER.getAndIncrement(this) > 0) {
+            return;
+        }
+
         HttpServletRequest request = (HttpServletRequest) event.getSuppliedRequest();
         request.removeAttribute(TRANSACTION_ATTRIBUTE);
 


### PR DESCRIPTION
### General
Investigation started due to #371 
A race condition introduced due to implementation failure of some fine-grained definitions of the `HttpServletRequest.startAsync` API in some application servers requires a shift in how we instrument this. The full explanation is below, but the short version is- `AsyncContext.isAsyncStarted` is not fully reliable when invoked at the end of `service/doFilter` in which `HttpServletRequest.startAsync` was used, due to race condition between both threads handling the request. 
Basic rationale behind the suggested solution: if `HttpServletRequest.startAsync` is used, then the transaction data should not be updated by the `service/doFilter` instrumentation route, but only through the `AsyncListener` we register. This should hold for all `AsyncContext` APIs and regardless of multiple dispatches. Furthermore, we assume that if an `AsyncListener` was registered- it must be invoked when response gets committed, so we rely on it to clear states.

### Detailed explanation
The javadoc for `AsyncContext.isAsyncStarted` says that it will return `false` after `AsyncContext.dispatch` or `AsyncContext.complete` are invoked. Looking further into the `dispatch` and `complete` javadoc shows that this is a bit more complicated, as it says:

> If this method is called before the container-initiated dispatch that called startAsync has returned to the container, the dispatch operation will be delayed until after the container-initiated dispatch has returned to the container.

This means that querying `AsyncContext.isAsyncStarted` should be safe at the end of `service`/`doFilter`, as the container should wait for those to return before actually invoking `dispatch/complete`.  When testing multiple WildFly versions, I saw that while this is indeed the case with `dispatch`, it is not so in the case of `complete`, at least in WildFly versions
8 through 11. Specifically, the `AsyncContext` offers a `start` API for conveniently invoke logic on a separate thread, where `complete` is likely to be called, making it a common use case.