### PR TITLE
Add infrastructure to capture the request body of HTTP requests

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Request.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Request.java
@@ -72,11 +72,6 @@ public class Request implements Recyclable {
      */
     private final PotentiallyMultiValuedMap cookies = new PotentiallyMultiValuedMap();
     /**
-     * Data should only contain the request body (not the query string). It can either be a dictionary (for standard HTTP requests) or a raw request body.
-     */
-    @Nullable
-    private String rawBody;
-    /**
      * HTTP version.
      */
     @Nullable
@@ -98,18 +93,15 @@ public class Request implements Recyclable {
         if (!postParams.isEmpty()) {
             return postParams;
         } else {
-            return rawBody;
+            return bodyBuffer;
         }
-    }
-
-    @Nullable
-    public String getRawBody() {
-        return rawBody;
     }
 
     public void redactBody() {
         postParams.resetState();
-        rawBody = "[REDACTED]";
+        if (bodyBuffer != null) {
+            bodyBuffer.clear().append("[REDACTED]").flip();
+        }
     }
 
     public Request addFormUrlEncodedParameter(String key, String value) {
@@ -119,11 +111,6 @@ public class Request implements Recyclable {
 
     public Request addFormUrlEncodedParameters(String key, String[] values) {
         this.postParams.set(key, values);
-        return this;
-    }
-
-    public Request withRawBody(String rawBody) {
-        this.rawBody = rawBody;
         return this;
     }
 
@@ -246,7 +233,6 @@ public class Request implements Recyclable {
 
     @Override
     public void resetState() {
-        rawBody = null;
         postParams.resetState();
         headers.resetState();
         httpVersion = null;
@@ -261,7 +247,6 @@ public class Request implements Recyclable {
     }
 
     public void copyFrom(Request other) {
-        this.rawBody = other.rawBody;
         this.postParams.copyFrom(other.postParams);
         this.headers.copyFrom(other.headers);
         this.httpVersion = other.httpVersion;
@@ -284,7 +269,6 @@ public class Request implements Recyclable {
             headers.size() > 0 ||
             httpVersion != null ||
             cookies.size() > 0 ||
-            rawBody != null ||
             postParams.size() > 0 ||
             socket.hasContent() ||
             url.hasContent();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Request.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Request.java
@@ -128,7 +128,7 @@ public class Request implements Recyclable {
     }
 
     /**
-     * Gets a pooled {@link CharBuffer} to record the DB statement and associates it with this instance.
+     * Gets a pooled {@link CharBuffer} to record the request body and associates it with this instance.
      * <p>
      * Note: you may not hold a reference to the returned {@link CharBuffer} as it will be reused.
      * </p>
@@ -136,7 +136,7 @@ public class Request implements Recyclable {
      * Note: This method is not thread safe
      * </p>
      *
-     * @return a {@link CharBuffer} to record the DB statement
+     * @return a {@link CharBuffer} to record the request body
      */
     public CharBuffer withBodyBuffer() {
         if (this.bodyBuffer == null) {
@@ -146,12 +146,12 @@ public class Request implements Recyclable {
     }
 
     /**
-     * Returns the associated pooled {@link CharBuffer} to record the DB statement.
+     * Returns the associated pooled {@link CharBuffer} to record the request body.
      * <p>
      * Note: returns {@code null} unless {@link #withBodyBuffer()} has previously been called
      * </p>
      *
-     * @return a {@link CharBuffer} to record the DB statement, or {@code null}
+     * @return a {@link CharBuffer} to record the request body, or {@code null}
      */
     @Nullable
     public CharBuffer getBodyBuffer() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Request.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Request.java
@@ -19,10 +19,18 @@
  */
 package co.elastic.apm.agent.impl.context;
 
+import co.elastic.apm.agent.objectpool.Allocator;
+import co.elastic.apm.agent.objectpool.ObjectPool;
 import co.elastic.apm.agent.objectpool.Recyclable;
+import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
+import co.elastic.apm.agent.objectpool.impl.Resetter;
+import co.elastic.apm.agent.report.serialize.DslJsonSerializer;
 import co.elastic.apm.agent.util.PotentiallyMultiValuedMap;
+import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
 
 import javax.annotation.Nullable;
+import java.nio.Buffer;
+import java.nio.CharBuffer;
 import java.util.Enumeration;
 
 
@@ -32,6 +40,21 @@ import java.util.Enumeration;
  * If a log record was generated as a result of a http request, the http interface can be used to collect this information.
  */
 public class Request implements Recyclable {
+
+
+    private final ObjectPool<CharBuffer> charBufferPool = QueueBasedObjectPool.of(new MpmcAtomicArrayQueue<CharBuffer>(128), false,
+        new Allocator<CharBuffer>() {
+            @Override
+            public CharBuffer createInstance() {
+                return CharBuffer.allocate(DslJsonSerializer.MAX_LONG_STRING_VALUE_LENGTH);
+            }
+        },
+        new Resetter<CharBuffer>() {
+            @Override
+            public void recycle(CharBuffer object) {
+                ((Buffer) object).clear();
+            }
+        });
 
     private final PotentiallyMultiValuedMap postParams = new PotentiallyMultiValuedMap();
     /**
@@ -64,6 +87,8 @@ public class Request implements Recyclable {
      */
     @Nullable
     private String method;
+    @Nullable
+    private CharBuffer bodyBuffer;
 
     /**
      * Data should only contain the request body (not the query string). It can either be a dictionary (for standard HTTP requests) or a raw request body.
@@ -100,6 +125,37 @@ public class Request implements Recyclable {
     public Request withRawBody(String rawBody) {
         this.rawBody = rawBody;
         return this;
+    }
+
+    /**
+     * Gets a pooled {@link CharBuffer} to record the DB statement and associates it with this instance.
+     * <p>
+     * Note: you may not hold a reference to the returned {@link CharBuffer} as it will be reused.
+     * </p>
+     * <p>
+     * Note: This method is not thread safe
+     * </p>
+     *
+     * @return a {@link CharBuffer} to record the DB statement
+     */
+    public CharBuffer withBodyBuffer() {
+        if (this.bodyBuffer == null) {
+            this.bodyBuffer = charBufferPool.createInstance();
+        }
+        return this.bodyBuffer;
+    }
+
+    /**
+     * Returns the associated pooled {@link CharBuffer} to record the DB statement.
+     * <p>
+     * Note: returns {@code null} unless {@link #withBodyBuffer()} has previously been called
+     * </p>
+     *
+     * @return a {@link CharBuffer} to record the DB statement, or {@code null}
+     */
+    @Nullable
+    public CharBuffer getBodyBuffer() {
+        return bodyBuffer;
     }
 
     public PotentiallyMultiValuedMap getFormUrlEncodedParameters() {
@@ -198,6 +254,10 @@ public class Request implements Recyclable {
         socket.resetState();
         url.resetState();
         cookies.resetState();
+        if (bodyBuffer != null) {
+            charBufferPool.recycle(bodyBuffer);
+        }
+        bodyBuffer = null;
     }
 
     public void copyFrom(Request other) {
@@ -209,6 +269,14 @@ public class Request implements Recyclable {
         this.socket.copyFrom(other.socket);
         this.url.copyFrom(other.url);
         this.cookies.copyFrom(other.cookies);
+        if (other.bodyBuffer != null) {
+            final CharBuffer otherBuffer = other.getBodyBuffer();
+            final CharBuffer thisBuffer = this.withBodyBuffer();
+            for (int i = 0; i < otherBuffer.length(); i++) {
+                thisBuffer.append(otherBuffer.charAt(i));
+            }
+            thisBuffer.flip();
+        }
     }
 
     public boolean hasContent() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Url.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Url.java
@@ -161,8 +161,10 @@ public class Url implements Recyclable {
 
     public void copyFrom(Url other) {
         this.protocol = other.protocol;
+        this.full.setLength(0);
         this.full.append(other.full);
         this.hostname = other.hostname;
+        this.port.setLength(0);
         this.port.append(other.port);
         this.pathname = other.pathname;
         this.search = other.search;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -758,8 +758,15 @@ public class DslJsonSerializer implements PayloadSerializer {
             writeField("headers", request.getHeaders());
             writeField("cookies", request.getCookies());
             // only one of those can be non-empty
-            writeField("body", request.getFormUrlEncodedParameters());
-            writeField("body", request.getRawBody());
+            if (!request.getFormUrlEncodedParameters().isEmpty()) {
+                writeField("body", request.getFormUrlEncodedParameters());
+            } else if (request.getRawBody() != null) {
+                writeField("body", request.getRawBody());
+            } else if (request.getBodyBuffer() != null && request.getBodyBuffer().length() > 0) {
+                writeFieldName("body");
+                jw.writeString(request.getBodyBuffer());
+                jw.writeByte(COMMA);
+            }
             if (request.getUrl().hasContent()) {
                 serializeUrl(request.getUrl());
             }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -760,8 +760,6 @@ public class DslJsonSerializer implements PayloadSerializer {
             // only one of those can be non-empty
             if (!request.getFormUrlEncodedParameters().isEmpty()) {
                 writeField("body", request.getFormUrlEncodedParameters());
-            } else if (request.getRawBody() != null) {
-                writeField("body", request.getRawBody());
             } else if (request.getBodyBuffer() != null && request.getBodyBuffer().length() > 0) {
                 writeFieldName("body");
                 jw.writeString(request.getBodyBuffer());

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/IOUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/IOUtils.java
@@ -32,10 +32,11 @@ import java.nio.charset.StandardCharsets;
 
 @VisibleForAdvice
 public class IOUtils {
+    static final int BYTE_BUFFER_CAPACITY = 2048;
     private static ThreadLocal<ByteBuffer> threadLocalByteBuffer = new ThreadLocal<ByteBuffer>() {
         @Override
         protected ByteBuffer initialValue() {
-            return ByteBuffer.allocate(1024);
+            return ByteBuffer.allocate(BYTE_BUFFER_CAPACITY);
         }
     };
     private static ThreadLocal<CharsetDecoder> threadLocalCharsetDecoder = new ThreadLocal<CharsetDecoder>() {
@@ -87,6 +88,111 @@ public class IOUtils {
             ((Buffer) buffer).clear();
             charsetDecoder.reset();
             is.close();
+        }
+    }
+
+    /**
+     * Decodes a UTF-8 encoded byte array into a char buffer, without allocating memory.
+     * <p>
+     * The {@code byte[]} is assumed to yield an UTF-8 encoded string.
+     * If this is not true, the returned {@link CoderResult} will have the {@link CoderResult#isError()} flag set to true.
+     * </p>
+     * <p>
+     * If the {@code byte[]} yields more chars than the {@link CharBuffer#limit()} of the provided {@link CharBuffer},
+     * the returned {@link CoderResult} will have the {@link CoderResult#isOverflow()} flag set to true.
+     * </p>
+     * <p>
+     * NOTE: This method does not {@link CharBuffer#flip()} the provided {@link CharBuffer} so that this method can be called multiple times
+     * with the same {@link CharBuffer}.
+     * If you are done with appending to the {@link CharBuffer}, you have to call {@link CharBuffer#flip()} manually.
+     * </p>
+     *
+     * @param bytes      the source byte[], which should be encoded with UTF-8.
+     * @param charBuffer the {@link CharBuffer} the {@link InputStream} should be written into
+     * @return a {@link CoderResult}, indicating the success or failure of the decoding
+     */
+    @VisibleForAdvice
+    public static CoderResult decodeUtf8Bytes(final byte[] bytes, final CharBuffer charBuffer) {
+        return decodeUtf8Bytes(bytes, 0, bytes.length, charBuffer);
+    }
+
+    /**
+     * Decodes a UTF-8 encoded byte array into a char buffer, without allocating memory.
+     * <p>
+     * The {@code byte[]} is assumed to yield an UTF-8 encoded string.
+     * If this is not true, the returned {@link CoderResult} will have the {@link CoderResult#isError()} flag set to true.
+     * </p>
+     * <p>
+     * If the {@code byte[]} yields more chars than the {@link CharBuffer#limit()} of the provided {@link CharBuffer},
+     * the returned {@link CoderResult} will have the {@link CoderResult#isOverflow()} flag set to true.
+     * </p>
+     * <p>
+     * NOTE: This method does not {@link CharBuffer#flip()} the provided {@link CharBuffer} so that this method can be called multiple times
+     * with the same {@link CharBuffer}.
+     * If you are done with appending to the {@link CharBuffer}, you have to call {@link CharBuffer#flip()} manually.
+     * </p>
+     *
+     * @param bytes      the source byte[], which should be encoded with UTF-8
+     * @param charBuffer the {@link CharBuffer} the {@link InputStream} should be written into
+     * @param offset     the start offset in array <code>bytes</code> at which the data is read
+     * @param length     the maximum number of bytes to read
+     * @return a {@link CoderResult}, indicating the success or failure of the decoding
+     */
+    @VisibleForAdvice
+    public static CoderResult decodeUtf8Bytes(final byte[] bytes, final int offset, final int length, final CharBuffer charBuffer) {
+        // to be compatible with Java 8, we have to cast to buffer because of different return types
+        final ByteBuffer buffer;
+        if (BYTE_BUFFER_CAPACITY < length) {
+            // allocates a ByteBuffer wrapper object, the underlying byte[] is not copied
+            buffer = ByteBuffer.wrap(bytes, offset, length);
+        } else {
+            buffer = threadLocalByteBuffer.get();
+            buffer.put(bytes, offset, length);
+            ((Buffer) buffer).position(0);
+            ((Buffer) buffer).limit(length);
+        }
+        return decode(charBuffer, buffer);
+    }
+
+    /**
+     * Decodes a single UTF-8 encoded byte into a char buffer, without allocating memory.
+     * <p>
+     * The {@code byte} is assumed to yield an UTF-8 encoded string.
+     * If this is not true, the returned {@link CoderResult} will have the {@link CoderResult#isError()} flag set to true.
+     * </p>
+     * <p>
+     * If the provided {@link CharBuffer} has already reached its {@link CharBuffer#limit()},
+     * the returned {@link CoderResult} will have the {@link CoderResult#isOverflow()} flag set to true.
+     * </p>
+     * <p>
+     * NOTE: This method does not {@link CharBuffer#flip()} the provided {@link CharBuffer} so that this method can be called multiple times
+     * with the same {@link CharBuffer}.
+     * If you are done with appending to the {@link CharBuffer}, you have to call {@link CharBuffer#flip()} manually.
+     * </p>
+     *
+     * @param b          the source byte[], which should be encoded with UTF-8
+     * @param charBuffer the {@link CharBuffer} the {@link InputStream} should be written into
+     * @return a {@link CoderResult}, indicating the success or failure of the decoding
+     */
+    @VisibleForAdvice
+    public static CoderResult decodeUtf8Byte(final byte b, final CharBuffer charBuffer) {
+        // to be compatible with Java 8, we have to cast to buffer because of different return types
+        final ByteBuffer buffer = threadLocalByteBuffer.get();
+        buffer.put(b);
+        ((Buffer) buffer).position(0);
+        ((Buffer) buffer).limit(1);
+        return decode(charBuffer, buffer);
+    }
+
+    private static CoderResult decode(CharBuffer charBuffer, ByteBuffer buffer) {
+        final CharsetDecoder charsetDecoder = threadLocalCharsetDecoder.get();
+        try {
+            final CoderResult coderResult = charsetDecoder.decode(buffer, charBuffer, true);
+            charsetDecoder.flush(charBuffer);
+            return coderResult;
+        } finally {
+            ((Buffer) buffer).clear();
+            charsetDecoder.reset();
         }
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/TransactionUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/TransactionUtils.java
@@ -47,7 +47,7 @@ public class TransactionUtils {
         Request request = context.getRequest();
         request.withHttpVersion("1.1");
         request.withMethod("POST");
-        request.withRawBody("Hello World");
+        request.withBodyBuffer().append("Hello World").flip();
         request.getUrl()
             .withProtocol("https")
             .appendToFull("https://www.example.com/p/a/t/h?query=string#hash")

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/TransactionContextTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/TransactionContextTest.java
@@ -57,7 +57,7 @@ class TransactionContextTest {
         Request request = context.getRequest();
         request.withHttpVersion("1.1");
         request.withMethod("POST");
-        request.withRawBody("Hello World");
+        request.withBodyBuffer().append("Hello World").flip();
         request.getUrl()
             .withProtocol("https")
             .appendToFull("https://www.example.com/p/a/t/h?query=string#hash")

--- a/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/agent/web/BodyProcessorTest.java
+++ b/apm-agent-plugins/apm-web-plugin/src/test/java/co/elastic/apm/agent/web/BodyProcessorTest.java
@@ -52,7 +52,7 @@ class BodyProcessorTest {
 
         final Transaction transaction = processTransaction();
 
-        assertThat(transaction.getContext().getRequest().getBody()).isEqualTo("foo");
+        assertThat(transaction.getContext().getRequest().getBody().toString()).isEqualTo("foo");
     }
 
     @Test
@@ -61,7 +61,7 @@ class BodyProcessorTest {
 
         final Transaction transaction = processTransaction();
 
-        assertThat(transaction.getContext().getRequest().getBody()).isEqualTo("foo");
+        assertThat(transaction.getContext().getRequest().getBody().toString()).isEqualTo("foo");
     }
 
     @Test
@@ -70,7 +70,7 @@ class BodyProcessorTest {
 
         final Transaction transaction = processTransaction();
 
-        assertThat(transaction.getContext().getRequest().getBody()).isEqualTo("[REDACTED]");
+        assertThat(transaction.getContext().getRequest().getBody().toString()).isEqualTo("[REDACTED]");
     }
 
     @Test
@@ -79,7 +79,7 @@ class BodyProcessorTest {
 
         final Transaction transaction = processTransaction();
 
-        assertThat(transaction.getContext().getRequest().getBody()).isEqualTo("[REDACTED]");
+        assertThat(transaction.getContext().getRequest().getBody().toString()).isEqualTo("[REDACTED]");
     }
 
     @Test
@@ -88,7 +88,7 @@ class BodyProcessorTest {
 
         final ErrorCapture error = processError();
 
-        assertThat(error.getContext().getRequest().getBody()).isEqualTo("foo");
+        assertThat(error.getContext().getRequest().getBody().toString()).isEqualTo("foo");
     }
 
     @Test
@@ -97,7 +97,7 @@ class BodyProcessorTest {
 
         final ErrorCapture error = processError();
 
-        assertThat(error.getContext().getRequest().getBody()).isEqualTo("[REDACTED]");
+        assertThat(error.getContext().getRequest().getBody().toString()).isEqualTo("[REDACTED]");
     }
 
     @Test
@@ -106,7 +106,7 @@ class BodyProcessorTest {
 
         final ErrorCapture error = processError();
 
-        assertThat(error.getContext().getRequest().getBody()).isEqualTo("foo");
+        assertThat(error.getContext().getRequest().getBody().toString()).isEqualTo("foo");
     }
 
     @Test
@@ -115,19 +115,19 @@ class BodyProcessorTest {
 
         final ErrorCapture error = processError();
 
-        assertThat(error.getContext().getRequest().getBody()).isEqualTo("[REDACTED]");
+        assertThat(error.getContext().getRequest().getBody().toString()).isEqualTo("[REDACTED]");
     }
 
     private Transaction processTransaction() {
         final Transaction transaction = new Transaction(tracer);
-        transaction.getContext().getRequest().withRawBody("foo");
+        transaction.getContext().getRequest().withBodyBuffer().append("foo").flip();
         bodyProcessor.processBeforeReport(transaction);
         return transaction;
     }
 
     private ErrorCapture processError() {
         final ErrorCapture error = new ErrorCapture(tracer);
-        error.getContext().getRequest().withRawBody("foo");
+        error.getContext().getRequest().withBodyBuffer().append("foo").flip();
         bodyProcessor.processBeforeReport(error);
         return error;
     }


### PR DESCRIPTION
- Add Transaction.context.request.bodyBuffer (CharBuffer)
- Add ability to decode byte[]/byte into a CharBuffer
- Adjust serialization to take the body buffer into account
- Recycling of Transaction.context.request.bodyBuffer
- -> reading is garbage free