### PR TITLE
Fix logging integration

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActivationListener.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActivationListener.java
@@ -44,7 +44,8 @@ public interface ActivationListener {
      * That's why there is no {@link TraceContextHolder} parameter.
      * </p>
      *
+     * @param context the {@link TraceContextHolder} which is being deactivated
      * @throws Throwable if there was an error while calling this method
      */
-    void onDeactivate() throws Throwable;
+    void onDeactivate(TraceContextHolder<?> context) throws Throwable;
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActivationListener.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActivationListener.java
@@ -35,7 +35,7 @@ public interface ActivationListener {
      * @param context the {@link TraceContextHolder} which is being activated
      * @throws Throwable if there was an error while calling this method
      */
-    void onActivate(TraceContextHolder<?> context) throws Throwable;
+    void beforeActivate(TraceContextHolder<?> context) throws Throwable;
 
     /**
      * A callback for {@link TraceContextHolder#deactivate()}
@@ -44,8 +44,7 @@ public interface ActivationListener {
      * That's why there is no {@link TraceContextHolder} parameter.
      * </p>
      *
-     * @param context the {@link TraceContextHolder} which is being deactivated
      * @throws Throwable if there was an error while calling this method
      */
-    void onDeactivate(TraceContextHolder<?> context) throws Throwable;
+    void afterDeactivate() throws Throwable;
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -211,6 +211,10 @@ public class ElasticApmTracer {
         return null;
     }
 
+    public boolean isThreadRootContext(TraceContextHolder traceContextHolder) {
+        return activeStack.get().peekLast() == traceContextHolder;
+    }
+
     /**
      * Starts a span with a given parent context.
      * <p>

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -211,10 +211,6 @@ public class ElasticApmTracer {
         return null;
     }
 
-    public boolean isThreadRootContext(TraceContextHolder traceContextHolder) {
-        return activeStack.get().peekLast() == traceContextHolder;
-    }
-
     /**
      * Starts a span with a given parent context.
      * <p>

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
@@ -78,16 +78,19 @@ public abstract class TraceContextHolder<T extends TraceContextHolder> implement
     }
 
     public T deactivate() {
-        tracer.deactivate(this);
-        List<ActivationListener> activationListeners = tracer.getActivationListeners();
-        for (int i = 0; i < activationListeners.size(); i++) {
-            try {
-                activationListeners.get(i).onDeactivate();
-            } catch (Error e) {
-                throw e;
-            } catch (Throwable t) {
-                logger.warn("Exception while calling {}#onDeactivate", activationListeners.get(i).getClass().getSimpleName(), t);
+        try {
+            List<ActivationListener> activationListeners = tracer.getActivationListeners();
+            for (int i = 0; i < activationListeners.size(); i++) {
+                try {
+                    activationListeners.get(i).onDeactivate(this);
+                } catch (Error e) {
+                    throw e;
+                } catch (Throwable t) {
+                    logger.warn("Exception while calling {}#onDeactivate", activationListeners.get(i).getClass().getSimpleName(), t);
+                }
             }
+        } finally {
+            tracer.deactivate(this);
         }
         return (T) this;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
@@ -63,34 +63,31 @@ public abstract class TraceContextHolder<T extends TraceContextHolder> implement
     public abstract boolean isChildOf(TraceContextHolder other);
 
     public T activate() {
-        tracer.activate(this);
         List<ActivationListener> activationListeners = tracer.getActivationListeners();
         for (int i = 0; i < activationListeners.size(); i++) {
             try {
-                activationListeners.get(i).onActivate(this);
+                activationListeners.get(i).beforeActivate(this);
             } catch (Error e) {
                 throw e;
             } catch (Throwable t) {
-                logger.warn("Exception while calling {}#onActivate", activationListeners.get(i).getClass().getSimpleName(), t);
+                logger.warn("Exception while calling {}#beforeActivate", activationListeners.get(i).getClass().getSimpleName(), t);
             }
         }
+        tracer.activate(this);
         return (T) this;
     }
 
     public T deactivate() {
-        try {
-            List<ActivationListener> activationListeners = tracer.getActivationListeners();
-            for (int i = 0; i < activationListeners.size(); i++) {
-                try {
-                    activationListeners.get(i).onDeactivate(this);
-                } catch (Error e) {
-                    throw e;
-                } catch (Throwable t) {
-                    logger.warn("Exception while calling {}#onDeactivate", activationListeners.get(i).getClass().getSimpleName(), t);
-                }
+        tracer.deactivate(this);
+        List<ActivationListener> activationListeners = tracer.getActivationListeners();
+        for (int i = 0; i < activationListeners.size(); i++) {
+            try {
+                activationListeners.get(i).afterDeactivate();
+            } catch (Error e) {
+                throw e;
+            } catch (Throwable t) {
+                logger.warn("Exception while calling {}#afterDeactivate", activationListeners.get(i).getClass().getSimpleName(), t);
             }
-        } finally {
-            tracer.deactivate(this);
         }
         return (T) this;
     }

--- a/apm-agent-plugins/apm-slf4j-plugin/src/main/java/co/elastic/apm/agent/slf4j/Slf4JMdcActivationListener.java
+++ b/apm-agent-plugins/apm-slf4j-plugin/src/main/java/co/elastic/apm/agent/slf4j/Slf4JMdcActivationListener.java
@@ -39,7 +39,6 @@ public class Slf4JMdcActivationListener implements ActivationListener {
     private static final String TRACE_ID = "trace.id";
     private static final String SPAN_ID = "span.id";
     private static final String TRANSACTION_ID = "transaction.id";
-    private static final String NA_SPAN_ID = "NA";
 
     private final WeakKeySoftValueLoadingCache<ClassLoader, MethodHandle> mdcPutMethodHandleCache =
         new WeakKeySoftValueLoadingCache<>(new WeakKeySoftValueLoadingCache.ValueSupplier<ClassLoader, MethodHandle>() {

--- a/apm-agent-plugins/apm-slf4j-plugin/src/test/java/co/elastic/apm/agent/slf4j/Slf4JMdcActivationListenerTest.java
+++ b/apm-agent-plugins/apm-slf4j-plugin/src/test/java/co/elastic/apm/agent/slf4j/Slf4JMdcActivationListenerTest.java
@@ -22,6 +22,8 @@ package co.elastic.apm.agent.slf4j;
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.configuration.SpyConfiguration;
 import co.elastic.apm.agent.impl.Scope;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.logging.LoggingConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -51,13 +53,23 @@ class Slf4JMdcActivationListenerTest extends AbstractInstrumentationTest {
         assertMdcIsEmpty();
         try (Scope scope = transaction.activateInScope()) {
             assertMdcIsSet(transaction);
+            Span child = transaction.createSpan();
+            try (Scope childScope = child.activateInScope()) {
+                assertMdcIsSet(child);
+                Span grandchild = child.createSpan();
+                try (Scope grandchildScope = grandchild.activateInScope()) {
+                    assertMdcIsSet(grandchild);
+                }
+                assertMdcIsSet(child);
+            }
+            assertMdcIsSet(transaction);
         }
         assertMdcIsEmpty();
         transaction.end();
     }
 
     @Test
-    void testMdcIntegrationScopeInDifferentThread() throws Exception {
+    void testMdcIntegrationTransactionScopeInDifferentThread() throws Exception {
         when(loggingConfiguration.isLogCorrelationEnabled()).thenReturn(true);
         Transaction transaction = tracer.startTransaction().withType("request").withName("test");
         assertMdcIsEmpty();
@@ -75,6 +87,33 @@ class Slf4JMdcActivationListenerTest extends AbstractInstrumentationTest {
     }
 
     @Test
+    void testMdcIntegrationContextScopeInDifferentThread() throws Exception {
+        when(loggingConfiguration.isLogCorrelationEnabled()).thenReturn(true);
+        final Transaction transaction = tracer.startTransaction().withType("request").withName("test");
+        assertMdcIsEmpty();
+        try (Scope scope = transaction.activateInScope()) {
+            assertMdcIsSet(transaction);
+            final Span child = transaction.createSpan();
+            try (Scope childScope = child.activateInScope()) {
+                assertMdcIsSet(child);
+                Thread thread = new Thread(() -> {
+                    assertMdcIsEmpty();
+                    try (Scope otherThreadScope = child.getTraceContext().activateInScope()) {
+                        assertMdcIsSet(child);
+                    }
+                    assertMdcIsEmpty();
+                });
+                thread.start();
+                thread.join();
+                assertMdcIsSet(child);
+            }
+            assertMdcIsSet(transaction);
+        }
+        assertMdcIsEmpty();
+        transaction.end();
+    }
+
+    @Test
     void testDisablingAtRuntimeNotPossible() throws IOException {
         assertThat(loggingConfiguration.isLogCorrelationEnabled()).isFalse();
         config.save("enable_log_correlation", "true", SpyConfiguration.CONFIG_SOURCE_NAME);
@@ -85,9 +124,10 @@ class Slf4JMdcActivationListenerTest extends AbstractInstrumentationTest {
         assertThat(loggingConfiguration.isLogCorrelationEnabled()).isTrue();
     }
 
-    private void assertMdcIsSet(Transaction transaction) {
-        assertThat(MDC.get("trace.id")).isEqualTo(transaction.getTraceContext().getTraceId().toString());
-        assertThat(MDC.get("transaction.id")).isEqualTo(transaction.getTraceContext().getId().toString());
+    private void assertMdcIsSet(AbstractSpan span) {
+        assertThat(MDC.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
+        assertThat(MDC.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
+        assertThat(MDC.get("span.id")).isEqualTo(span.getTraceContext().getId().toString());
     }
 
     private void assertMdcIsEmpty() {


### PR DESCRIPTION
Fixes elastic/apm-agent-java#499 and also enables proper logging integration for async spans/transactions as well.
In the sake of simplification, I added a `span.id` in all cases (even from transactions), so ID will be duplicated in logs created when the active context is a transaction. This means that log lines will be consistent for all types, so aggregations done for `span.id` will include transaction-related events as well. We need to decide whether this is a good thing (supports aggregations for all spans AND transactions easily) or a bad thing (doesn't support aggregations for spans AND NOT transactions).