### PR TITLE
Fix dsl-json initialization when using attachment

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
@@ -48,7 +48,7 @@ public class ApmServerHealthChecker implements Callable<Version> {
     private static final Logger logger = LoggerFactory.getLogger(ApmServerHealthChecker.class);
 
     private final ApmServerClient apmServerClient;
-    private final DslJson<Object> dslJson = new DslJson<>();
+    private final DslJson<Object> dslJson = new DslJson<>(new DslJson.Settings<>());
 
     public ApmServerHealthChecker(ApmServerClient apmServerClient) {
         this.apmServerClient = apmServerClient;


### PR DESCRIPTION
Avoid using service loader by manually providing settings

closes #776