### PR TITLE
Fix intake v2 trace logging

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -107,9 +107,9 @@ public class DslJsonSerializer implements PayloadSerializer {
             this.os = new ByteArrayOutputStream() {
                 @Override
                 public void flush() throws IOException {
-                    os.write(buf);
+                    os.write(buf, 0, size());
                     os.flush();
-                    logger.trace(new String(buf, Charset.forName("UTF-8")));
+                    logger.trace(new String(buf, 0, size(), Charset.forName("UTF-8")));
                 }
             };
         } else {


### PR DESCRIPTION
`TRACE` logging could corrupt the intake v2 events previously