### PR TITLE
WIP: Add support for org.asynchttpclient

### DIFF
--- a/apm-agent-plugins/apm-asynchttpclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apm-agent-plugins</artifactId>
+        <groupId>co.elastic.apm</groupId>
+        <version>1.6.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-asynchttpclient-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>8</source>
+                    <target>8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <properties>
+        <version.asynchttpclient>2.8.1</version.asynchttpclient>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-httpclient-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.asynchttpclient</groupId>
+            <artifactId>async-http-client</artifactId>
+            <version>${version.asynchttpclient}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/pom.xml
@@ -39,6 +39,13 @@
             <artifactId>async-http-client</artifactId>
             <version>${version.asynchttpclient}</version>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-httpclient-core</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentation.java
@@ -1,0 +1,105 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.asynchttpclient;
+
+import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
+import co.elastic.apm.agent.bci.VisibleForAdvice;
+import co.elastic.apm.agent.http.client.HttpClientHelper;
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.asynchttpclient.Request;
+import org.asynchttpclient.Response;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.ExecutionException;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+
+public class AsyncHttpClientInstrumentation extends ElasticApmInstrumentation {
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named("org.asynchttpclient.AsyncHttpClient");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription>  getMethodMatcher() {
+        return named("execute")
+            .and(returns(named("org.asynchttpclient.ListenableFuture")));
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        return Arrays.asList("http-client", "org.asynchttpclient");
+    }
+
+    @VisibleForAdvice
+    public static class AsyncHttpClientExecuteAdvice {
+
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        private static void onBeforeExecute(
+            @Advice.Argument(typing = Assigner.Typing.DYNAMIC, readOnly = true, value = 1) Request request,
+            @Advice.Local("span") Span span) {
+
+            if (tracer == null || tracer.getActive() == null) {
+                return;
+            }
+
+            final TraceContextHolder<?> parent = tracer.getActive();
+
+            span = HttpClientHelper.startHttpClientSpan(parent, request.getMethod(), request.getUrl(), request.getUri().getHost());
+
+            if(span != null) {
+                span.activate();
+                request.getHeaders().add(TraceContext.TRACE_PARENT_HEADER, span.getTraceContext().getOutgoingTraceParentHeader().toString());
+            }
+        }
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+        public static void onAfterExecute(@Advice.Return @Nullable org.asynchttpclient.ListenableFuture<Response> response,
+                                          @Advice.Local("span") @Nullable Span span,
+                                          @Advice.Thrown @Nullable Throwable t) {
+            if (span != null) {
+                try {
+                    if (response != null) {
+                        int statusCode = response.get().getStatusCode();
+                        span.getContext().getHttp().withStatusCode(statusCode);
+                    }
+                    span.captureException(t);
+                } catch (InterruptedException e) {
+                    span.captureException(e);
+                } catch (ExecutionException e) {
+                    span.captureException(e);
+                } finally {
+                    span.deactivate().end();
+                }
+            }
+        }
+    }
+}

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentation.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,81 +25,129 @@ import co.elastic.apm.agent.http.client.HttpClientHelper;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
+import io.netty.handler.codec.http.HttpHeaders;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.asynchttpclient.Request;
-import org.asynchttpclient.Response;
+import org.asynchttpclient.*;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.concurrent.ExecutionException;
 
-import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.*;
 
 public class AsyncHttpClientInstrumentation extends ElasticApmInstrumentation {
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return named("org.asynchttpclient.AsyncHttpClient");
+        return hasSuperType(named("org.asynchttpclient.AsyncHttpClient"));
     }
 
     @Override
-    public ElementMatcher<? super MethodDescription>  getMethodMatcher() {
-        return named("execute")
-            .and(returns(named("org.asynchttpclient.ListenableFuture")));
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named("executeRequest")
+            .and(takesArgument(0, named("org.asynchttpclient.Request")))
+            .and(takesArgument(1, named("org.asynchttpclient.AsyncHandler")));
+
     }
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        return Arrays.asList("http-client", "org.asynchttpclient");
+        return Arrays.asList("http-client", "asynchttpclient");
     }
 
