### PR TITLE
ci(jenkins): notify first time contributor github check

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         stage('Checkout') {
           steps {
             deleteDir()
-            gitCheckout(basedir: "${BASE_DIR}", githubNotifyIfFirstTimeContributor: true)
+            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,7 @@ pipeline {
         stage('Checkout') {
           steps {
             deleteDir()
-            gitCheckout(basedir: "${BASE_DIR}")
+            gitCheckout(basedir: "${BASE_DIR}", githubNotifyIfFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
           }
         }


### PR DESCRIPTION
Enable `githubNotifyFirstTimeContributor` parameter to notify the PR with a new github check whether the checkout failed related with the first time contributor validation.

## Highlights
- Rather than creating a new GitHub check for each pipeline let's use the shared library to drive that particular behaviour.