### PR TITLE
Support for property based distinguisher for APM Agent attacher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Features
  * Add ability to manually specify reported [hostname](https://www.elastic.co/guide/en/apm/agent/java/current/config-core.html#config-hostname)
  * Add support for Redis Jedis client
+ * Add support for identifying target JVM to attach apm agent to using JMV property.
 
 ## Bug Fixes
  * Error in log when setting [server_urls](https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html#config-server-urls) 

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/JvmDiscoverer.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/JvmDiscoverer.java
@@ -78,7 +78,7 @@ public interface JvmDiscoverer {
 
         @Nonnull
         private static String getJpsOutput() throws IOException, InterruptedException {
-            final Process jps = new ProcessBuilder("jps", "-l").start();
+            final Process jps = new ProcessBuilder("jps", "-lv").start();
             if (jps.waitFor() == 0) {
                 return RemoteAttacher.toString(jps.getInputStream());
             } else {
@@ -104,7 +104,7 @@ public interface JvmDiscoverer {
         @Override
         public boolean isAvailable() {
             try {
-                return new ProcessBuilder("jps", "-l").start().waitFor() == 0;
+                return new ProcessBuilder("jps", "-lv").start().waitFor() == 0;
             } catch (Exception e) {
                 return false;
             }
@@ -143,7 +143,12 @@ public interface JvmDiscoverer {
                 if (temporaryDirectory == null) {
                     temporaryDirectory = "/tmp";
                 }
-            } else {
+            } else if (Platform.isWindows()) {
+				temporaryDirectory = System.getenv("TEMP");
+				if (temporaryDirectory == null) {
+                    temporaryDirectory = "c:/Temp";
+                }
+			} else {
                 temporaryDirectory = "/tmp";
             }
             return new ForHotSpotVm(temporaryDirectory);

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/JvmInfo.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/JvmInfo.java
@@ -28,11 +28,11 @@ import java.util.Objects;
 
 class JvmInfo {
     final String pid;
-    final String packageOrPath;
+    final String packageOrPathOrJvmProperties;
 
-    JvmInfo(String pid, String packageOrPath) {
+    JvmInfo(String pid, String packageOrPathOrJvmProperties) {
         this.pid = pid;
-        this.packageOrPath = packageOrPath;
+        this.packageOrPathOrJvmProperties = packageOrPathOrJvmProperties;
     }
 
     static JvmInfo parse(String jpsLine) {
@@ -42,7 +42,7 @@ class JvmInfo {
 
     @Override
     public String toString() {
-        return pid + ' ' + packageOrPath;
+        return pid + ' ' + packageOrPathOrJvmProperties;
     }
 
     @Override

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -138,7 +138,7 @@ public class RemoteAttacher {
     }
 
     private String getArgsProviderOutput(JvmInfo jvmInfo) throws IOException, InterruptedException {
-        final Process argsProvider = new ProcessBuilder(arguments.getArgsProvider(), jvmInfo.pid, jvmInfo.packageOrPath).start();
+        final Process argsProvider = new ProcessBuilder(arguments.getArgsProvider(), jvmInfo.pid, jvmInfo.packageOrPathOrJvmProperties).start();
         if (argsProvider.waitFor() == 0) {
             return toString(argsProvider.getInputStream());
         } else {
@@ -153,7 +153,7 @@ public class RemoteAttacher {
             return true;
         }
         for (String include : arguments.getIncludes()) {
-            if (jvmInfo.packageOrPath.matches(include)) {
+            if (jvmInfo.packageOrPathOrJvmProperties.matches(include)) {
                 return true;
             }
         }
@@ -162,7 +162,7 @@ public class RemoteAttacher {
 
     private boolean isExcluded(JvmInfo jvmInfo) {
         for (String exclude : arguments.getExcludes()) {
-            if (jvmInfo.packageOrPath.matches(exclude)) {
+            if (jvmInfo.packageOrPathOrJvmProperties.matches(exclude)) {
                 return true;
             }
         }

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -311,12 +311,12 @@ public class RemoteAttacher {
             out.println("        If provided, this program continuously runs and attaches to all running and starting JVMs which match the --exclude and --include filters.");
             out.println();
             out.println("    -e, --exclude <exclude_pattern>...");
-            out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications the java agent should not be attached to.");
+            out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications or any Jvm  system property of the java process the java agent should not be attached to.");
             out.println("        (Matches the output of 'jps -l')");
             out.println("        Note: this is only available if jps is installed");
             out.println();
             out.println("    -i, --include <include_pattern>...");
-            out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications the java agent should be attached to.");
+            out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications or any Jvm  system property of the java process the java agent should be attached to.");
             out.println("        (Matches the output of 'jps -l')");
             out.println("        Note: this is only available if jps is installed");
             out.println();

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -302,7 +302,7 @@ public class RemoteAttacher {
             out.println();
             out.println("OPTIONS");
             out.println("    -l, --list");
-            out.println("        Lists all running JVMs. Same output as 'jps -l'.");
+            out.println("        Lists all running JVMs. Same output as 'jps -lv'.");
             out.println();
             out.println("    -p, --pid <pid>");
             out.println("        PID of the JVM to attach. If not provided, attaches to all currently running JVMs which match the --exclude and --include filters.");

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -317,7 +317,7 @@ public class RemoteAttacher {
             out.println();
             out.println("    -i, --include <include_pattern>...");
             out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications or any Jvm  system property of the java process the java agent should be attached to.");
-            out.println("        (Matches the output of 'jps -l')");
+            out.println("        (Matches the output of 'jps -lv')");
             out.println("        Note: this is only available if jps is installed");
             out.println();
             out.println("    -a, --args <agent_arguments>");

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -312,11 +312,11 @@ public class RemoteAttacher {
             out.println();
             out.println("    -e, --exclude <exclude_pattern>...");
             out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications or any JVM system property of the java process the java agent should not be attached to.");
-            out.println("        (Matches the output of 'jps -l')");
+            out.println("        (Matches the output of 'jps -lv')");
             out.println("        Note: this is only available if jps is installed");
             out.println();
             out.println("    -i, --include <include_pattern>...");
-            out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications or any Jvm  system property of the java process the java agent should be attached to.");
+            out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications or any JVM system property of the java process the java agent should be attached to.");
             out.println("        (Matches the output of 'jps -lv')");
             out.println("        Note: this is only available if jps is installed");
             out.println();

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -311,7 +311,7 @@ public class RemoteAttacher {
             out.println("        If provided, this program continuously runs and attaches to all running and starting JVMs which match the --exclude and --include filters.");
             out.println();
             out.println("    -e, --exclude <exclude_pattern>...");
-            out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications or any Jvm  system property of the java process the java agent should not be attached to.");
+            out.println("        A list of regular expressions of fully qualified main class names or paths to JARs of applications or any JVM system property of the java process the java agent should not be attached to.");
             out.println("        (Matches the output of 'jps -l')");
             out.println("        Note: this is only available if jps is installed");
             out.println();

--- a/docs/setup-attach-cli.asciidoc
+++ b/docs/setup-attach-cli.asciidoc
@@ -108,7 +108,7 @@ java -jar apm-agent-attach-standalone.jar --list
 *-l, --list*::
 +
 --
-Lists all running JVMs. Same output as `jps -l`.
+Lists all running JVMs. Same output as `jps -lv`.
 --
 
 *-p, --pid <pid>*::
@@ -130,8 +130,8 @@ NOTE: This option cannot be used in conjunction with `--pid`
 *-e, --exclude <exclude_pattern>...*::
 +
 --
-A list of regular expressions of fully qualified main class names or paths to JARs of applications the java agent should not be attached to.
-(Matches the output of `jps -l`)
+A list of regular expressions of fully qualified main class names or paths to JARs of applications or any JVM system property of the java process the java agent should not be attached to.
+(Matches the output of `jps -lv`)
 
 NOTE: This option cannot be used in conjunction with `--pid` and requires the `jps` command to be installed
 --
@@ -139,8 +139,8 @@ NOTE: This option cannot be used in conjunction with `--pid` and requires the `j
 *-i, --include <include_pattern>...*::
 +
 --
-A list of regular expressions of fully qualified main class names or paths to JARs of applications the java agent should be attached to.
-(Matches the output of `jps -l`)
+A list of regular expressions of fully qualified main class names or paths to JARs of applications or any JVM system property of the java process the java agent should be attached to.
+(Matches the output of `jps -lv`)
 
 NOTE: This option cannot be used in conjunction with `--pid` and requires the `jps` command to be installed
 --


### PR DESCRIPTION
APM Agent attacher supports identifying target process either with PID or with name of main class/ path of the executing jar. It is common practice in in multiple applications to have same MainClass for multiple process with each process using different configuration files which are set as -D parameters while starting the process.

The existing property which holds Main Class name/ Path to the executing jar can hold the entire system properties for the jvm. This can be retrieved using "jps -lv".

It will continue to support existing properties i.e. main class name and path of executable jar along with support for any property/ config file name set in the -D properties.

- [x] Implement code

