### PR TITLE
Enabling build on Windows

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/SystemInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/SystemInfo.java
@@ -34,7 +34,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -165,10 +164,10 @@ public class SystemInfo {
         final String[] fields = line.split(":");
         if (fields.length == 3) {
             String cGroupPath = fields[2];
-            Path idPathPart = Paths.get(cGroupPath).getFileName();
+            int indexOfLastSlash = cGroupPath.lastIndexOf('/');
 
-            if (idPathPart != null) {
-                String idPart = idPathPart.toString();
+            if (indexOfLastSlash >= 0) {
+                String idPart = cGroupPath.substring(indexOfLastSlash + 1);
 
                 // Legacy, e.g.: /system.slice/docker-<CID>.scope
                 if (idPart.endsWith(".scope")) {
@@ -176,9 +175,8 @@ public class SystemInfo {
                 }
 
                 // Looking for kubernetes info
-                Path dirPathPart = Paths.get(cGroupPath).getParent();
-                if (dirPathPart != null) {
-                    String dir = dirPathPart.toString();
+                String dir = cGroupPath.substring(0, indexOfLastSlash);
+                if (dir.length() > 0) {
                     final Pattern pattern = Pattern.compile(POD_REGEX);
                     final Matcher matcher = pattern.matcher(dir);
                     if (matcher.find()) {

--- a/pom.xml
+++ b/pom.xml
@@ -410,7 +410,7 @@
                 <configuration>
                     <verbose>false</verbose>
                     <licenseName>apache2_license</licenseName>
-                    <licenseResolver>file://${apm-agent-parent.base.dir}/licenses</licenseResolver>
+                    <licenseResolver>file:///${apm-agent-parent.base.dir}/licenses</licenseResolver>
                     <addJavaLicenseAfterPackage>false</addJavaLicenseAfterPackage>
                     <failOnMissingHeader>true</failOnMissingHeader>
                     <failOnNotUptodateHeader>true</failOnNotUptodateHeader>


### PR DESCRIPTION
Fixes elastic/apm-agent-java#674 

Changed the license file URI prefix from `file://` to `file:///`, which basically is a shortcut for a file on the localhost. In Unix-style paths this may be appended by a fourth slash for the root directory, but effectively the extra slashes should be collapsed.

Full solution would be to use `classpath://` for the license resolver, thus avoid using the
base dir path property in all modules - http://www.mojohaus.org/license-maven-plugin/examples/example-add-license.html, but out of the scope for now...

In addition, I changed the container ID parsing logic to not use file system APIs, as these are only strings and not real file system paths.