### PR TITLE
Fixing TraceContext recycling and making OpenTracing replaceable span volatile

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -240,6 +240,7 @@ public class TraceContext extends TraceContextHolder {
         traceId.resetState();
         id.resetState();
         parentId.resetState();
+        transactionId.resetState();
         outgoingHeader.setLength(0);
         flags = 0;
         discard = false;

--- a/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmSpan.java
+++ b/apm-opentracing/src/main/java/co/elastic/apm/opentracing/ApmSpan.java
@@ -38,7 +38,7 @@ class ApmSpan implements Span {
     private final TraceContextSpanContext spanContext;
     @Nullable
     // co.elastic.apm.agent.impl.transaction.AbstractSpan in case of unfinished spans
-    private Object dispatcher;
+    private volatile Object dispatcher;
 
     ApmSpan(@Nullable Object dispatcher) {
         this.dispatcher = dispatcher;


### PR DESCRIPTION
- changed `ApmSpan#dispatcher` to `volatile`
- resetting `TraceContext#transactionId` when recycled