### PR TITLE
[APM-CI ]fix xsltproc error on docs build by using an immutable agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -245,6 +245,7 @@ pipeline {
       Build the documentation.
     */
     stage('Documentation') {
+      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,9 +255,12 @@ pipeline {
       }
       when {
         beforeAgent true
-        allOf {
-          branch 'master'
-          expression { return params.doc_ci }
+        anyOf{
+          allOf {
+            branch 'master'
+            expression { return params.doc_ci }
+          }
+          expression { return params.Run_As_Master_Branch && params.doc_ci }
         }
       }
       steps {


### PR DESCRIPTION

```
+ ./scripts/jenkins/docs.sh

Old PATH=/var/lib/jenkins/.java/java10/bin:/command:/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin

New PATH=/var/lib/jenkins/workspace/t-java_apm-agent-java-mbp_master/elastic/docs/resources/asciidoc-8.6.8:/var/lib/jenkins/workspace/t-java_apm-agent-java-mbp_master/elastic/docs/resources/asciidoctor/bin:/var/lib/jenkins/workspace/t-java_apm-agent-java-mbp_master/elastic/docs:/var/lib/jenkins/.java/java10/bin:/command:/usr/local/bin:/usr/local/sbin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R6/bin

Please install <xsltproc> at /var/lib/jenkins/workspace/t-java_apm-agent-java-mbp_master/elastic/docs/build_docs.pl line 541.

script returned exit code 255
```