### PR TITLE
Setting JDBC statement map cleaner thread ccl to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
    This makes the runtime attachment work in more environments such as minimal Docker containers.
    Note that the runtime attachment currently does not work for OSGi containers like those used in many application servers such as JBoss and WildFly.
    See the [documentation](https://www.elastic.co/guide/en/apm/agent/java/master/setup-attach-cli.html) for more information.
+ * JDBC statement map is leaking in Tomcat if the application that first used it is udeployed/redeployed. See [this 
+   related discussion](https://discuss.elastic.co/t/elastic-apm-agent-jdbchelper-seems-to-use-a-lot-of-memory/195295).
 
 # Breaking Changes
  * The `apm-agent-attach.jar` is not executable anymore.

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelper.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelper.java
@@ -35,7 +35,12 @@ import java.sql.Connection;
 public abstract class JdbcHelper {
     @SuppressWarnings("WeakerAccess")
     @VisibleForAdvice
-    public static final WeakConcurrentMap<Object, String> statementSqlMap = new WeakConcurrentMap<>(true);
+    public static final WeakConcurrentMap<Object, String> statementSqlMap;
+
+    static {
+        statementSqlMap = new WeakConcurrentMap<>(true);
+        statementSqlMap.getCleanerThread().setContextClassLoader(null);
+    }
 
     /**
      * Maps the provided sql to the provided Statement object

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelper.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelper.java
@@ -39,6 +39,11 @@ public abstract class JdbcHelper {
 
     static {
         statementSqlMap = new WeakConcurrentMap<>(true);
+        // This class will probably be loaded in the context of a request processing thread
+        // whose context class loader is the web application ClassLoader.
+        // This leaks the web application ClassLoader when the application is undeployed/redeployed.
+        // Tomcat will then stop the thread because it thinks it was created by the web application.
+        // That means that the map will never be cleared, creating a severe memory leak.
         statementSqlMap.getCleanerThread().setContextClassLoader(null);
     }
 


### PR DESCRIPTION
Fixing the problem reported in https://discuss.elastic.co/t/elastic-apm-agent-jdbchelper-seems-to-use-a-lot-of-memory/195295/8.

According to [the WebappClassLoderBase code](https://github.com/apache/tomcat/blob/master//java/org/apache/catalina/loader/WebappClassLoaderBase.java#L1722), setting the Context class loader of the cleaner thread to the system or bootstrap classloader should solve the problem.

### Checklist

- [x] Implement code
- [x] Update documentation (comment in code)
- [x] Update [CHANGELOG.md](CHANGELOG.md)