### PR TITLE
[typo,docs] Fix build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,5 +32,5 @@ Download the latest snapshot from master
 
 ## Build form source
 
-Execute `./mvnw clean install -PskipTests=true` to build the artifacts and to install them to your local maven repository.
+Execute `./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true` to build the artifacts and to install them to your local maven repository. The build process requires JDK 9.
 The agent jar is in the folder `elastic-apm-agent/target`.


### PR DESCRIPTION
README was instructing `./mvnw clean install -PskipTests=true` to build/install, but apparently `-PskipTests=true` doesn't work:
```
[WARNING] The requested profile "skipTests=true" could not be activated because it does not exist.
```
A bunch of tests failed on my machine, which seems to be the reason the `-P` mistake bubbled up.
I got the "correct" one from the jenkins file.

Also, even though `maven.compiler.testTarget` is the one asking for JDK 9, skipping tests does't lower the requirement to `maven.compiler.target` (7), so JDK 9 is effectively required, AFAIK, to build from source.