### PR TITLE
Revert "ci(jenkins): avoid using the any agent to skip running in the master-worker (#810)"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,16 +1,9 @@
 #!/usr/bin/env groovy
+
 @Library('apm@current') _
 
-import groovy.transform.Field
-
-/**
-This is the git commit sha which it's required to be used in different stages.
-It does store the env GIT_SHA
-*/
-@Field def gitCommit
-
 pipeline {
-  agent none
+  agent any
   environment {
     REPO = 'apm-agent-java'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -62,9 +55,6 @@ pipeline {
             deleteDir()
             gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true)
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-            script {
-              gitCommit = env.GIT_SHA
-            }
           }
         }
         /**
@@ -286,10 +276,10 @@ pipeline {
         log(level: 'INFO', text: 'Launching Async ITs')
         build(job: env.ITS_PIPELINE, propagate: false, wait: false,
               parameters: [string(name: 'AGENT_INTEGRATION_TEST', value: 'Java'),
-                           string(name: 'BUILD_OPTS', value: "--java-agent-version ${gitCommit}"),
+                           string(name: 'BUILD_OPTS', value: "--java-agent-version ${env.GIT_BASE_COMMIT}"),
                            string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                           string(name: 'GITHUB_CHECK_SHA1', value: gitCommit)])
+                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
         githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
       }
     }


### PR DESCRIPTION
This reverts commit 8585b4a3bafd58d04c041dad5e57b8b6cfdbcf67.

## Highlights
- As long as we use the share step `gitCheckout` we might need to use the agent top-level to share the env variables between stages.
- It's not ideal but even though the changes were quite straight, its behavior was not as expected. 
- Let's keep the pipeline stable for now and we will figure out what's going on.