### PR TITLE
ci: packer cache script should fail never to help to cache dependencies

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 source /usr/local/bin/bash_standard_lib.sh
 
-JAVA_HOME=$HOME/.java/java10 ./mvnw clean verify
+JAVA_HOME=$HOME/.java/java10 ./mvnw clean verify --fail-never
 
 (retry 2 docker pull docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev) \
   && docker tag docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev store/oracle/weblogic:12.2.1.3-dev


### PR DESCRIPTION
Closed #805 

## Highlights
- The responsibility to validate the build should not be addressed within the packer cache script.
- This will help to fetch and cache all the maven dependencies and also the docker images independently of the maven build status.
- `-Dmaven.test.failure.ignore=true` could be an option but I'd rather prefer to avoid failing the maven build instead.