### PR TITLE
Fix service loading for WebLogic 12.2.1.2.0

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilder.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -34,6 +34,7 @@ import co.elastic.apm.agent.context.LifecycleListener;
 import co.elastic.apm.agent.logging.LoggingConfiguration;
 import co.elastic.apm.agent.report.Reporter;
 import co.elastic.apm.agent.report.ReporterFactory;
+import co.elastic.apm.agent.util.DependencyInjectingServiceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
@@ -48,7 +49,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.ServiceLoader;
 import java.util.concurrent.TimeUnit;
 
 public class ElasticApmTracerBuilder {
@@ -104,7 +104,7 @@ public class ElasticApmTracerBuilder {
             reporter = new ReporterFactory().createReporter(configurationRegistry, null, null);
         }
         if (lifecycleListeners == null) {
-            lifecycleListeners = ServiceLoader.load(LifecycleListener.class, getClass().getClassLoader());
+            lifecycleListeners = DependencyInjectingServiceLoader.load(LifecycleListener.class);
         }
         return new ElasticApmTracer(configurationRegistry, reporter, lifecycleListeners);
     }
@@ -113,7 +113,7 @@ public class ElasticApmTracerBuilder {
         try {
             final ConfigurationRegistry configurationRegistry = ConfigurationRegistry.builder()
                 .configSources(configSources)
-                .optionProviders(ServiceLoader.load(ConfigurationOptionProvider.class, ElasticApmTracer.class.getClassLoader()))
+                .optionProviders(DependencyInjectingServiceLoader.load(ConfigurationOptionProvider.class))
                 .failOnMissingRequiredValues(true)
                 .build();
             configurationRegistry.scheduleReloadAtRate(30, TimeUnit.SECONDS);
@@ -126,7 +126,7 @@ public class ElasticApmTracerBuilder {
                     .add(CoreConfiguration.INSTRUMENT, "false")
                     .add(CoreConfiguration.SERVICE_NAME, "none")
                     .add(CoreConfiguration.SAMPLE_RATE, "0"))
-                .optionProviders(ServiceLoader.load(ConfigurationOptionProvider.class, ElasticApmTracer.class.getClassLoader()))
+                .optionProviders(DependencyInjectingServiceLoader.load(ConfigurationOptionProvider.class))
                 .build();
         }
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/DependencyInjectingServiceLoader.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/DependencyInjectingServiceLoader.java
@@ -58,7 +58,7 @@ public class DependencyInjectingServiceLoader<T> {
         }
         constructorTypes = types.toArray(new Class[]{});
         try {
-            final Enumeration<URL> resources = getResources(clazz);
+            final Enumeration<URL> resources = getServiceDescriptors(clazz);
             Set<String> implementations = getImplementations(resources);
             instantiate(implementations);
         } catch (IOException e) {
@@ -66,7 +66,7 @@ public class DependencyInjectingServiceLoader<T> {
         }
     }
 
-    private Enumeration<URL> getResources(Class<T> clazz) throws IOException {
+    private Enumeration<URL> getServiceDescriptors(Class<T> clazz) throws IOException {
         if (classLoader != null) {
             return classLoader.getResources("META-INF/services/" + clazz.getName());
         } else {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/DependencyInjectingServiceLoader.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/DependencyInjectingServiceLoader.java
@@ -45,19 +45,20 @@ public class DependencyInjectingServiceLoader<T> {
     private final Object[] constructorArguments;
     private final Class<?>[] constructorTypes;
     private final List<T> instances = new ArrayList<>();
+    @Nullable
     private final ClassLoader classLoader;
 
     private DependencyInjectingServiceLoader(Class<T> clazz, Object... constructorArguments) {
         this.clazz = clazz;
         this.constructorArguments = constructorArguments;
-        this.classLoader = getClassLoader(clazz);
+        this.classLoader = clazz.getClassLoader();
         List<Class<?>> types = new ArrayList<>(constructorArguments.length);
         for (Object constructorArgument : constructorArguments) {
             types.add(constructorArgument.getClass());
         }
         constructorTypes = types.toArray(new Class[]{});
         try {
-            final Enumeration<URL> resources = classLoader.getResources("META-INF/services/" + clazz.getName());
+            final Enumeration<URL> resources = getResources(clazz);
             Set<String> implementations = getImplementations(resources);
             instantiate(implementations);
         } catch (IOException e) {
@@ -65,12 +66,12 @@ public class DependencyInjectingServiceLoader<T> {
         }
     }
 
-    private ClassLoader getClassLoader(Class<T> clazz) {
-        ClassLoader classLoader = clazz.getClassLoader();
-        if (classLoader == null) {
-            classLoader = ClassLoader.getSystemClassLoader();
+    private Enumeration<URL> getResources(Class<T> clazz) throws IOException {
+        if (classLoader != null) {
+            return classLoader.getResources("META-INF/services/" + clazz.getName());
+        } else {
+            return ClassLoader.getSystemResources("META-INF/services/" + clazz.getName());
         }
-        return classLoader;
     }
 
     public static <T> List<T> load(Class<T> clazz, Object... constructorArguments) {
@@ -106,7 +107,7 @@ public class DependencyInjectingServiceLoader<T> {
 
     private T instantiate(String implementation) {
         try {
-            final Class<?> implementationClass = classLoader.loadClass(implementation);
+            final Class<?> implementationClass = Class.forName(implementation, true, classLoader);
             Constructor<?> constructor = getMatchingConstructor(implementationClass);
             if (constructor != null) {
                 return clazz.cast(constructor.newInstance(constructorArguments));


### PR DESCRIPTION
The issue has to do with how `ServiceLoader`s behave on that particular version of WebLogic. I'm not sure how WebLogic can even mess with such low-level stuff...

When `ServiceLoader`s are asked to load a resource for the bootstrap class loader (which is represented with `null`), they actually use `ClassLoader.getSystemClassLoader().loadClass(String)` and rely on the parent delegation to load the classes from the bootstrap CL.

Our agent is actually present on both the system and the bootstrap CL (which is not ideal tbh) and on this specific WebLogic version, the boot delegation for `ClassLoader.getSystemClassLoader().loadClass(String)` does not seem to work for some reason. The workaround is to load the classes via `java.lang.Class#forName(java.lang.String, boolean, java.lang.ClassLoader)` which allows the `ClassLoader` to be `null` which then reliably loads the classes from the bootstrap classloader.