### PR TITLE
Consistently rename tags to labels in DslJsonSerializer

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/AbstractContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/AbstractContext.java
@@ -35,7 +35,7 @@ public abstract class AbstractContext implements Recyclable {
      */
     private final Map<String, Object> labels = new ConcurrentHashMap<>();
 
-    public Iterator<? extends Map.Entry<String, ?>> getTagsIterator() {
+    public Iterator<? extends Map.Entry<String, ?>> getLabelIterator() {
         return labels.entrySet().iterator();
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistrySerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistrySerializer.java
@@ -52,7 +52,7 @@ public class MetricRegistrySerializer {
 
                 if (!metricSet.getLabels().isEmpty()) {
                     DslJsonSerializer.writeFieldName("tags", jw);
-                    DslJsonSerializer.serializeStringTags(metricSet.getLabels().entrySet().iterator(), replaceBuilder, jw);
+                    DslJsonSerializer.serializeStringLabels(metricSet.getLabels().entrySet().iterator(), replaceBuilder, jw);
                     jw.writeByte(JsonWriter.COMMA);
                 }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -182,7 +182,7 @@ class DslJsonSerializerTest {
     private String serializeTags(Map<String, String> tags) {
         final AbstractContext context = new AbstractContext() {};
         tags.forEach(context::addLabel);
-        serializer.serializeTags(context);
+        serializer.serializeLabels(context);
         final String jsonString = serializer.jw.toString();
         serializer.jw.reset();
         return jsonString;


### PR DESCRIPTION
Avoid allocation of tags iterator if there are no tags