### PR TITLE
Fix 6.x APM Server version parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next (1.9.0)
+# Next
 
 ## Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Next (1.9.0)
+
+## Features
+
+## Bug Fixes
+ * A warning in logs saying APM server is not available when using 1.8 with APM server 6.x
+
 # 1.8.0
 
 ## Features

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>com.dslplatform</groupId>
             <artifactId>dsl-json</artifactId>
-            <version>1.8.4</version>
+            <version>1.9.3</version>
         </dependency>
         <!--Used to test excluding old class file versions-->
         <dependency>

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientTest.java
@@ -69,9 +69,11 @@ public class ApmServerClientTest {
     public void setUp() throws MalformedURLException {
         URL url1 = new URL("http", "localhost", apmServer1.port(), "/");
         URL url2 = new URL("http", "localhost", apmServer2.port(), "/");
-        apmServer1.stubFor(get(urlEqualTo("/")).willReturn(okForJson(Map.of("version", "6.7.0-SNAPSHOT"))));
+        // APM server 6.x style
+        apmServer1.stubFor(get(urlEqualTo("/")).willReturn(okForJson(Map.of("ok", Map.of("version", "6.7.0-SNAPSHOT")))));
         apmServer1.stubFor(get(urlEqualTo("/test")).willReturn(notFound()));
         apmServer1.stubFor(get(urlEqualTo("/not-found")).willReturn(notFound()));
+        // APM server 7+ style
         apmServer2.stubFor(get(urlEqualTo("/")).willReturn(okForJson(Map.of("version", "7.3.0-RC1"))));
         apmServer2.stubFor(get(urlEqualTo("/test")).willReturn(ok("hello from server 2")));
         apmServer2.stubFor(get(urlEqualTo("/not-found")).willReturn(notFound()));


### PR DESCRIPTION
Adding parsing version of APM server 6.x.

- [x] Implement code
- [x] Add tests
- [ ] ~Update documentation~
- [x] Update [CHANGELOG.md](CHANGELOG.md)
- [ ] ~Update [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~
- [ ] ~Added an API method or config option? Document in which version this will be introduced.~
