### PR TITLE
Jms receiveNoWait test

### DIFF
--- a/apm-agent-plugins/apm-jms-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jms-plugin/pom.xml
@@ -29,12 +29,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>
-            <artifactId>activemq-pool</artifactId>
-            <version>5.15.9</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.activemq</groupId>
             <artifactId>artemis-jms-client</artifactId>
             <version>2.8.1</version>
             <scope>test</scope>

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/ActiveMqFacade.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/ActiveMqFacade.java
@@ -25,7 +25,6 @@
 package co.elastic.apm.agent.jms;
 
 import org.apache.activemq.ActiveMQConnectionFactory;
-import org.apache.activemq.pool.PooledConnectionFactory;
 
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
@@ -50,8 +49,7 @@ class ActiveMqFacade implements BrokerFacade {
 
     @Override
     public void prepareResources() throws JMSException {
-        ConnectionFactory connectionFactory = new PooledConnectionFactory(
-            new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false"));
+        ConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
         connection = connectionFactory.createConnection();
         connection.start();
     }


### PR DESCRIPTION
Maybe this has something to do with [the way ActiveMQ works relying on prefetch buffers](http://activemq.apache.org/what-is-the-prefetch-limit-for.html) 🤷‍♂ 
If this doesn't work, we should consider giving up the `receiveNoWait` tests for ActiveMQ, as they may be lacking the guarantees we need for unit tests.