### PR TITLE
Add hibernate search support

### DIFF
--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
@@ -37,40 +37,9 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hibernate</groupId>
-            <artifactId>hibernate-entitymanager</artifactId>
-            <version>5.4.1.Final</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
             <version>${version.h2}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.2.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-core</artifactId>
-            <version>2.2.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>2.2.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>activation</artifactId>
-            <version>1.1.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-hibernate-search-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.8.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apm-hibernate-search-plugin</artifactId>
+        <groupId>co.elastic.apm</groupId>
+        <version>1.7.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-hibernate-search-plugin-5_x</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-hibernate-search-plugin-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-search-orm</artifactId>
+            <version>5.11.1.Final</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-hibernate-search-plugin-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <version>5.4.1.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${version.h2}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.2.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.2.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.2.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
 import co.elastic.apm.agent.bci.VisibleForAdvice;
 import co.elastic.apm.agent.hibernate.search.HibernateSearchConstants;
+import co.elastic.apm.agent.hibernate.search.HibernateSearchHelper;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
 import net.bytebuddy.asm.Advice;
@@ -90,16 +91,7 @@ public class HibernateSearch5Instrumentation extends ElasticApmInstrumentation {
                     return;
                 }
 
-                final @Nullable String queryString = query.getQueryString();
-                span = active.createSpan().activate();
-
-                span.withType("db")
-                    .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                    .withAction("request");
-                span.getContext().getDb()
-                    .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                    .withStatement(queryString);
-                span.setName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME);
+                span = HibernateSearchHelper.createAndActivateSpan(active, query.getQueryString());
             }
         }
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search.v5_x;
 
 import java.util.Collection;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
