### PR TITLE
automatic instrumentation does not override manual results

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -78,11 +78,6 @@ public class Transaction extends AbstractSpan<Transaction> {
      */
     @Nullable
     private String result;
-    
-    /**
-     * true if the result was set by the Transaction.setResult
-     */
-    private boolean userDefinedResult;
 
     /**
      * Noop transactions won't be reported at all, in contrast to non-sampled transactions.
@@ -164,27 +159,24 @@ public class Transaction extends AbstractSpan<Transaction> {
     }
 
     /**
-     * true if the result was set by the Transaction.setResult
+     * The result of the transaction. HTTP status code for HTTP-related
+     * transactions. This sets the result only if it is not already set. should be
+     * used for instrumentations
      */
-    public boolean isUserDefinedResult() {
-        return userDefinedResult;
-    }
-
-    /**
-     * The result of the transaction. HTTP status code for HTTP-related transactions.
-     */
-    public Transaction withResult(@Nullable String result) {
-        if (!userDefinedResult) {
+    public Transaction withResultIfUnset(@Nullable String result) {
+        if (this.result == null) {
             this.result = result;
         }
         return this;
     }
+
     /**
-     * The result of the transaction set withTransaction.setResult. HTTP status code for HTTP-related transactions.
+     * The result of the transaction. HTTP status code for HTTP-related
+     * transactions. This sets the result regardless of an already existing value.
+     * should be used for user defined results
      */
-    public Transaction withUserResult(@Nullable String result) {
+    public Transaction withResult(@Nullable String result) {
         this.result = result;
-        this.userDefinedResult = true;
         return this;
     }
 
@@ -226,7 +218,6 @@ public class Transaction extends AbstractSpan<Transaction> {
         super.resetState();
         context.resetState();
         result = null;
-        userDefinedResult = false;
         spanCount.resetState();
         noop = false;
         type = null;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -73,10 +73,16 @@ public class Transaction extends AbstractSpan<Transaction> {
     private final WriterReaderPhaser phaser = new WriterReaderPhaser();
 
     /**
-     * The result of the transaction. HTTP status code for HTTP-related transactions.
+     * The result of the transaction. HTTP status code for HTTP-related
+     * transactions.
      */
     @Nullable
     private String result;
+    
+    /**
+     * true if the result was set by the Transaction.setResult
+     */
+    private boolean userDefinedResult;
 
     /**
      * Noop transactions won't be reported at all, in contrast to non-sampled transactions.
@@ -158,10 +164,27 @@ public class Transaction extends AbstractSpan<Transaction> {
     }
 
     /**
+     * true if the result was set by the Transaction.setResult
+     */
+    public boolean isUserDefinedResult() {
+        return userDefinedResult;
+    }
+
+    /**
      * The result of the transaction. HTTP status code for HTTP-related transactions.
      */
     public Transaction withResult(@Nullable String result) {
+        if (!userDefinedResult) {
+            this.result = result;
+        }
+        return this;
+    }
+    /**
+     * The result of the transaction set withTransaction.setResult. HTTP status code for HTTP-related transactions.
+     */
+    public Transaction withUserResult(@Nullable String result) {
         this.result = result;
+        this.userDefinedResult = true;
         return this;
     }
 
@@ -203,6 +226,7 @@ public class Transaction extends AbstractSpan<Transaction> {
         super.resetState();
         context.resetState();
         result = null;
+        userDefinedResult = false;
         spanCount.resetState();
         noop = false;
         type = null;

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/TransactionInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/TransactionInstrumentation.java
@@ -99,7 +99,7 @@ public class TransactionInstrumentation extends ApiInstrumentation {
         @Advice.OnMethodEnter(suppress = Throwable.class)
         private static void ensureParentId(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Transaction transaction,
                                            @Advice.Argument(0) String result) {
-            transaction.withResult(result);
+            transaction.withUserResult(result);
         }
     }
 

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/TransactionInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/TransactionInstrumentation.java
@@ -99,7 +99,7 @@ public class TransactionInstrumentation extends ApiInstrumentation {
         @Advice.OnMethodEnter(suppress = Throwable.class)
         private static void ensureParentId(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Transaction transaction,
                                            @Advice.Argument(0) String result) {
-            transaction.withUserResult(result);
+            transaction.withResult(result);
         }
     }
 

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/plugin/api/TransactionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/plugin/api/TransactionInstrumentationTest.java
@@ -79,6 +79,9 @@ class TransactionInstrumentationTest extends AbstractInstrumentationTest {
         transaction.setResult("foo");
         endTransaction();
         assertThat(reporter.getFirstTransaction().getResult()).isEqualTo("foo");
+        assertThat(reporter.getFirstTransaction().isUserDefinedResult()).isEqualTo(true);
+        reporter.getFirstTransaction().withResult("200");
+        assertThat(reporter.getFirstTransaction().getResult()).isEqualTo("foo");
     }
 
     @Test

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/plugin/api/TransactionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/plugin/api/TransactionInstrumentationTest.java
@@ -79,9 +79,22 @@ class TransactionInstrumentationTest extends AbstractInstrumentationTest {
         transaction.setResult("foo");
         endTransaction();
         assertThat(reporter.getFirstTransaction().getResult()).isEqualTo("foo");
-        assertThat(reporter.getFirstTransaction().isUserDefinedResult()).isEqualTo(true);
-        reporter.getFirstTransaction().withResult("200");
+    }
+
+    @Test
+    void testInstrumentationDoesNotOverrideUserResult() {
+        transaction.setResult("foo");
+        endTransaction();
+        reporter.getFirstTransaction().withResultIfUnset("200");
         assertThat(reporter.getFirstTransaction().getResult()).isEqualTo("foo");
+    }
+
+    @Test
+    void testUserCanOverrideResult() {
+        transaction.setResult("foo");
+        transaction.setResult("bar");
+        endTransaction();
+        assertThat(reporter.getFirstTransaction().getResult()).isEqualTo("bar");
     }
 
     @Test

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
@@ -71,7 +71,7 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
         Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, null).activate();
         transaction.setName("ES Transaction");
         transaction.withType("request");
-        transaction.withResult("success");
+        transaction.withResultIfUnset("success");
     }
 
     @After

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         transaction = tracer.startTransaction(TraceContext.asRoot(), null, null).activate();
         transaction.setName("transaction");
         transaction.withType("request");
-        transaction.withResult("success");
+        transaction.withResultIfUnset("success");
         signatureParser = new SignatureParser();
     }
 

--- a/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/ApmSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/ApmSpanInstrumentation.java
@@ -212,15 +212,13 @@ public class ApmSpanInstrumentation extends OpenTracingBridgeInstrumentation {
                 transaction.withResult(value.toString());
                 return true;
             } else if ("error".equals(key)) {
-                if (transaction.getResult() == null && Boolean.FALSE.equals(value)) {
-                    transaction.withResult("error");
+                if (Boolean.FALSE.equals(value)) {
+                    transaction.withResultIfUnset("error");
                 }
                 return true;
             } else if ("http.status_code".equals(key) && value instanceof Number) {
                 transaction.getContext().getResponse().withStatusCode(((Number) value).intValue());
-                if (transaction.getResult() == null) {
-                    transaction.withResult(ResultUtil.getResultByHttpStatus(((Number) value).intValue()));
-                }
+                transaction.withResultIfUnset(ResultUtil.getResultByHttpStatus(((Number) value).intValue()));
                 transaction.withType(Transaction.TYPE_REQUEST);
                 return true;
             } else if ("http.method".equals(key)) {

--- a/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameAdvice.java
+++ b/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameAdvice.java
@@ -68,7 +68,7 @@ public class JobTransactionNameAdvice {
                                              @Advice.Local("transaction") @Nullable Transaction transaction, @Advice.Thrown Throwable t) {
         if (transaction != null) {
             if (context != null && context.getResult() != null) {
-                transaction.withResult(context.getResult().toString());
+                transaction.withResultIfUnset(context.getResult().toString());
             }
             transaction.captureException(t)
                 .deactivate()

--- a/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameAdvice.java
+++ b/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameAdvice.java
@@ -67,7 +67,7 @@ public class JobTransactionNameAdvice {
     public static void onMethodExitException(@Advice.Argument(value = 0) @Nullable JobExecutionContext context,
                                              @Advice.Local("transaction") @Nullable Transaction transaction, @Advice.Thrown Throwable t) {
         if (transaction != null) {
-            if (transaction.getResult() == null && context != null && context.getResult() != null) {
+            if (context != null && context.getResult() != null) {
                 transaction.withResult(context.getResult().toString());
             }
             transaction.captureException(t)

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -187,7 +187,7 @@ public class ServletTransactionHelper {
             status = 500;
         }
         fillResponse(transaction.getContext().getResponse(), committed, status);
-        transaction.withResult(ResultUtil.getResultByHttpStatus(status));
+        transaction.withResultIfUnset(ResultUtil.getResultByHttpStatus(status));
         transaction.withType("request");
         if (transaction.getName().length() == 0) {
             applyDefaultTransactionName(method, servletPath, pathInfo, transaction.getName());


### PR DESCRIPTION
This PR changes the logic of the result so results set via the API takes precedence. Until now, a result set via the API would be overridden by the automatic instrumentation(for example on a HTTP call).

I have removed the check in the quartz plugin which I have added while writing it because it did the same thing.

### Checklist

- [x] Implement code
- [x] Add tests
