### PR TITLE
Adding support for Apache HTTP Async Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # next (1.6.0)
 
 ## Features
+ * Support Apache HttpAsyncClient - span creation and cross-service trace context propagation
 
 ## Bug Fixes
-* Avoid that the agent blocks server shutdown in case the APM Server is not available
+ * Avoid that the agent blocks server shutdown in case the APM Server is not available
 
 # 1.5.0
 

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -142,5 +142,11 @@
             <version>1.17.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -168,6 +168,7 @@ public class ElasticApmAgent {
         final boolean typeMatchingWithNamePreFilter = tracer.getConfig(CoreConfiguration.class).isTypeMatchingWithNamePreFilter();
         final ElementMatcher.Junction<ClassLoader> classLoaderMatcher = advice.getClassLoaderMatcher();
         final ElementMatcher<? super NamedElement> typeMatcherPreFilter = advice.getTypeMatcherPreFilter();
+        final ElementMatcher.Junction<ProtectionDomain> versionPostFilter = advice.getImplementationVersionPostFilter();
         final ElementMatcher<? super TypeDescription> typeMatcher = advice.getTypeMatcher();
         final ElementMatcher<? super MethodDescription> methodMatcher = advice.getMethodMatcher();
         return agentBuilder
@@ -184,7 +185,7 @@ public class ElasticApmAgent {
                         }
                         boolean typeMatches;
                         try {
-                            typeMatches = typeMatcher.matches(typeDescription);
+                            typeMatches = typeMatcher.matches(typeDescription) && versionPostFilter.matches(protectionDomain);
                         } catch (Exception ignored) {
                             // could be because of a missing type
                             typeMatches = false;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmInstrumentation.java
@@ -28,6 +28,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import net.bytebuddy.matcher.ElementMatchers;
 
 import javax.annotation.Nullable;
+import java.security.ProtectionDomain;
 import java.util.Collection;
 
 import static net.bytebuddy.matcher.ElementMatchers.any;
@@ -84,6 +85,13 @@ public abstract class ElasticApmInstrumentation {
      * </p>
      */
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+        return any();
+    }
+
+    /**
+     * Post filters classes that pass the {@link #getTypeMatcher()} by version.
+     */
+    public ElementMatcher.Junction<ProtectionDomain> getImplementationVersionPostFilter() {
         return any();
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
@@ -108,6 +108,7 @@ public abstract class AbstractSpan<T extends AbstractSpan> extends TraceContextH
 
     @Override
     public void resetState() {
+        super.resetState();
         finished = true;
         name.setLength(0);
         timestamp = 0;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
@@ -53,11 +53,6 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
     private String action;
 
     /**
-     * Flag to mark a span as representing an exit event
-     */
-    private boolean isExit;
-
-    /**
      * Any other arbitrary data captured by the agent, optionally provided by the user
      */
     private final SpanContext context = new SpanContext();
@@ -125,11 +120,6 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
         return this;
     }
 
-    public Span asExit() {
-        isExit = true;
-        return this;
-    }
-
     /**
      * Sets span.type, span.subtype and span.action. If no subtype and action are provided, assumes the legacy usage of hierarchical
      * typing system and attempts to split the type by dots to discover subtype and action.
@@ -177,10 +167,6 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
         return action;
     }
 
-    public boolean isExit() {
-        return isExit;
-    }
-
     @Override
     public void doEnd(long epochMicros) {
         if (logger.isDebugEnabled()) {
@@ -203,7 +189,6 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
         type = null;
         subtype = null;
         action = null;
-        isExit = false;
     }
 
     @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
@@ -53,6 +53,11 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
     private String action;
 
     /**
+     * Flag to mark a span as representing an exit event
+     */
+    private boolean isExit;
+
+    /**
      * Any other arbitrary data captured by the agent, optionally provided by the user
      */
     private final SpanContext context = new SpanContext();
@@ -120,6 +125,11 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
         return this;
     }
 
+    public Span asExit() {
+        isExit = true;
+        return this;
+    }
+
     /**
      * Sets span.type, span.subtype and span.action. If no subtype and action are provided, assumes the legacy usage of hierarchical
      * typing system and attempts to split the type by dots to discover subtype and action.
@@ -167,6 +177,10 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
         return action;
     }
 
+    public boolean isExit() {
+        return isExit;
+    }
+
     @Override
     public void doEnd(long epochMicros) {
         if (logger.isDebugEnabled()) {
@@ -189,6 +203,7 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
         type = null;
         subtype = null;
         action = null;
+        isExit = false;
     }
 
     @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -227,6 +227,7 @@ public class TraceContext extends TraceContextHolder {
 
     @Override
     public void resetState() {
+        super.resetState();
         traceId.resetState();
         id.resetState();
         parentId.resetState();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
@@ -52,13 +52,37 @@ public abstract class TraceContextHolder<T extends TraceContextHolder> implement
 
     protected final ElasticApmTracer tracer;
 
+    /**
+     * Flag to mark a span as representing an exit event
+     */
+    private boolean isExit;
+
     protected TraceContextHolder(ElasticApmTracer tracer) {
         this.tracer = tracer;
+    }
+
+    public TraceContextHolder<T> asExit() {
+        isExit = true;
+        return this;
     }
 
     public abstract TraceContext getTraceContext();
 
     public abstract Span createSpan();
+
+    /**
+     * Creates a child Span representing a remote call event, unless this TraceContextHolder already represents an exit event.
+     * If current TraceContextHolder is representing an Exit- returns null
+     *
+     * @return an Exit span if this TraceContextHolder is not an exit span, null othewise
+     */
+    @Nullable
+    public Span createExitSpan() {
+        if (isExit) {
+            return null;
+        }
+        return (Span) createSpan().asExit();
+    }
 
     public abstract boolean isChildOf(TraceContextHolder other);
 
@@ -110,6 +134,10 @@ public abstract class TraceContextHolder<T extends TraceContextHolder> implement
         return getTraceContext().isSampled();
     }
 
+    public boolean isExit() {
+        return isExit;
+    }
+
     public void captureException(long epochMicros, Throwable t) {
         tracer.captureException(epochMicros, t, this);
     }
@@ -131,4 +159,8 @@ public abstract class TraceContextHolder<T extends TraceContextHolder> implement
      */
     public abstract <V> Callable<V> withActive(Callable<V> callable);
 
+    @Override
+    public void resetState() {
+        isExit = false;
+    }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchersTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchersTest.java
@@ -20,11 +20,14 @@
 package co.elastic.apm.agent.bci.bytebuddy;
 
 import net.bytebuddy.description.type.TypeDescription;
+import org.apache.http.client.HttpClient;
 import org.junit.jupiter.api.Test;
 
+import java.security.ProtectionDomain;
 import java.util.List;
 
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.implementationVersionLte;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPackage;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,5 +47,22 @@ class CustomElementMatchersTest {
         assertThat(classLoaderCanLoadClass(Object.class.getName()).matches(ClassLoader.getSystemClassLoader())).isTrue();
         assertThat(classLoaderCanLoadClass(Object.class.getName()).matches(null)).isTrue();
         assertThat(classLoaderCanLoadClass("not.Here").matches(ClassLoader.getSystemClassLoader())).isFalse();
+    }
+
+    @Test
+    void testSemVerLteMatcher() {
+        // Relying on Apache httpclient-4.3.2.jar
+        ProtectionDomain protectionDomain = HttpClient.class.getProtectionDomain();
+        assertThat(implementationVersionLte("3").matches(protectionDomain)).isFalse();
+        assertThat(implementationVersionLte("3.2").matches(protectionDomain)).isFalse();
+        assertThat(implementationVersionLte("3.15.10").matches(protectionDomain)).isFalse();
+        assertThat(implementationVersionLte("4.2.19").matches(protectionDomain)).isFalse();
+        assertThat(implementationVersionLte("4.3.1").matches(protectionDomain)).isFalse();
+        assertThat(implementationVersionLte("4.3.2").matches(protectionDomain)).isTrue();
+        assertThat(implementationVersionLte("4.3.3").matches(protectionDomain)).isTrue();
+        assertThat(implementationVersionLte("4.7.3").matches(protectionDomain)).isTrue();
+        assertThat(implementationVersionLte("5.7.3").matches(protectionDomain)).isTrue();
+        assertThat(implementationVersionLte("5.0").matches(protectionDomain)).isTrue();
+        assertThat(implementationVersionLte("5").matches(protectionDomain)).isTrue();
     }
 }

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/pom.xml
@@ -23,8 +23,8 @@
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>
+            <artifactId>httpasyncclient</artifactId>
+            <version>4.1.4</version>
             <scope>provided</scope>
         </dependency>
 

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientHelper.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientHelper.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.httpclient;
+
+import co.elastic.apm.agent.impl.transaction.Span;
+
+public interface ApacheHttpAsyncClientHelper<P, F, C> {
+    P wrapRequestProducer(P requestProducer, Span span);
+
+    F wrapFutureCallback(F futureCallback, C context, Span span);
+}

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientHelperImpl.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientHelperImpl.java
@@ -1,0 +1,81 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.httpclient;
+
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.objectpool.Allocator;
+import co.elastic.apm.agent.objectpool.ObjectPool;
+import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.http.protocol.HttpContext;
+import org.jctools.queues.atomic.AtomicQueueFactory;
+
+import static org.jctools.queues.spec.ConcurrentQueueSpec.createBoundedMpmc;
+
+public class ApacheHttpAsyncClientHelperImpl implements ApacheHttpAsyncClientHelper<HttpAsyncRequestProducer, FutureCallback<?>, HttpContext> {
+
+    private static final int MAX_POOLED_ELEMENTS = 256;
+
+    private final ObjectPool<HttpAsyncRequestProducerWrapper> requestProducerWrapperObjectPool;
+    private final ObjectPool<FutureCallbackWrapper<?>> futureCallbackWrapperObjectPool;
+
+    public ApacheHttpAsyncClientHelperImpl() {
+        requestProducerWrapperObjectPool = QueueBasedObjectPool.ofRecyclable(
+            AtomicQueueFactory.<HttpAsyncRequestProducerWrapper>newQueue(createBoundedMpmc(MAX_POOLED_ELEMENTS)),
+            false, new RequestProducerWrapperAllocator());
+
+        futureCallbackWrapperObjectPool = QueueBasedObjectPool.ofRecyclable(
+            AtomicQueueFactory.<FutureCallbackWrapper<?>>newQueue(createBoundedMpmc(MAX_POOLED_ELEMENTS)),
+            false, new FutureCallbackWrapperAllocator());
+    }
+
+    private class RequestProducerWrapperAllocator implements Allocator<HttpAsyncRequestProducerWrapper> {
+        @Override
+        public HttpAsyncRequestProducerWrapper createInstance() {
+            return new HttpAsyncRequestProducerWrapper(ApacheHttpAsyncClientHelperImpl.this);
+        }
+    }
+
+    private class FutureCallbackWrapperAllocator implements Allocator<FutureCallbackWrapper<?>> {
+        @Override
+        public FutureCallbackWrapper<?> createInstance() {
+            return new FutureCallbackWrapper(ApacheHttpAsyncClientHelperImpl.this);
+        }
+    }
+
+    @Override
+    public HttpAsyncRequestProducer wrapRequestProducer(HttpAsyncRequestProducer requestProducer, Span span) {
+        return requestProducerWrapperObjectPool.createInstance().with(requestProducer, span);
+    }
+
+    @Override
+    public FutureCallback wrapFutureCallback(FutureCallback futureCallback, HttpContext context, Span span) {
+        return futureCallbackWrapperObjectPool.createInstance().with(futureCallback, context, span);
+    }
+
+    void recycle(HttpAsyncRequestProducerWrapper requestProducerWrapper) {
+        requestProducerWrapperObjectPool.recycle(requestProducerWrapper);
+    }
+
+    void recycle(FutureCallbackWrapper futureCallbackWrapper) {
+        futureCallbackWrapperObjectPool.recycle(futureCallbackWrapper);
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentation.java
@@ -1,0 +1,132 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.httpclient;
+
+import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
+import co.elastic.apm.agent.bci.HelperClassManager;
+import co.elastic.apm.agent.http.client.HttpClientHelper;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.http.protocol.HttpContext;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
+
+public class ApacheHttpAsyncClientInstrumentation extends ElasticApmInstrumentation {
+
+    // Referencing specific Apache HTTP client classes are allowed due to type erasure
+    public static HelperClassManager<ApacheHttpAsyncClientHelper<HttpAsyncRequestProducer, FutureCallback<?>, HttpContext>> helperManager;
+
+    private static class ApacheHttpAsyncClientAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        private static void onBeforeExecute(@Advice.Argument(value = 0, readOnly = false) HttpAsyncRequestProducer requestProducer,
+                                            @Advice.Argument(2) HttpContext context,
+                                            @Advice.Argument(value = 3, readOnly = false) FutureCallback futureCallback,
+                                            @Advice.Local("span") @Nullable Span span,
+                                            @Advice.Local("wrapped") boolean wrapped) {
+            if (tracer == null || tracer.getActive() == null) {
+                return;
+            }
+            final TraceContextHolder<?> parent = tracer.getActive();
+            if (!HttpClientHelper.isExit(parent)) {
+                span = parent.createSpan()
+                    .asExit()
+                    .withType(HttpClientHelper.EXTERNAL_TYPE)
+                    .withSubtype(HttpClientHelper.HTTP_SUBTYPE)
+                    .activate();
+            }
+
+            // wrap
+            if (span != null) {
+                ApacheHttpAsyncClientHelper<HttpAsyncRequestProducer, FutureCallback<?>, HttpContext> helper =
+                    helperManager.getForClassLoaderOfClass(HttpAsyncRequestProducer.class);
+                if (helper != null) {
+                    requestProducer = helper.wrapRequestProducer(requestProducer, span);
+                    futureCallback = helper.wrapFutureCallback(futureCallback, context, span);
+                    wrapped = true;
+                }
+            }
+        }
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+        public static void onAfterExecute(@Advice.Local("span") @Nullable Span span,
+                                          @Advice.Local("wrapped") boolean wrapped,
+                                          @Advice.Thrown @Nullable Throwable t) {
+            if (span != null) {
+                // Deactivate in this thread. Span will be ended and reported by the listener
+                span.deactivate();
+
+                if (!wrapped) {
+                    // Listener is not wrapped- we need to end the span so to avoid leak and report error if occurred during method invocation
+                    span.captureException(t);
+                    span.end();
+                }
+            }
+        }
+    }
+
+    @Override
+    public void init(ElasticApmTracer tracer) {
+        helperManager = HelperClassManager.ForAnyClassLoader.of(tracer,
+            "co.elastic.apm.agent.httpclient.ApacheHttpAsyncClientHelperImpl",
+            "co.elastic.apm.agent.httpclient.HttpAsyncRequestProducerWrapper",
+            "co.elastic.apm.agent.httpclient.ApacheHttpAsyncClientHelperImpl$RequestProducerWrapperAllocator",
+            "co.elastic.apm.agent.httpclient.FutureCallbackWrapper",
+            "co.elastic.apm.agent.httpclient.ApacheHttpAsyncClientHelperImpl$FutureCallbackWrapperAllocator");
+    }
+
+    @Override
+    public Class<?> getAdviceClass() {
+        return ApacheHttpAsyncClientAdvice.class;
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return hasSuperType(named("org.apache.http.nio.client.HttpAsyncClient"));
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named("execute")
+            .and(takesArguments(4))
+            .and(takesArgument(0, hasSuperType(named("org.apache.http.nio.protocol.HttpAsyncRequestProducer"))))
+            .and(takesArgument(1, hasSuperType(named("org.apache.http.nio.protocol.HttpAsyncResponseConsumer"))))
+            .and(takesArgument(2, hasSuperType(named("org.apache.http.protocol.HttpContext"))))
+            .and(takesArgument(3, hasSuperType(named("org.apache.http.concurrent.FutureCallback"))));
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        return Arrays.asList("http-client", "apache-httpclient");
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentation.java
@@ -58,16 +58,12 @@ public class ApacheHttpAsyncClientInstrumentation extends ElasticApmInstrumentat
                 return;
             }
             final TraceContextHolder<?> parent = tracer.getActive();
-            if (!HttpClientHelper.isExit(parent)) {
-                span = parent.createSpan()
-                    .asExit()
-                    .withType(HttpClientHelper.EXTERNAL_TYPE)
+            span = parent.createExitSpan();
+            if (span != null) {
+                span.withType(HttpClientHelper.EXTERNAL_TYPE)
                     .withSubtype(HttpClientHelper.HTTP_SUBTYPE)
                     .activate();
-            }
 
-            // wrap
-            if (span != null) {
                 ApacheHttpAsyncClientHelper<HttpAsyncRequestProducer, FutureCallback<?>, HttpContext> helper =
                     helperManager.getForClassLoaderOfClass(HttpAsyncRequestProducer.class);
                 if (helper != null) {
@@ -119,10 +115,10 @@ public class ApacheHttpAsyncClientInstrumentation extends ElasticApmInstrumentat
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
         return named("execute")
             .and(takesArguments(4))
-            .and(takesArgument(0, hasSuperType(named("org.apache.http.nio.protocol.HttpAsyncRequestProducer"))))
-            .and(takesArgument(1, hasSuperType(named("org.apache.http.nio.protocol.HttpAsyncResponseConsumer"))))
-            .and(takesArgument(2, hasSuperType(named("org.apache.http.protocol.HttpContext"))))
-            .and(takesArgument(3, hasSuperType(named("org.apache.http.concurrent.FutureCallback"))));
+            .and(takesArgument(0, named("org.apache.http.nio.protocol.HttpAsyncRequestProducer")))
+            .and(takesArgument(1, named("org.apache.http.nio.protocol.HttpAsyncResponseConsumer")))
+            .and(takesArgument(2, named("org.apache.http.protocol.HttpContext")))
+            .and(takesArgument(3, named("org.apache.http.concurrent.FutureCallback")));
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientRedirectInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientRedirectInstrumentation.java
@@ -1,0 +1,89 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.httpclient;
+
+import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.apache.http.HttpRequest;
+
+import javax.annotation.Nullable;
+import java.security.ProtectionDomain;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.implementationVersionLte;
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+/**
+ * In versions 4.0.1 or lower, the headers are not automatically copied to redirected HttpRequests, so this copies them over
+ */
+public class ApacheHttpAsyncClientRedirectInstrumentation extends ElasticApmInstrumentation {
+
+    private static class ApacheHttpAsyncClientRedirectAdvice {
+        @Advice.OnMethodExit(suppress = Throwable.class)
+        private static void onAfterExecute(@Advice.Argument(value = 0) HttpRequest original,
+                                           @Advice.Return(typing = Assigner.Typing.DYNAMIC) @Nullable HttpRequest redirect) {
+            if (tracer == null || redirect == null) {
+                return;
+            }
+            if (original.containsHeader(TraceContext.TRACE_PARENT_HEADER) && !redirect.containsHeader(TraceContext.TRACE_PARENT_HEADER)) {
+                String traceContext = original.getFirstHeader(TraceContext.TRACE_PARENT_HEADER).getValue();
+                if (traceContext != null) {
+                    redirect.setHeader(TraceContext.TRACE_PARENT_HEADER, traceContext);
+                }
+            }
+        }
+    }
+
+    @Override
+    public Class<?> getAdviceClass() {
+        return ApacheHttpAsyncClientRedirectAdvice.class;
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return hasSuperType(named("org.apache.http.client.RedirectStrategy"));
+    }
+
+    /**
+     * Apache HTTP Async client 4.0.1 is dependent on Apache HTTP client 4.3.2
+     * @return a matcher for LTE 4.3.2
+     */
+    @Override
+    public ElementMatcher.Junction<ProtectionDomain> getImplementationVersionPostFilter() {
+        return implementationVersionLte("4.3.2");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named("getRedirect");
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        return Arrays.asList("http-client", "apache-httpclient");
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/FutureCallbackWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/FutureCallbackWrapper.java
@@ -1,0 +1,112 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.httpclient;
+
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.objectpool.Recyclable;
+import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.protocol.HttpCoreContext;
+
+import javax.annotation.Nullable;
+
+public class FutureCallbackWrapper<T> implements FutureCallback<T>, Recyclable {
+    private final ApacheHttpAsyncClientHelperImpl helper;
+    @Nullable private FutureCallback<T> delegate;
+    @Nullable private HttpContext context;
+    private volatile Span span;
+
+    FutureCallbackWrapper(ApacheHttpAsyncClientHelperImpl helper) {
+        this.helper = helper;
+    }
+
+    FutureCallbackWrapper<T> with(@Nullable FutureCallback<T> delegate, @Nullable HttpContext context, Span span) {
+        this.delegate = delegate;
+        this.context = context;
+        // write to volatile field last
+        this.span = span;
+        return this;
+    }
+
+    @Override
+    public void completed(T result) {
+        try {
+            finishSpan(null);
+        } finally {
+            if (delegate != null) {
+                delegate.completed(result);
+            }
+            helper.recycle(this);
+        }
+    }
+
+    @Override
+    public void failed(Exception ex) {
+        try {
+            finishSpan(ex);
+        } finally {
+            if (delegate != null) {
+                delegate.failed(ex);
+            }
+            helper.recycle(this);
+        }
+    }
+
+    @Override
+    public void cancelled() {
+        try {
+            finishSpan(null);
+        } finally {
+            if (delegate != null) {
+                delegate.cancelled();
+            }
+            helper.recycle(this);
+        }
+    }
+
+    private void finishSpan(@Nullable Exception e) {
+        // start by reading the volatile field
+        final Span localSpan = span;
+        try {
+            if (context != null) {
+                Object responseObject = context.getAttribute(HttpCoreContext.HTTP_RESPONSE);
+                if (responseObject instanceof HttpResponse) {
+                    StatusLine statusLine = ((HttpResponse) responseObject).getStatusLine();
+                    if (statusLine != null) {
+                        span.getContext().getHttp().withStatusCode(statusLine.getStatusCode());
+                    }
+                }
+            }
+            localSpan.captureException(e);
+        } finally {
+            localSpan.end();
+        }
+    }
+
+    @Override
+    public void resetState() {
+        delegate = null;
+        context = null;
+        // write to volatile field last
+        span = null;
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpAsyncRequestProducerWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpAsyncRequestProducerWrapper.java
@@ -1,0 +1,126 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.httpclient;
+
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import co.elastic.apm.agent.objectpool.Recyclable;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.RequestLine;
+import org.apache.http.nio.ContentEncoder;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
+import org.apache.http.protocol.HttpContext;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+public class HttpAsyncRequestProducerWrapper implements HttpAsyncRequestProducer, Recyclable {
+    private final ApacheHttpAsyncClientHelperImpl helper;
+    private HttpAsyncRequestProducer delegate;
+    private @Nullable HttpRequest request;
+    private volatile Span span;
+
+    HttpAsyncRequestProducerWrapper(ApacheHttpAsyncClientHelperImpl helper) {
+        this.helper = helper;
+    }
+
+    public HttpAsyncRequestProducerWrapper with(HttpAsyncRequestProducer delegate, Span span) {
+        // Order is important due to visibility - write to span last on this (initiating) thread
+        this.delegate = delegate;
+        this.span = span;
+        return this;
+    }
+
+    @Override
+    public HttpHost getTarget() {
+        return delegate.getTarget();
+    }
+
+    @Override
+    public HttpRequest generateRequest() throws IOException, HttpException {
+        // first read the volatile span
+        final Span localSpan = this.span;
+        request = delegate.generateRequest();
+
+        if (request != null) {
+            RequestLine requestLine = request.getRequestLine();
+            if (requestLine != null) {
+                String method = requestLine.getMethod();
+                localSpan.withName(method).appendToName(" ");
+                span.getContext().getHttp().withMethod(method).withUrl(requestLine.getUri());
+            }
+
+            request.setHeader(TraceContext.TRACE_PARENT_HEADER, localSpan.getTraceContext().getOutgoingTraceParentHeader().toString());
+        }
+
+        HttpHost host = getTarget();
+        //noinspection ConstantConditions
+        if (host != null) {
+            String hostname = host.getHostName();
+            if (hostname != null) {
+                localSpan.appendToName(hostname);
+            }
+        }
+
+        //noinspection ConstantConditions
+        return request;
+    }
+
+    @Override
+    public void produceContent(ContentEncoder encoder, IOControl ioctrl) throws IOException {
+        delegate.produceContent(encoder, ioctrl);
+    }
+
+    @Override
+    public void requestCompleted(HttpContext context) {
+        delegate.requestCompleted(context);
+    }
+
+    @Override
+    public void failed(Exception ex) {
+        delegate.failed(ex);
+    }
+
+    @Override
+    public boolean isRepeatable() {
+        return delegate.isRepeatable();
+    }
+
+    @Override
+    public void resetRequest() throws IOException {
+        delegate.resetRequest();
+    }
+
+    @Override
+    public void close() throws IOException {
+        helper.recycle(this);
+        delegate.close();
+    }
+
+    @Override
+    public void resetState() {
+        request = null;
+        delegate = null;
+        span = null;
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
@@ -1,1 +1,3 @@
 co.elastic.apm.agent.httpclient.ApacheHttpClientInstrumentation
+co.elastic.apm.agent.httpclient.ApacheHttpAsyncClientInstrumentation
+co.elastic.apm.agent.httpclient.ApacheHttpAsyncClientRedirectInstrumentation

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentationTest.java
@@ -1,0 +1,78 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.httpclient;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClients;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.util.concurrent.CompletableFuture;
+
+public class ApacheHttpAsyncClientInstrumentationTest extends AbstractHttpClientInstrumentationTest {
+
+    private static CloseableHttpAsyncClient client;
+
+    @BeforeClass
+    public static void setUp() {
+        client = HttpAsyncClients.createDefault();
+        client.start();
+    }
+
+    @AfterClass
+    public static void tearDown() throws IOException {
+        client.close();
+    }
+
+    @Override
+    protected void performGet(String path) throws Exception {
+        final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
+
+        RequestConfig requestConfig = RequestConfig.custom()
+            .setCircularRedirectsAllowed(true)
+            .build();
+        HttpClientContext httpClientContext = HttpClientContext.create();
+        httpClientContext.setRequestConfig(requestConfig);
+        client.execute(new HttpGet(path), httpClientContext, new FutureCallback<>() {
+            @Override
+            public void completed(HttpResponse result) {
+                responseFuture.complete(result);
+            }
+
+            @Override
+            public void failed(Exception ex) {
+                responseFuture.completeExceptionally(ex);
+            }
+
+            @Override
+            public void cancelled() {
+                responseFuture.cancel(true);
+            }
+        });
+
+        responseFuture.get().getStatusLine().getStatusCode();
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentationTest.java
@@ -73,6 +73,6 @@ public class ApacheHttpAsyncClientInstrumentationTest extends AbstractHttpClient
             }
         });
 
-        responseFuture.get().getStatusLine().getStatusCode();
+        responseFuture.get();
     }
 }

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/es/restclient/ElasticsearchRestClientInstrumentationHelperImpl.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/es/restclient/ElasticsearchRestClientInstrumentationHelperImpl.java
@@ -75,14 +75,14 @@ public class ElasticsearchRestClientInstrumentationHelperImpl implements Elastic
             return null;
         }
 
+        Span span = activeSpan.createExitSpan();
+
         // Don't record nested spans. In 5.x clients the instrumented sync method is calling the instrumented async method
-        if (activeSpan instanceof Span && ((Span) activeSpan).isExit()) {
+        if (span == null) {
             return null;
         }
 
-        Span span = activeSpan.createSpan()
-            .asExit()
-            .withType(SPAN_TYPE)
+        span.withType(SPAN_TYPE)
             .withSubtype(ELASTICSEARCH)
             .withAction(SPAN_ACTION)
             .appendToName("Elasticsearch: ").appendToName(method).appendToName(" ").appendToName(endpoint);

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/es/restclient/ElasticsearchRestClientInstrumentationHelperImpl.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/es/restclient/ElasticsearchRestClientInstrumentationHelperImpl.java
@@ -76,11 +76,12 @@ public class ElasticsearchRestClientInstrumentationHelperImpl implements Elastic
         }
 
         // Don't record nested spans. In 5.x clients the instrumented sync method is calling the instrumented async method
-        if (activeSpan instanceof Span && ELASTICSEARCH.equals(((Span) activeSpan).getSubtype())) {
+        if (activeSpan instanceof Span && ((Span) activeSpan).isExit()) {
             return null;
         }
 
         Span span = activeSpan.createSpan()
+            .asExit()
             .withType(SPAN_TYPE)
             .withSubtype(ELASTICSEARCH)
             .withAction(SPAN_ACTION)

--- a/apm-agent-plugins/apm-httpclient-core/src/main/java/co/elastic/apm/agent/http/client/HttpClientHelper.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/main/java/co/elastic/apm/agent/http/client/HttpClientHelper.java
@@ -39,12 +39,9 @@ public class HttpClientHelper {
     @Nullable
     @VisibleForAdvice
     public static Span startHttpClientSpan(TraceContextHolder<?> parent, String method, @Nullable String uri, String hostName) {
-        Span span = null;
-        if (!isExit(parent)) {
-            span = parent
-                .createSpan()
-                .asExit()
-                .withType(EXTERNAL_TYPE)
+        Span span = parent.createExitSpan();
+        if (span != null) {
+            span.withType(EXTERNAL_TYPE)
                 .withSubtype(HTTP_SUBTYPE)
                 .appendToName(method).appendToName(" ").appendToName(hostName);
 
@@ -53,15 +50,5 @@ public class HttpClientHelper {
             }
         }
         return span;
-    }
-
-    /*
-     * Identify nested invocations
-     */
-    public static boolean isExit(TraceContextHolder<?> parent) {
-        if (parent instanceof Span) {
-            return ((Span) parent).isExit();
-        }
-        return false;
     }
 }

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -167,6 +167,11 @@ The spans are named after the schema `<method> <host>`, for example `GET elastic
 |
 | 0.7.0
 
+|Apache HttpAsyncClient
+|4.0+
+|
+| 1.6.0
+
 |Spring RestTemplate
 |4+
 |


### PR DESCRIPTION
Supports from first official version 4.0 released at October 2013. Since this API is much more likely to be used for async calls, I decided not to support the async API of the old client.
Currently not supporting the pipelining API, not sure how commonly it is used, we can add that later.
Includes a new post-type-matching API based on implementation version (without loading the class, only reading the manifest file), to ease support of specific class versions.