@@ -88,8 +88,9 @@ public class HibernateSearch5Instrumentation extends ElasticApmInstrumentation {
 
         @Advice.OnMethodEnter(suppress = Throwable.class)
         private static void onBeforeExecute(@Advice.This FullTextQueryImpl query,
-                                            @Advice.Local("span") Span span) {
-            span = HibernateSearchHelper.createAndActivateSpan(tracer, query.getQueryString());
+                                            @Advice.Local("span") Span span,
+                                            @Advice.Origin("#m") String methodName) {
+            span = HibernateSearchHelper.createAndActivateSpan(tracer, methodName, query.getQueryString());
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
@@ -32,7 +32,7 @@ public class HibernateSearch5Instrumentation extends ElasticApmInstrumentation {
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        return named("list");
+        return named("list").or(named("scroll")).or(named("iterate"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -42,7 +42,9 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.search.query.hibernate.impl.FullTextQueryImpl;
 
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -58,6 +60,12 @@ public class HibernateSearch5Instrumentation extends ElasticApmInstrumentation {
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
         return nameContains("Query");
+    }
+
+    @Override
+    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
+        return not(isBootstrapClassLoader())
+            .and(classLoaderCanLoadClass("org.hibernate.search.FullTextQuery"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
@@ -1,0 +1,82 @@
+package co.elastic.apm.agent.hibernate.search.v5_x;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.annotation.Nullable;
+
+import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
+import co.elastic.apm.agent.bci.VisibleForAdvice;
+import co.elastic.apm.agent.hibernate.search.HibernateSearchConstants;
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.hibernate.search.query.hibernate.impl.FullTextQueryImpl;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public class HibernateSearch5Instrumentation extends ElasticApmInstrumentation {
+
+    @Override
+    public Class<?> getAdviceClass() {
+        return HibernateSearch5ExecuteAdvice.class;
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named("org.hibernate.search.query.hibernate.impl.FullTextQueryImpl");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named("list");
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        return Collections.singleton(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
+    }
+
+    @VisibleForAdvice
+    public static class HibernateSearch5ExecuteAdvice {
+
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        private static void onBeforeExecute(@Advice.This FullTextQueryImpl query,
+            @Advice.Local("span") Span span) {
+            if (tracer != null) {
+                TraceContextHolder<?> active = tracer.getActive();
+                if (active == null || active instanceof Span && HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE
+                    .equals(((Span) active).getSubtype())) {
+                    return;
+                }
+
+                final @Nullable String queryString = query.getQueryString();
+                span = active.createSpan().activate();
+
+                span.withType("db")
+                    .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                    .withAction("request");
+                span.getContext().getDb()
+                    .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                    .withStatement(queryString);
+                span.setName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME);
+            }
+        }
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+        public static void onAfterExecute(@Advice.Local("span") @Nullable Span span,
+            @Advice.Thrown Throwable t) {
+            if (span != null) {
+                try {
+                    span.captureException(t);
+                } finally {
+                    span.end();
+                    span.deactivate();
+                }
+            }
+        }
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
@@ -35,6 +35,7 @@ import co.elastic.apm.agent.hibernate.search.HibernateSearchConstants;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -42,6 +43,7 @@ import org.hibernate.search.query.hibernate.impl.FullTextQueryImpl;
 
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
 
@@ -50,6 +52,11 @@ public class HibernateSearch5Instrumentation extends ElasticApmInstrumentation {
     @Override
     public Class<?> getAdviceClass() {
         return HibernateSearch5ExecuteAdvice.class;
+    }
+
+    @Override
+    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+        return nameContains("Query");
     }
 
     @Override

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
@@ -16,7 +16,10 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.search.query.hibernate.impl.FullTextQueryImpl;
 
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 public class HibernateSearch5Instrumentation extends ElasticApmInstrumentation {
 
@@ -27,12 +30,15 @@ public class HibernateSearch5Instrumentation extends ElasticApmInstrumentation {
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return named("org.hibernate.search.query.hibernate.impl.FullTextQueryImpl");
+        return not(isInterface())
+            .and(hasSuperType(named("org.hibernate.search.FullTextQuery")));
     }
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        return named("list").or(named("scroll")).or(named("iterate"));
+        return named("list")
+            .or(named("scroll"))
+            .or(named("iterate"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
@@ -1,0 +1,1 @@
+co.elastic.apm.agent.hibernate.search.v5_x.HibernateSearch5Instrumentation

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/Dog.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/Dog.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search.v5_x;
 
 import org.hibernate.search.annotations.Analyze;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/Dog.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/Dog.java
@@ -1,0 +1,44 @@
+package co.elastic.apm.agent.hibernate.search.v5_x;
+
+import org.hibernate.search.annotations.Analyze;
+import org.hibernate.search.annotations.Field;
+import org.hibernate.search.annotations.Index;
+import org.hibernate.search.annotations.Indexed;
+import org.hibernate.search.annotations.Store;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+@Indexed
+public class Dog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Field(index = Index.YES, analyze = Analyze.YES, store = Store.NO)
+    private String name;
+
+    public Dog(final String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/EntityManagerFactoryHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/EntityManagerFactoryHelper.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search.v5_x;
 
 import java.nio.file.Path;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/EntityManagerFactoryHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/EntityManagerFactoryHelper.java
@@ -1,0 +1,18 @@
+package co.elastic.apm.agent.hibernate.search.v5_x;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+public class EntityManagerFactoryHelper {
+
+    public static EntityManagerFactory buildEntityManagerFactory(final Path tempDirectory) {
+        Map<String, Object> configOverrides = new HashMap<>();
+        configOverrides.put("hibernate.search.default.indexBase", tempDirectory.toAbsolutePath().toString());
+        return Persistence.createEntityManagerFactory("templatePU", configOverrides);
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
@@ -1,0 +1,112 @@
+package co.elastic.apm.agent.hibernate.search.v5_x;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.hibernate.search.DeleteFileVisitor;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import org.apache.lucene.search.Query;
+import org.hibernate.search.jpa.FullTextEntityManager;
+import org.hibernate.search.jpa.FullTextQuery;
+import org.hibernate.search.jpa.Search;
+import org.hibernate.search.query.dsl.BooleanJunction;
+import org.hibernate.search.query.dsl.QueryBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
+
+    private Path tempDirectory;
+
+    private EntityManagerFactory entityManagerFactory;
+
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempDirectory = Files.createTempDirectory("HibernateSearch5InstrumentationTest");
+        entityManagerFactory = EntityManagerFactoryHelper.buildEntityManagerFactory(tempDirectory);
+        entityManager = entityManagerFactory.createEntityManager();
+        tracer.startTransaction(TraceContext.asRoot(), null, null).activate();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        tracer.currentTransaction().deactivate().end();
+        entityManager.close();
+        entityManagerFactory.close();
+        Files.walkFileTree(tempDirectory, new DeleteFileVisitor());
+    }
+
+    @Test
+    public void performLuceneIndexSearch() {
+        saveDogsToIndex();
+
+        FullTextEntityManager fullTextSession = Search.getFullTextEntityManager(entityManager);
+        QueryBuilder builder = fullTextSession.getSearchFactory().buildQueryBuilder().forEntity(Dog.class).get();
+
+        BooleanJunction<BooleanJunction> bool = builder.bool();
+        bool.should(builder.keyword().onField("name").matching("dog1").createQuery());
+
+        Query query = bool.createQuery();
+
+        FullTextQuery ftq = fullTextSession.createFullTextQuery(query, Dog.class);
+
+        List<Dog> result = (List<Dog>) ftq.getResultList();
+
+        assertAll(() -> {
+            assertEquals(1, result.size(), "Query result is not 1");
+            assertEquals("dog1", result.get(0).getName(), "Result is not 'dog1'");
+            assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
+            assertEquals("hibernate-search", reporter.getFirstSpan().getSubtype(),
+                "Subtype of span is not 'hibernate-search'");
+            assertEquals("name:dog1", reporter.getFirstSpan().getContext().getDb().getStatement(),
+                "Statement is not 'name:dog1'");
+        });
+    }
+
+    @Test
+    public void performMutiResultLuceneIndexSearch() {
+        saveDogsToIndex();
+
+        FullTextEntityManager fullTextSession = Search.getFullTextEntityManager(entityManager);
+        QueryBuilder builder = fullTextSession.getSearchFactory().buildQueryBuilder().forEntity(Dog.class).get();
+
+        BooleanJunction<BooleanJunction> bool = builder.bool();
+        bool.should(builder.keyword().wildcard().onField("name").matching("dog*").createQuery());
+
+        Query query = bool.createQuery();
+
+        FullTextQuery ftq = fullTextSession.createFullTextQuery(query, Dog.class);
+
+        List<Dog> result = (List<Dog>) ftq.getResultList();
+
+        assertAll(() -> {
+            assertEquals(2, result.size(), "Query result is not 2");
+            assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
+            assertEquals("hibernate-search", reporter.getFirstSpan().getSubtype(),
+                "Subtype of span is not 'hibernate-search'");
+            assertEquals("name:dog*", reporter.getFirstSpan().getContext().getDb().getStatement(),
+                "Statement is not 'name:dog*'");
+        });
+    }
+
+    private void saveDogsToIndex() {
+        entityManager.getTransaction().begin();
+        Dog dog1 = new Dog("dog1");
+        Dog dog2 = new Dog("dog2");
+        entityManager.persist(dog1);
+        entityManager.persist(dog2);
+        entityManager.getTransaction().commit();
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
@@ -158,6 +158,18 @@ class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
         });
     }
 
+    @Test
+    void performUniqueResultIndexSearch() {
+        Object uniqueResult = createNonJpaFullTextQuery(createQueryForDog1()).uniqueResult();
+
+        assertThat(uniqueResult).isNotNull();
+        final Dog dog = (Dog) uniqueResult;
+        assertAll(() -> {
+            assertThat(dog.getName()).isEqualTo("dog1");
+            assertApmSpanInformation(reporter, "name:dog1", "list");
+        });
+    }
+
     private Query createQueryForDog1() {
         BooleanQuery.Builder builder = new BooleanQuery.Builder();
         builder.add(new BooleanClause(new TermQuery(new Term("name", "dog1")), BooleanClause.Occur.SHOULD));

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
@@ -55,10 +55,8 @@ import java.util.Iterator;
 import java.util.List;
 
 import static co.elastic.apm.agent.hibernate.search.HibernateSearchAssertionHelper.assertApmSpanInformation;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
 
@@ -102,8 +100,8 @@ class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
         List<Dog> result = (List<Dog>) ftq.getResultList();
 
         assertAll(() -> {
-            assertEquals(1, result.size(), "Query result is not 1");
-            assertEquals("dog1", result.get(0).getName(), "Result is not 'dog1'");
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).getName()).isEqualTo("dog1");
             assertApmSpanInformation(reporter, "name:dog1", "list");
         });
     }
@@ -123,7 +121,7 @@ class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
         List<Dog> result = (List<Dog>) ftq.getResultList();
 
         assertAll(() -> {
-            assertEquals(2, result.size(), "Query result is not 2");
+            assertThat(result.size()).isEqualTo(2);
             assertApmSpanInformation(reporter, "name:dog*", "list");
         });
     }
@@ -131,14 +129,14 @@ class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
     @Test
     void performScrollLuceneIndexSearch() {
         try (ScrollableResults scroll = createNonJpaFullTextQuery(createQueryForDog1()).scroll()) {
-            assertTrue(scroll.next());
+            assertThat(scroll.next()).isTrue();
 
             assertAll(() -> {
                 Object[] dogs = scroll.get();
-                assertEquals(1, dogs.length, "The result does not contain 1 dog");
-                assertEquals("dog1", ((Dog) dogs[0]).getName());
-                assertTrue(scroll.isFirst());
-                assertTrue(scroll.isLast());
+                assertThat(dogs.length).isEqualTo(1);
+                assertThat(((Dog) dogs[0]).getName()).isEqualTo("dog1");
+                assertThat(scroll.isFirst()).isTrue();
+                assertThat(scroll.isLast()).isTrue();
 
                 assertApmSpanInformation(reporter, "name:dog1", "scroll");
             });
@@ -149,12 +147,12 @@ class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
     void performIteratorLuceneIndexSearch() {
         Iterator<Dog> iterate = (Iterator<Dog>) createNonJpaFullTextQuery(createQueryForDog1()).iterate();
 
-        assertTrue(iterate.hasNext());
+        assertThat(iterate.hasNext()).isTrue();
         final Dog dog = iterate.next();
-        assertFalse(iterate.hasNext());
+        assertThat(iterate.hasNext()).isFalse();
 
         assertAll(() -> {
-            assertEquals("dog1", dog.getName());
+            assertThat(dog.getName()).isEqualTo("dog1");
 
             assertApmSpanInformation(reporter, "name:dog1", "iterate");
         });

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -104,7 +104,7 @@ class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
         assertAll(() -> {
             assertEquals(1, result.size(), "Query result is not 1");
             assertEquals("dog1", result.get(0).getName(), "Result is not 'dog1'");
-            assertApmSpanInformation(reporter, "name:dog1");
+            assertApmSpanInformation(reporter, "name:dog1", "list");
         });
     }
 
@@ -124,7 +124,7 @@ class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
 
         assertAll(() -> {
             assertEquals(2, result.size(), "Query result is not 2");
-            assertApmSpanInformation(reporter, "name:dog*");
+            assertApmSpanInformation(reporter, "name:dog*", "list");
         });
     }
 
@@ -140,7 +140,7 @@ class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
                 assertTrue(scroll.isFirst());
                 assertTrue(scroll.isLast());
 
-                assertApmSpanInformation(reporter, "name:dog1");
+                assertApmSpanInformation(reporter, "name:dog1", "scroll");
             });
         }
     }
@@ -156,7 +156,7 @@ class HibernateSearch5InstrumentationTest extends AbstractInstrumentationTest {
         assertAll(() -> {
             assertEquals("dog1", dog.getName());
 
-            assertApmSpanInformation(reporter, "name:dog1");
+            assertApmSpanInformation(reporter, "name:dog1", "iterate");
         });
     }
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5InstrumentationTest.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search.v5_x;
 
 import java.io.IOException;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/resources/META-INF/persistence.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,39 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+             http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+             version="2.1">
+
+    <persistence-unit name="templatePU" transaction-type="RESOURCE_LOCAL">
+
+        <description>Hibernate test case template Persistence Unit</description>
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+
+        <properties>
+            <property name="hibernate.archive.autodetection" value="class, hbm"/>
+
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+            <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1"/>
+            <property name="hibernate.connection.username" value="sa"/>
+
+            <property name="hibernate.connection.pool_size" value="5"/>
+
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+
+            <property name="hibernate.max_fetch_depth" value="5"/>
+
+            <!--NOTE: hibernate.jdbc.batch_versioned_data should be set to false when testing with Oracle-->
+            <property name="hibernate.jdbc.batch_versioned_data" value="true"/>
+
+            <property name="javax.persistence.validation.mode" value="NONE"/>
+            <property name="hibernate.service.allow_crawling" value="false"/>
+            <property name="hibernate.session.events.log" value="true"/>
+        </properties>
+
+    </persistence-unit>
+</persistence>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apm-hibernate-search-plugin</artifactId>
+        <groupId>co.elastic.apm</groupId>
+        <version>1.7.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-hibernate-search-plugin-6_x</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <version.hibernate.search>6.0.0.Alpha6</version.hibernate.search>
+        <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-hibernate-search-plugin-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-mapper-orm</artifactId>
+            <version>${version.hibernate.search}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.search</groupId>
+            <artifactId>hibernate-search-backend-lucene</artifactId>
+            <version>${version.hibernate.search}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-hibernate-search-plugin-common</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${version.h2}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
@@ -30,13 +30,13 @@
             <version>${version.hibernate.search}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.hibernate.search</groupId>
             <artifactId>hibernate-search-backend-lucene</artifactId>
             <version>${version.hibernate.search}</version>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-hibernate-search-plugin-common</artifactId>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-hibernate-search-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.8.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -41,7 +41,9 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
@@ -58,6 +60,12 @@ public class HibernateSearch6Instrumentation extends ElasticApmInstrumentation {
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
         return nameContains("Search");
+    }
+
+    @Override
+    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
+        return not(isBootstrapClassLoader())
+            .and(classLoaderCanLoadClass("org.hibernate.search.engine.search.query.SearchFetchable"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search.v6_x;
 
 import co.elastic.apm.agent.bci.ElasticApmInstrumentation;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -27,6 +27,7 @@ package co.elastic.apm.agent.hibernate.search.v6_x;
 import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
 import co.elastic.apm.agent.bci.VisibleForAdvice;
 import co.elastic.apm.agent.hibernate.search.HibernateSearchConstants;
+import co.elastic.apm.agent.hibernate.search.HibernateSearchHelper;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
 import net.bytebuddy.asm.Advice;
@@ -88,16 +89,7 @@ public class HibernateSearch6Instrumentation extends ElasticApmInstrumentation {
                     return;
                 }
 
-                final @Nullable String queryString = query.getQueryString();
-                span = active.createSpan().activate();
-
-                span.withType("db")
-                    .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                    .withAction("request");
-                span.getContext().getDb()
-                    .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                    .withStatement(queryString);
-                span.setName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME);
+                span = HibernateSearchHelper.createAndActivateSpan(active, query.getQueryString());
             }
         }
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -86,8 +86,9 @@ public class HibernateSearch6Instrumentation extends ElasticApmInstrumentation {
 
         @Advice.OnMethodEnter(suppress = Throwable.class)
         private static void onBeforeExecute(@Advice.This SearchQuery query,
-                                            @Advice.Local("span") Span span) {
-            span = HibernateSearchHelper.createAndActivateSpan(tracer, query.getQueryString());
+                                            @Advice.Local("span") Span span,
+                                            @Advice.Origin("#m") String methodName) {
+            span = HibernateSearchHelper.createAndActivateSpan(tracer, methodName, query.getQueryString());
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -30,6 +30,7 @@ import co.elastic.apm.agent.hibernate.search.HibernateSearchConstants;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -41,6 +42,7 @@ import java.util.Collections;
 
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -50,6 +52,11 @@ public class HibernateSearch6Instrumentation extends ElasticApmInstrumentation {
     @Override
     public Class<?> getAdviceClass() {
         return Hibernate6ExecuteAdvice.class;
+    }
+
+    @Override
+    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+        return nameContains("Search");
     }
 
     @Override

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -34,11 +34,11 @@ import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryImpl;
+import org.hibernate.search.engine.search.query.SearchQuery;
 
 import javax.annotation.Nullable;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
@@ -72,14 +72,14 @@ public class HibernateSearch6Instrumentation extends ElasticApmInstrumentation {
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        return Collections.singleton(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
+        return Arrays.asList(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE, "incubating");
     }
 
     @VisibleForAdvice
     public static class Hibernate6ExecuteAdvice {
 
         @Advice.OnMethodEnter(suppress = Throwable.class)
-        private static void onBeforeExecute(@Advice.This LuceneSearchQueryImpl query,
+        private static void onBeforeExecute(@Advice.This SearchQuery query,
             @Advice.Local("span") Span span) {
             if (tracer != null) {
                 TraceContextHolder<?> active = tracer.getActive();

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -1,10 +1,5 @@
 package co.elastic.apm.agent.hibernate.search.v6_x;
 
-import java.util.Collection;
-import java.util.Collections;
-
-import javax.annotation.Nullable;
-
 import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
 import co.elastic.apm.agent.bci.VisibleForAdvice;
 import co.elastic.apm.agent.hibernate.search.HibernateSearchConstants;
@@ -16,7 +11,15 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryImpl;
 
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 public class HibernateSearch6Instrumentation extends ElasticApmInstrumentation {
 
@@ -27,12 +30,13 @@ public class HibernateSearch6Instrumentation extends ElasticApmInstrumentation {
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return named("org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryImpl");
+        return not(isInterface())
+            .and(hasSuperType(named("org.hibernate.search.engine.search.query.SearchFetchable")));
     }
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        return named("fetch");
+        return nameStartsWith("fetch");
     }
 
     @Override

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -1,0 +1,82 @@
+package co.elastic.apm.agent.hibernate.search.v6_x;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import javax.annotation.Nullable;
+
+import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
+import co.elastic.apm.agent.bci.VisibleForAdvice;
+import co.elastic.apm.agent.hibernate.search.HibernateSearchConstants;
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryImpl;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public class HibernateSearch6Instrumentation extends ElasticApmInstrumentation {
+
+    @Override
+    public Class<?> getAdviceClass() {
+        return Hibernate6ExecuteAdvice.class;
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named("org.hibernate.search.backend.lucene.search.query.impl.LuceneSearchQueryImpl");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named("fetch");
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        return Collections.singleton(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
+    }
+
+    @VisibleForAdvice
+    public static class Hibernate6ExecuteAdvice {
+
+        @Advice.OnMethodEnter(suppress = Throwable.class)
+        private static void onBeforeExecute(@Advice.This LuceneSearchQueryImpl query,
+            @Advice.Local("span") Span span) {
+            if (tracer != null) {
+                TraceContextHolder<?> active = tracer.getActive();
+                if (active == null || active instanceof Span && HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE
+                    .equals(((Span) active).getSubtype())) {
+                    return;
+                }
+
+                final @Nullable String queryString = query.getQueryString();
+                span = active.createSpan().activate();
+
+                span.withType("db")
+                    .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                    .withAction("request");
+                span.getContext().getDb()
+                    .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                    .withStatement(queryString);
+                span.setName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME);
+            }
+        }
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+        public static void onAfterExecute(@Advice.Local("span") @Nullable Span span,
+            @Advice.Thrown Throwable t) {
+            if (span != null) {
+                try {
+                    span.captureException(t);
+                } finally {
+                    span.end();
+                    span.deactivate();
+                }
+            }
+        }
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
@@ -1,0 +1,1 @@
+co.elastic.apm.agent.hibernate.search.v6_x.HibernateSearch6Instrumentation

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/Dog.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/Dog.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search.v6_x;
 
 import javax.persistence.Entity;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/Dog.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/Dog.java
@@ -1,0 +1,41 @@
+package co.elastic.apm.agent.hibernate.search.v6_x;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
+import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
+
+@Entity
+@Indexed
+public class Dog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @GenericField
+    private String name;
+
+    public Dog(final String name) {
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/EntityManagerFactoryHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/EntityManagerFactoryHelper.java
@@ -1,0 +1,20 @@
+package co.elastic.apm.agent.hibernate.search.v6_x;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+public class EntityManagerFactoryHelper {
+
+    public static EntityManagerFactory buildEntityManagerFactory(final Path tempDirectory) {
+        Map<String, Object> configOverrides = new HashMap<>();
+        configOverrides.put("hibernate.search.backends.testBackend.type", "lucene");
+        configOverrides.put("hibernate.search.backends.testBackend.directory_provider", "local_directory");
+        configOverrides.put("hibernate.search.backends.testBackend.root_directory", tempDirectory.toAbsolutePath().toString());
+        configOverrides.put("hibernate.search.default_backend", "testBackend");
+        return Persistence.createEntityManagerFactory("templatePU", configOverrides);
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/EntityManagerFactoryHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/EntityManagerFactoryHelper.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search.v6_x;
 
 import java.nio.file.Path;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search.v6_x;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
@@ -1,0 +1,95 @@
+package co.elastic.apm.agent.hibernate.search.v6_x;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+
+import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.hibernate.search.DeleteFileVisitor;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import org.hibernate.search.mapper.orm.Search;
+import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
+
+    private Path tempDirectory;
+
+    private EntityManagerFactory entityManagerFactory;
+
+    private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        tempDirectory = Files.createTempDirectory("HibernateSearch5InstrumentationTest");
+        entityManagerFactory = EntityManagerFactoryHelper.buildEntityManagerFactory(tempDirectory);
+        entityManager = entityManagerFactory.createEntityManager();
+        tracer.startTransaction(TraceContext.asRoot(), null, null).activate();
+    }
+
+    @AfterEach
+    void tearDown() throws IOException {
+        tracer.currentTransaction().deactivate().end();
+        entityManager.close();
+        entityManagerFactory.close();
+        Files.walkFileTree(tempDirectory, new DeleteFileVisitor());
+    }
+
+    @Test
+    public void performLuceneIndexSearch() {
+        saveDogsToIndex();
+
+        SearchSession searchSession = Search.getSearchSession(entityManager);
+        List<Dog> result = searchSession.search(Dog.class)
+            .predicate(f -> f.match().onField("name").matching("dog1"))
+            .fetchHits();
+
+        assertAll(() -> {
+            assertEquals(1, result.size(), "Query result is not 1");
+            assertEquals("dog1", result.get(0).getName(), "Result is not 'dog1'");
+            assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
+            assertEquals("hibernate-search", reporter.getFirstSpan().getSubtype(),
+                "Subtype of span is not 'hibernate-search'");
+            assertEquals("+name:dog1 #__HSEARCH_type:main", reporter.getFirstSpan().getContext().getDb().getStatement(),
+                "Statement is not '+name:dog1 #__HSEARCH_type:main'");
+        });
+    }
+
+    @Test
+    public void performMutiResultLuceneIndexSearch() {
+        saveDogsToIndex();
+
+        SearchSession searchSession = Search.getSearchSession(entityManager);
+        List<Dog> result = searchSession.search(Dog.class)
+            .predicate(f -> f.wildcard().onField("name").matching("dog*"))
+            .fetchHits();
+
+        assertAll(() -> {
+            assertEquals(2, result.size(), "Query result is not 2");
+            assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
+            assertEquals("hibernate-search", reporter.getFirstSpan().getSubtype(),
+                "Subtype of span is not 'hibernate-search'");
+            assertEquals("+name:dog* #__HSEARCH_type:main", reporter.getFirstSpan().getContext().getDb().getStatement(),
+                "Statement is not '+name:dog1 #__HSEARCH_type:main'");
+        });
+    }
+
+    private void saveDogsToIndex() {
+        entityManager.getTransaction().begin();
+        Dog dog1 = new Dog("dog1");
+        Dog dog2 = new Dog("dog2");
+        entityManager.persist(dog1);
+        entityManager.persist(dog2);
+        entityManager.getTransaction().commit();
+    }
+
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -91,7 +91,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         assertAll(() -> {
             assertEquals(1, result.size(), "Query result is not 1");
             assertEquals("dog1", result.get(0).getName(), "Result is not 'dog1'");
-            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetchHits");
         });
     }
 
@@ -101,7 +101,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
         assertAll(() -> {
             assertEquals(2, result.size(), "Query result is not 2");
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetchHits");
         });
     }
 
@@ -112,7 +112,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         assertAll(() -> {
             assertEquals(1, result.size(), "Query result is not 1");
             assertEquals("dog1", result.get(0).getName());
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetchHits");
         });
     }
 
@@ -123,7 +123,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         assertAll(() -> {
             assertEquals(1, result.size(), "Query result is not 1");
             assertEquals("dog2", result.get(0).getName());
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetchHits");
         });
     }
 
@@ -133,7 +133,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
         assertAll(() -> {
             assertEquals(1, resultCount, "Query hit count is not 1");
-            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetchTotalHitCount");
         });
     }
 
@@ -145,7 +145,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
             assertEquals(1, result.getHits().size(), "Query result is not 1");
             assertEquals(1, result.getTotalHitCount(), "Total hit count is not 1");
             assertEquals("dog1", result.getHits().get(0).getName(), "Result is not 'dog1'");
-            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetch");
         });
     }
 
@@ -156,7 +156,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         assertAll(() -> {
             assertEquals(2, result.getHits().size(), "Query result is not 2");
             assertEquals(2, result.getTotalHitCount(), "Total hit count is no 2");
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetch");
         });
     }
 
@@ -168,7 +168,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
             assertEquals(1, result.getHits().size(), "Query result is not 1");
             assertEquals(2, result.getTotalHitCount(), "Total hit count is not 2");
             assertEquals("dog1", result.getHits().get(0).getName());
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetch");
         });
     }
 
@@ -180,7 +180,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
             assertEquals(1, result.getHits().size(), "Query result is not 1");
             assertEquals(2, result.getTotalHitCount(), "Total hit count is not 2");
             assertEquals("dog2", result.getHits().get(0).getName());
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetch");
         });
     }
 
@@ -191,7 +191,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         assertTrue(result.isPresent());
         assertAll(() -> {
             assertEquals("dog1", result.get().getName(), "Result is not 'dog1'");
-            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main");
+            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetchSingleHit");
         });
     }
 
