### PR TITLE
Calculate free memory based on /proc/meminfo on Linux

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/SystemMetrics.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/SystemMetrics.java
@@ -134,10 +134,10 @@ public class SystemMetrics implements LifecycleListener {
         if (meminfo.canRead()) {
             metricRegistry.addUnlessNan("system.memory.actual.free", Collections.<String, String>emptyMap(), new DoubleSupplier() {
                 final List<WildcardMatcher> relevantLines = Arrays.asList(
-                    caseSensitiveMatcher("MemAvailable:*"),
-                    caseSensitiveMatcher("MemFree:*"),
-                    caseSensitiveMatcher("Buffers:*"),
-                    caseSensitiveMatcher("Cached:*"));
+                    caseSensitiveMatcher("MemAvailable:*kB"),
+                    caseSensitiveMatcher("MemFree:*kB"),
+                    caseSensitiveMatcher("Buffers:*kB"),
+                    caseSensitiveMatcher("Cached:*kB"));
 
                 @Override
                 public double get() {
@@ -146,13 +146,15 @@ public class SystemMetrics implements LifecycleListener {
                         for (String memInfoLine = fileReader.readLine(); memInfoLine != null && !memInfoLine.isEmpty(); memInfoLine = fileReader.readLine()) {
                             if (WildcardMatcher.isAnyMatch(relevantLines, memInfoLine)) {
                                 final String[] memInfoSplit = StringUtils.split(memInfoLine, ' ');
-                                memInfo.put(memInfoSplit[0], Long.parseLong(memInfoSplit[1]));
+                                memInfo.put(memInfoSplit[0], Long.parseLong(memInfoSplit[1]) * 1024);
                             }
                         }
                         if (memInfo.containsKey("MemAvailable:")) {
                             return memInfo.get("MemAvailable:");
-                        } else {
+                        } else if (memInfo.containsKey("MemFree:")) {
                             return memInfo.get("MemFree:") + memInfo.get("Buffers:") + memInfo.get("Cached:");
+                        } else {
+                            return Double.NaN;
                         }
                     } catch (Exception e) {
                         return Double.NaN;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/SystemMetrics.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/SystemMetrics.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,16 +26,25 @@ package co.elastic.apm.agent.metrics.builtin;
 
 import co.elastic.apm.agent.context.LifecycleListener;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.matcher.WildcardMatcher;
 import co.elastic.apm.agent.metrics.DoubleSupplier;
 import co.elastic.apm.agent.metrics.MetricRegistry;
+import org.stagemonitor.util.StringUtils;
 
 import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.lang.management.ManagementFactory;
 import java.lang.management.OperatingSystemMXBean;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
+import static co.elastic.apm.agent.matcher.WildcardMatcher.caseSensitiveMatcher;
 
 /**
  * Record metrics related to the CPU, gathered by the JVM.
@@ -78,8 +87,13 @@ public class SystemMetrics implements LifecycleListener {
 
     @Nullable
     private final Method virtualProcessMemory;
+    private final File meminfo;
 
     public SystemMetrics() {
+        this(new File("/proc/meminfo"));
+    }
+
+    SystemMetrics(File meminfo) {
         this.operatingSystemBean = ManagementFactory.getOperatingSystemMXBean();
         this.operatingSystemBeanClass = getFirstClassFound(OPERATING_SYSTEM_BEAN_CLASS_NAMES);
         this.systemCpuUsage = detectMethod("getSystemCpuLoad");
@@ -87,6 +101,7 @@ public class SystemMetrics implements LifecycleListener {
         this.freeMemory = detectMethod("getFreePhysicalMemorySize");
         this.totalMemory = detectMethod("getTotalPhysicalMemorySize");
         this.virtualProcessMemory = detectMethod("getCommittedVirtualMemorySize");
+        this.meminfo = meminfo;
     }
 
     @Override
@@ -116,12 +131,42 @@ public class SystemMetrics implements LifecycleListener {
             }
         });
 
-        metricRegistry.addUnlessNan("system.memory.actual.free", Collections.<String, String>emptyMap(), new DoubleSupplier() {
-            @Override
-            public double get() {
-                return invoke(freeMemory);
-            }
-        });
+        if (meminfo.canRead()) {
+            metricRegistry.addUnlessNan("system.memory.actual.free", Collections.<String, String>emptyMap(), new DoubleSupplier() {
+                final List<WildcardMatcher> relevantLines = Arrays.asList(
+                    caseSensitiveMatcher("MemAvailable:*"),
+                    caseSensitiveMatcher("MemFree:*"),
+                    caseSensitiveMatcher("Buffers:*"),
+                    caseSensitiveMatcher("Cached:*"));
+
+                @Override
+                public double get() {
+                    Map<String, Long> memInfo = new HashMap<>();
+                    try (BufferedReader fileReader = new BufferedReader(new FileReader(meminfo))) {
+                        for (String memInfoLine = fileReader.readLine(); memInfoLine != null && !memInfoLine.isEmpty(); memInfoLine = fileReader.readLine()) {
+                            if (WildcardMatcher.isAnyMatch(relevantLines, memInfoLine)) {
+                                final String[] memInfoSplit = StringUtils.split(memInfoLine, ' ');
+                                memInfo.put(memInfoSplit[0], Long.parseLong(memInfoSplit[1]));
+                            }
+                        }
+                        if (memInfo.containsKey("MemAvailable:")) {
+                            return memInfo.get("MemAvailable:");
+                        } else {
+                            return memInfo.get("MemFree:") + memInfo.get("Buffers:") + memInfo.get("Cached:");
+                        }
+                    } catch (Exception e) {
+                        return Double.NaN;
+                    }
+                }
+            });
+        } else {
+            metricRegistry.addUnlessNan("system.memory.actual.free", Collections.<String, String>emptyMap(), new DoubleSupplier() {
+                @Override
+                public double get() {
+                    return invoke(freeMemory);
+                }
+            });
+        }
 
         metricRegistry.addUnlessNegative("system.process.memory.size", Collections.<String, String>emptyMap(), new DoubleSupplier() {
             @Override

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/SystemMetricsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/SystemMetricsTest.java
@@ -57,8 +57,8 @@ class SystemMetricsTest {
 
     @ParameterizedTest
     @CsvSource({
-        "/proc/meminfo, 6088992",
-        "/proc/meminfo-3.14,  543584"
+        "/proc/meminfo,     6235127808",
+        "/proc/meminfo-3.14, 556630016"
     })
     void testFreeMemoryMeminfo(String file, long value) throws Exception {
         SystemMetrics systemMetrics = new SystemMetrics(new File(getClass().getResource(file).toURI()));

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/SystemMetricsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/SystemMetricsTest.java
@@ -28,7 +28,10 @@ import co.elastic.apm.agent.metrics.MetricRegistry;
 import co.elastic.apm.agent.report.ReporterConfiguration;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
+import java.io.File;
 import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -50,6 +53,17 @@ class SystemMetricsTest {
         assertThat(metricRegistry.get("system.memory.total", Collections.emptyMap())).isGreaterThan(0.0);
         assertThat(metricRegistry.get("system.memory.actual.free", Collections.emptyMap())).isGreaterThan(0.0);
         assertThat(metricRegistry.get("system.process.memory.size", Collections.emptyMap())).isGreaterThan(0.0);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "/proc/meminfo, 6088992",
+        "/proc/meminfo-3.14,  543584"
+    })
+    void testFreeMemoryMeminfo(String file, long value) throws Exception {
+        SystemMetrics systemMetrics = new SystemMetrics(new File(getClass().getResource(file).toURI()));
+        systemMetrics.bindTo(metricRegistry);
+        assertThat(metricRegistry.get("system.memory.actual.free", Collections.emptyMap())).isEqualTo(value);
     }
 
     private void consumeCpu() {

--- a/apm-agent-core/src/test/resources/proc/meminfo
+++ b/apm-agent-core/src/test/resources/proc/meminfo
@@ -1,0 +1,6 @@
+MemTotal:        7778104 kB
+MemFree:         4806144 kB
+Buffers:          211756 kB
+Cached:          1071092 kB
+SwapTotal:       4194296 kB
+SwapFree:        4194296 kB

--- a/apm-agent-core/src/test/resources/proc/meminfo-3.14
+++ b/apm-agent-core/src/test/resources/proc/meminfo-3.14
@@ -1,0 +1,7 @@
+MemTotal:        7778104 kB
+MemFree:         4806144 kB
+Buffers:          211756 kB
+Cached:          1071092 kB
+SwapTotal:       4194296 kB
+SwapFree:        4194296 kB
+MemAvailable:     543584 kB


### PR DESCRIPTION
Use OperatingSystemMXBean#getFreePhysicalMemorySize on other platforms

closes elastic/apm-agent-java#570