### PR TITLE
Add instructions to update documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,6 +223,16 @@ See [`apm-agent-core/README.md`](apm-agent-core/README.md)
 
 See [`apm-agent-plugins/README.md`](apm-agent-plugins/README.md)
 
+### Documenting
+
+Documentation is generated text files stored in `docs` folder using [AsciiDoc](http://asciidoc.org/) format.
+The ``configuration.asciidoc`` file is generated from running `co.elastic.apm.agent.configuration.ConfigurationExporterTest`.
+
+A preview of documentation is generated for each pull-request.
+
+In order to generate a local copy of agent documentation, you will need to clone [docs](https://github.com/elastic/docs) repository
+and follow [those instructions](https://github.com/elastic/docs#for-a-local-repo).
+
 ### Releasing
 
 If you have access to make releases, the process is as follows:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,8 +225,9 @@ See [`apm-agent-plugins/README.md`](apm-agent-plugins/README.md)
 
 ### Documenting
 
-Documentation is generated text files stored in `docs` folder using [AsciiDoc](http://asciidoc.org/) format.
-The ``configuration.asciidoc`` file is generated from running `co.elastic.apm.agent.configuration.ConfigurationExporterTest`.
+HTML Documentation is generated from text files stored in `docs` folder using [AsciiDoc](http://asciidoc.org/) format.
+The ``configuration.asciidoc`` file is generated from running `co.elastic.apm.agent.configuration.ConfigurationExporterTest`,
+all the other asciidoc text files are written manually.
 
 A preview of the documentation is generated for each pull-request.
 Click on the build `Details` of the `elasticsearch-ci/docs` job and go to the bottom of the `Console Output` to see the link.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,7 +228,8 @@ See [`apm-agent-plugins/README.md`](apm-agent-plugins/README.md)
 Documentation is generated text files stored in `docs` folder using [AsciiDoc](http://asciidoc.org/) format.
 The ``configuration.asciidoc`` file is generated from running `co.elastic.apm.agent.configuration.ConfigurationExporterTest`.
 
-A preview of documentation is generated for each pull-request.
+A preview of the documentation is generated for each pull-request.
+Click on the build `Details` of the `elasticsearch-ci/docs` job and go to the bottom of the `Console Output` to see the link.
 
 In order to generate a local copy of agent documentation, you will need to clone [docs](https://github.com/elastic/docs) repository
 and follow [those instructions](https://github.com/elastic/docs#for-a-local-repo).


### PR DESCRIPTION
Instructions on how to update and build documentation were missing into `CONTRIBUTING.MD`.