### PR TITLE
Update supported-technologies.asciidoc

### DIFF
--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -23,7 +23,7 @@ the agent does not capture transactions.
 
 [float]
 [[supported-java-versions]]
-=== Java versions
+=== Java versions (32-bit and 64-bit)
 
 |===
 |Vendor |Supported versions | Notes


### PR DESCRIPTION
Added reference to 32-bit and 64-bit for Java versions for clarification

Per discussion with @eyalkoren, as long as the supported Java version is used, both 32-bit and 64-bit Java should work.