### PR TITLE
Exclude constructors in TraceMethodInstrumentation

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/methodmatching/TraceMethodInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/methodmatching/TraceMethodInstrumentation.java
@@ -37,6 +37,8 @@ import java.util.List;
 
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.matches;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isConstructor;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
@@ -104,7 +106,9 @@ public class TraceMethodInstrumentation extends ElasticApmInstrumentation {
                 matcher = matcher.and(takesArgument(i, matches(argumentMatchers.get(i))));
             }
         }
-        return matcher;
+        // Byte Buddy can't catch exceptions (onThrowable = Throwable.class) during a constructor call:
+        // java.lang.IllegalStateException: Cannot catch exception during constructor call
+        return matcher.and(not(isConstructor()));
     }
 
     @Override

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/methodmatching/TraceMethodInstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/methodmatching/TraceMethodInstrumentationTest.java
@@ -85,8 +85,11 @@ class TraceMethodInstrumentationTest {
     // Byte Buddy can't catch exceptions (onThrowable = Throwable.class) during a constructor call:
     @Test
     void testNotMatched_Constructor() {
-        new TestExcludeConstructor();
+        final TestExcludeConstructor testClass = new TestExcludeConstructor();
         assertThat(reporter.getTransactions()).isEmpty();
+        testClass.traceMe();
+        assertThat(reporter.getTransactions()).hasSize(1);
+        assertThat(reporter.getFirstTransaction().getName().toString()).isEqualTo("TestExcludeConstructor#traceMe");
     }
 
     public static class TestClass {
@@ -108,6 +111,9 @@ class TraceMethodInstrumentationTest {
 
     public static class TestExcludeConstructor {
         public TestExcludeConstructor() {
+        }
+
+        public void traceMe() {
         }
     }
 


### PR DESCRIPTION
because Byte Buddy complains about catching exceptions in constructors:
java.lang.IllegalStateException: Cannot catch exception during constructor call