### PR TITLE
[APM-CI] use current as pipeline shared library version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-@Library('apm@v1.0.6') _
+@Library('apm@current') _
   
 pipeline {
   agent any
@@ -274,14 +274,8 @@ pipeline {
       steps {
         deleteDir()
         unstash 'source'
-        checkoutElasticDocsTools(basedir: "${ELASTIC_DOCS}")
         dir("${BASE_DIR}"){
-          sh './scripts/jenkins/docs.sh'
-        }
-      }
-      post{
-        success {
-          tar(file: "doc-files.tgz", archive: true, dir: "html", pathPrefix: "${BASE_DIR}/docs")
+          buildDocs(docsDir: "docs", archive: true)
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ pipeline {
     ansiColor('xterm')
     disableResume()
     durabilityHint('PERFORMANCE_OPTIMIZED')
+    rateLimitBuilds(throttle: [count: 60, durationName: 'hour', userBoost: true])
+    quietPeriod(10)
   }
   triggers {
     issueCommentTrigger('.*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')

--- a/scripts/jenkins/docs.sh
+++ b/scripts/jenkins/docs.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-if [ -z "${ELASTIC_DOCS}" -o ! -d "${ELASTIC_DOCS}" ]; then
-  echo "ELASTIC_DOCS is not defined, it should point to a folder where you checkout https://github.com/elastic/docs.git."
-  echo "You also can define BUILD_DOCS_ARGS for aditional build options."
-  exit 1
-fi
-
-${ELASTIC_DOCS}/build_docs.pl --chunk=1 ${BUILD_DOCS_ARGS} --doc docs/index.asciidoc -out docs/html


### PR DESCRIPTION
* to avoid to have changing the Jenkinsfile every time we set a pipeline shared library as a stable version to use.
* Use buildDocs pipeline step to build docs
* limit max PR builds per hour to 60
* set quiet period to 10 seconds