### PR TITLE
Channelling span creation through a common path

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -217,7 +217,11 @@ public class ElasticApmTracer {
      * @return a new started span
      */
     public <T> Span startSpan(TraceContext.ChildContextCreator<T> childContextCreator, T parentContext) {
-        return spanPool.createInstance().start(childContextCreator, parentContext);
+        return startSpan(childContextCreator, parentContext, -1);
+    }
+
+    public Span startSpan(AbstractSpan<?> parent, long epochMicros) {
+        return startSpan(TraceContext.fromParent(), parent, epochMicros);
     }
 
     /**
@@ -227,12 +231,7 @@ public class ElasticApmTracer {
      * @see #startSpan(TraceContext.ChildContextCreator, Object)
      */
     public <T> Span startSpan(TraceContext.ChildContextCreator<T> childContextCreator, T parentContext, long epochMicros) {
-        return spanPool.createInstance().start(childContextCreator, parentContext, epochMicros);
-    }
-
-    public Span startSpan(AbstractSpan<?> parent, long epochMicros) {
-        Span span;
-        span = spanPool.createInstance();
+        Span span = spanPool.createInstance();
         final boolean dropped;
         Transaction transaction = currentTransaction();
         if (transaction != null) {
@@ -246,7 +245,7 @@ public class ElasticApmTracer {
         } else {
             dropped = false;
         }
-        span.start(TraceContext.fromParent(), parent, epochMicros, dropped);
+        span.start(childContextCreator, parentContext, epochMicros, dropped);
         return span;
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
@@ -63,15 +63,6 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
         super(tracer);
     }
 
-    public <T> Span start(TraceContext.ChildContextCreator<T> childContextCreator, T parentContext) {
-        // we can't get the timestamp here as the clock has not yet been initialized
-        return start(childContextCreator, parentContext, -1);
-    }
-
-    public <T> Span start(TraceContext.ChildContextCreator<T> childContextCreator, T parentContext, long epochMicros) {
-        return start(childContextCreator, parentContext, epochMicros, false);
-    }
-
     public <T> Span start(TraceContext.ChildContextCreator<T> childContextCreator, T parentContext, long epochMicros, boolean dropped) {
         onStart();
         childContextCreator.asChildOf(traceContext, parentContext);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/TransactionUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/TransactionUtils.java
@@ -86,7 +86,7 @@ public class TransactionUtils {
     public static List<Span> getSpans(Transaction t) {
         List<Span> spans = new ArrayList<>();
         Span span = new Span(mock(ElasticApmTracer.class))
-            .start(TraceContext.fromParent(), t)
+            .start(TraceContext.fromParent(), t, -1, false)
             .withName("SELECT FROM product_types")
             .withType("db")
             .withSubtype("postgresql")
@@ -101,20 +101,20 @@ public class TransactionUtils {
         spans.add(span);
 
         spans.add(new Span(mock(ElasticApmTracer.class))
-            .start(TraceContext.fromParent(), t)
+            .start(TraceContext.fromParent(), t, -1, false)
             .withName("GET /api/types")
             .withType("request"));
         spans.add(new Span(mock(ElasticApmTracer.class))
-            .start(TraceContext.fromParent(), t)
+            .start(TraceContext.fromParent(), t, -1, false)
             .withName("GET /api/types")
             .withType("request"));
         spans.add(new Span(mock(ElasticApmTracer.class))
-            .start(TraceContext.fromParent(), t)
+            .start(TraceContext.fromParent(), t, -1, false)
             .withName("GET /api/types")
             .withType("request"));
 
         span = new Span(mock(ElasticApmTracer.class))
-            .start(TraceContext.fromParent(), t)
+            .start(TraceContext.fromParent(), t, -1, false)
             .appendToName("GET ")
             .appendToName("test.elastic.co")
             .withType("ext")

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/TransactionPayloadJsonSchemaTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/TransactionPayloadJsonSchemaTest.java
@@ -62,7 +62,7 @@ class TransactionPayloadJsonSchemaTest {
         final Transaction transaction = createTransactionWithRequiredValues();
         payload.getTransactions().add(transaction);
         Span span = new Span(mock(ElasticApmTracer.class));
-        span.start(TraceContext.fromParent(), transaction)
+        span.start(TraceContext.fromParent(), transaction, -1, false)
             .withType("type")
             .withSubtype("subtype")
             .withAction("action")


### PR DESCRIPTION
Maybe related to https://discuss.elastic.co/t/kibana-apm-not-showing-spans-which-are-visible-in-discover-too-many-spans/171690, where we ignore the span limit setting