### PR TITLE
Executors instrumentation - select wrapper based on span lifecycle

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/async/ContextInScopeRunnableWrapper.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/async/ContextInScopeRunnableWrapper.java
@@ -17,10 +17,11 @@
  * limitations under the License.
  * #L%
  */
-package co.elastic.apm.agent.impl;
+package co.elastic.apm.agent.impl.async;
 
 
 import co.elastic.apm.agent.bci.VisibleForAdvice;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.objectpool.Recyclable;
 import org.slf4j.Logger;
@@ -36,12 +37,12 @@ public class ContextInScopeRunnableWrapper implements Runnable, Recyclable {
     @Nullable
     private volatile Runnable delegate;
 
-    ContextInScopeRunnableWrapper(ElasticApmTracer tracer) {
+    public ContextInScopeRunnableWrapper(ElasticApmTracer tracer) {
         this.tracer = tracer;
         context = TraceContext.with64BitId(tracer);
     }
 
-    ContextInScopeRunnableWrapper wrap(Runnable delegate, TraceContext context) {
+    public ContextInScopeRunnableWrapper wrap(Runnable delegate, TraceContext context) {
         this.context.copyFrom(context);
         // ordering is important: volatile write has to be after copying the TraceContext to ensure visibility in #run
         this.delegate = delegate;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/async/SpanInScopeRunnableWrapper.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/async/SpanInScopeRunnableWrapper.java
@@ -1,0 +1,92 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.impl.async;
+
+
+import co.elastic.apm.agent.bci.VisibleForAdvice;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.objectpool.Recyclable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+@VisibleForAdvice
+public class SpanInScopeRunnableWrapper implements Runnable, Recyclable {
+    private static final Logger logger = LoggerFactory.getLogger(SpanInScopeRunnableWrapper.class);
+    private final ElasticApmTracer tracer;
+    @Nullable
+    private volatile Runnable delegate;
+    @Nullable
+    private volatile AbstractSpan<?> span;
+
+    public SpanInScopeRunnableWrapper(ElasticApmTracer tracer) {
+        this.tracer = tracer;
+    }
+
+    public SpanInScopeRunnableWrapper wrap(Runnable delegate, AbstractSpan<?> span) {
+        this.delegate = delegate;
+        this.span = span;
+        return this;
+    }
+
+    // Exceptions in the agent may never affect the monitored application
+    // normally, advices act as the boundary of user and agent code and exceptions are handled via @Advice.OnMethodEnter(suppress = Throwable.class)
+    // In this case, this class acts as the boundary of user and agent code so we have to do the tedious exception handling here
+    @Override
+    public void run() {
+        // minimize volatile reads
+        AbstractSpan<?> localSpan = span;
+        if (localSpan != null) {
+            try {
+                localSpan.activate();
+            } catch (Throwable t) {
+                try {
+                    logger.error("Unexpected error while activating span", t);
+                } catch (Throwable ignore) {
+                }
+            }
+        }
+        try {
+            //noinspection ConstantConditions
+            delegate.run();
+            // the span may be ended at this point
+        } finally {
+            try {
+                if (localSpan != null) {
+                    localSpan.deactivate();
+                }
+                tracer.recycle(this);
+            } catch (Throwable t) {
+                try {
+                    logger.error("Unexpected error while deactivating or recycling span", t);
+                } catch (Throwable ignore) {
+                }
+            }
+        }
+    }
+
+    @Override
+    public void resetState() {
+        delegate = null;
+        span = null;
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
@@ -24,12 +24,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 public abstract class AbstractSpan<T extends AbstractSpan> extends TraceContextHolder<T> {
     private static final Logger logger = LoggerFactory.getLogger(AbstractSpan.class);
     protected static final double MS_IN_MICROS = TimeUnit.MILLISECONDS.toMicros(1);
     protected final TraceContext traceContext;
+
+    // used to mark this span as expected to switch lifecycle-managing-thread, eg span created by one thread and ended by another
+    private volatile boolean isLifecycleManagingThreadSwitch;
+
     /**
      * Generic designation of a transaction in the scope of a single service (eg: 'GET /users/:id')
      */
@@ -107,6 +112,7 @@ public abstract class AbstractSpan<T extends AbstractSpan> extends TraceContextH
         name.setLength(0);
         timestamp = 0;
         duration = 0;
+        isLifecycleManagingThreadSwitch = false;
         traceContext.resetState();
         // don't reset previouslyActive, as deactivate can be called after end
     }
@@ -155,16 +161,47 @@ public abstract class AbstractSpan<T extends AbstractSpan> extends TraceContextH
         return getTraceContext().isChildOf(other);
     }
 
+    public void markLifecycleManagingThreadSwitchExpected() {
+        isLifecycleManagingThreadSwitch = true;
+    }
+
     /**
      * Wraps the provided runnable and makes this {@link AbstractSpan} active in the {@link Runnable#run()} method.
      *
      * <p>
      * Note: does activates the {@link AbstractSpan} and not only the {@link TraceContext}.
-     * This should only be used span is closed in thread the provided {@link Runnable} is executed in.
+     * This should only be used when the span is closed in thread the provided {@link Runnable} is executed in.
      * </p>
      */
-    public Runnable withActiveSpan(Runnable runnable) {
-        return tracer.wrapRunnable(runnable, this);
+    @Override
+    public Runnable withActive(Runnable runnable) {
+        if (isLifecycleManagingThreadSwitch) {
+            // reset the lifecycle management flag, so that the executing thread will remain in charge until set otherwise by setting
+            // this flag once more
+            isLifecycleManagingThreadSwitch = false;
+            return tracer.wrapRunnable(runnable, this);
+        } else {
+            return tracer.wrapRunnable(runnable, traceContext);
+        }
     }
 
+    /**
+     * Wraps the provided runnable and makes this {@link AbstractSpan} active in the {@link Runnable#run()} method.
+     *
+     * <p>
+     * Note: does activates the {@link AbstractSpan} and not only the {@link TraceContext}.
+     * This should only be used when the span is closed in thread the provided {@link Runnable} is executed in.
+     * </p>
+     */
+    @Override
+    public <V> Callable<V> withActive(Callable<V> callable) {
+        if (isLifecycleManagingThreadSwitch) {
+            // reset the lifecycle management flag, so that the executing thread will remain in charge until set otherwise by setting
+            // this flag once more
+            isLifecycleManagingThreadSwitch = false;
+            return tracer.wrapCallable(callable, this);
+        } else {
+            return tracer.wrapCallable(callable, traceContext);
+        }
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -25,6 +25,8 @@ import co.elastic.apm.agent.util.HexUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.Callable;
+
 /**
  * This is an implementation of the
  * <a href="https://w3c.github.io/trace-context/#traceparent-field">w3c traceparent header draft</a>.
@@ -377,4 +379,29 @@ public class TraceContext extends TraceContextHolder {
         return copy;
     }
 
+    /**
+     * Wraps the provided {@link Runnable} and makes this {@link TraceContext} active in the {@link Runnable#run()} method.
+     *
+     * <p>
+     * Note: does not activate the {@link AbstractSpan} but only the {@link TraceContext}.
+     * This is useful if this span is closed in a different thread than the provided {@link Runnable} is executed in.
+     * </p>
+     */
+    @Override
+    public Runnable withActive(Runnable runnable) {
+        return tracer.wrapRunnable(runnable, this);
+    }
+
+    /**
+     * Wraps the provided {@link Callable} and makes this {@link TraceContext} active in the {@link Callable#call()} method.
+     *
+     * <p>
+     * Note: does not activate the {@link AbstractSpan} but only the {@link TraceContext}.
+     * This is useful if this span is closed in a different thread than the provided {@link java.util.concurrent.Callable} is executed in.
+     * </p>
+     */
+    @Override
+    public Callable withActive(Callable callable) {
+        return tracer.wrapCallable(callable, this);
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
@@ -122,27 +122,13 @@ public abstract class TraceContextHolder<T extends TraceContextHolder> implement
     }
 
     /**
-     * Wraps the provided {@link Runnable} and makes this {@link TraceContext} active in the {@link Runnable#run()} method.
-     *
-     * <p>
-     * Note: does not activate the {@link AbstractSpan} but only the {@link TraceContext}.
-     * This is useful if this span is closed in a different thread than the provided {@link Runnable} is executed in.
-     * </p>
+     * Wraps the provided {@link Runnable} and makes this {@link TraceContextHolder} active in the {@link Runnable#run()} method.
      */
-    public Runnable withActiveContext(Runnable runnable) {
-        return tracer.wrapRunnable(runnable, getTraceContext());
-    }
+    public abstract Runnable withActive(Runnable runnable);
 
     /**
      * Wraps the provided {@link Callable} and makes this {@link TraceContext} active in the {@link Callable#call()} method.
-     *
-     * <p>
-     * Note: does not activate the {@link AbstractSpan} but only the {@link TraceContext}.
-     * This is useful if this span is closed in a different thread than the provided {@link java.util.concurrent.Callable} is executed in.
-     * </p>
      */
-    public <V> Callable<V> withActiveContext(Callable<V> runnable) {
-        return tracer.wrapCallable(runnable, getTraceContext());
-    }
+    public abstract <V> Callable<V> withActive(Callable<V> callable);
 
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ScopeManagementTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ScopeManagementTest.java
@@ -29,7 +29,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
+import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -102,10 +104,11 @@ class ScopeManagementTest {
     }
 
     @Test
-    void testContextAndSpanActivation() {
+    void testContextAndSpanRunnableActivation() {
         runTestWithAssertionsDisabled(() -> {
             final Transaction transaction = tracer.startTransaction().activate();
-            transaction.withActiveContext(transaction.withActiveSpan(() ->
+            transaction.markLifecycleManagingThreadSwitchExpected();
+            transaction.withActive(transaction.withActive((Runnable) () ->
                 assertThat(tracer.getActive()).isSameAs(transaction))).run();
             transaction.deactivate();
 
@@ -114,11 +117,15 @@ class ScopeManagementTest {
     }
 
     @Test
-    void testSpanAndContextActivation() {
+    void testContextAndSpanCallableActivation() {
         runTestWithAssertionsDisabled(() -> {
             final Transaction transaction = tracer.startTransaction().activate();
-            transaction.withActiveSpan(transaction.withActiveContext((Runnable) () ->
-                assertThat(tracer.currentTransaction()).isSameAs(transaction))).run();
+            transaction.markLifecycleManagingThreadSwitchExpected();
+            try {
+                assertThat(transaction.withActive(transaction.withActive(() -> tracer.currentTransaction())).call()).isSameAs(transaction);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
             transaction.deactivate();
 
             assertThat(tracer.getActive()).isNull();
@@ -126,9 +133,41 @@ class ScopeManagementTest {
     }
 
     @Test
-    void testContextAndSpanActivationInDifferentThread() throws Exception {
+    void testSpanAndContextRunnableActivation() {
+        runTestWithAssertionsDisabled(() -> {
+            final Transaction transaction = tracer.startTransaction().activate();
+            Runnable runnable = transaction.withActive((Runnable) () ->
+                assertThat(tracer.currentTransaction()).isSameAs(transaction));
+            transaction.markLifecycleManagingThreadSwitchExpected();
+            transaction.withActive(runnable).run();
+            transaction.deactivate();
+
+            assertThat(tracer.getActive()).isNull();
+        });
+    }
+
+    @Test
+    void testSpanAndContextCallableActivation() {
+        runTestWithAssertionsDisabled(() -> {
+            final Transaction transaction = tracer.startTransaction().activate();
+            Callable<Transaction> callable = transaction.withActive(() -> tracer.currentTransaction());
+            transaction.markLifecycleManagingThreadSwitchExpected();
+            try {
+                assertThat(transaction.withActive(callable).call()).isSameAs(transaction);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            transaction.deactivate();
+
+            assertThat(tracer.getActive()).isNull();
+        });
+    }
+
+    @Test
+    void testContextAndSpanRunnableActivationInDifferentThread() throws Exception {
         final Transaction transaction = tracer.startTransaction().activate();
-        Executors.newSingleThreadExecutor().submit(transaction.withActiveContext(transaction.withActiveSpan(() -> {
+        transaction.markLifecycleManagingThreadSwitchExpected();
+        Executors.newSingleThreadExecutor().submit(transaction.withActive(transaction.withActive(() -> {
             assertThat(tracer.getActive()).isSameAs(transaction);
             assertThat(tracer.currentTransaction()).isSameAs(transaction);
         }))).get();
@@ -138,12 +177,42 @@ class ScopeManagementTest {
     }
 
     @Test
-    void testSpanAndContextActivationInDifferentThread() throws Exception {
+    void testContextAndSpanCallableActivationInDifferentThread() throws Exception {
         final Transaction transaction = tracer.startTransaction().activate();
-        Executors.newSingleThreadExecutor().submit(transaction.withActiveSpan(transaction.withActiveContext(() -> {
+        transaction.markLifecycleManagingThreadSwitchExpected();
+        Future<Transaction> transactionFuture = Executors.newSingleThreadExecutor().submit(transaction.withActive(transaction.withActive(() -> {
+            assertThat(tracer.getActive()).isSameAs(transaction);
+            return tracer.currentTransaction();
+        })));
+        assertThat(transactionFuture.get()).isSameAs(transaction);
+        transaction.deactivate();
+
+        assertThat(tracer.getActive()).isNull();
+    }
+
+    @Test
+    void testSpanAndContextRunnableActivationInDifferentThread() throws Exception {
+        final Transaction transaction = tracer.startTransaction().activate();
+        Runnable runnable = transaction.withActive(() -> {
             assertThat(tracer.currentTransaction()).isSameAs(transaction);
             assertThat(tracer.getActive()).isInstanceOf(TraceContext.class);
-        }))).get();
+        });
+        transaction.markLifecycleManagingThreadSwitchExpected();
+        Executors.newSingleThreadExecutor().submit(transaction.withActive(runnable)).get();
+        transaction.deactivate();
+
+        assertThat(tracer.getActive()).isNull();
+    }
+
+    @Test
+    void testSpanAndContextCallableActivationInDifferentThread() throws Exception {
+        final Transaction transaction = tracer.startTransaction().activate();
+        Callable<Transaction> callable = transaction.withActive(() -> {
+            assertThat(tracer.getActive()).isInstanceOf(TraceContext.class);
+            return tracer.currentTransaction();
+        });
+        transaction.markLifecycleManagingThreadSwitchExpected();
+        assertThat(Executors.newSingleThreadExecutor().submit(transaction.withActive(callable)).get()).isSameAs(transaction);
         transaction.deactivate();
 
         assertThat(tracer.getActive()).isNull();

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
@@ -73,7 +73,7 @@ public abstract class ExecutorInstrumentation extends ElasticApmInstrumentation 
             final TraceContextHolder<?> active = ExecutorInstrumentation.getActive();
             if (active != null && runnable != null && !excluded.contains(thiz)) {
                 original = runnable;
-                runnable = active.withActiveContext(runnable);
+                runnable = active.withActive(runnable);
             }
         }
 
@@ -115,7 +115,7 @@ public abstract class ExecutorInstrumentation extends ElasticApmInstrumentation 
             final TraceContextHolder<?> active = ExecutorInstrumentation.getActive();
             if (active != null && callable != null && !excluded.contains(thiz)) {
                 original = callable;
-                callable = active.withActiveContext(callable);
+                callable = active.withActive(callable);
             }
         }
 

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/FailingExecutorInstrumentationTest.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/FailingExecutorInstrumentationTest.java
@@ -20,8 +20,8 @@
 package co.elastic.apm.agent.concurrent;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
-import co.elastic.apm.agent.impl.ContextInScopeCallableWrapper;
-import co.elastic.apm.agent.impl.ContextInScopeRunnableWrapper;
+import co.elastic.apm.agent.impl.async.ContextInScopeCallableWrapper;
+import co.elastic.apm.agent.impl.async.ContextInScopeRunnableWrapper;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
@@ -168,7 +168,8 @@ public abstract class AsyncInstrumentation extends ElasticApmInstrumentation {
                 if (tracer != null && runnable != null) {
                     final Transaction transaction = tracer.currentTransaction();
                     if (transaction != null) {
-                        runnable = transaction.withActiveSpan(runnable);
+                        transaction.markLifecycleManagingThreadSwitchExpected();
+                        runnable = transaction.withActive(runnable);
                     }
                 }
             }

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
@@ -54,7 +54,7 @@ public class HttpUrlConnectionInstrumentationTest extends AbstractHttpClientInst
     public void testEndInDifferentThread() throws Exception {
         final HttpURLConnection urlConnection = new HttpURLConnectionWrapper(new HttpURLConnectionWrapper((HttpURLConnection) new URL(getBaseUrl() + "/").openConnection()));
         urlConnection.connect();
-        final Thread thread = new Thread(tracer.getActive().withActiveContext(() -> {
+        final Thread thread = new Thread(tracer.getActive().withActive(() -> {
             try {
                 urlConnection.getInputStream();
             } catch (IOException e) {


### PR DESCRIPTION
ExecutorsService instrumentation enhancement that enables pre-setting the lifecycle management mechanics - mark spans that are expected to switch threads managing their lifecycle and decide how to wrap based on that.