### PR TITLE
Fix metrics NaN issue

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistrySerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistrySerializer.java
@@ -69,23 +69,24 @@ public class MetricRegistrySerializer {
         final int size = samples.size();
         if (size > 0) {
             final Iterator<Map.Entry<String, DoubleSupplier>> iterator = samples.entrySet().iterator();
-            String key = null;
+
+            // serialize first valid value
             double value = Double.NaN;
-            Map.Entry<String, DoubleSupplier> kv;
             while (iterator.hasNext() && !isValid(value)) {
-                kv = iterator.next();
-                key = kv.getKey();
+                Map.Entry<String, DoubleSupplier> kv = iterator.next();
                 value = kv.getValue().get();
+                if (isValid(value)) {
+                    serializeSample(kv.getKey(), value, jw);
+                }
             }
-            if (isValid(value)) {
-                serializeSample(key, value, jw);
-                while (iterator.hasNext()) {
-                    kv = iterator.next();
-                    value = kv.getValue().get();
-                    if (isValid(value)) {
-                        jw.writeByte(JsonWriter.COMMA);
-                        serializeSample(kv.getKey(), value, jw);
-                    }
+
+            // serialize rest
+            while (iterator.hasNext()) {
+                Map.Entry<String, DoubleSupplier> kv = iterator.next();
+                value = kv.getValue().get();
+                if (isValid(value)) {
+                    jw.writeByte(JsonWriter.COMMA);
+                    serializeSample(kv.getKey(), value, jw);
                 }
             }
         }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/MetricSetSerializationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/MetricSetSerializationTest.java
@@ -55,14 +55,34 @@ class MetricSetSerializationTest {
         metricSet.add("infinite", () -> Double.POSITIVE_INFINITY);
         metricSet.add("NaN", () -> Double.NaN);
         metricSet.add("negative.infinite", () -> Double.NEGATIVE_INFINITY);
+        metricSet.add("also.valid", () -> 5.0);
         MetricRegistrySerializer.serializeMetricSet(metricSet, System.currentTimeMillis() * 1000, new StringBuilder(), jw);
         final String metricSetAsString = jw.toString();
         System.out.println(metricSetAsString);
         final JsonNode jsonNode = objectMapper.readTree(metricSetAsString);
         JsonNode samples = jsonNode.get("metricset").get("samples");
+        assertThat(samples.size()).isEqualTo(2);
         assertThat(samples.get("valid").get("value").doubleValue()).isEqualTo(4.0);
-        assertThat(samples.get("infinite").get("value").isNull()).isTrue();
-        assertThat(samples.get("NaN").get("value").isNull()).isTrue();
-        assertThat(samples.get("negative.infinite").get("value").isNull()).isTrue();
+        assertThat(samples.get("also.valid").get("value").doubleValue()).isEqualTo(5.0);
+    }
+
+    @Test
+    void testNonFiniteCornerCasesSerialization() throws IOException {
+        final MetricSet metricSet = new MetricSet(Collections.emptyMap());
+        MetricRegistrySerializer.serializeMetricSet(metricSet, System.currentTimeMillis() * 1000, new StringBuilder(), jw);
+        String metricSetAsString = jw.toString();
+        System.out.println(metricSetAsString);
+        JsonNode jsonNode = objectMapper.readTree(metricSetAsString);
+        JsonNode samples = jsonNode.get("metricset").get("samples");
+        assertThat(samples.size()).isEqualTo(0);
+
+        metricSet.add("infinite", () -> Double.POSITIVE_INFINITY);
+        metricSet.add("NaN", () -> Double.NaN);
+        metricSet.add("negative.infinite", () -> Double.NEGATIVE_INFINITY);
+        MetricRegistrySerializer.serializeMetricSet(metricSet, System.currentTimeMillis() * 1000, new StringBuilder(), jw);
+        metricSetAsString = jw.toString();
+        jsonNode = objectMapper.readTree(metricSetAsString);
+        samples = jsonNode.get("metricset").get("samples");
+        assertThat(samples.size()).isEqualTo(0);
     }
 }


### PR DESCRIPTION
Not the prettiest, but given the way our metrics serialization is working, it is a simple solution without extra allocation. 
It may send empty metrics sets if ALL have `NaN` values but I decided it doesn't make sense to compromise performance or code simplicity for this unexpected extreme (should't cause an error, just send empty data event)