@@ -200,7 +200,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         Optional<Dog> result = createMatchNameSearch("dog1234").fetchSingleHit();
 
         assertFalse(result.isPresent());
-        assertAll(() -> assertApmSpanInformation(reporter, "+name:dog1234 #__HSEARCH_type:main"));
+        assertAll(() -> assertApmSpanInformation(reporter, "+name:dog1234 #__HSEARCH_type:main", "fetchSingleHit"));
     }
 
     private SearchQueryContext<?, Dog, ?> createMatchNameSearch(final String dogName) {

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
@@ -29,7 +29,9 @@ import co.elastic.apm.agent.hibernate.search.DeleteFileVisitor;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import org.hibernate.search.mapper.orm.Search;
 import org.hibernate.search.mapper.orm.session.SearchSession;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -40,37 +42,45 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static co.elastic.apm.agent.hibernate.search.HibernateSearchAssertionHelper.assertApmSpanInformation;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
-    private Path tempDirectory;
+    private static Path tempDirectory;
 
-    private EntityManagerFactory entityManagerFactory;
+    private static EntityManagerFactory entityManagerFactory;
 
-    private EntityManager entityManager;
+    private static EntityManager entityManager;
 
-    @BeforeEach
-    void setUp() throws IOException {
+    @BeforeAll
+    static void setUp() throws IOException {
         tempDirectory = Files.createTempDirectory("HibernateSearch5InstrumentationTest");
         entityManagerFactory = EntityManagerFactoryHelper.buildEntityManagerFactory(tempDirectory);
         entityManager = entityManagerFactory.createEntityManager();
+        saveDogsToIndex();
+    }
+
+    @BeforeEach
+    void initSingleTest() {
         tracer.startTransaction(TraceContext.asRoot(), null, null).activate();
     }
 
     @AfterEach
-    void tearDown() throws IOException {
+    void tearDownTest() {
         tracer.currentTransaction().deactivate().end();
+    }
+
+    @AfterAll
+    static void tearDown() throws IOException {
         entityManager.close();
         entityManagerFactory.close();
         Files.walkFileTree(tempDirectory, new DeleteFileVisitor());
     }
 
     @Test
-    public void performLuceneIndexSearch() {
-        saveDogsToIndex();
-
+    void performLuceneIndexSearch() {
         SearchSession searchSession = Search.getSearchSession(entityManager);
         List<Dog> result = searchSession.search(Dog.class)
             .predicate(f -> f.match().onField("name").matching("dog1"))
@@ -79,18 +89,12 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         assertAll(() -> {
             assertEquals(1, result.size(), "Query result is not 1");
             assertEquals("dog1", result.get(0).getName(), "Result is not 'dog1'");
-            assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
-            assertEquals("hibernate-search", reporter.getFirstSpan().getSubtype(),
-                "Subtype of span is not 'hibernate-search'");
-            assertEquals("+name:dog1 #__HSEARCH_type:main", reporter.getFirstSpan().getContext().getDb().getStatement(),
-                "Statement is not '+name:dog1 #__HSEARCH_type:main'");
+            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main");
         });
     }
 
     @Test
-    public void performHitCountLuceneIndexSearch() {
-        saveDogsToIndex();
-
+    void performHitCountLuceneIndexSearch() {
         SearchSession searchSession = Search.getSearchSession(entityManager);
         long resultCount = searchSession.search(Dog.class)
             .predicate(f -> f.match().onField("name").matching("dog1"))
@@ -98,18 +102,12 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
         assertAll(() -> {
             assertEquals(1, resultCount, "Query hit count is not 1");
-            assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
-            assertEquals("hibernate-search", reporter.getFirstSpan().getSubtype(),
-                "Subtype of span is not 'hibernate-search'");
-            assertEquals("+name:dog1 #__HSEARCH_type:main", reporter.getFirstSpan().getContext().getDb().getStatement(),
-                "Statement is not '+name:dog1 #__HSEARCH_type:main'");
+            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main");
         });
     }
 
     @Test
-    public void performMultiResultLuceneIndexSearch() {
-        saveDogsToIndex();
-
+    void performMultiResultLuceneIndexSearch() {
         SearchSession searchSession = Search.getSearchSession(entityManager);
         List<Dog> result = searchSession.search(Dog.class)
             .predicate(f -> f.wildcard().onField("name").matching("dog*"))
@@ -117,15 +115,11 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
         assertAll(() -> {
             assertEquals(2, result.size(), "Query result is not 2");
-            assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
-            assertEquals("hibernate-search", reporter.getFirstSpan().getSubtype(),
-                "Subtype of span is not 'hibernate-search'");
-            assertEquals("+name:dog* #__HSEARCH_type:main", reporter.getFirstSpan().getContext().getDb().getStatement(),
-                "Statement is not '+name:dog1 #__HSEARCH_type:main'");
+            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main");
         });
     }
 
-    private void saveDogsToIndex() {
+    private static void saveDogsToIndex() {
         entityManager.getTransaction().begin();
         Dog dog1 = new Dog("dog1");
         Dog dog2 = new Dog("dog2");

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6InstrumentationTest.java
@@ -46,10 +46,8 @@ import java.util.List;
 import java.util.Optional;
 
 import static co.elastic.apm.agent.hibernate.search.HibernateSearchAssertionHelper.assertApmSpanInformation;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
@@ -89,8 +87,8 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         List<Dog> result = createMatchNameSearch("dog1").fetchHits();
 
         assertAll(() -> {
-            assertEquals(1, result.size(), "Query result is not 1");
-            assertEquals("dog1", result.get(0).getName(), "Result is not 'dog1'");
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).getName()).isEqualTo("dog1");
             assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetchHits");
         });
     }
@@ -100,7 +98,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         List<Dog> result = createWildcardNameSearch().fetchHits();
 
         assertAll(() -> {
-            assertEquals(2, result.size(), "Query result is not 2");
+            assertThat(result.size()).isEqualTo(2);
             assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetchHits");
         });
     }
@@ -110,8 +108,8 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         List<Dog> result = createWildcardNameSearch().fetchHits(1);
 
         assertAll(() -> {
-            assertEquals(1, result.size(), "Query result is not 1");
-            assertEquals("dog1", result.get(0).getName());
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).getName()).isEqualTo("dog1");
             assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetchHits");
         });
     }
@@ -121,8 +119,8 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         List<Dog> result = createWildcardNameSearch().fetchHits(1, 1);
 
         assertAll(() -> {
-            assertEquals(1, result.size(), "Query result is not 1");
-            assertEquals("dog2", result.get(0).getName());
+            assertThat(result.size()).isEqualTo(1);
+            assertThat(result.get(0).getName()).isEqualTo("dog2");
             assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetchHits");
         });
     }
