### PR TITLE
Make log correlation GA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
  * Some JMS Consumers and Producers are filtered due to class name filtering in instrumentation matching
  * Jetty: When no display name is set and context path is "/" transaction service names will now correctly fall back to configured values
 
+## Breaking changes
+ * The log correlation feature does not add `span.id` to the MDC anymore but only `trace.id` and `transaction.id` (see #742).
+
 # 1.7.0
 
 ## Features

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActivationListener.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActivationListener.java
@@ -50,7 +50,8 @@ public interface ActivationListener {
      * That's why there is no {@link TraceContextHolder} parameter.
      * </p>
      *
+     * @param deactivatedContext the context which has just been deactivated
      * @throws Throwable if there was an error while calling this method
      */
-    void afterDeactivate() throws Throwable;
+    void afterDeactivate(TraceContextHolder<?> deactivatedContext) throws Throwable;
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -225,17 +225,19 @@ public class ElasticApmTracer {
      * @param parent                the parent of the transaction. May be a traceparent header.
      * @param sampler               the {@link Sampler} instance which is responsible for determining the sampling decision if this is a root transaction
      * @param epochMicros           the start timestamp
-     * @param initiatingClassLoader the class loader corresponding to the service which initiated the creation of the transaction
-     *                              Used to determine the service name.
+     * @param initiatingClassLoader the class loader corresponding to the service which initiated the creation of the transaction.
+     *                              Used to determine the service name and to load application-scoped classes like the {@link org.slf4j.MDC},
+     *                              for log correlation.
      * @param <T>                   the type of the parent. {@code String} in case of a traceparent header.
      * @return a transaction which is a child of the provided parent
      */
-    public <T> Transaction startTransaction(TraceContext.ChildContextCreator<T> childContextCreator, @Nullable T parent, Sampler sampler, long epochMicros, @Nullable ClassLoader initiatingClassLoader) {
+    public <T> Transaction startTransaction(TraceContext.ChildContextCreator<T> childContextCreator, @Nullable T parent, Sampler sampler,
+                                            long epochMicros, @Nullable ClassLoader initiatingClassLoader) {
         Transaction transaction;
         if (!coreConfiguration.isActive()) {
             transaction = noopTransaction();
         } else {
-            transaction = createTransaction().start(childContextCreator, parent, epochMicros, sampler);
+            transaction = createTransaction().start(childContextCreator, parent, epochMicros, sampler, initiatingClassLoader);
         }
         if (logger.isDebugEnabled()) {
             logger.debug("startTransaction {} {", transaction);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -101,6 +101,8 @@ public class TraceContext extends TraceContextHolder {
     private final StringBuilder outgoingHeader = new StringBuilder(TRACE_PARENT_LENGTH);
     private byte flags;
     private boolean discard;
+    @Nullable
+    private ClassLoader applicationClassLoader;
 
     /**
      * Avoids clock drifts within a transaction.
@@ -227,6 +229,7 @@ public class TraceContext extends TraceContextHolder {
         id.setToRandomValue();
         clock.init(parent.clock);
         serviceName = parent.serviceName;
+        applicationClassLoader = parent.applicationClassLoader;
         onMutation();
     }
 
@@ -245,6 +248,7 @@ public class TraceContext extends TraceContextHolder {
         discard = false;
         clock.resetState();
         serviceName = null;
+        applicationClassLoader = null;
     }
 
     /**
@@ -361,6 +365,7 @@ public class TraceContext extends TraceContextHolder {
         discard = other.discard;
         clock.init(other.clock);
         serviceName = other.serviceName;
+        applicationClassLoader = other.applicationClassLoader;
         onMutation();
     }
 
@@ -404,6 +409,15 @@ public class TraceContext extends TraceContextHolder {
     @Override
     public Span createSpan(long epochMicros) {
         return tracer.startSpan(fromParent(), this, epochMicros);
+    }
+
+    void setApplicationClassLoader(@Nullable ClassLoader classLoader) {
+        this.applicationClassLoader = classLoader;
+    }
+
+    @Nullable
+    public ClassLoader getApplicationClassLoader() {
+        return applicationClassLoader;
     }
 
     public interface ChildContextCreator<T> {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContextHolder.java
@@ -113,7 +113,8 @@ public abstract class TraceContextHolder<T extends TraceContextHolder> implement
         List<ActivationListener> activationListeners = tracer.getActivationListeners();
         for (int i = 0; i < activationListeners.size(); i++) {
             try {
-                activationListeners.get(i).afterDeactivate();
+                // `this` is guaranteed to not be recycled yet as the reference count is only decremented after this method has executed
+                activationListeners.get(i).afterDeactivate(this);
             } catch (Error e) {
                 throw e;
             } catch (Throwable t) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -94,7 +94,9 @@ public class Transaction extends AbstractSpan<Transaction> {
         super(tracer);
     }
 
-    public <T> Transaction start(TraceContext.ChildContextCreator<T> childContextCreator, @Nullable T parent, long epochMicros, Sampler sampler) {
+    public <T> Transaction start(TraceContext.ChildContextCreator<T> childContextCreator, @Nullable T parent, long epochMicros,
+                                 Sampler sampler, @Nullable ClassLoader initiatingClassLoader) {
+        traceContext.setApplicationClassLoader(initiatingClassLoader);
         if (parent == null || !childContextCreator.asChildOf(traceContext, parent)) {
             traceContext.asRootSpan(sampler);
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
@@ -103,7 +103,7 @@ public class LoggingConfiguration extends ConfigurationOptionProvider {
         .description("A boolean specifying if the agent should integrate into SLF4J's https://www.slf4j.org/api/org/slf4j/MDC.html[MDC] to enable trace-log correlation.\n" +
             "If set to `true`, the agent will set the `trace.id` and `transaction.id` for the currently active spans and transactions to the MDC.\n" +
             "You can then use the pattern format of your logging implementation to write the MDC values to your log file.\n" +
-            "If you are using logback or log4j, add `%X` to the format to log all MDC values or `%X{trace.id}` to only log the trace id." +
+            "If you are using logback or log4j, add `%X` to the format to log all MDC values or `%X{trace.id}` to only log the trace id.\n" +
             "With the help of Filebeat and Logstash or an Elasticsearch ingest pipeline,\n" +
             "you can index your log files and correlate them with APM traces.\n" +
             "With this integration you can get all logs belonging to a particular trace and vice-versa:\n" +

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
@@ -100,17 +100,16 @@ public class LoggingConfiguration extends ConfigurationOptionProvider {
     private final ConfigurationOption<Boolean> logCorrelationEnabled = ConfigurationOption.booleanOption()
         .key("enable_log_correlation")
         .configurationCategory(LOGGING_CATEGORY)
-        .description("A boolean specifying if the agent should integrate into SLF4J's MDC to enable trace-log correlation.\n" +
-            "If set to `true`, the agent will set the `spanId` and `traceId` for the currently active spans and transactions to the MDC.\n" +
+        .description("A boolean specifying if the agent should integrate into SLF4J's https://www.slf4j.org/api/org/slf4j/MDC.html[MDC] to enable trace-log correlation.\n" +
+            "If set to `true`, the agent will set the `trace.id` and `transaction.id` for the currently active spans and transactions to the MDC.\n" +
             "You can then use the pattern format of your logging implementation to write the MDC values to your log file.\n" +
+            "If you are using logback or log4j, add `%X` to the format to log all MDC values or `%X{trace.id}` to only log the trace id." +
             "With the help of Filebeat and Logstash or an Elasticsearch ingest pipeline,\n" +
             "you can index your log files and correlate them with APM traces.\n" +
             "With this integration you can get all logs belonging to a particular trace and vice-versa:\n" +
             "for a specific log, see in which context it has been logged and which parameters the user provided. " +
             "\n" +
-            "While it's allowed to enable this setting at runtime, you can't disable it without a restart.\n" +
-            "\n" +
-            "NOTE: This is an incubating feature and the MDC key names might change.")
+            "While it's allowed to enable this setting at runtime, you can't disable it without a restart.")
         .dynamic(true)
         .addValidator(new ConfigurationOption.Validator<Boolean>() {
             @Override

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/TransactionUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/TransactionUtils.java
@@ -37,7 +37,7 @@ import java.util.List;
 public class TransactionUtils {
 
     public static void fillTransaction(Transaction t) {
-        t.start(TraceContext.asRoot(), null, (long) 0, ConstantSampler.of(true));
+        t.start(TraceContext.asRoot(), null, (long) 0, ConstantSampler.of(true), TransactionUtils.class.getClassLoader());
         t.setName("GET /api/types");
         t.withType("request");
         t.withResult("success");

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/TransactionPayloadJsonSchemaTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/TransactionPayloadJsonSchemaTest.java
@@ -26,7 +26,6 @@ package co.elastic.apm.agent.impl.payload;
 
 import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.TransactionUtils;
-import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.sampling.ConstantSampler;
 import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.impl.transaction.Span;
@@ -80,7 +79,7 @@ class TransactionPayloadJsonSchemaTest {
 
     private Transaction createTransactionWithRequiredValues() {
         Transaction t = new Transaction(MockTracer.create());
-        t.start(TraceContext.asRoot(), null, (long) 0, ConstantSampler.of(true));
+        t.start(TraceContext.asRoot(), null, (long) 0, ConstantSampler.of(true), getClass().getClassLoader());
         t.withType("type");
         t.getContext().getRequest().withMethod("GET");
         t.getContext().getRequest().getUrl().appendToFull("http://localhost:8080/foo/bar");

--- a/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/ApmSpanBuilderInstrumentation.java
+++ b/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/ApmSpanBuilderInstrumentation.java
@@ -72,7 +72,7 @@ public class ApmSpanBuilderInstrumentation extends OpenTracingBridgeInstrumentat
 
         @Advice.OnMethodExit(suppress = Throwable.class)
         public static void createSpan(@Advice.Argument(value = 0, typing = Assigner.Typing.DYNAMIC) @Nullable TraceContext parentContext,
-                                      @Advice.This Class<?> spanBuilderClass,
+                                      @Advice.Origin Class<?> spanBuilderClass,
                                       @Advice.FieldValue(value = "tags") Map<String, Object> tags,
                                       @Advice.FieldValue(value = "operationName") String operationName,
                                       @Advice.FieldValue(value = "microseconds") long microseconds,

--- a/apm-agent-plugins/apm-slf4j-plugin/src/test/java/co/elastic/apm/agent/slf4j/Slf4JMdcActivationListenerTest.java
+++ b/apm-agent-plugins/apm-slf4j-plugin/src/test/java/co/elastic/apm/agent/slf4j/Slf4JMdcActivationListenerTest.java
@@ -57,7 +57,7 @@ class Slf4JMdcActivationListenerTest extends AbstractInstrumentationTest {
     @Test
     void testMdcIntegration() {
         when(loggingConfiguration.isLogCorrelationEnabled()).thenReturn(true);
-        Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, null).withType("request").withName("test");
+        Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, getClass().getClassLoader()).withType("request").withName("test");
         assertMdcIsEmpty();
         try (Scope scope = transaction.activateInScope()) {
             assertMdcIsSet(transaction);
@@ -79,7 +79,7 @@ class Slf4JMdcActivationListenerTest extends AbstractInstrumentationTest {
     @Test
     void testMdcIntegrationTransactionScopeInDifferentThread() throws Exception {
         when(loggingConfiguration.isLogCorrelationEnabled()).thenReturn(true);
-        Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, null).withType("request").withName("test");
+        Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, getClass().getClassLoader()).withType("request").withName("test");
         assertMdcIsEmpty();
         final CompletableFuture<Boolean> result = new CompletableFuture<>();
         Thread thread = new Thread(() -> {
@@ -121,7 +121,7 @@ class Slf4JMdcActivationListenerTest extends AbstractInstrumentationTest {
     @Test
     void testWithNullContextClassLoader() throws Exception {
         when(loggingConfiguration.isLogCorrelationEnabled()).thenReturn(true);
-        Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, null).withType("request").withName("test");
+        Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, getClass().getClassLoader()).withType("request").withName("test");
         assertMdcIsEmpty();
         final CompletableFuture<Boolean> result = new CompletableFuture<>();
         Thread thread = new Thread(() -> {
@@ -134,7 +134,30 @@ class Slf4JMdcActivationListenerTest extends AbstractInstrumentationTest {
         });
         thread.setContextClassLoader(null);
         thread.start();
-        assertThat(result.get(1000, TimeUnit.MILLISECONDS).booleanValue()).isTrue();
+        assertThat(result.get().booleanValue()).isTrue();
+        assertMdcIsEmpty();
+        thread.join();
+        transaction.end();
+    }
+
+    @Test
+    void testWithNullApplicationClassLoaderFallbackPlatformCL() throws Exception {
+        when(loggingConfiguration.isLogCorrelationEnabled()).thenReturn(true);
+        Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, null).withType("request").withName("test");
+        assertMdcIsEmpty();
+        final CompletableFuture<Boolean> result = new CompletableFuture<>();
+        Thread thread = new Thread(() -> {
+            assertMdcIsEmpty();
+            try (Scope scope = transaction.activateInScope()) {
+                // the platform CL can't load the MDC
+                assertMdcIsEmpty();
+            }
+            assertMdcIsEmpty();
+            result.complete(true);
+        });
+        thread.setContextClassLoader(ClassLoader.getPlatformClassLoader());
+        thread.start();
+        assertThat(result.get().booleanValue()).isTrue();
         assertMdcIsEmpty();
         thread.join();
         transaction.end();
@@ -143,7 +166,7 @@ class Slf4JMdcActivationListenerTest extends AbstractInstrumentationTest {
     @Test
     void testMdcIntegrationContextScopeInDifferentThread() throws Exception {
         when(loggingConfiguration.isLogCorrelationEnabled()).thenReturn(true);
-        final Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, null).withType("request").withName("test");
+        final Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, getClass().getClassLoader()).withType("request").withName("test");
         assertMdcIsEmpty();
         try (Scope scope = transaction.activateInScope()) {
             assertMdcIsSet(transaction);
@@ -183,13 +206,11 @@ class Slf4JMdcActivationListenerTest extends AbstractInstrumentationTest {
     private void assertMdcIsSet(AbstractSpan span) {
         assertThat(MDC.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
         assertThat(MDC.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
-        assertThat(MDC.get("span.id")).isEqualTo(span.getTraceContext().getId().toString());
     }
 
     private void assertMdcIsEmpty() {
         assertThat(MDC.get("trace.id")).isNull();
         assertThat(MDC.get("transaction.id")).isNull();
-        assertThat(MDC.get("span.id")).isNull();
     }
 
 }

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -815,16 +815,14 @@ it's content is deleted when the application starts.
 [[config-enable-log-correlation]]
 ==== `enable_log_correlation`
 
-A boolean specifying if the agent should integrate into SLF4J's MDC to enable trace-log correlation.
-If set to `true`, the agent will set the `spanId` and `traceId` for the currently active spans and transactions to the MDC.
+A boolean specifying if the agent should integrate into SLF4J's https://www.slf4j.org/api/org/slf4j/MDC.html[MDC] to enable trace-log correlation.
+If set to `true`, the agent will set the `trace.id` and `transaction.id` for the currently active spans and transactions to the MDC.
 You can then use the pattern format of your logging implementation to write the MDC values to your log file.
-With the help of Filebeat and Logstash or an Elasticsearch ingest pipeline,
+If you are using logback or log4j, add `%X` to the format to log all MDC values or `%X{trace.id}` to only log the trace id.With the help of Filebeat and Logstash or an Elasticsearch ingest pipeline,
 you can index your log files and correlate them with APM traces.
 With this integration you can get all logs belonging to a particular trace and vice-versa:
 for a specific log, see in which context it has been logged and which parameters the user provided. 
 While it's allowed to enable this setting at runtime, you can't disable it without a restart.
-
-NOTE: This is an incubating feature and the MDC key names might change.
 
 
 [options="header"]
@@ -1590,16 +1588,14 @@ The default unit for this option is `ms`
 #
 # log_file=System.out
 
-# A boolean specifying if the agent should integrate into SLF4J's MDC to enable trace-log correlation.
-# If set to `true`, the agent will set the `spanId` and `traceId` for the currently active spans and transactions to the MDC.
+# A boolean specifying if the agent should integrate into SLF4J's https://www.slf4j.org/api/org/slf4j/MDC.html[MDC] to enable trace-log correlation.
+# If set to `true`, the agent will set the `trace.id` and `transaction.id` for the currently active spans and transactions to the MDC.
 # You can then use the pattern format of your logging implementation to write the MDC values to your log file.
-# With the help of Filebeat and Logstash or an Elasticsearch ingest pipeline,
+# If you are using logback or log4j, add `%X` to the format to log all MDC values or `%X{trace.id}` to only log the trace id.With the help of Filebeat and Logstash or an Elasticsearch ingest pipeline,
 # you can index your log files and correlate them with APM traces.
 # With this integration you can get all logs belonging to a particular trace and vice-versa:
 # for a specific log, see in which context it has been logged and which parameters the user provided. 
 # While it's allowed to enable this setting at runtime, you can't disable it without a restart.
-# 
-# NOTE: This is an incubating feature and the MDC key names might change.
 #
 # This setting can be changed at runtime
 # Type: Boolean

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -270,6 +270,21 @@ NOTE: only classes from packages configured in <<config-application-packages>>  
 |1.8.0
 |===
 
+[float]
+[[supported-logging-frameworks]]
+=== Logging frameworks
+
+|===
+|Framework |Supported versions | Description | Since
+
+|slf4j
+|1.4.1+
+|When <<config-enable-log-correlation>> is set to `true`,
+ the agent will add a https://www.slf4j.org/api/org/slf4j/MDC.html[MDC] entry for `trace.id` and `transaction.id`.
+ See the <<config-enable-log-correlation>> configuration option for more details.
+|1.0.0
+
+|===
 
 [float]
 [[supported-technologies-caveats]]


### PR DESCRIPTION
- Load the MDC with the application class loader, as opposed to the
  Thread's context classloader (fixes #720)
- Remove span.id MDC entry
  This causes the most allocations as in contrast to transaction.id and
  trace.id, the String manifestation can't be reused.
  Other agents also don't add the span.id so it makes sense to align on that
- Docs improvements 
- Mention slf4j in supported technologies page

closes #724


<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.

-->


<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Update [CHANGELOG.md](CHANGELOG.md)
- [x] Update [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)