### PR TITLE
Transaction service name: exception for jetty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ## Bug Fixes
  * Some JMS Consumers and Producers are filtered due to class name filtering in instrumentation matching
+ * Jetty: When no display name is set and context path is "/" transaction service names will now correctly fall back to configured values
 
 # 1.7.0
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletContextServiceNameInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletContextServiceNameInstrumentation.java
@@ -89,9 +89,10 @@ public class ServletContextServiceNameInstrumentation extends ElasticApmInstrume
             }
             @Nullable
             String serviceName = servletContext.getServletContextName();
-            if ("application".equals(serviceName) || "".equals(serviceName)) {
+            if ("application".equals(serviceName) || "".equals(serviceName) || "/".equals(serviceName)) {
                 // payara returns an empty string as opposed to null
                 // spring applications which did not set spring.application.name have application as the default
+                // jetty returns context path when no display name is set, which could be the root context of "/"
                 // this is a worse default than the one we would otherwise choose
                 serviceName = null;
             }


### PR DESCRIPTION
Jetty returns context path if no display name was set. In that case it can be "/" for the root context path, which gets escaped to "-" as the transaction name.

This PR resets the displayName from "/" to null, so that normal logic for context path based naming applies. 

This fixes issue #730 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Update [CHANGELOG.md](CHANGELOG.md)
