### PR TITLE
Managing ApmScope active stack

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -238,6 +238,7 @@ public class TraceContext extends TraceContextHolder {
         traceId.resetState();
         id.resetState();
         parentId.resetState();
+        transactionId.resetState();
         outgoingHeader.setLength(0);
         flags = 0;
         discard = false;

--- a/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/ApmSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/ApmSpanInstrumentation.java
@@ -308,4 +308,36 @@ public class ApmSpanInstrumentation extends OpenTracingBridgeInstrumentation {
         }
     }
 
+    public static class CompareSpanInstrumentation extends ApmSpanInstrumentation {
+
+        public CompareSpanInstrumentation() {
+            super(named("compareSpan"));
+        }
+
+        @Advice.OnMethodExit(suppress = Throwable.class)
+        public static void compareSpan(@Advice.Argument(value = 0, typing = Assigner.Typing.DYNAMIC) @Nullable TraceContext thisTraceContext,
+                                       @Advice.Argument(value = 1, typing = Assigner.Typing.DYNAMIC) @Nullable AbstractSpan<?> otherSpan,
+                                       @Advice.Return(readOnly = false) boolean isSame) {
+            if (thisTraceContext != null && otherSpan != null) {
+                isSame = thisTraceContext.getId().equals(otherSpan.getTraceContext().getId());
+            }
+        }
+    }
+
+    public static class CompareSpanContextInstrumentation extends ApmSpanInstrumentation {
+
+        public CompareSpanContextInstrumentation() {
+            super(named("compareSpanContext"));
+        }
+
+        @Advice.OnMethodExit(suppress = Throwable.class)
+        public static void compareSpan(@Advice.Argument(value = 0, typing = Assigner.Typing.DYNAMIC) @Nullable TraceContext thisTraceContext,
+                                       @Advice.Argument(value = 1, typing = Assigner.Typing.DYNAMIC) @Nullable TraceContext otherTraceContext,
+                                       @Advice.Return(readOnly = false) boolean isSame) {
+            if (thisTraceContext != null && otherTraceContext != null) {
+                isSame = thisTraceContext.getId().equals(otherTraceContext.getId());
+            }
+        }
+    }
+
 }

--- a/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/LoggerInstrumentation.java
+++ b/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/LoggerInstrumentation.java
@@ -1,0 +1,93 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.opentracing.impl;
+
+import co.elastic.apm.agent.bci.VisibleForAdvice;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public class LoggerInstrumentation extends OpenTracingBridgeInstrumentation {
+
+    @VisibleForAdvice
+    public static final Logger logger = LoggerFactory.getLogger(LoggerInstrumentation.class);
+
+    private final ElementMatcher<? super MethodDescription> methodMatcher;
+
+    public LoggerInstrumentation(ElementMatcher<? super MethodDescription> methodMatcher) {
+        this.methodMatcher = methodMatcher;
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named("co.elastic.apm.opentracing.Logger");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return methodMatcher;
+    }
+
+    public static class LogWarningInstrumentation extends LoggerInstrumentation {
+
+        public LogWarningInstrumentation() {
+            super(named("warn"));
+        }
+
+        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+        public static void logWarning(@Advice.Argument(0) String message,
+                                      @Advice.Argument(1) @Nullable Throwable throwable) {
+            if (throwable != null) {
+                logger.warn(message, throwable);
+            } else {
+                logger.warn(message);
+            }
+        }
+    }
+
+    public static class LogDebugInstrumentation extends LoggerInstrumentation {
+
+        public LogDebugInstrumentation() {
+            super(named("debug"));
+        }
+
+        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+        public static void logDebug(@Advice.Argument(0) String message,
+                                    @Advice.Argument(1) @Nullable Throwable throwable) {
+            if (throwable != null) {
+                logger.debug(message, throwable);
+            } else {
+                logger.debug(message);
+            }
+        }
+    }
+}

--- a/apm-agent-plugins/apm-opentracing-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-opentracing-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
@@ -3,9 +3,13 @@ co.elastic.apm.agent.opentracing.impl.ApmSpanInstrumentation$LogInstrumentation
 co.elastic.apm.agent.opentracing.impl.ApmSpanInstrumentation$TagInstrumentation
 co.elastic.apm.agent.opentracing.impl.ApmSpanInstrumentation$SetOperationName
 co.elastic.apm.agent.opentracing.impl.ApmSpanInstrumentation$GetTraceContextInstrumentation
