### PR TITLE
Decrease JUnit version to 5.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
         <version.error_prone>2.2.0</version.error_prone>
         <version.h2>1.4.196</version.h2>
         <version.jackson>2.10.0.pr1</version.jackson>
-        <version.junit-jupiter>5.5.1</version.junit-jupiter>
+        <version.junit-jupiter>5.4.2</version.junit-jupiter>
         <version.junit.vintage>4.12</version.junit.vintage>
         <version.logback>1.2.3</version.logback>
         <version.okhttp>3.9.1</version.okhttp>


### PR DESCRIPTION
Tests did not run apparently with 5.5.1. Not sure yet which dependency is missing and if we can fix that while still have the JUnit 4 dependency, so for now just a quick fix to restore tests