### PR TITLE
Test runtime attach

### DIFF
--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/CachedAttachmentProvider.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/CachedAttachmentProvider.java
@@ -1,0 +1,52 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.attach;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+
+/**
+ * Successive attachments would lead to the VirtualMachine class to be loaded from multiple class loaders
+ * (see net.bytebuddy.agent.ByteBuddyAgent.AttachmentProvider.ForStandardToolsJarVm#attempt()).
+ * That leads to a UnsatisfiedLinkError on Java 7 and 9 because the native library libattach can only be loaded by one class loader.
+ * By caching the {@link net.bytebuddy.agent.ByteBuddyAgent.AttachmentProvider.Accessor}, the same
+ */
+public class CachedAttachmentProvider implements ByteBuddyAgent.AttachmentProvider {
+    private final Accessor accessor;
+
+    public CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider provider) {
+        this.accessor = provider.attempt();
+        if (accessor == Accessor.Unavailable.INSTANCE) {
+            throw new IllegalStateException("Attaching the Elastic APM Java agent is not possible on this JVM. " +
+                "For Java 7 and 8 VMs, make sure to use a JDK (not a JRE) so that the tools.jar is present. " +
+                "On Java 9 or later, make sure the jdk.attach module is available.");
+        }
+    }
+
+    @Override
+    public Accessor attempt() {
+        return accessor;
+    }
+
+}

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
@@ -41,6 +41,8 @@ import java.util.Properties;
  */
 public class ElasticApmAttacher {
 
+    private static final ByteBuddyAgent.AttachmentProvider ATTACHMENT_PROVIDER = new CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider.DEFAULT);
+
     /**
      * Attaches the Elastic Apm agent to the current JVM.
      * <p>
@@ -101,7 +103,7 @@ public class ElasticApmAttacher {
      * @param configuration the agent configuration
      */
     public static void attach(String pid, Map<String, String> configuration) {
-        ByteBuddyAgent.attach(AgentJarFileHolder.INSTANCE.agentJarFile, pid, toAgentArgs(configuration));
+        ByteBuddyAgent.attach(AgentJarFileHolder.INSTANCE.agentJarFile, pid, toAgentArgs(configuration), ATTACHMENT_PROVIDER);
     }
 
     /**
@@ -111,7 +113,7 @@ public class ElasticApmAttacher {
      * @param agentArgs the agent arguments
      */
     public static void attach(String pid, String agentArgs) {
-        ByteBuddyAgent.attach(AgentJarFileHolder.INSTANCE.agentJarFile, pid, agentArgs);
+        ByteBuddyAgent.attach(AgentJarFileHolder.INSTANCE.agentJarFile, pid, agentArgs, ATTACHMENT_PROVIDER);
     }
 
     private enum AgentJarFileHolder {

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -104,7 +104,10 @@ public class RemoteAttacher {
     private void attachToNewJvms(String jpsOutput) {
         final Set<JvmInfo> currentlyRunningJvms = getJVMs(jpsOutput);
         for (JvmInfo jvmInfo : getStartedJvms(currentlyRunningJvms)) {
-            if (!jvmInfo.packageOrPath.endsWith(".Jps") && !jvmInfo.packageOrPath.isEmpty()) {
+            if (!jvmInfo.packageOrPath.endsWith(".Jps")
+                && !jvmInfo.packageOrPath.isEmpty()
+                && !jvmInfo.packageOrPath.contains("apm-agent-attach")
+                && !jvmInfo.packageOrPath.contains(getClass().getName())) {
                 onJvmStart(jvmInfo);
             }
         }

--- a/integration-tests/application-server-integration-tests/pom.xml
+++ b/integration-tests/application-server-integration-tests/pom.xml
@@ -42,6 +42,12 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-attach</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>apm-agent-core</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -41,6 +41,7 @@ import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.SocatContainer;
@@ -77,6 +78,7 @@ import static org.mockserver.model.HttpRequest.request;
  */
 public abstract class AbstractServletContainerIntegrationTest {
     private static final String pathToJavaagent;
+    private static final String pathToAttach;
     private static final Logger logger = LoggerFactory.getLogger(AbstractServletContainerIntegrationTest.class);
     static boolean ENABLE_DEBUGGING = false;
     private static MockServerContainer mockServerContainer = new MockServerContainer()
@@ -96,7 +98,9 @@ public abstract class AbstractServletContainerIntegrationTest {
             .readTimeout(ENABLE_DEBUGGING ? 0 : 10, TimeUnit.SECONDS)
             .build();
         pathToJavaagent = AgentFileIT.getPathToJavaagent();
+        pathToAttach = AgentFileIT.getPathToAttacher();
         checkFilePresent(pathToJavaagent);
+        checkFilePresent(pathToAttach);
     }
 
     private final MockReporter mockReporter = new MockReporter();
@@ -130,6 +134,7 @@ public abstract class AbstractServletContainerIntegrationTest {
             .withLogConsumer(new StandardOutLogConsumer().withPrefix(containerName))
             .withExposedPorts(webPort)
             .withFileSystemBind(pathToJavaagent, "/elastic-apm-agent.jar")
+            .withFileSystemBind(pathToAttach, "/apm-agent-attach.jar")
             .withStartupTimeout(Duration.ofMinutes(5));
         if (isDeployViaFileSystemBind()) {
             for (TestApp testApp : getTestApps()) {
@@ -139,6 +144,13 @@ public abstract class AbstractServletContainerIntegrationTest {
             }
         }
         this.servletContainer.start();
+        try {
+            final Container.ExecResult result = this.servletContainer.execInContainer("java", "-jar", "/apm-agent-attach.jar", "--config");
+            System.out.println(result.getStdout());
+            System.out.println(result.getStderr());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
         if (!isDeployViaFileSystemBind()) {
             for (TestApp testApp : getTestApps()) {
                 String pathToAppFile = testApp.getAppFilePath();
@@ -153,6 +165,10 @@ public abstract class AbstractServletContainerIntegrationTest {
      */
     protected boolean isDeployViaFileSystemBind() {
         return true;
+    }
+
+    protected boolean runtimeAttach() {
+        return false;
     }
 
     private static void checkFilePresent(String pathToWar) {

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AgentFileIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AgentFileIT.java
@@ -27,6 +27,7 @@ package co.elastic.apm.servlet;
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileFilter;
 import java.io.IOException;
@@ -38,8 +39,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AgentFileIT {
 
     static String getPathToJavaagent() {
-        File agentBuildDir = new File("../../elastic-apm-agent/target/");
-        FileFilter fileFilter = new WildcardFileFilter("elastic-apm-agent-*.jar");
+        return getTargetJar("elastic-apm-agent");
+    }
+
+    static String getPathToAttacher() {
+        return getTargetJar("apm-agent-attach");
+    }
+
+    @Nullable
+    private static String getTargetJar(String project) {
+        File agentBuildDir = new File("../../" + project + "/target/");
+        FileFilter fileFilter = new WildcardFileFilter(project + "-*.jar");
         for (File file : agentBuildDir.listFiles(fileFilter)) {
             if (!file.getAbsolutePath().endsWith("javadoc.jar") && !file.getAbsolutePath().endsWith("sources.jar")) {
                 return file.getAbsolutePath();

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
@@ -42,11 +42,6 @@ public class JettyIT extends AbstractServletContainerIntegrationTest {
 
     public JettyIT(final String version) {
         super(new GenericContainer<>("jetty:" + version)
-                .withEnv("JAVA_OPTIONS", "-javaagent:/elastic-apm-agent.jar")
-                .withEnv("ELASTIC_APM_SERVER_URL", "http://apm-server:1080")
-                .withEnv("ELASTIC_APM_IGNORE_URLS", "/status*,/favicon.ico")
-                .withEnv("ELASTIC_APM_REPORT_SYNC", "true")
-                .withEnv("ELASTIC_APM_LOGGING_LOG_LEVEL", "DEBUG")
                 .withExposedPorts(8080),
             "jetty-application",
             "/var/lib/jetty/webapps",

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebLogicIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebLogicIT.java
@@ -44,7 +44,6 @@ public class WebLogicIT extends AbstractServletContainerIntegrationTest {
 
     public WebLogicIT(final String webLogicVersion) {
         super(new GenericContainer<>("store/oracle/weblogic:" + webLogicVersion)
-                .withEnv("EXTRA_JAVA_PROPERTIES", "-javaagent:/elastic-apm-agent.jar")
                 .withClasspathResourceMapping("domain.properties", "/u01/oracle/properties/domain.properties", BindMode.READ_WRITE),
             7001,
             "weblogic-application",
@@ -82,5 +81,10 @@ public class WebLogicIT extends AbstractServletContainerIntegrationTest {
         // WebLogic requires the files to be writable
         // Even binding with BindMode.READ_WRITE does not work for some reason
         return false;
+    }
+
+    @Override
+    protected boolean runtimeAttach() {
+        return true;
     }
 }


### PR DESCRIPTION
Does not work for JBoss, Jetty and Tomcat because they are missing `jps` or the `tools.jar`.