+co.elastic.apm.agent.opentracing.impl.ApmSpanInstrumentation$CompareSpanInstrumentation
+co.elastic.apm.agent.opentracing.impl.ApmSpanInstrumentation$CompareSpanContextInstrumentation
 co.elastic.apm.agent.opentracing.impl.ApmSpanBuilderInstrumentation$CreateSpanInstrumentation
 co.elastic.apm.agent.opentracing.impl.ScopeManagerInstrumentation$ActivateInstrumentation
 co.elastic.apm.agent.opentracing.impl.ScopeManagerInstrumentation$CurrentSpanInstrumentation
 co.elastic.apm.agent.opentracing.impl.ScopeManagerInstrumentation$CurrentTraceContextInstrumentation
 co.elastic.apm.agent.opentracing.impl.ApmScopeInstrumentation
 co.elastic.apm.agent.opentracing.impl.SpanContextInstrumentation
+co.elastic.apm.agent.opentracing.impl.LoggerInstrumentation$LogWarningInstrumentation
+co.elastic.apm.agent.opentracing.impl.LoggerInstrumentation$LogDebugInstrumentation

--- a/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmScope.java
+++ b/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmScope.java
@@ -28,16 +28,19 @@ import io.opentracing.Scope;
 
 class ApmScope implements Scope {
 
+    private final ApmScopeManager apmScopeManager;
     private final boolean finishSpanOnClose;
     private final ApmSpan apmSpan;
 
-    ApmScope(boolean finishSpanOnClose, ApmSpan apmSpan) {
+    ApmScope(ApmScopeManager apmScopeManager, boolean finishSpanOnClose, ApmSpan apmSpan) {
+        this.apmScopeManager = apmScopeManager;
         this.finishSpanOnClose = finishSpanOnClose;
         this.apmSpan = apmSpan;
     }
 
     @Override
     public void close() {
+        apmScopeManager.deactivate(this);
         release(apmSpan.getSpan(), apmSpan.context().getTraceContext());
         if (finishSpanOnClose) {
             apmSpan.finish();

--- a/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmScopeManager.java
+++ b/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmScopeManager.java
@@ -29,40 +29,79 @@ import io.opentracing.Span;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 class ApmScopeManager implements ScopeManager {
+
+    private static final Logger logger = new Logger();
+
+    private final ThreadLocal<Deque<ApmScope>> activeStack = new ThreadLocal<Deque<ApmScope>>() {
+        @Override
+        protected Deque<ApmScope> initialValue() {
+            return new ArrayDeque<ApmScope>();
+        }
+    };
 
     @Override
     public ApmScope activate(@Nonnull Span span, boolean finishSpanOnClose) {
         final ApmSpan apmSpan = (ApmSpan) span;
         final Object traceContext = apmSpan.context().getTraceContext();
         if (traceContext != null) {
-            // prevents other threads from concurrently setting ApmSpan.dispatcher to null
+            // prevents other threads from concurrently setting ApmSpan#dispatcher to null through ApmSpan.finish.
             // we can't synchronize on the internal span object, as it might be finished already
-            // we can't synchronize on the ApmSpan, as ApmScopeManager.active() returns a different instance than ApmScopeManager.activate(Span)
+            // we can't synchronize on the ApmSpan, as we better not rely on any specific ApmScope
             synchronized (traceContext) {
                 // apmSpan.getSpan() has to be called within the synchronized block to avoid race conditions,
                 // so we can't do the synchronization in ScopeManagerInstrumentation
                 doActivate(apmSpan.getSpan(), traceContext);
             }
         }
-        return new ApmScope(finishSpanOnClose, apmSpan);
+        ApmScope scope = new ApmScope(this, finishSpanOnClose, apmSpan);
+        activeStack.get().push(scope);
+        logger.debug("Activated OpenTracing scope", null);
+        return scope;
     }
 
     private void doActivate(@Nullable Object span, Object traceContext) {
         // implementation is injected at runtime via co.elastic.apm.agent.opentracing.impl.ScopeManagerInstrumentation
     }
 
+    void deactivate(ApmScope scope) {
+        ApmScope activeScope = null;
+        Deque<ApmScope> stack = activeStack.get();
+
+        if (!stack.isEmpty()) {
+            activeScope = stack.pop();
+        }
+
+        if (scope == activeScope) {
+            logger.debug("Deactivated OpenTracing scope", null);
+        } else {
+            // someone is attempting to close a span it did not create - clearing the stack to avoid leak
+            stack.clear();
+            logger.warn("An OpenTracing user is trying to close a scope which it apparently did not create: " +
+                scope.span().context().getTraceContext(), new Throwable());
+        }
+    }
+
     @Override
     @Nullable
     public ApmScope active() {
+        ApmScope scope = activeStack.get().peek();
         final Object span = getCurrentSpan();
         if (span != null) {
-            return new ApmScope(false, new ApmSpan(span));
+            if (scope != null && scope.span().isSameSpan(span)) {
+                return scope;
+            }
+            return new ApmScope(this, false, new ApmSpan(span));
         } else {
             final Object traceContext = getCurrentTraceContext();
             if (traceContext != null) {
-                return new ApmScope(false, new ApmSpan(new TraceContextSpanContext(traceContext)));
+                if (scope != null && scope.span().isSameContext(traceContext)) {
+                    return scope;
+                }
+                return new ApmScope(this, false, new ApmSpan(new TraceContextSpanContext(traceContext)));
             }
         }
         return null;

--- a/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmSpan.java
+++ b/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmSpan.java
@@ -38,7 +38,7 @@ class ApmSpan implements Span {
     private final TraceContextSpanContext spanContext;
     @Nullable
     // co.elastic.apm.agent.impl.transaction.AbstractSpan in case of unfinished spans
-    private Object dispatcher;
+    private volatile Object dispatcher;
 
     ApmSpan(@Nullable Object dispatcher) {
         this.dispatcher = dispatcher;
@@ -53,6 +53,24 @@ class ApmSpan implements Span {
     private Object getTraceContext(@Nullable Object dispatcher) {
         // co.elastic.apm.agent.opentracing.impl.ApmSpanInstrumentation$GetTraceContextInstrumentation
         return null;
+    }
+
+    boolean isSameSpan(Object otherSpan) {
+        return compareSpan(context().getTraceContext(), otherSpan);
+    }
+
+    private boolean compareSpan(Object thisTraceContext, Object otherSpan) {
+        // co.elastic.apm.agent.opentracing.impl.ApmSpanInstrumentation$CompareSpanInstrumentation
+        return false;
+    }
+
+    boolean isSameContext(Object otherSpanContext) {
+        return compareSpanContext(context().getTraceContext(), otherSpanContext);
+    }
+
+    private boolean compareSpanContext(Object thisTraceContext, Object otherTraceContext) {
+        // co.elastic.apm.agent.opentracing.impl.ApmSpanInstrumentation$CompareSpanContextInstrumentation
+        return false;
     }
 
     @Override

--- a/apm-opentracing/src/main/java/co/elastic/apm/opentracing/Logger.java
+++ b/apm-opentracing/src/main/java/co/elastic/apm/opentracing/Logger.java
@@ -1,0 +1,36 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.opentracing;
+
+class Logger {
+
+    void debug(String message, Throwable throwable) {
+        // co.elastic.apm.agent.opentracing.impl.LoggerInstrumentation$LogDebugInstrumentation
+    }
+
+    void warn(String message, Throwable throwable) {
+        // co.elastic.apm.agent.opentracing.impl.LoggerInstrumentation$LogWarningInstrumentation
+    }
+}


### PR DESCRIPTION
Closes elastic/apm-agent-java#703 

Added an OpenTracing scope stack. It is used for the ability to return an OpenTracing library the same scope object it had created when using the `ScopeManager#active` API.
In case the internal stack state had progressed and someone calls `ScopeManager#active`, they will get a newly created Scope that is good for context propagation, but if the scope in such scenario will be attempted to `close`, we assume this is an error. In this case, removing the interfering instrumentation (eg changing the `instrument` config to false) will fix the error.

Additional changes:
- Added basic logging capabilities to the OT bridge
- changed `ApmSpan#dispatcher` to `volatile`
- resetting `TraceContext#transactionId` when recycled