### PR TITLE
Avoid creating a temp agent file for each attachment

### DIFF
--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
@@ -167,7 +167,8 @@ public class ElasticApmAttacher {
         try (InputStream agentJar = resourceAsStream) {
             MessageDigest md = MessageDigest.getInstance("MD5");
             byte[] buffer = new byte[1024];
-            while (new DigestInputStream(agentJar, md).read(buffer) != -1) {}
+            DigestInputStream dis = new DigestInputStream(agentJar, md);
+            while (dis.read(buffer) != -1) {}
             return String.format("%032x", new BigInteger(1, md.digest()));
         }
     }

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
@@ -27,6 +27,7 @@ package co.elastic.apm.attach;
 import net.bytebuddy.agent.ByteBuddyAgent;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -151,6 +152,8 @@ public class ElasticApmAttacher {
                             out.write(buffer, 0, length);
                         }
                     }
+                } else if (!md5Hash(new FileInputStream(tempAgentJar)).equals(hash)) {
+                    throw new IllegalStateException("Invalid MD5 checksum of " + tempAgentJar + ". Please delete this file.");
                 }
                 return tempAgentJar;
             } catch (NoSuchAlgorithmException | IOException e) {

--- a/apm-agent-attach/src/test/java/co/elastic/apm/attach/ElasticApmAttacherTest.java
+++ b/apm-agent-attach/src/test/java/co/elastic/apm/attach/ElasticApmAttacherTest.java
@@ -1,0 +1,39 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.attach;
+
+import org.junit.jupiter.api.Test;
+import wiremock.org.apache.commons.codec.digest.DigestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ElasticApmAttacherTest {
+
+    @Test
+    void testHash() throws Exception {
+        assertThat(ElasticApmAttacher.md5Hash(getClass().getResourceAsStream(ElasticApmAttacher.class.getSimpleName() + ".class")))
+            .isEqualTo(DigestUtils.md5Hex(getClass().getResourceAsStream(ElasticApmAttacher.class.getSimpleName() + ".class")));
+    }
+}


### PR DESCRIPTION
Currently, every time the attacher is executed, it extracts a temp jar file for the agent. This PR attaches a MD5 checksum to the agent's file name. If a file with the same checksum is found, it's used instead of extracting the file again.

This avoids filling the disk with lots of agent jars.