@@ -132,7 +130,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         long resultCount = createMatchNameSearch("dog1").fetchTotalHitCount();
 
         assertAll(() -> {
-            assertEquals(1, resultCount, "Query hit count is not 1");
+            assertThat(resultCount).isEqualTo(1);
             assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetchTotalHitCount");
         });
     }
@@ -142,9 +140,9 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         SearchResult<Dog> result = createMatchNameSearch("dog1").fetch();
 
         assertAll(() -> {
-            assertEquals(1, result.getHits().size(), "Query result is not 1");
-            assertEquals(1, result.getTotalHitCount(), "Total hit count is not 1");
-            assertEquals("dog1", result.getHits().get(0).getName(), "Result is not 'dog1'");
+            assertThat(result.getHits().size()).isEqualTo(1);
+            assertThat(result.getTotalHitCount()).isEqualTo(1);
+            assertThat(result.getHits().get(0).getName()).isEqualTo("dog1");
             assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetch");
         });
     }
@@ -154,8 +152,8 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         SearchResult<Dog> result = createWildcardNameSearch().fetch();
 
         assertAll(() -> {
-            assertEquals(2, result.getHits().size(), "Query result is not 2");
-            assertEquals(2, result.getTotalHitCount(), "Total hit count is no 2");
+            assertThat(result.getHits().size()).isEqualTo(2);
+            assertThat(result.getTotalHitCount()).isEqualTo(2);
             assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetch");
         });
     }
