### PR TITLE
Excluded proxy classes in JaxRs and Executor instrumentation

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchers.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchers.java
@@ -38,6 +38,7 @@ import java.util.Collection;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 
+import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
@@ -229,5 +230,9 @@ public class CustomElementMatchers {
                 return "matches(" + matcher + ")";
             }
         };
+    }
+
+    public static <T extends NamedElement> ElementMatcher.Junction<T> isProxy() {
+        return nameContains("$Proxy").or(nameContains("$$"));
     }
 }

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
@@ -38,6 +38,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
 
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isProxy;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
@@ -75,7 +76,8 @@ public abstract class ExecutorInstrumentation extends ElasticApmInstrumentation 
             // executes on same thread, no need to wrap to activate again
             .and(not(named("org.apache.felix.resolver.ResolverImpl$DumbExecutor")))
             // hazelcast tries to serialize the Runnables/Callables to execute them on remote JVMs
-            .and(not(nameStartsWith("com.hazelcast")));
+            .and(not(nameStartsWith("com.hazelcast")))
+            .and(not(isProxy()));
     }
 
     @Override

--- a/apm-agent-plugins/apm-jaxrs-plugin/src/main/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-jaxrs-plugin/src/main/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentation.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPackage;
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isProxy;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.overridesOrImplementsMethodThat;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
@@ -80,8 +81,7 @@ public class JaxRsTransactionNameInstrumentation extends ElasticApmInstrumentati
         // (matching on the class hierarchy vs matching one class)
         if (configuration.isEnableJaxrsAnnotationInheritance()) {
             return not(isInterface())
-                .and(not(ElementMatchers.<TypeDescription>nameContains("$Proxy")))
-                .and(not(ElementMatchers.<TypeDescription>nameContains("$view")))
+                .and(not(isProxy()))
                 .and(isAnnotatedWith(named("javax.ws.rs.Path"))
                     .or(hasSuperType(isAnnotatedWith(named("javax.ws.rs.Path"))))
                 );

--- a/apm-agent-plugins/apm-jaxrs-plugin/src/test/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jaxrs-plugin/src/test/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentationTest.java
@@ -138,10 +138,10 @@ public class JaxRsTransactionNameInstrumentationTest extends JerseyTest {
     @Override
     protected Application configure() {
         return new ResourceConfig(ResourceWithPath.class,
-                ResourceWithPathOnInterface.class,
-                ResourceWithPathOnAbstract.class,
-                ProxiedClass$view.class,
-                ProxiedClass$Proxy.class);
+            ResourceWithPathOnInterface.class,
+            ResourceWithPathOnAbstract.class,
+            ProxiedClass$$$view.class,
+            ProxiedClass$Proxy.class);
     }
 
     /**
@@ -180,7 +180,7 @@ public class JaxRsTransactionNameInstrumentationTest extends JerseyTest {
     }
 
     @Path("testViewProxy")
-    public static class ProxiedClass$view implements SuperResourceInterface {
+    public static class ProxiedClass$$$view implements SuperResourceInterface {
         public String testMethod() {
             return "ok";
         }


### PR DESCRIPTION
closes elastic/apm-agent-java#547