### PR TITLE
Avoid that the reporter blocks server shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
 
 ## Bug Fixes
+* Avoid that the agent blocks server shutdown in case the APM Server is not available
 
 # 1.5.0
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandler.java
@@ -398,9 +398,10 @@ public class IntakeV2ReportingEventHandler implements ReportingEventHandler {
 
         @Override
         public void run() {
-            // if the ring buffer is full this waits until a slot becomes available
-            // as this happens on a different thread,
-            // the reporting does not block and thus there is no danger of deadlocks
+            // If the ring buffer is full this throws an exception.
+            // In case it's full due to a traffic spike it means that it will eventually flush anyway because of the max request size
+            // If the APM Server is down for a longer period and the ring buffer is full because of that,
+            // the timeout task will not be started as the connection attempt resulted in an exception
             logger.debug("Request flush because the request timeout occurred");
             flush = reporter.flush();
         }


### PR DESCRIPTION
This only happens after the APM Server is not available for a while. In that case, the reporter queue fills up and can never really drain because the reporter blocks its thread to throttle APM Server connection retries. On shutdown, the reporter tries to flush by registering a flush event. The registration blocks until a new slot in the ring buffer becomes available. But due to the throttling only once every 36 seconds, an event is picked up from the ring buffer. So a shutdown takes around 512 * 36 seconds.