### PR TITLE
Add thread count metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
  * Support Apache HttpAsyncClient - span creation and cross-service trace context propagation
+ * Added the `jvm.thread.count` metric, indicating the number of live threads in the JVM (daemon and non-daemon) 
 
 ## Bug Fixes
  * Avoid that the agent blocks server shutdown in case the APM Server is not available

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/ThreadMetrics.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/ThreadMetrics.java
@@ -1,0 +1,51 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.metrics.builtin;
+
+import co.elastic.apm.agent.context.LifecycleListener;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.metrics.DoubleSupplier;
+import co.elastic.apm.agent.metrics.MetricRegistry;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.Collections;
+
+public class ThreadMetrics implements LifecycleListener {
+
+    @Override
+    public void start(ElasticApmTracer tracer) {
+        bindTo(tracer.getMetricRegistry());
+    }
+
+    void bindTo(final MetricRegistry registry) {
+        final ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+        registry.add("jvm.thread.count", Collections.<String, String>emptyMap(), new DoubleSupplier() {
+            @Override
+            public double get() {
+                return threadMXBean.getThreadCount();
+            }
+        });
+    }
+
+    @Override
+    public void stop() throws Exception {
+    }
+}

--- a/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.context.LifecycleListener
+++ b/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.context.LifecycleListener
@@ -4,3 +4,4 @@ co.elastic.apm.agent.bci.MatcherTimerLifecycleListener
 co.elastic.apm.agent.metrics.builtin.JvmMemoryMetrics
 co.elastic.apm.agent.metrics.builtin.SystemMetrics
 co.elastic.apm.agent.metrics.builtin.JvmGcMetrics
+co.elastic.apm.agent.metrics.builtin.ThreadMetrics

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/ThreadMetricsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/ThreadMetricsTest.java
@@ -1,0 +1,56 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.metrics.builtin;
+
+import co.elastic.apm.agent.metrics.MetricRegistry;
+import co.elastic.apm.agent.report.ReporterConfiguration;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class ThreadMetricsTest {
+
+    private static final double NUM_ADDED_THREADS = 12.0;
+    private final ThreadMetrics threadMetrics = new ThreadMetrics();
+    private MetricRegistry registry = new MetricRegistry(mock(ReporterConfiguration.class));
+
+    @Test
+    void testThreadCount() {
+        threadMetrics.bindTo(registry);
+        double numThreads = registry.get("jvm.thread.count", Collections.emptyMap());
+        assertThat(numThreads).isNotZero();
+        for (int i = 0; i < NUM_ADDED_THREADS; i++) {
+            Thread thread = new Thread(() -> {
+                try {
+                    while (true) {
+                        Thread.sleep(1000);
+                    }
+                } catch (InterruptedException e) {
+                }
+            });
+            thread.setDaemon(true);
+            thread.start();
+        }
+        assertThat(registry.get("jvm.thread.count", Collections.emptyMap())).isEqualTo(numThreads + NUM_ADDED_THREADS);
+    }
+}

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -157,6 +157,15 @@ If the maximum memory size is undefined, the value is `-1`.
 --
 
 
+*`jvm.thread.count`*::
++
+--
+type: int
+
+The current number of live threads in the JVM, including both daemon and non-daemon threads.
+--
+
+
 *`jvm.gc.count`*::
 +
 --


### PR DESCRIPTION
Closes elastic/apm-agent-java#574 

Basic thread count support- sending global JVM thread count as `jvm.thread.count` in metrics.