### PR TITLE
Fix javadoc errors

### DIFF
--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -139,7 +139,6 @@
                                         <Can-Redefine-Classes>true</Can-Redefine-Classes>
                                         <Can-Retransform-Classes>true</Can-Retransform-Classes>
                                         <Can-Set-Native-Method-Prefix>true</Can-Set-Native-Method-Prefix>
-                                        <Automatic-Module-Name>${project.groupId}.agent</Automatic-Module-Name>
                                     </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />


### PR DESCRIPTION
Executing `mvn clean package -DskipTests` yields in the following error:

```
[ERROR] Creating an aggregated report for both named and unnamed modules is not possible.
[ERROR] Ensure that every module has a module descriptor or is a jar with a MANIFEST.MF containing an Automatic-Module-Name.
[ERROR] Fix the following projects:
[ERROR]  - co.elastic.apm:apm-hibernate-search-plugin-5_x
[ERROR]  - co.elastic.apm:apm-hibernate-search-plugin-6_x
[ERROR]  - co.elastic.apm:apm-es-restclient-plugin-5_6
[ERROR]  - co.elastic.apm:apm-es-restclient-plugin-6_4
...
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-javadoc-plugin:3.1.0:jar (default) on project elastic-apm-agent: MavenReportException: Error while generating Javadoc: Aggregator report contains named and unnamed modules -> [Help 1]
```

I'm really confused why we didn't notice this earlier and why it's not a problem on CI.

I don't think we need a module name for the agent jar as it's not used as a dependency.