### PR TITLE
Set stacktrace.abs_path

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -682,10 +682,21 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
         writeField("lineno", stacktrace.getLineNumber());
         int lastDotIndex = className.lastIndexOf('.');
         if (lastDotIndex > 0) {
-            writeField("abs_path", className.substring(0, lastDotIndex).replace('.', '/') + "/" + stacktrace.getFileName());
+            StringBuilder replaceBuilder = getReplaceBuilder();
+            replaceBuilder.append(className, 0, lastDotIndex);
+            replace(replaceBuilder, ".", "/", 0);
+            replaceBuilder.append("/");
+            replaceBuilder.append(stacktrace.getFileName());
+            writeField("abs_path", replaceBuilder);
         }
         serializeStackFrameModule(className);
         jw.writeByte(OBJECT_END);
+    }
+
+    private StringBuilder getReplaceBuilder() {
+        StringBuilder builder = this.replaceBuilder;
+        builder.setLength(0);
+        return builder;
     }
 
     private void serializeStackFrameModule(final String fullyQualifiedClassName) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -677,9 +677,14 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
         jw.writeByte(OBJECT_START);
         writeField("filename", stacktrace.getFileName());
         writeField("function", stacktrace.getMethodName());
-        writeField("library_frame", isLibraryFrame(stacktrace.getClassName()));
+        String className = stacktrace.getClassName();
+        writeField("library_frame", isLibraryFrame(className));
         writeField("lineno", stacktrace.getLineNumber());
-        serializeStackFrameModule(stacktrace.getClassName());
+        int lastDotIndex = className.lastIndexOf('.');
+        if (lastDotIndex > 0) {
+            writeField("abs_path", className.substring(0, lastDotIndex).replace('.', '/') + "/" + stacktrace.getFileName());
+        }
+        serializeStackFrameModule(className);
         jw.writeByte(OBJECT_END);
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -123,6 +123,7 @@ class DslJsonSerializerTest {
         assertThat(stackTraceElement.get("library_frame")).isNotNull();
         assertThat(stackTraceElement.get("lineno")).isNotNull();
         assertThat(stackTraceElement.get("module")).isNotNull();
+        assertThat(stackTraceElement.get("abs_path").textValue()).isEqualTo(stackTraceElement.get("module").textValue().replace('.', '/') + "/" + stackTraceElement.get("filename").textValue());
         assertThat(exception.get("type").textValue()).isEqualTo(Exception.class.getName());
         assertThat(errorTree.get("transaction").get("sampled").booleanValue()).isTrue();
         assertThat(errorTree.get("transaction").get("type").textValue()).isEqualTo("test-type");


### PR DESCRIPTION
To make the integration with the Code app easier, they need the `abs_path` of the stack frame. In Java it's impossible to determine the exact path within the root of the git repository, like `apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java` but based on the package name and file name, we can get something like `co/elastic/apm/agent/report/serialize/DslJsonSerializer.java`.

The question is if it's ok to put a relative path in `abs_path`.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] ~Update documentation~
- [ ] Update [CHANGELOG.md](CHANGELOG.md)
- [ ] ~Update [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~
- [ ] ~Added an API method or config option? Document in which version this will be introduced.~
