### PR TITLE
ci(jenkins): avoid using the any agent to skip running in the master-worker

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,13 @@
 #!/usr/bin/env groovy
-
 @Library('apm@current') _
+
+import groovy.transform.Field
+
+/**
+This is the git commit sha which it's required to be used in different stages.
+It does store the env GIT_BASE_COMMIT
+*/
+@Field def gitBaseCommit
 
 pipeline {
   agent none
@@ -55,6 +62,9 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+            script {
+              gitBaseCommit = env.GIT_BASE_COMMIT
+            }
           }
         }
         /**
@@ -276,10 +286,10 @@ pipeline {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
               parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Java'),
-                           string(name: 'BUILD_OPTS', value: "--java-agent-version ${env.GIT_BASE_COMMIT}"),
+                           string(name: 'BUILD_OPTS', value: "--java-agent-version ${gitBaseCommit}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
+                           string(name: 'GITHUB_CHECK_SHA1', value: gitBaseCommit)])
         githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,9 @@ import groovy.transform.Field
 
 /**
 This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_BASE_COMMIT
+It does store the env GIT_SHA
 */
-@Field def gitBaseCommit
+@Field def gitCommit
 
 pipeline {
   agent none
@@ -63,7 +63,7 @@ pipeline {
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
-              gitBaseCommit = env.GIT_BASE_COMMIT
+              gitCommit = env.GIT_SHA
             }
           }
         }
@@ -286,10 +286,10 @@ pipeline {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
               parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Java'),
-                           string(name: 'BUILD_OPTS', value: "--java-agent-version ${gitBaseCommit}"),
+                           string(name: 'BUILD_OPTS', value: "--java-agent-version ${gitCommit}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                           string(name: 'GITHUB_CHECK_SHA1', value: gitBaseCommit)])
+                           string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)])
         githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent { label 'linux && immutable' }
+  agent none
   environment {
     REPO = 'apm-agent-java'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -286,7 +286,9 @@ pipeline {
   }
   post {
     cleanup {
-      notifyBuildResult()
+      node('linux && immutable') {
+        notifyBuildResult()
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-agent-java'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,9 +286,7 @@ pipeline {
   }
   post {
     cleanup {
-      node('linux && immutable') {
-        notifyBuildResult()
-      }
+      notifyBuildResult()
     }
   }
 }


### PR DESCRIPTION
## Highlights
- When working with ephemeral workers the only agent which might be always up is the `master` one, besides the static workers if any. So far, we don't have any after moving to windows ephemeral workers.
- This particular change will help to scale up when the build queue is long but will increase a bit the wait time.
- In other words, there are three major concepts regarding the overall time:
  - Waste of time for resources during the build
  - Waste of time for resources in the queue
  - Real build time.
- This particular fix will reduce the time for the first and second one.
- GIT_SHA rather than GIT_BASE_COMMIT as the last one is caused when doing a merge within a PR.
