### PR TITLE
ci(jenkins): MAVEN_CONFIG at the top level and also per group of stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,7 @@ pipeline {
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-java-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
+    MAVEN_CONFIG = '-Dmaven.repo.local=.m2'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -28,7 +29,7 @@ pipeline {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
-    string(name: 'MAVEN_CONFIG', defaultValue: "-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dmaven.repo.local=.m2", description: "Additional maven options.")
+    string(name: 'MAVEN_CONFIG', defaultValue: '-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn', description: 'Additional maven options.')
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'test_ci', defaultValue: true, description: 'Enable test')
     booleanParam(name: 'smoketests_ci', defaultValue: true, description: 'Enable Smoke tests')
@@ -43,7 +44,7 @@ pipeline {
         HOME = "${env.WORKSPACE}"
         JAVA_HOME = "${env.HUDSON_HOME}/.java/java10"
         PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
-        MAVEN_CONFIG = "${params.MAVEN_CONFIG}"
+        MAVEN_CONFIG = "${params.MAVEN_CONFIG} ${env.MAVEN_CONFIG}"
       }
       stages(){
         /**
@@ -82,6 +83,9 @@ pipeline {
       }
     }
     stage('Tests') {
+      environment {
+        MAVEN_CONFIG = "${params.MAVEN_CONFIG} ${env.MAVEN_CONFIG}"
+      }
       failFast true
       parallel {
         /**


### PR DESCRIPTION
## Highlights
- Ensure the `'-Dmaven.repo.local=.m2'` cannot be overridden even when triggering the build manually with the parameter `MAVEN_CONFIG`
- Ensure all the top-level stages, aka `stage('Tests')` and `stage('Initializing')` append the `MAVEN_CONFIG` env variable in conjunction with the `MAVEN_CONFIG` parameter.
- It does solve the very first build issues for new PRs, see https://github.com/elastic/apm-agent-java/pull/792#issuecomment-521601006

## Some other thoughts
- I initially thought to use a profile but unfortunately the maven.repo.local is not supported at that level.