### PR TITLE
Fix rendering of bootdelegation examples

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -341,13 +341,17 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "If set with an empty string, nothing will be appended to the boot delegation system property.\n" +
             "Values to set in known environments:\n\n" +
             "Nexus:\n\n" +
-            "`boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*," +
-            "co.elastic.apm.agent.*`\n\n" +
-            "Pentaho:\n\n" +
-            "`boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, " +
+            "----\n" +
+            "boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*," +
+            "co.elastic.apm.agent.*\n" +
+            "----\n\n" +
+            "Pentaho and RedHat JBoss Fuse:\n\n" +
+            "----\n" +
+            "boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, " +
             "sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, " +
             "org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, " +
-            "org.apache.xerces.dom, co.elastic.apm.agent.*`")
+            "org.apache.xerces.dom, co.elastic.apm.agent.*\n" +
+            "----\n")
         .buildWithDefault("co.elastic.apm.agent.*");
 
     public boolean isActive() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -340,10 +340,14 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .description("A comma-separated list of packages to be appended to the boot delegation system property. \n" +
             "If set with an empty string, nothing will be appended to the boot delegation system property.\n" +
             "Values to set in known environments:\n\n" +
-            "Nexus:\n" +
-            "boot_delegation_packages=com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,sun.*,co.elastic.apm.agent.*\n\n" +
-            "Pentaho:\n" +
-            "boot_delegation_packages=org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,org.apache.karaf.management.boot,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,co.elastic.apm.agent.*")
+            "Nexus:\n\n" +
+            "`boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*," +
+            "co.elastic.apm.agent.*`\n\n" +
+            "Pentaho:\n\n" +
+            "`boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, " +
+            "sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, " +
+            "org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, " +
+            "org.apache.xerces.dom, co.elastic.apm.agent.*`")
         .buildWithDefault("co.elastic.apm.agent.*");
 
     public boolean isActive() {

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -488,11 +488,16 @@ Values to set in known environments:
 
 Nexus:
 
-`boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*,co.elastic.apm.agent.*`
+----
+boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*,co.elastic.apm.agent.*
+----
 
-Pentaho:
+Pentaho and RedHat JBoss Fuse:
 
-`boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, co.elastic.apm.agent.*`
+----
+boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, co.elastic.apm.agent.*
+----
+
 
 
 [options="header"]
@@ -1368,11 +1373,16 @@ The default unit for this option is `ms`
 # 
 # Nexus:
 # 
-# `boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*,co.elastic.apm.agent.*`
+# ----
+# boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*,co.elastic.apm.agent.*
+# ----
 # 
-# Pentaho:
+# Pentaho and RedHat JBoss Fuse:
 # 
-# `boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, co.elastic.apm.agent.*`
+# ----
+# boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, co.elastic.apm.agent.*
+# ----
+# 
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -487,10 +487,12 @@ If set with an empty string, nothing will be appended to the boot delegation sys
 Values to set in known environments:
 
 Nexus:
-boot_delegation_packages=com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,sun.*,co.elastic.apm.agent.*
+
+`boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*,co.elastic.apm.agent.*`
 
 Pentaho:
-boot_delegation_packages=org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,org.apache.karaf.management.boot,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,co.elastic.apm.agent.*
+
+`boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, co.elastic.apm.agent.*`
 
 
 [options="header"]
@@ -1365,10 +1367,12 @@ The default unit for this option is `ms`
 # Values to set in known environments:
 # 
 # Nexus:
-# boot_delegation_packages=com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,sun.*,co.elastic.apm.agent.*
+# 
+# `boot_delegation_packages=com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, sun.*,co.elastic.apm.agent.*`
 # 
 # Pentaho:
-# boot_delegation_packages=org.apache.karaf.jaas.boot,org.apache.karaf.jaas.boot.principal,org.apache.karaf.management.boot,sun.*,com.sun.*,javax.transaction,javax.transaction.*,javax.xml.crypto,javax.xml.crypto.*,org.apache.xerces.jaxp.datatype,org.apache.xerces.stax,org.apache.xerces.parsers,org.apache.xerces.jaxp,org.apache.xerces.jaxp.validation,org.apache.xerces.dom,co.elastic.apm.agent.*
+# 
+# `boot_delegation_packages=org.apache.karaf.jaas.boot, org.apache.karaf.jaas.boot.principal, org.apache.karaf.management.boot, sun.*, com.sun.*, javax.transaction, javax.transaction.*, javax.xml.crypto, javax.xml.crypto.*, org.apache.xerces.jaxp.datatype, org.apache.xerces.stax, org.apache.xerces.parsers, org.apache.xerces.jaxp, org.apache.xerces.jaxp.validation, org.apache.xerces.dom, co.elastic.apm.agent.*`
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String


### PR DESCRIPTION
context: https://discuss.elastic.co/t/monitoring-jboss-fuse-using-apm/185758/8

Before:
<img width="1076" alt="Screen Shot 2019-06-21 at 10 02 54" src="https://user-images.githubusercontent.com/2163464/59907732-0c656200-940c-11e9-898f-dbf3883e3533.png">

After:
<img width="753" alt="Screen Shot 2019-07-15 at 13 46 38" src="https://user-images.githubusercontent.com/2163464/61214010-04e16200-a707-11e9-829d-b3912e368b88.png">
