### PR TITLE
Changing Byte Buddy Location Strategy to WEAK

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -297,7 +297,7 @@ public class ElasticApmAgent {
     private static AgentBuilder getAgentBuilder(final ByteBuddy byteBuddy, final CoreConfiguration coreConfiguration) {
         final List<WildcardMatcher> classesExcludedFromInstrumentation = coreConfiguration.getClassesExcludedFromInstrumentation();
 
-        AgentBuilder.LocationStrategy locationStrategy = AgentBuilder.LocationStrategy.ForClassLoader.STRONG;
+        AgentBuilder.LocationStrategy locationStrategy = AgentBuilder.LocationStrategy.ForClassLoader.WEAK;
         if (agentJarFile != null) {
             try {
                 locationStrategy =


### PR DESCRIPTION
According to https://stackoverflow.com/questions/55616650/byte-buddy-locationstrategy-types - this should be fine, since we are using a per-class-loader cache for the resolved `TypeDescription`s, and therefore preferable in our case as it avoids class loader leaks.