### PR TITLE
Override span.id instead of removing and adding

### DIFF
--- a/apm-agent-plugins/apm-slf4j-plugin/src/main/java/co/elastic/apm/agent/slf4j/Slf4JMdcActivationListener.java
+++ b/apm-agent-plugins/apm-slf4j-plugin/src/main/java/co/elastic/apm/agent/slf4j/Slf4JMdcActivationListener.java
@@ -108,8 +108,8 @@ public class Slf4JMdcActivationListener implements ActivationListener {
 
                 MethodHandle remove = mdcRemoveMethodHandleCache.get(contextClassLoader);
                 if (remove != null) {
-                    remove.invokeExact(SPAN_ID);
                     if (active == null) {
+                        remove.invokeExact(SPAN_ID);
                         remove.invokeExact(TRACE_ID);
                         remove.invokeExact(TRANSACTION_ID);
                     }


### PR DESCRIPTION
Each remove or add operation results in duplicating the MDC map
Therefore, this change minimizes allocations while retaining the same semantics