### PR TITLE
Exclude $view proxies from JAX-RS instrumentation

### DIFF
--- a/apm-agent-plugins/apm-jaxrs-plugin/src/main/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-jaxrs-plugin/src/main/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentation.java
@@ -81,6 +81,7 @@ public class JaxRsTransactionNameInstrumentation extends ElasticApmInstrumentati
         if (configuration.isEnableJaxrsAnnotationInheritance()) {
             return not(isInterface())
                 .and(not(ElementMatchers.<TypeDescription>nameContains("$Proxy")))
+                .and(not(ElementMatchers.<TypeDescription>nameContains("$view")))
                 .and(isAnnotatedWith(named("javax.ws.rs.Path"))
                     .or(hasSuperType(isAnnotatedWith(named("javax.ws.rs.Path"))))
                 );

--- a/apm-agent-plugins/apm-jaxrs-plugin/src/test/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jaxrs-plugin/src/test/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentationTest.java
@@ -104,12 +104,31 @@ public class JaxRsTransactionNameInstrumentationTest extends JerseyTest {
         assertThat(actualTransactions.get(2).getName().toString()).isEqualTo("ResourceWithPathOnAbstract#testMethod");
     }
 
+    @Test
+    public void testProxyClassInstrumentationExclusion() {
+        when(config.getConfig(JaxRsConfiguration.class).isEnableJaxrsAnnotationInheritance()).thenReturn(true);
+        ElasticApmAgent.initInstrumentation(tracer, ByteBuddyAgent.install());
+
+        doRequest("testViewProxy");
+        doRequest("testProxyProxy");
+
+        List<Transaction> actualTransactions = reporter.getTransactions();
+        assertThat(actualTransactions).hasSize(2);
+        assertThat(actualTransactions.get(0).getName().toString()).isEqualTo("unnamed");
+        assertThat(actualTransactions.get(1).getName().toString()).isEqualTo("unnamed");
+    }
+
 
     /**
      * @return configuration for the jersey test server. Includes all resource classes in the co.elastic.apm.agent.jaxrs.resources package.
      */
+    @Override
     protected Application configure() {
-        return new ResourceConfig(ResourceWithPath.class, ResourceWithPathOnInterface.class, ResourceWithPathOnAbstract.class);
+        return new ResourceConfig(ResourceWithPath.class,
+                ResourceWithPathOnInterface.class,
+                ResourceWithPathOnAbstract.class,
+                ProxiedClass$view.class,
+                ProxiedClass$Proxy.class);
     }
 
     /**
@@ -134,7 +153,6 @@ public class JaxRsTransactionNameInstrumentationTest extends JerseyTest {
     @Path("testInterface")
     public interface ResourceInterfaceWithPath extends SuperResourceInterface {
         String testMethod();
-
     }
 
     public interface ResourceInterfaceWithoutPath extends SuperResourceInterface {
@@ -142,13 +160,24 @@ public class JaxRsTransactionNameInstrumentationTest extends JerseyTest {
     }
 
     public abstract static class AbstractResourceClassWithoutPath implements ResourceInterfaceWithoutPath {
-
     }
 
     @Path("testAbstract")
     public abstract static class AbstractResourceClassWithPath implements ResourceInterfaceWithoutPath {
+    }
 
+    @Path("testViewProxy")
+    public static class ProxiedClass$view implements SuperResourceInterface {
+        public String testMethod() {
+            return "ok";
+        }
+    }
 
+    @Path("testProxyProxy")
+    public static class ProxiedClass$Proxy implements SuperResourceInterface {
+        public String testMethod() {
+            return "ok";
+        }
     }
 
     @Path("test")
@@ -156,7 +185,6 @@ public class JaxRsTransactionNameInstrumentationTest extends JerseyTest {
         public String testMethod() {
             return "ok";
         }
-
     }
 
     public static class ResourceWithPathOnAbstract extends AbstractResourceClassWithPath {


### PR DESCRIPTION
Excluding `$view` proxy classes prevents explosion of transaction names in certain scenarios, see #512.