### PR TITLE
Handling recycling race and volatile read-writes in Apache Async client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
  * ClassCastException related to async instrumentation of Pilotfish Executor causing thread hang (applied workaround)
  * NullPointerException when computing Servlet transaction name with null HTTP method name
  * FileNotFoundException when trying to find implementation version of jar with encoded URL
+ * NullPointerException when closing Apache AsyncHttpClient request producer
 
 # 1.6.1
 


### PR DESCRIPTION
Fixes the issue reported at https://discuss.elastic.co/t/a-null-pointer-exception-is-possible-when-performing-asynchronous-requests/185315