@@ -165,9 +163,9 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         SearchResult<Dog> result = createWildcardNameSearch().fetch(1);
 
         assertAll(() -> {
-            assertEquals(1, result.getHits().size(), "Query result is not 1");
-            assertEquals(2, result.getTotalHitCount(), "Total hit count is not 2");
-            assertEquals("dog1", result.getHits().get(0).getName());
+            assertThat(result.getHits().size()).isEqualTo(1);
+            assertThat(result.getTotalHitCount()).isEqualTo(2);
+            assertThat(result.getHits().get(0).getName()).isEqualTo("dog1");
             assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetch");
         });
     }
@@ -177,9 +175,9 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         SearchResult<Dog> result = createWildcardNameSearch().fetch(1, 1);
 
         assertAll(() -> {
-            assertEquals(1, result.getHits().size(), "Query result is not 1");
-            assertEquals(2, result.getTotalHitCount(), "Total hit count is not 2");
-            assertEquals("dog2", result.getHits().get(0).getName());
+            assertThat(result.getHits().size()).isEqualTo(1);
+            assertThat(result.getTotalHitCount()).isEqualTo(2);
+            assertThat(result.getHits().get(0).getName()).isEqualTo("dog2");
             assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetch");
         });
     }
@@ -188,9 +186,9 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
     void performSingleHitLuceneIndexSearchWithResult()    {
         Optional<Dog> result = createMatchNameSearch("dog1").fetchSingleHit();
 
-        assertTrue(result.isPresent());
+        assertThat(result.isPresent()).isTrue();
         assertAll(() -> {
-            assertEquals("dog1", result.get().getName(), "Result is not 'dog1'");
+            assertThat(result.get().getName()).isEqualTo("dog1");
             assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetchSingleHit");
         });
     }
