### PR TITLE
Loading plugins from System CL and parent hierarchy

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -97,7 +97,7 @@ public class ElasticApmAgent {
     @Nonnull
     private static Iterable<ElasticApmInstrumentation> loadInstrumentations(ElasticApmTracer tracer) {
         final ArrayList<ElasticApmInstrumentation> instrumentations = new ArrayList<ElasticApmInstrumentation>();
-        for (ElasticApmInstrumentation instrumentation : ServiceLoader.load(ElasticApmInstrumentation.class, ElasticApmInstrumentation.class.getClassLoader())) {
+        for (ElasticApmInstrumentation instrumentation : ServiceLoader.load(ElasticApmInstrumentation.class, ClassLoader.getSystemClassLoader())) {
             instrumentations.add(instrumentation);
         }
         for (MethodMatcher traceMethod : tracer.getConfig(CoreConfiguration.class).getTraceMethods()) {

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -170,7 +170,7 @@ Also keep that in mind when creating alerts.
 [[config-transaction-sample-rate]]
 ==== `transaction_sample_rate`
 
-By default, the agent will sample every transaction (e.g. request to your service). To reduce overhead and storage requirements, you can set the sample rate to a value between 0.0 and 1.0. We still record overall time and the result for unsampled transactions, but no context information, labels, or spans.
+By default, the agent will sample every transaction (e.g. request to your service). To reduce overhead and storage requirements, you can set the sample rate to a value between 0.0 and 1.0. We still record overall time and the result for unsampled transactions, but no context information, tags, or spans.
 
 
 [options="header"]
@@ -1037,7 +1037,7 @@ The default unit for this option is `ms`
 #
 # environment=
 
-# By default, the agent will sample every transaction (e.g. request to your service). To reduce overhead and storage requirements, you can set the sample rate to a value between 0.0 and 1.0. We still record overall time and the result for unsampled transactions, but no context information, labels, or spans.
+# By default, the agent will sample every transaction (e.g. request to your service). To reduce overhead and storage requirements, you can set the sample rate to a value between 0.0 and 1.0. We still record overall time and the result for unsampled transactions, but no context information, tags, or spans.
 #
 # This setting can be changed at runtime
 # Type: Double


### PR DESCRIPTION
Related Discuss topic: https://discuss.elastic.co/t/custom-plugin-for-java-agent/171249.
Letting agent load plugins located in the classpath, in the platform/ext libs or bootclasspath.
Here is an attach jar for testing: [apm-agent-attach-1.4.1-SNAPSHOT.jar.zip](https://github.com/elastic/apm-agent-java/files/2949676/apm-agent-attach-1.4.1-SNAPSHOT.jar.zip)