### PR TITLE
ci(jenkins): trigger async ITs and update github check for the pull requests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,15 +1,18 @@
 #!/usr/bin/env groovy
 
 @Library('apm@current') _
-  
+
 pipeline {
   agent any
   environment {
-    BASE_DIR="src/github.com/elastic/apm-agent-java"
+    REPO = 'apm-agent-java'
+    BASE_DIR = "src/github.com/elastic/${env.REPO}"
     NOTIFY_TO = credentials('notify-to')
     JOB_GCS_BUCKET = credentials('gcs-bucket')
     DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-java-codecov'
+    GITHUB_CHECK_ITS_NAME = 'Integration Tests'
+    ITS_PIPELINE = 'apm-integration-tests-mbp/PR-470'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -267,6 +270,27 @@ pipeline {
         }
       }
     }
+    stage('Integration Tests') {
+      agent none
+      when {
+        beforeAgent true
+        allOf {
+          anyOf {
+            environment name: 'GIT_BUILD_CAUSE', value: 'pr'
+            expression { return !params.Run_As_Master_Branch }
+          }
+        }
+      }
+      steps {
+        log(level: 'INFO', text: 'Launching Async ITs')
+        build(job: env.ITS_PIPELINE, propagate: false, wait: false,
+              parameters: [string(name: 'BUILD_OPTS', value: "--with-agent-java --java-agent-version ${env.GIT_BASE_COMMIT}"),
+                           string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
+                           string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
+                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
+        githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+      }
+    }
   }
   post {
     success {
@@ -289,5 +313,5 @@ def reportTestResults(){
   junit(allowEmptyResults: true,
     keepLongStdio: true,
     testResults: "${BASE_DIR}/**/junit-*.xml,${BASE_DIR}/**/TEST-*.xml")
-  codecov(repo: 'apm-agent-java', basedir: "${BASE_DIR}", secret: "${CODECOV_SECRET}")
+  codecov(repo: env.REPO, basedir: "${BASE_DIR}", secret: "${CODECOV_SECRET}")
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -284,7 +284,7 @@ pipeline {
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-              parameters: [string(name: 'BUILD_OPTS', value: "--with-agent-java --java-agent-version ${env.GIT_BASE_COMMIT}"),
+              parameters: [string(name: 'BUILD_OPTS', value: "--java-agent-version ${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-java-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-mbp/PR-470'
+    ITS_PIPELINE = 'apm-integration-tests-mbp/master'
   }
   options {
     timeout(time: 1, unit: 'HOURS')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
     DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-java-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-mbp/master'
+    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -284,7 +284,7 @@ pipeline {
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-              parameters: [booleanParam(name: 'Run_As_Master_Branch', value: true),
+              parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Java'),
                            string(name: 'BUILD_OPTS', value: "--java-agent-version ${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -284,7 +284,8 @@ pipeline {
       steps {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-              parameters: [string(name: 'BUILD_OPTS', value: "--java-agent-version ${env.GIT_BASE_COMMIT}"),
+              parameters: [booleanParam(name: 'Run_As_Master_Branch', value: true),
+                           string(name: 'BUILD_OPTS', value: "--java-agent-version ${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])


### PR DESCRIPTION
fixes https://github.com/elastic/apm-integration-testing/issues/41

## Highlights
- It's triggered for each PR by default and disabled to any upstream branches.
- Trigger the Integration Tests, aka ITs, pipelines from https://github.com/elastic/apm-integration-testing based on PRs or on demand, aka manually.
- It does trigger only the `Java` stage in the ITs.
- ITs should be async.
- This new stage notifies the GitHub check with the status of the execution.
- Depends on https://github.com/elastic/apm-integration-testing/pull/470

## Tasks
- [x] Agree with the stakeholders
- [x] It does require to support ITs from commits rather than branches.