### PR TITLE
[APM-CI] force pull weblogic image from CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,6 +158,7 @@ pipeline {
             unstash 'build'
             dir("${BASE_DIR}"){
               dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: "docker.io")
+              sh(label: 'pull weblogic Docker image', script: 'docker pull store/oracle/weblogic:12.2.1.3-dev')
               sh './scripts/jenkins/smoketests-02.sh'
             }
           }


### PR DESCRIPTION
testcontainers it is failing to pull the image so I guess it needs the image pulled before to use it, so until we could have that Docker image pre-pulled on VMs, we can force to pull it.
 
related to https://github.com/elastic/apm-agent-java/pull/555