### PR TITLE
Fixed Nullpointer in maven-shade.plugin by upgrading to 3.2.1 

### DIFF
--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -20,7 +20,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>


### PR DESCRIPTION
(see https://issues.apache.org/jira/browse/MSHADE-289)

When running the on my windows machine with the current openjdk version (11.0.2) the build fails in the elastic-apm-agent shade step, throwing a nullpointer exception.

Upgrading the Maven Shade plugin used for elastic-apm-agent to the current version (3.2.1) fixes the problem