### PR TITLE
Removing beans.xml from the JSF test app

### DIFF
--- a/integration-tests/jsf-app/jsf-app-dependent/src/main/webapp/WEB-INF/beans.xml
+++ b/integration-tests/jsf-app/jsf-app-dependent/src/main/webapp/WEB-INF/beans.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<beans xmlns="http://xmlns.jcp.org/xml/ns/javaee"
-       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-       xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/beans_1_1.xsd"
-       bean-discovery-mode="annotated">
-</beans>


### PR DESCRIPTION
JBoss 6 integration tests started failing- seems like some kind of regression in the JBoss 6 docker image causing parsing failure of the `beans.xml` file because it's empty, thus failing the entire JSF app deployment (three other JBoss 7.x tests succeed). As it is empty, it is not required.