### PR TITLE
[APM-CI] we only need the dockerLogin in the smoke test 2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,6 @@ pipeline {
             deleteDir()
             unstash 'build'
             dir("${BASE_DIR}"){
-              dockerLogin(secret: "${DOCKERHUB_SECRET}", registry: "docker.io")
               sh './scripts/jenkins/smoketests-01.sh'
             }
           }


### PR DESCRIPTION
Remove the step from Smoke test 1, it is not needed there