### PR TITLE
Adding WildFly 14 and 15 with Java 11

### DIFF
--- a/integration-tests/simple-webapp-integration-test/src/test/java/co/elastic/apm/servlet/WildFlyIT.java
+++ b/integration-tests/simple-webapp-integration-test/src/test/java/co/elastic/apm/servlet/WildFlyIT.java
@@ -61,7 +61,9 @@ public class WildFlyIT extends AbstractServletContainerIntegrationTest {
             {"10.0.0.Final"},
             {"11.0.0.Final"},
             {"12.0.0.Final"},
-            {"13.0.0.Final"}
+            {"13.0.0.Final"},
+            {"14.0.0.Final"},
+            {"15.0.0.Final"}
         });
     }
 


### PR DESCRIPTION
Following https://github.com/elastic/apm-agent-java/issues/395 - added tests for WildFly 14.0 and 15.0, the latter is based on a Java 11 image.