### PR TITLE
Do not throw Exception from remote config poller with empty server_urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-# Next
+# Next (1.10.0)
 
 ## Features
  * Add ability to manually specify reported [hostname](https://www.elastic.co/guide/en/apm/agent/java/current/config-core.html#config-hostname)
+
 ## Bug Fixes
+ * Error in log when setting [server_urls](https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html#config-server-urls) 
+ to an empty string - `co.elastic.apm.agent.configuration.ApmServerConfigurationSource - Expected previousException not to be null`
  
 # 1.9.0
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
@@ -198,9 +198,14 @@ public class ApmServerClient {
      */
     @Nullable
     public <V> V execute(String path, ConnectionHandler<V> connectionHandler) throws Exception {
+        final List<URL> prioritizedUrlList = getPrioritizedUrlList();
+        if (prioritizedUrlList.isEmpty()) {
+            return null;
+        }
+
         int expectedErrorCount = errorCount.get();
         Exception previousException = null;
-        for (URL serverUrl : getPrioritizedUrlList()) {
+        for (URL serverUrl : prioritizedUrlList) {
             HttpURLConnection connection = null;
             try {
                 connection = startRequestToUrl(appendPath(serverUrl, path));

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientTest.java
@@ -41,6 +41,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -191,5 +192,17 @@ public class ApmServerClientTest {
         config.save("server_urls", new URL("http", "localhost", apmServer1.port(), "/").toString(), SpyConfiguration.CONFIG_SOURCE_NAME);
         assertThat(apmServerClient.supportsNonStringLabels()).isFalse();
 
+    }
+
+    @Test
+    public void testWithEmptyServerUrlList() {
+        ApmServerClient client = new ApmServerClient(reporterConfiguration, Collections.emptyList());
+        Exception exception = null;
+        try {
+            client.execute("/irrelevant", connection -> null);
+        } catch (Exception e) {
+            exception = e;
+        }
+        assertThat(exception).isNull();
     }
 }


### PR DESCRIPTION
Reported in https://discuss.elastic.co/t/unable-to-disable-java-apm-agent-in-1-9-0/197669.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update [CHANGELOG.md](CHANGELOG.md)
