### PR TITLE
[docs] Clarify application_packages

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/stacktrace/StacktraceConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/stacktrace/StacktraceConfiguration.java
@@ -40,11 +40,23 @@ public class StacktraceConfiguration extends ConfigurationOptionProvider {
         .key(APPLICATION_PACKAGES)
         .configurationCategory(STACKTRACE_CATEGORY)
         .description("Used to determine whether a stack trace frame is an 'in-app frame' or a 'library frame'.\n" +
-            "Multiple packages can be set as a comma-separated list.\n" +
-            "Setting this option can also improve the startup time.\n" +
+            "This allows the UI to collapse the stack frames of library code,\n" +
+            "and highlight the stack frames that originate from your application.\n" +
+            "Multiple root packages can be set as a comma-separated list;\n" +
+            "there's no need to configure sub-packages.\n" +
+            "Because this setting helps determine which classes to scan on startup,\n" +
+            "setting this option can also improve startup time.\n" +
             "\n" +
-            "In order to be able to use the API annotations @CaptureTransaction and @CaptureSpan,\n" +
-            "it is required to set these options.")
+            "You must set this option in order to use the API annotations `@CaptureTransaction` and `@CaptureSpan`.\n" +
+            "\n" +
+            "**Example**\n" +
+            "\n" +
+            "Most Java projects have a root package, e.g. `com.myproject`. " +
+            "You can set the application package using Java system properties:\n" +
+            "`-Delastic.apm.application_packages=com.myproject`\n" +
+            "\n" +
+            "If you are only interested in specific subpackages, you can separate them with commas:\n" + 
+            "`-Delastic.apm.application_packages=com.myproject.api,com.myproject.impl`")
         .dynamic(true)
         .buildWithDefault(Collections.<String>emptyList());
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1166,11 +1166,22 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 ==== `application_packages`
 
 Used to determine whether a stack trace frame is an 'in-app frame' or a 'library frame'.
-Multiple packages can be set as a comma-separated list.
-Setting this option can also improve the startup time.
+This allows the UI to collapse the stack frames of library code,
+and highlight the stack frames that originate from your application.
+Multiple root packages can be set as a comma-separated list;
+there's no need to configure sub-packages.
+Because this setting helps determine which classes to scan on startup,
+setting this option can also improve startup time.
 
-In order to be able to use the API annotations @CaptureTransaction and @CaptureSpan,
-it is required to set these options.
+You must set this option in order to use the API annotations `@CaptureTransaction` and `@CaptureSpan`.
+
+**Example**
+
+Most Java projects have a root package, e.g. `com.myproject`. You can set the application package using Java system properties:
+`-Delastic.apm.application_packages=com.myproject`
+
+If you are only interested in specific subpackages, you can separate them with commas:
+`-Delastic.apm.application_packages=com.myproject.api,com.myproject.impl`
 
 
 [options="header"]
@@ -1840,11 +1851,22 @@ The default unit for this option is `ms`
 ############################################
 
 # Used to determine whether a stack trace frame is an 'in-app frame' or a 'library frame'.
-# Multiple packages can be set as a comma-separated list.
-# Setting this option can also improve the startup time.
+# This allows the UI to collapse the stack frames of library code,
+# and highlight the stack frames that originate from your application.
+# Multiple root packages can be set as a comma-separated list;
+# there's no need to configure sub-packages.
+# Because this setting helps determine which classes to scan on startup,
+# setting this option can also improve startup time.
 # 
-# In order to be able to use the API annotations @CaptureTransaction and @CaptureSpan,
-# it is required to set these options.
+# You must set this option in order to use the API annotations `@CaptureTransaction` and `@CaptureSpan`.
+# 
+# **Example**
+# 
+# Most Java projects have a root package, e.g. `com.myproject`. You can set the application package using Java system properties:
+# `-Delastic.apm.application_packages=com.myproject`
+# 
+# If you are only interested in specific subpackages, you can separate them with commas:
+# `-Delastic.apm.application_packages=com.myproject.api,com.myproject.impl`
 #
 # This setting can be changed at runtime
 # Type: comma separated list


### PR DESCRIPTION
Closes: https://github.com/elastic/apm-agent-java/issues/726.

Adds more detail and an example for `application_packages`. Thanks to Felix's discuss response for clarifying things.

I still need to sit down with one of you and discuss how the Java Agent asciidoc files are generated. Do I need to update this in `StacktraceConfiguration.java` and run something to update this asciidoc file? Somewhere else?