### PR TITLE
Mark some reporter configurations as dynamic

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReporterConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReporterConfiguration.java
@@ -75,6 +75,7 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
             "\n" +
             "WARNING: If timeouts are disabled or set to a high value, your app could experience memory issues if the APM server times " +
             "out.")
+        .dynamic(true)
         .buildWithDefault(TimeDuration.of("5s"));
 
     private final ConfigurationOption<Boolean> verifyServerCert = ConfigurationOption.booleanOption()
@@ -119,6 +120,7 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
     private final ConfigurationOption<TimeDuration> apiRequestTime = TimeDurationValueConverter.durationOption("s")
         .key("api_request_time")
         .configurationCategory(REPORTER_CATEGORY)
+        .dynamic(true)
         .description("Maximum time to keep an HTTP request to the APM Server open for.\n" +
             "\n" +
             "NOTE: This value has to be lower than the APM Server's `read_timeout` setting.")
@@ -127,6 +129,7 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
     private final ConfigurationOption<ByteValue> apiRequestSize = ByteValueConverter.byteOption()
         .key("api_request_size")
         .configurationCategory(REPORTER_CATEGORY)
+        .dynamic(true)
         .description("The maximum total compressed size of the request body which is sent to the APM server intake api via a " +
             "chunked encoding (HTTP streaming).\n" +
             "Note that a small overshoot is possible.\n" +

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -820,7 +820,7 @@ The default unit for this option is `s`
 [options="header"]
 |============
 | Default                          | Type                | Dynamic
-| `5s` | TimeDuration | false
+| `5s` | TimeDuration | true
 |============
 
 
@@ -916,7 +916,7 @@ The default unit for this option is `s`
 [options="header"]
 |============
 | Default                          | Type                | Dynamic
-| `10s` | TimeDuration | false
+| `10s` | TimeDuration | true
 |============
 
 
@@ -939,7 +939,7 @@ Allowed byte units are `b`, `kb` and `mb`. `1kb` is equal to `1024b`.
 [options="header"]
 |============
 | Default                          | Type                | Dynamic
-| `768kb` | ByteValue | false
+| `768kb` | ByteValue | true
 |============
 
 
@@ -1506,7 +1506,7 @@ The default unit for this option is `ms`
 # 
 # WARNING: If timeouts are disabled or set to a high value, your app could experience memory issues if the APM server times out.
 #
-# This setting can not be changed at runtime. Changes require a restart of the application.
+# This setting can be changed at runtime
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 5s.
 # The default unit for this option is s.
@@ -1553,7 +1553,7 @@ The default unit for this option is `ms`
 # 
 # NOTE: This value has to be lower than the APM Server's `read_timeout` setting.
 #
-# This setting can not be changed at runtime. Changes require a restart of the application.
+# This setting can be changed at runtime
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 10s.
 # The default unit for this option is s.
@@ -1566,7 +1566,7 @@ The default unit for this option is `ms`
 # 
 # Allowed byte units are `b`, `kb` and `mb`. `1kb` is equal to `1024b`.
 #
-# This setting can not be changed at runtime. Changes require a restart of the application.
+# This setting can be changed at runtime
 # Type: ByteValue
 # Default value: 768kb
 #


### PR DESCRIPTION
Those options are already dynamically read from but are not marked as dynamic.