-    @VisibleForAdvice
-    public static class AsyncHttpClientExecuteAdvice {
+    @Override
+    public Class<?> getAdviceClass() {
+        return AsyncHttpClientInstrumentationAdvice.class;
+    }
 
+    public static class AsyncHttpClientInstrumentationAdvice {
+        @Nullable
+        @VisibleForAdvice
         @Advice.OnMethodEnter(suppress = Throwable.class)
-        private static void onBeforeExecute(
-            @Advice.Argument(typing = Assigner.Typing.DYNAMIC, readOnly = true, value = 1) Request request,
-            @Advice.Local("span") Span span) {
-
-            if (tracer == null || tracer.getActive() == null) {
+        public static void onBeforeExecute(@Advice.Argument(value = 0, readOnly = true) Request request,
+                                           @Advice.Argument(value = 1, readOnly = false) AsyncHandler asyncHandler,
+                                           @Advice.Local("span") Span span) {
+            if(tracer == null || tracer.getActive() == null) {
                 return;
             }
 
             final TraceContextHolder<?> parent = tracer.getActive();
-
-            span = HttpClientHelper.startHttpClientSpan(parent, request.getMethod(), request.getUrl(), request.getUri().getHost());
+            span = HttpClientHelper.startHttpClientSpan(parent, request.getMethod(), request.getUri().toFullUrl(), request.getUri().getHost());
 
             if(span != null) {
                 span.activate();
                 request.getHeaders().add(TraceContext.TRACE_PARENT_HEADER, span.getTraceContext().getOutgoingTraceParentHeader().toString());
             }
+            if(!request.getHeaders().contains(TraceContext.TRACE_PARENT_HEADER) && parent != null) {
+                request.getHeaders().add(TraceContext.TRACE_PARENT_HEADER, parent.getTraceContext().getOutgoingTraceParentHeader().toString());
+            }
+
+            // TODO: Optimize the new call away
+            asyncHandler = new AsyncHandlerWrapperCreator().wrap(asyncHandler, span, request);
         }
 
+        @Nullable
+        @VisibleForAdvice
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-        public static void onAfterExecute(@Advice.Return @Nullable org.asynchttpclient.ListenableFuture<Response> response,
-                                          @Advice.Local("span") @Nullable Span span,
-                                          @Advice.Thrown @Nullable Throwable t) {
-            if (span != null) {
-                try {
-                    if (response != null) {
-                        int statusCode = response.get().getStatusCode();
-                        span.getContext().getHttp().withStatusCode(statusCode);
-                    }
-                    span.captureException(t);
-                } catch (InterruptedException e) {
-                    span.captureException(e);
-                } catch (ExecutionException e) {
-                    span.captureException(e);
-                } finally {
-                    span.deactivate().end();
-                }
+        public static void onAfterExecute(@Advice.Local("span") Span span,
+                                          @Advice.Thrown Throwable t) {
+            if(span != null) {
+                span.deactivate();
             }
         }
     }
+
+    public static class AsyncHandlerWrapperCreator {
+        public AsyncHandler<Object> wrap(final AsyncHandler asyncHandler, Span span, Request originalRequest) {
+            return new AsyncHandlerWrapper(asyncHandler, span, originalRequest);
+        }
+
+        private static class AsyncHandlerWrapper implements AsyncHandler {
+            private Span span;
+            private AsyncHandler delegate;
+            private Request originalRequest;
+
+            public AsyncHandlerWrapper(AsyncHandler delegate, Span span, Request originalRequest) {
+                this.span = span;
+                this.delegate = delegate;
+                this.originalRequest = originalRequest;
+            }
+
+            @Override
+            public State onStatusReceived(HttpResponseStatus responseStatus) throws Exception {
+                span.getContext().getHttp().withStatusCode(responseStatus.getStatusCode());
+                return delegate.onStatusReceived(responseStatus);
+            }
+
+            @Override
+            public State onHeadersReceived(HttpHeaders headers) throws Exception {
+                if(!headers.contains(TraceContext.TRACE_PARENT_HEADER)) {
+                    headers.add(TraceContext.TRACE_PARENT_HEADER, "");
+                }
+                return delegate.onHeadersReceived(headers);
+            }
+
+            @Override
+            public State onBodyPartReceived(HttpResponseBodyPart bodyPart) throws Exception {
+                return delegate.onBodyPartReceived(bodyPart);
+            }
+
+            @Override
+            public void onThrowable(Throwable t) {
+                span.captureException(t).end();
+                delegate.onThrowable(t);
+            }
+
+            @Override
+            public Object onCompleted() throws Exception {
+                span.end();
+                return delegate.onCompleted();
+            }
+        }
+
+    }
+
 }

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientRedirectInstrumentation.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientRedirectInstrumentation.java
@@ -1,0 +1,71 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.asynchttpclient;
+
+import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.asynchttpclient.Request;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public class AsyncHttpClientRedirectInstrumentation extends ElasticApmInstrumentation {
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named("org.asynchttpclient.netty.handler.intercept.Redirect30xInterceptor");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return null; //named("exitAfterHandlingRedirect");
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        return Arrays.asList("http-client", "asynchttpclient");
+    }
+
+    @Override
+    public Class<?> getAdviceClass() {
+        return AsyncHttpClientRedirectAdvice.class;
+    }
+
+    public static class AsyncHttpClientRedirectAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        public void onAfterExecute(@Advice.Argument(value = 3) Request originalRequest) {
+            if (tracer == null || originalRequest == null) {
+                return;
+            }
+
+            if (originalRequest.getHeaders().contains(TraceContext.TRACE_PARENT_HEADER)) {
+                String traceContext = originalRequest.getHeaders().get(TraceContext.TRACE_PARENT_HEADER);
+                if (traceContext != null) {
+                    originalRequest.getHeaders().add(TraceContext.TRACE_PARENT_HEADER, traceContext);
+                }
+            }
+        }
+    }
+}

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/package-info.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/package-info.java
@@ -1,0 +1,19 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/package-info.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/package-info.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,3 +17,7 @@
  * limitations under the License.
  * #L%
  */
+@NonnullApi
+package co.elastic.apm.agent.asynchttpclient;
+
+import co.elastic.apm.agent.annotation.NonnullApi;

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
@@ -1,0 +1,1 @@
+co.elastic.apm.agent.asynchttpclient.AsyncHttpClientInstrumentation

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/test/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/test/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentationTest.java
@@ -1,0 +1,108 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.asynchttpclient;
+
+import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
+import io.netty.handler.codec.http.HttpHeaders;
+import org.asynchttpclient.*;
+import org.junit.Assert;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import static org.asynchttpclient.Dsl.asyncHttpClient;
+
+public class AsyncHttpClientInstrumentationTest extends AbstractHttpClientInstrumentationTest {
+
+    private AsyncHttpClient client;
+
+    @BeforeEach
+    void setUp() {
+        AsyncHttpClientConfig config = Dsl.config()
+            .setFollowRedirect(true)
+            .build();
+        client = asyncHttpClient(config);
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            if(client != null) {
+                client.close();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    protected void performGet(String path) throws ExecutionException, InterruptedException, TimeoutException { ;
+        Request request = new RequestBuilder()
+            .setUrl(path)
+            .build();
+
+        AsyncHandler asyncHandler = new AsyncHandler<Object>() {
+            private final Logger logger = LoggerFactory.getLogger(AsyncHandler.class);
+
+            @Override
+            public State onBodyPartReceived(HttpResponseBodyPart bodyPart) throws Exception {
+                logger.info("ON_BODY_PART_RECEIVED");
+                return State.CONTINUE;
+            }
+
+            @Override
+            public void onThrowable(Throwable t) { }
+
+            @Override
+            public Object onCompleted() throws Exception {
+                logger.info("ON_COMPLETED");
+                return null;
+            }
+
+            @Override
+            public State onStatusReceived(HttpResponseStatus responseStatus) throws Exception {
+                logger.info("ON_STATUS_RECEIVED: " + responseStatus.getStatusCode());
+                return State.CONTINUE;
+            }
+
+            @Override
+            public State onHeadersReceived(HttpHeaders headers) throws Exception {
+                logger.info("ON_HEADERS_RECEIVED: " + headers.toString());
+                return State.CONTINUE;
+            }
+        };
+
+        asyncHttpClient()
+            .executeRequest(request).get();
+    }
+
+    @Test
+    void testGetAdviceClassReturnsAsyncInstrumentationClass() {
+        AsyncHttpClientInstrumentation asyncHttpClientInstrumentation = new AsyncHttpClientInstrumentation();
+
+        Assert.assertEquals(asyncHttpClientInstrumentation.getAdviceClass(), AsyncHttpClientInstrumentation.AsyncHttpClientInstrumentationAdvice.class);
+    }
+}

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -26,6 +26,7 @@
         <module>apm-urlconnection-plugin</module>
         <module>apm-jaxws-plugin</module>
         <module>apm-scheduled-annotation-plugin</module>
+        <module>apm-asynchttpclient-plugin</module>
     </modules>
 
     <properties>

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -320,7 +320,7 @@ you should add an additional entry to this list (make sure to also include the d
 ==== `disable_instrumentations`
 
 A list of instrumentations which should be disabled.
-Valid options are `annotations`, `apache-httpclient`, `concurrent`, `dispatcher-servlet`, `elasticsearch-restclient`, `executor`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jsf`, `okhttp`, `opentracing`, `public-api`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `servlet-service-name`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `urlconnection`.
+Valid options are `annotations`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `dispatcher-servlet`, `elasticsearch-restclient`, `executor`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jsf`, `okhttp`, `opentracing`, `public-api`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `servlet-service-name`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `urlconnection`.
 If you want to try out incubating features,
 set the value to an empty string.
 
@@ -1204,7 +1204,7 @@ If the service name is set explicitly, it overrides all of the above.
 # sanitize_field_names=password,passwd,pwd,secret,*key,*token*,*session*,*credit*,*card*,authorization,set-cookie
 
 # A list of instrumentations which should be disabled.
-# Valid options are `annotations`, `apache-httpclient`, `concurrent`, `dispatcher-servlet`, `elasticsearch-restclient`, `executor`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jsf`, `okhttp`, `opentracing`, `public-api`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `servlet-service-name`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `urlconnection`.
+# Valid options are `annotations`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `dispatcher-servlet`, `elasticsearch-restclient`, `executor`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jsf`, `okhttp`, `opentracing`, `public-api`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `servlet-service-name`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `urlconnection`.
 # If you want to try out incubating features,
 # set the value to an empty string.
 #

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -197,6 +197,11 @@ The spans are named after the schema `<method> <host>`, for example `GET elastic
  inherently support context propagation as they are using `HttpUrlConnection` underneath.
 |1.4.0
 
+|Asynchronous Http Client
+|
+|
+| 2.8.1
+
 |===
 
 

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -152,6 +152,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>apm-asynchttpclient-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>apm-httpclient-core</artifactId>
             <version>${project.version}</version>
         </dependency>


### PR DESCRIPTION
**WORK IN PROGRESS**

This PR adds tracing support for [org.asynchtclient](https://mvnrepository.com/artifact/org.asynchttpclient/async-http-client/2.8.1). 

## TODOs

* Test cases for redirects are not pasing. Need to investigate how the client configuration is supposed to be or work around by adding some tricks into the APM instrumentation to keep the tracing headers