### PR TITLE
Add LGTM.com Configuration

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  java:
+    index:
+      java_version: "9"


### PR DESCRIPTION
This configuration tells LGTM.com to use the Java 9 SDK to compile this project, which is required for successful compilation.

This follows a discussion on the LGTM forums here: https://discuss.lgtm.com/t/wrong-lanuguage-detected-no-way-to-reset/583/24