@@ -199,7 +197,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
     void performSingleHitLuceneIndexSearchWithoutResult() {
         Optional<Dog> result = createMatchNameSearch("dog1234").fetchSingleHit();
 
-        assertFalse(result.isPresent());
+        assertThat(result.isPresent()).isFalse();
         assertAll(() -> assertApmSpanInformation(reporter, "+name:dog1234 #__HSEARCH_type:main", "fetchSingleHit"));
     }
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/resources/META-INF/persistence.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/resources/META-INF/persistence.xml
@@ -1,0 +1,39 @@
+<persistence xmlns="http://xmlns.jcp.org/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence
+             http://xmlns.jcp.org/xml/ns/persistence/persistence_2_1.xsd"
+             version="2.1">
+
+    <persistence-unit name="templatePU" transaction-type="RESOURCE_LOCAL">
+
+        <description>Hibernate test case template Persistence Unit</description>
+        <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+
+        <properties>
+            <property name="hibernate.archive.autodetection" value="class, hbm"/>
+
+            <property name="hibernate.dialect" value="org.hibernate.dialect.H2Dialect"/>
+            <property name="hibernate.connection.driver_class" value="org.h2.Driver"/>
+            <property name="hibernate.connection.url" value="jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1"/>
+            <property name="hibernate.connection.username" value="sa"/>
+
+            <property name="hibernate.connection.pool_size" value="5"/>
+
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+
+            <property name="hibernate.max_fetch_depth" value="5"/>
+
+            <!--NOTE: hibernate.jdbc.batch_versioned_data should be set to false when testing with Oracle-->
+            <property name="hibernate.jdbc.batch_versioned_data" value="true"/>
+
+            <property name="javax.persistence.validation.mode" value="NONE"/>
+            <property name="hibernate.service.allow_crawling" value="false"/>
+            <property name="hibernate.session.events.log" value="true"/>
+        </properties>
+
+    </persistence-unit>
+</persistence>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
@@ -24,4 +24,20 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${version.plugin.jar}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-hibernate-search-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.8.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apm-hibernate-search-plugin</artifactId>
+        <groupId>co.elastic.apm</groupId>
+        <version>1.7.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-hibernate-search-plugin-common</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-httpclient-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,7 +26,9 @@ package co.elastic.apm.agent.hibernate.search;
 
 public final class HibernateSearchConstants {
 
-    public static final String HIBERNATE_SEARCH_ORM_TYPE = "hibernate-search";
+    public static final String HIBERNATE_SEARCH_ORM_TYPE = "hibernate";
+
+    public static final String HIBERNATE_SEARCH_ORM_ACTION = "search";
 
     public static final String HIBERNATE_SEARCH_ORM_SPAN_NAME = "Hibernate Search";
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
@@ -1,0 +1,9 @@
+package co.elastic.apm.agent.hibernate.search;
+
+public final class HibernateSearchConstants {
+
+    public static final String HIBERNATE_SEARCH_ORM_TYPE = "hibernate-search";
+
+    public static final String HIBERNATE_SEARCH_ORM_SPAN_NAME = "Hibernate Search";
+
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search;
 
 public final class HibernateSearchConstants {

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
@@ -26,9 +26,7 @@ package co.elastic.apm.agent.hibernate.search;
 
 public final class HibernateSearchConstants {
 
-    public static final String HIBERNATE_SEARCH_ORM_TYPE = "hibernate";
-
-    public static final String HIBERNATE_SEARCH_ORM_ACTION = "search";
+    public static final String HIBERNATE_SEARCH_ORM_TYPE = "hibernate-search";
 
     public static final String HIBERNATE_SEARCH_ORM_SPAN_NAME = "Hibernate-Search";
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
@@ -30,6 +30,6 @@ public final class HibernateSearchConstants {
 
     public static final String HIBERNATE_SEARCH_ORM_ACTION = "search";
 
-    public static final String HIBERNATE_SEARCH_ORM_SPAN_NAME = "Hibernate Search";
+    public static final String HIBERNATE_SEARCH_ORM_SPAN_NAME = "Hibernate-Search";
 
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
@@ -56,12 +56,9 @@ public final class HibernateSearchHelper {
             span.getContext().getDb()
                 .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
                 .withStatement(query);
-            span.setName(buildSpanName(methodName));
+            span.withName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME)
+                .appendToName(" ").appendToName(methodName).appendToName("()");
         }
         return span;
-    }
-
-    public static String buildSpanName(final String methodName) {
-        return HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME + " " + methodName + "()";
     }
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
@@ -53,7 +53,7 @@ public final class HibernateSearchHelper {
 
             span.withType("db")
                 .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                .withAction(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_ACTION);
+                .withAction(methodName);
             span.getContext().getDb()
                 .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
                 .withStatement(query);

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
@@ -43,6 +43,7 @@ public final class HibernateSearchHelper {
 
         if (tracer != null) {
             TraceContextHolder<?> active = tracer.getActive();
+            // avoid creating the same span twice for example, when an instrumented API is wrapped
             if (active == null || active instanceof Span && HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE
                 .equals(((Span) active).getSubtype())) {
                 return null;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
@@ -51,7 +51,7 @@ public final class HibernateSearchHelper {
 
             span.withType("db")
                 .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                .withAction("request");
+                .withAction(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_ACTION);
             span.getContext().getDb()
                 .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
                 .withStatement(query);

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.hibernate.search;
+
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
+
+public final class HibernateSearchHelper {
+
+    private HibernateSearchHelper() {
+
+    }
+
+    public static Span createAndActivateSpan(final TraceContextHolder traceContextHolder, final String query) {
+        Span span = traceContextHolder.createSpan().activate();
+
+        span.withType("db")
+            .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+            .withAction("request");
+        span.getContext().getDb()
+            .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+            .withStatement(query);
+        span.setName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME);
+
+        return span;
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
@@ -37,7 +37,8 @@ public final class HibernateSearchHelper {
     }
 
     @VisibleForAdvice
-    public static Span createAndActivateSpan(final ElasticApmTracer tracer, final String query) {
+    public static Span createAndActivateSpan(final ElasticApmTracer tracer, final String methodName,
+                                             final String query) {
         Span span = null;
 
         if (tracer != null) {
@@ -55,8 +56,12 @@ public final class HibernateSearchHelper {
             span.getContext().getDb()
                 .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
                 .withStatement(query);
-            span.setName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME);
+            span.setName(buildSpanName(methodName));
         }
         return span;
+    }
+
+    public static String buildSpanName(final String methodName) {
+        return HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME + " " + methodName + "()";
     }
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,26 +24,39 @@
  */
 package co.elastic.apm.agent.hibernate.search;
 
+import co.elastic.apm.agent.bci.VisibleForAdvice;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
 
+@VisibleForAdvice
 public final class HibernateSearchHelper {
 
     private HibernateSearchHelper() {
 
     }
 
-    public static Span createAndActivateSpan(final TraceContextHolder traceContextHolder, final String query) {
-        Span span = traceContextHolder.createSpan().activate();
+    @VisibleForAdvice
+    public static Span createAndActivateSpan(final ElasticApmTracer tracer, final String query) {
+        Span span = null;
 
-        span.withType("db")
-            .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-            .withAction("request");
-        span.getContext().getDb()
-            .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-            .withStatement(query);
-        span.setName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME);
+        if (tracer != null) {
+            TraceContextHolder<?> active = tracer.getActive();
+            if (active == null || active instanceof Span && HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE
+                .equals(((Span) active).getSubtype())) {
+                return null;
+            }
 
+            span = active.createSpan().activate();
+
+            span.withType("db")
+                .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                .withAction("request");
+            span.getContext().getDb()
+                .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                .withStatement(query);
+            span.setName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME);
+        }
         return span;
     }
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/DeleteFileVisitor.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/DeleteFileVisitor.java
@@ -1,0 +1,23 @@
+package co.elastic.apm.agent.hibernate.search;
+
+import java.io.IOException;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+
+public class DeleteFileVisitor extends SimpleFileVisitor<Path> {
+
+    @Override
+    public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+        Files.delete(file);
+        return FileVisitResult.CONTINUE;
+    }
+
+    @Override
+    public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+        Files.delete(dir);
+        return FileVisitResult.CONTINUE;
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/DeleteFileVisitor.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/DeleteFileVisitor.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.hibernate.search;
 
 import java.io.IOException;

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,6 +25,7 @@
 package co.elastic.apm.agent.hibernate.search;
 
 import co.elastic.apm.agent.MockReporter;
+import co.elastic.apm.agent.impl.transaction.Span;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -36,9 +37,11 @@ public final class HibernateSearchAssertionHelper {
 
     public static void assertApmSpanInformation(final MockReporter reporter, final String expectedQuery) {
         assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
-        assertEquals("hibernate-search", reporter.getFirstSpan().getSubtype(),
-            "Subtype of span is not 'hibernate-search'");
-        assertEquals(expectedQuery, reporter.getFirstSpan().getContext().getDb().getStatement(),
-            "Statement is not '" + expectedQuery + "'");
+        final Span span = reporter.getFirstSpan();
+        assertEquals("hibernate-search", span.getSubtype(), "Subtype of span is not 'hibernate-search'");
+        assertEquals(expectedQuery, span.getContext().getDb().getStatement(),"Statement is not '" + expectedQuery + "'");
+        assertEquals("db", span.getType());
+        assertEquals("request", span.getAction());
+        assertEquals("Hibernate Search", span.getName().toString());
     }
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -38,10 +38,14 @@ public final class HibernateSearchAssertionHelper {
     public static void assertApmSpanInformation(final MockReporter reporter, final String expectedQuery, final String searchMethod) {
         assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
         final Span span = reporter.getFirstSpan();
-        assertEquals(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE, span.getSubtype(), "Subtype of span is not 'hibernate-search'");
+        assertEquals(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE, span.getSubtype(), "Subtype of span is not 'hibernate'");
         assertEquals(expectedQuery, span.getContext().getDb().getStatement(),"Statement is not '" + expectedQuery + "'");
         assertEquals("db", span.getType());
         assertEquals(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_ACTION, span.getAction());
-        assertEquals(HibernateSearchHelper.buildSpanName(searchMethod), span.getName().toString());
+        assertEquals(buildSpanName(searchMethod), span.getName().toString());
+    }
+
+    private static String buildSpanName(final String methodName) {
+        return HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME + " " + methodName + "()";
     }
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -38,10 +38,10 @@ public final class HibernateSearchAssertionHelper {
     public static void assertApmSpanInformation(final MockReporter reporter, final String expectedQuery) {
         assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
         final Span span = reporter.getFirstSpan();
-        assertEquals("hibernate-search", span.getSubtype(), "Subtype of span is not 'hibernate-search'");
+        assertEquals(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE, span.getSubtype(), "Subtype of span is not 'hibernate-search'");
         assertEquals(expectedQuery, span.getContext().getDb().getStatement(),"Statement is not '" + expectedQuery + "'");
         assertEquals("db", span.getType());
-        assertEquals("request", span.getAction());
+        assertEquals(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_ACTION, span.getAction());
         assertEquals("Hibernate Search", span.getName().toString());
     }
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -27,7 +27,7 @@ package co.elastic.apm.agent.hibernate.search;
 import co.elastic.apm.agent.MockReporter;
 import co.elastic.apm.agent.impl.transaction.Span;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public final class HibernateSearchAssertionHelper {
 
@@ -36,13 +36,13 @@ public final class HibernateSearchAssertionHelper {
     }
 
     public static void assertApmSpanInformation(final MockReporter reporter, final String expectedQuery, final String searchMethod) {
-        assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
+        assertThat(reporter.getSpans().size()).isEqualTo(1);
         final Span span = reporter.getFirstSpan();
-        assertEquals(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE, span.getSubtype(), "Subtype of span is not 'hibernate'");
-        assertEquals(expectedQuery, span.getContext().getDb().getStatement(),"Statement is not '" + expectedQuery + "'");
-        assertEquals("db", span.getType());
-        assertEquals(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_ACTION, span.getAction());
-        assertEquals(buildSpanName(searchMethod), span.getName().toString());
+        assertThat(span.getSubtype()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
+        assertThat(span.getContext().getDb().getStatement()).isEqualTo(expectedQuery);
+        assertThat(span.getType()).isEqualTo("db");
+        assertThat(span.getAction()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_ACTION);
+        assertThat(span.getName().toString()).isEqualTo(buildSpanName(searchMethod));
     }
 
     private static String buildSpanName(final String methodName) {

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -35,13 +35,13 @@ public final class HibernateSearchAssertionHelper {
 
     }
 
-    public static void assertApmSpanInformation(final MockReporter reporter, final String expectedQuery) {
+    public static void assertApmSpanInformation(final MockReporter reporter, final String expectedQuery, final String searchMethod) {
         assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
         final Span span = reporter.getFirstSpan();
         assertEquals(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE, span.getSubtype(), "Subtype of span is not 'hibernate-search'");
         assertEquals(expectedQuery, span.getContext().getDb().getStatement(),"Statement is not '" + expectedQuery + "'");
         assertEquals("db", span.getType());
         assertEquals(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_ACTION, span.getAction());
-        assertEquals("Hibernate Search", span.getName().toString());
+        assertEquals(HibernateSearchHelper.buildSpanName(searchMethod), span.getName().toString());
     }
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -42,7 +42,7 @@ public final class HibernateSearchAssertionHelper {
         assertThat(span.getContext().getDb().getStatement()).isEqualTo(expectedQuery);
         assertThat(span.getType()).isEqualTo("db");
         assertThat(span.getAction()).isEqualTo(searchMethod);
-        assertThat(span.getName().toString()).isEqualTo(buildSpanName(searchMethod));
+        assertThat(span.getNameAsString()).isEqualTo(buildSpanName(searchMethod));
     }
 
     private static String buildSpanName(final String methodName) {

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -1,0 +1,44 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.hibernate.search;
+
+import co.elastic.apm.agent.MockReporter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public final class HibernateSearchAssertionHelper {
+
+    private HibernateSearchAssertionHelper() {
+
+    }
+
+    public static void assertApmSpanInformation(final MockReporter reporter, final String expectedQuery) {
+        assertEquals(1, reporter.getSpans().size(), "Didn't find 1 span");
+        assertEquals("hibernate-search", reporter.getFirstSpan().getSubtype(),
+            "Subtype of span is not 'hibernate-search'");
+        assertEquals(expectedQuery, reporter.getFirstSpan().getContext().getDb().getStatement(),
+            "Statement is not '" + expectedQuery + "'");
+    }
+}

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -41,7 +41,7 @@ public final class HibernateSearchAssertionHelper {
         assertThat(span.getSubtype()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
         assertThat(span.getContext().getDb().getStatement()).isEqualTo(expectedQuery);
         assertThat(span.getType()).isEqualTo("db");
-        assertThat(span.getAction()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_ACTION);
+        assertThat(span.getAction()).isEqualTo(searchMethod);
         assertThat(span.getName().toString()).isEqualTo(buildSpanName(searchMethod));
     }
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.7.1-SNAPSHOT</version>
+        <version>1.8.1-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/pom.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>apm-agent-plugins</artifactId>
+        <groupId>co.elastic.apm</groupId>
+        <version>1.7.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <packaging>pom</packaging>
+
+    <properties>
+        <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
+    </properties>
+
+    <modules>
+        <module>apm-hibernate-search-plugin-5_x</module>
+        <module>apm-hibernate-search-plugin-6_x</module>
+        <module>apm-hibernate-search-plugin-common</module>
+    </modules>
+
+    <artifactId>apm-hibernate-search-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+</project>

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -29,6 +29,7 @@
         <module>apm-quartz-job-plugin</module>
         <module>apm-asynchttpclient-plugin</module>
         <module>apm-jms-plugin</module>
+        <module>apm-hibernate-search-plugin</module>
     </modules>
 
     <properties>

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -153,6 +153,10 @@ Other Servlet 3+ compliant servers will most likely work as well.
 |5.0.2+
 |The agent automatically creates Elasticsearch spans for queries done through the official REST client.
 
+|Hibernate Search
+|5.0.0+
+|The agent automatically creates Hibernate Search spans for queries done through the Hibernate Search API.
+
 |===
 
 [float]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -154,8 +154,11 @@ Other Servlet 3+ compliant servers will most likely work as well.
 |The agent automatically creates Elasticsearch spans for queries done through the official REST client.
 
 |Hibernate Search
-|5.0.0+
+|5.x (on by default), 6.x (off by default)
 |The agent automatically creates Hibernate Search spans for queries done through the Hibernate Search API.
+
+ *Note:* this feature is marked as incubating for version 6.x, which means it is off by default. In order to enable,
+ set the <<config-disable-instrumentations>> config option to an empty string
 
 |===
 

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -228,7 +228,12 @@
         </dependency>
         <dependency>
             <groupId>co.elastic.apm</groupId>
-            <artifactId>apm-hibernate-search-plugin</artifactId>
+            <artifactId>apm-hibernate-search-plugin-5_x</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-hibernate-search-plugin-6_x</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -227,6 +227,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-hibernate-search-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-es-restclient-plugin-5_6</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
Adds support for queries made by hibernate search. Supported versions are all 5.x versions and I also added support for the current alpha version of hibernate search 6.x.
Since I'm currently unable to execute the build with the license plugin the license header is missing in the files (See #674)