### PR TITLE
[docs][1.x] clarify javaagent flag

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -40,7 +40,7 @@ Please view the {apm-overview-ref-v}/index.html[APM Overview] for details on how
 
 There are three different ways to set up the Elastic APM Java Agent:
 
-. <<setup-javaagent>> - Manually set up and configure the agent with the `--javaagent` JVM flag.
+. <<setup-javaagent>> - Manually set up and configure the agent with the `-javaagent` JVM flag.
 . <<setup-attach-cli>> - Automatically set up the agent without needing to alter the configuration of your application server.
 . <<setup-attach-api>> - Use the `apm-agent-attach` artifact and the `attach` API to set up the agent.
 

--- a/docs/setup-javaagent.asciidoc
+++ b/docs/setup-javaagent.asciidoc
@@ -1,5 +1,5 @@
 [[setup-javaagent]]
-=== Manual setup with `--javaagent` flag
+=== Manual setup with `-javaagent` flag
 
 [float]
 [[setup-javaagent-download]]

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -8,7 +8,7 @@ endif::[]
 
 There are three different ways to set up the Elastic APM Java Agent:
 
-. <<setup-javaagent>> - Manually set up and configure the agent with the `--javaagent` JVM flag.
+. <<setup-javaagent>> - Manually set up and configure the agent with the `-javaagent` JVM flag.
 . <<setup-attach-cli>> - Automatically set up the agent without needing to alter the configuration of your application server.
 . <<setup-attach-api>> - Use the `apm-agent-attach` artifact and the `attach` API to set up the agent.
 


### PR DESCRIPTION
Changes `--javaagent` to `-javaagent` in `1.x`. See #590.

Not sure how you do backports, so feel free to close if this is wrong.