### PR TITLE
Add service.node.configured_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-# Next
+# 1.11.0 (Next)
 
 ## Features
+ * Add the ability to configure a unique name for a JVM within a service through the [`service_node_name` config option](
+ https://www.elastic.co/guide/en/apm/agent/java/master/config-core.html#config-service-node-name) (#872)
 
 ## Bug Fixes
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -54,6 +54,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
     public static final String ACTIVE = "active";
     public static final String INSTRUMENT = "instrument";
     public static final String SERVICE_NAME = "service_name";
+    public static final String SERVICE_NODE_NAME = "service_node_name";
     public static final String SAMPLE_RATE = "transaction_sample_rate";
     private static final String CORE_CATEGORY = "Core";
     public static final String DEFAULT_CONFIG_FILE = AGENT_HOME_PLACEHOLDER + "/elasticapm.properties";
@@ -106,6 +107,23 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .addValidator(RegexValidator.of("^[a-zA-Z0-9 _-]+$", "Your service name \"{0}\" must only contain characters " +
             "from the ASCII alphabet, numbers, dashes, underscores and spaces"))
         .buildWithDefault(ServiceNameUtil.getDefaultServiceName());
+
+    private final ConfigurationOption<String> serviceNodeName = ConfigurationOption.stringOption()
+        .key(SERVICE_NODE_NAME)
+        .configurationCategory(CORE_CATEGORY)
+        .label("A unique name for the service node")
+        .description("If set, this name is used to distinguish between different nodes of a service, \n" +
+            "therefore it should be unique for each JVM within a service. \n" +
+            "If not set, data aggregations will be done based on a container ID (where valid) or on \n" +
+            "the reported hostname (automatically discovered or manually configured through <<config-hostname>>). \n" +
+            "\n" +
+            "NOTE: JVM metrics views rely on aggregations that are based on the service node name. \n" +
+            "If you have multiple JVMs installed on the same host reporting data for the same service name, \n" +
+            "you must set a unique node name for each in order to view metrics at the JVM level.\n" +
+            "\n" +
+            "NOTE: Metrics views can utilize this configuration since APM Server 7.5")
+        .tags("added[1.11.0]")
+        .build();
 
     private final ConfigurationOption<String> serviceVersion = ConfigurationOption.stringOption()
         .key("service_version")
@@ -422,6 +440,15 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
 
     public ConfigurationOption<String> getServiceNameConfig() {
         return serviceName;
+    }
+
+    @Nullable
+    public String getServiceNodeName() {
+        String nodeName = serviceNodeName.get();
+        if (nodeName == null || nodeName.trim().isEmpty()) {
+            return null;
+        }
+        return nodeName;
     }
 
     public String getServiceVersion() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -114,8 +114,8 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .label("A unique name for the service node")
         .description("If set, this name is used to distinguish between different nodes of a service, \n" +
             "therefore it should be unique for each JVM within a service. \n" +
-            "If not set, data aggregations will be done based on a container ID (where valid) or on \n" +
-            "the reported hostname (automatically discovered or manually configured through <<config-hostname>>). \n" +
+            "If not set, data aggregations will be done based on a container ID (where valid) or on the reported \n" +
+            "hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>). \n" +
             "\n" +
             "NOTE: JVM metrics views rely on aggregations that are based on the service node name. \n" +
             "If you have multiple JVMs installed on the same host reporting data for the same service name, \n" +

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/Node.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/Node.java
@@ -1,0 +1,53 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.impl.payload;
+
+import javax.annotation.Nullable;
+
+/**
+ * A representation of a service node, ie JVM
+ */
+public class Node {
+
+    /**
+     * (Optional)
+     * A name representing this JVM. Should be unique within the service.
+     */
+    @Nullable
+    private final String name;
+
+    public Node(@Nullable String name) {
+        this.name = name;
+    }
+
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    public boolean hasContents() {
+        return name != null && !name.isEmpty();
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/Service.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/Service.java
@@ -50,6 +50,11 @@ public class Service {
     @Nullable
     private Language language;
     /**
+     * Representation of a service node
+     */
+    @Nullable
+    private Node node;
+    /**
      * Immutable name of the service emitting this event
      * (Required)
      */
@@ -118,6 +123,22 @@ public class Service {
      */
     public Service withLanguage(Language language) {
         this.language = language;
+        return this;
+    }
+
+    /**
+     * Representation of a service node
+     */
+    @Nullable
+    public Node getNode() {
+        return node;
+    }
+
+    /**
+     * Representation of a service node
+     */
+    public Service withNode(Node node) {
+        this.node = node;
         return this;
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/ServiceFactory.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/ServiceFactory.java
@@ -38,7 +38,8 @@ public class ServiceFactory {
             .withEnvironment(coreConfiguration.getEnvironment())
             .withAgent(new Agent("java", getAgentVersion()))
             .withRuntime(new RuntimeInfo("Java", System.getProperty("java.version")))
-            .withLanguage(new Language("Java", System.getProperty("java.version")));
+            .withLanguage(new Language("Java", System.getProperty("java.version")))
+            .withNode(new Node(coreConfiguration.getServiceNodeName()));
         if (frameworkName != null && frameworkVersion != null) {
             service.withFramework(new Framework(frameworkName, frameworkVersion));
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -38,6 +38,7 @@ import co.elastic.apm.agent.impl.error.ErrorPayload;
 import co.elastic.apm.agent.impl.payload.Agent;
 import co.elastic.apm.agent.impl.payload.Framework;
 import co.elastic.apm.agent.impl.payload.Language;
+import co.elastic.apm.agent.impl.payload.Node;
 import co.elastic.apm.agent.impl.payload.Payload;
 import co.elastic.apm.agent.impl.payload.ProcessInfo;
 import co.elastic.apm.agent.impl.payload.RuntimeInfo;
@@ -398,6 +399,11 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
             serializeLanguage(language);
         }
 
+        final Node node = service.getNode();
+        if (node != null && node.hasContents()) {
+            serializeNode(node);
+        }
+
         final RuntimeInfo runtime = service.getRuntime();
         if (runtime != null) {
             serializeRuntime(runtime);
@@ -431,6 +437,14 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
         jw.writeByte(JsonWriter.OBJECT_START);
         writeField("name", language.getName());
         writeLastField("version", language.getVersion());
+        jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(COMMA);
+    }
+
+    private void serializeNode(final Node node) {
+        writeFieldName("node");
+        jw.writeByte(JsonWriter.OBJECT_START);
+        writeLastField("configured_name", node.getName());
         jw.writeByte(JsonWriter.OBJECT_END);
         jw.writeByte(COMMA);
     }

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -211,12 +211,13 @@ If the service name is set explicitly, it overrides all of the above.
 ==== `service_node_name` (added[1.11.0])
 
 If set, this name is used to distinguish between different nodes of a service, therefore it should be unique for each JVM within a service.
-If not set, data aggregations will be done based on a container ID (where valid) or on the reported hostname (automatically discovered or manually configured through <<config-hostname>>).
+If not set, data aggregations will be done based on a container ID (where valid) or on the reported hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>).
 
 NOTE: JVM metrics views rely on aggregations that are based on the service node name.
 If you have multiple JVMs installed on the same host reporting data for the same service name, you must set a unique node name for each in order to view metrics at the JVM level.
 
 NOTE: Metrics views can utilize this configuration since APM Server 7.5
+
 
 [options="header"]
 |============
@@ -1503,8 +1504,8 @@ The default unit for this option is `ms`
 #
 # If set, this name is used to distinguish between different nodes of a service, 
 # therefore it should be unique for each JVM within a service. 
-# If not set, data aggregations will be done based on a container ID (where valid) or on 
-# the reported hostname (automatically discovered or manually configured through <<config-hostname>>). 
+# If not set, data aggregations will be done based on a container ID (where valid) or on the reported 
+# hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>). 
 # 
 # NOTE: JVM metrics views rely on aggregations that are based on the service node name. 
 # If you have multiple JVMs installed on the same host reporting data for the same service name, 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -64,6 +64,7 @@ Click on a key to get more information.
 ** <<config-active>>
 ** <<config-instrument>>
 ** <<config-service-name>>
+** <<config-service-node-name>>
 ** <<config-service-version>>
 ** <<config-hostname>>
 ** <<config-environment>>
@@ -203,6 +204,30 @@ If the service name is set explicitly, it overrides all of the above.
 |============
 | Java System Properties      | Property file   | Environment
 | `elastic.apm.service_name` | `service_name` | `ELASTIC_APM_SERVICE_NAME`
+|============
+
+[float]
+[[config-service-node-name]]
+==== `service_node_name` (added[1.11.0])
+
+If set, this name is used to distinguish between different nodes of a service, therefore it should be unique for each JVM within a service.
+If not set, data aggregations will be done based on a container ID (where valid) or on the reported hostname (automatically discovered or manually configured through <<config-hostname>>).
+
+NOTE: JVM metrics views rely on aggregations that are based on the service node name.
+If you have multiple JVMs installed on the same host reporting data for the same service name, you must set a unique node name for each in order to view metrics at the JVM level.
+
+NOTE: Metrics views can utilize this configuration since APM Server 7.5
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `<none>` | String | false
+|============
+
+[options="header"]
+|============
+| Java System Properties      | Property file   | Environment
+| `elastic.apm.service_node_name` | `service_node_name` | `ELASTIC_APM_SERVICE_NODE_NAME`
 |============
 
 [float]
@@ -1473,6 +1498,25 @@ The default unit for this option is `ms`
 # 
 #
 # service_name=
+
+# A unique name for the service node
+#
+# If set, this name is used to distinguish between different nodes of a service, 
+# therefore it should be unique for each JVM within a service. 
+# If not set, data aggregations will be done based on a container ID (where valid) or on 
+# the reported hostname (automatically discovered or manually configured through <<config-hostname>>). 
+# 
+# NOTE: JVM metrics views rely on aggregations that are based on the service node name. 
+# If you have multiple JVMs installed on the same host reporting data for the same service name, 
+# you must set a unique node name for each in order to view metrics at the JVM level.
+# 
+# NOTE: Metrics views can utilize this configuration since APM Server 7.5
+#
+# This setting can not be changed at runtime. Changes require a restart of the application.
+# Type: String
+# Default value: 
+#
+# service_node_name=
 
 # A version string for the currently deployed version of the service. If you don’t version your deployments, the recommended value for this field is the commit identifier of the deployed revision, e.g. the output of git rev-parse HEAD.
 #

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -14,6 +14,12 @@ You can adjust the interval with the setting <<config-metrics-interval>>.
 
 The metrics will be stored in the `apm-*` index and have the `processor.event` property set to `metric`.
 
+NOTE: Dedicated JVM metrics views are available since Elastic stack version 7.1.
+Since 7.5, metrics are aggregated separately for each JVM, relying on the ID of the underlying system- either container ID (where applicable) or hostname.
+Since Java agent version 1.11.0, it is possible to manually configure a unique name for each service node/JVM through
+<<config-service-node-name>>.
+When multiple JVMs are running on the same host and report data for the same service, this configuration is required in order to be able to view metrics at the JVM level.
+
 [float]
 [[metrics-system]]
 === System metrics

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -14,10 +14,10 @@ You can adjust the interval with the setting <<config-metrics-interval>>.
 
 The metrics will be stored in the `apm-*` index and have the `processor.event` property set to `metric`.
 
-NOTE: Dedicated JVM metrics views are available since Elastic stack version 7.1.
-Since 7.5, metrics are aggregated separately for each JVM, relying on the ID of the underlying system- either container ID (where applicable) or hostname.
-Since Java agent version 1.11.0, it is possible to manually configure a unique name for each service node/JVM through
-<<config-service-node-name>>.
+NOTE: Dedicated JVM metrics views are available since Elastic stack version 7.2.
+Starting in 7.5, metrics are aggregated separately for each JVM, relying on the ID of the underlying system -- either container ID (where applicable) or hostname.
+Starting in Java agent version 1.11.0, it is possible to manually configure a unique name for each service node/JVM through
+<<config-service-node-name, `service_node_name`>>.
 When multiple JVMs are running on the same host and report data for the same service, this configuration is required in order to be able to view metrics at the JVM level.
 
 [float]

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -10,7 +10,7 @@ The Java agent tracks certain system and application metrics.
 Some of them have built-in visualizations and some can only be visualized with custom Kibana dashboards.
 
 These metrics will be sent regularly to the APM Server and from there to Elasticsearch.
-You can adjust the interval with the setting <<config-metrics-interval>>.
+You can adjust the interval with the setting <<config-metrics-interval, `metrics_interval`>>.
 
 The metrics will be stored in the `apm-*` index and have the `processor.event` property set to `metric`.
 


### PR DESCRIPTION
Closes elastic/apm-agent-java#843 

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Update [CHANGELOG.md](CHANGELOG.md)
- [x] Manually test with server that `service.node.name` gets populated as expected
- [x] Added an API method or config option? Document in which version this will be introduced.
