### PR TITLE
[improvement,feature] Support groovy code with the annotation API:

### DIFF
--- a/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureSpan.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureSpan.java
@@ -19,8 +19,10 @@
  */
 package co.elastic.apm.api;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Annotating a method with {@code @}{@link CaptureSpan} creates a {@link Span} as the child of the currently active span or transaction
@@ -34,6 +36,7 @@ import java.lang.annotation.RetentionPolicy;
  * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
 public @interface CaptureSpan {
 
     /**

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureSpan.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureSpan.java
@@ -19,6 +19,9 @@
  */
 package co.elastic.apm.api;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
  * Annotating a method with {@code @}{@link CaptureSpan} creates a {@link Span} as the child of the currently active span or transaction
  * ({@link ElasticApm#currentSpan()}).
@@ -30,6 +33,7 @@ package co.elastic.apm.api;
  * Note: it is required to configure the {@code application_packages}, otherwise this annotation will be ignored.
  * </p>
  */
+@Retention(RetentionPolicy.RUNTIME)
 public @interface CaptureSpan {
 
     /**

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureTransaction.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureTransaction.java
@@ -19,8 +19,10 @@
  */
 package co.elastic.apm.api;
 
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Annotating a method with {@code @}{@link CaptureTransaction} creates a {@link Transaction} for that method.
@@ -32,6 +34,7 @@ import java.lang.annotation.RetentionPolicy;
  * </p>
  */
 @Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
 public @interface CaptureTransaction {
 
     /**

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureTransaction.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureTransaction.java
@@ -19,6 +19,9 @@
  */
 package co.elastic.apm.api;
 
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
  * Annotating a method with {@code @}{@link CaptureTransaction} creates a {@link Transaction} for that method.
  * <p>
@@ -28,6 +31,7 @@ package co.elastic.apm.api;
  * Note: it is required to configure the {@code application_packages}, otherwise this annotation will be ignored.
  * </p>
  */
+@Retention(RetentionPolicy.RUNTIME)
 public @interface CaptureTransaction {
 
     /**


### PR DESCRIPTION
As per https://discuss.elastic.co/t/kibana-apm-not-showing-capturespan-and-capturetransaction/173026 and a few other tests I did myself in the last few weeks, apm-agent-java couldn't support code that went through groovyc with the annotation API (`CaptureSpan`, `CaptureTransaction`). I initially only saw that the annotations weren't making it to the final `.class` file, but couldn't investigate properly at the time.

It was only recently that I noticed that there was no `RetentionPolicy` for these two annotations, which was making the default `RetentionPolicy#CLASS` the chosen one, which can't really be seen during runtime by bytebuddy for things it doesn't fully understand. See [this](https://stackoverflow.com/a/30032884/10700198) for more details on this, even though I can't really explain why bytebuddy would see it for java classes during runtime...

Changing the `RetentionPolicy` to `RUNTIME` enables everything I wanted and could test:
- tested on both:
  - grails[2.2.4], groovy[2.0.8]
  - grails[3.3.1], groovy[2.4.11]
- tested on both:
  - `@CompileStatic`
  - Normal(dynamic) compilation
- tested on both:
  - Spring components/artifacts
  - Raw code

Tests were already failing on my machine on master, so I really don't know if I could ever break anything with this change, but I'm willing to bet it will be inoffensive.