### PR TITLE
Configurable ignored exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next
 
 ## Features
+ * Add ability to ignore some exceptions to be reported as errors [ignore_exceptions](https://www.elastic.co/guide/en/apm/agent/java/master/config-core.html#config-ignore_exceptions)
 
 ## Bug Fixes
 
@@ -11,20 +12,20 @@
  * Add support for [Redis Jedis client](https://www.elastic.co/guide/en/apm/agent/java/master/supported-technologies-details.html#supported-databases)
  * Add support for identifying target JVM to attach apm agent to using JMV property. See also the documentation of the [`--include` and `--exclude` flags](https://www.elastic.co/guide/en/apm/agent/java/master/setup-attach-cli.html#setup-attach-cli-usage-list)
  * Added [`capture_jmx_metrics`](https://www.elastic.co/guide/en/apm/agent/java/master/config-jmx.html#config-capture-jmx-metrics) configuration option
-* Improve servlet error capture (#812)
+ * Improve servlet error capture (#812)
   Among others, now also takes Spring MVC `@ExceptionHandler`s into account 
-* Instrument Logger#error(String, Throwable) (#821)
+ * Instrument Logger#error(String, Throwable) (#821)
   Automatically captures exceptions when calling `logger.error("message", exception)`
-* Easier log correlation with https://github.com/elastic/java-ecs-logging. See [docs](https://www.elastic.co/guide/en/apm/agent/java/master/log-correlation.html).
-* Avoid creating a temp agent file for each attachment (#859)
-* Instrument `View#render` instead of `DispatcherServlet#render` (#829)
+ * Easier log correlation with https://github.com/elastic/java-ecs-logging. See [docs](https://www.elastic.co/guide/en/apm/agent/java/master/log-correlation.html).
+ * Avoid creating a temp agent file for each attachment (#859)
+ * Instrument `View#render` instead of `DispatcherServlet#render` (#829)
   This makes the transaction breakdown graph more useful. Instead of `dispatcher-servlet`, the graph now shows a type which is based on the view name, for example, `FreeMarker` or `Thymeleaf`.
 
 ## Bug Fixes
  * Error in log when setting [server_urls](https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html#config-server-urls) 
  to an empty string - `co.elastic.apm.agent.configuration.ApmServerConfigurationSource - Expected previousException not to be null`
-* Avoid terminating the TCP connection to APM Server when polling for configuration updates (#823)
-* Fixes potential segfault if attaching the agent with long arguments (#865)
+ * Avoid terminating the TCP connection to APM Server when polling for configuration updates (#823)
+ * Fixes potential segfault if attaching the agent with long arguments (#865)
  
 # 1.9.0
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -233,8 +233,13 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .description("A list of exceptions that should be ignored and not reported as errors.\n" +
             "This allows to ignore exceptions thrown in regular control flow that are not actual errors\n" +
             "\n" +
-            "This list supports wildcards patterns, thus using exception class qualified name is not required\n" +
-            "For example `com.mycompany.ExceptionToIgnore` could be shortened to `*ExceptionToIgnore`." +
+            WildcardMatcher.DOCUMENTATION + "\n" +
+            "\n" +
+            "Examples, all of them are equivalent:\n" +
+            "\n" +
+            " - `com.mycompany.ExceptionToIgnore`: using fully qualified name\n" +
+            " - `*ExceptionToIgnore`: using wildcard to avoid package name\n" +
+            " - `*exceptiontoignore`: case-insensitive by default\n" +
             "\n" +
             "NOTE: Exception inheritance is not supported, thus you have to explicitly list all the thrown exception types"
         )

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -233,7 +233,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .description("A list of exceptions that should be ignored and not reported as errors.\n" +
             "This allows to ignore exceptions thrown in regular control flow that are not actual errors")
         .dynamic(true)
-        .buildWithDefault(Collections.emptyList());
+        .buildWithDefault(Collections.<WildcardMatcher>emptyList());
 
     private final ConfigurationOption<Map<String, String>> globalLabels = ConfigurationOption
         .builder(new MapValueConverter<String, String>(StringValueConverter.INSTANCE, StringValueConverter.INSTANCE, "=", ","), Map.class)

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -56,8 +56,9 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
     public static final String SERVICE_NAME = "service_name";
     public static final String SAMPLE_RATE = "transaction_sample_rate";
     private static final String CORE_CATEGORY = "Core";
-    public static final String DEFAULT_CONFIG_FILE = AGENT_HOME_PLACEHOLDER + "/elasticapm.properties";
+    private static final String DEFAULT_CONFIG_FILE = AGENT_HOME_PLACEHOLDER + "/elasticapm.properties";
     public static final String CONFIG_FILE = "config_file";
+
     private final ConfigurationOption<Boolean> active = ConfigurationOption.booleanOption()
         .key(ACTIVE)
         .configurationCategory(CORE_CATEGORY)
@@ -114,7 +115,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "the recommended value for this field is the commit identifier of the deployed revision, " +
             "e.g. the output of git rev-parse HEAD.")
         .build();
-    
+
     private final ConfigurationOption<String> hostname = ConfigurationOption.stringOption()
         .key("hostname")
         .tags("added[1.10.0]")
@@ -344,7 +345,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "<<config-span-frames-min-duration, `span_frames_min_duration`>>.\n" +
             "When tracing a large number of methods (for example by using wildcards),\n" +
             "this may lead to high overhead.\n" +
-            "Consider increasing the threshold or disabling stack trace collection altogether.\n\n" + 
+            "Consider increasing the threshold or disabling stack trace collection altogether.\n\n" +
             "Common configurations:\n\n" +
             "Trace all public methods in CDI-Annotated beans:\n\n" +
             "----\n" +
@@ -441,7 +442,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
     public String getHostname() {
         return hostname.get();
     }
-    
+
     public String getEnvironment() {
         return environment.get();
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -231,7 +231,13 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .tags("added[1.11.0]")
         .configurationCategory(CORE_CATEGORY)
         .description("A list of exceptions that should be ignored and not reported as errors.\n" +
-            "This allows to ignore exceptions thrown in regular control flow that are not actual errors")
+            "This allows to ignore exceptions thrown in regular control flow that are not actual errors\n" +
+            "\n" +
+            "This list supports wildcards patterns, thus using exception class qualified name is not required\n" +
+            "For example `com.mycompany.ExceptionToIgnore` could be shortened to `*ExceptionToIgnore`." +
+            "\n" +
+            "NOTE: Exception inheritance is not supported, thus you have to explicitly list all the thrown exception types"
+        )
         .dynamic(true)
         .buildWithDefault(Collections.<WildcardMatcher>emptyList());
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -253,7 +253,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "\n" +
             WildcardMatcher.DOCUMENTATION + "\n" +
             "\n" +
-            "Examples, all of them are equivalent:\n" +
+            "Examples:\n" +
             "\n" +
             " - `com.mycompany.ExceptionToIgnore`: using fully qualified name\n" +
             " - `*ExceptionToIgnore`: using wildcard to avoid package name\n" +

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -224,6 +224,16 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .dynamic(true)
         .buildWithDefault(Collections.singletonList(WildcardMatcher.valueOf("(?-i)*Nested*Exception")));
 
+    private final ConfigurationOption<List<WildcardMatcher>> ignoreExceptions = ConfigurationOption
+        .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)
+        .key("ignore_exceptions")
+        .tags("added[1.11.0]")
+        .configurationCategory(CORE_CATEGORY)
+        .description("A list of exceptions that should be ignored and not reported as errors.\n" +
+            "This allows to ignore exceptions thrown in regular control flow that are not actual errors")
+        .dynamic(true)
+        .buildWithDefault(Collections.emptyList());
+
     private final ConfigurationOption<Map<String, String>> globalLabels = ConfigurationOption
         .builder(new MapValueConverter<String, String>(StringValueConverter.INSTANCE, StringValueConverter.INSTANCE, "=", ","), Map.class)
         .key("global_labels")
@@ -454,6 +464,10 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
 
     public List<WildcardMatcher> getUnnestExceptions() {
         return unnestExceptions.get();
+    }
+
+    public List<WildcardMatcher> getIgnoreExceptions(){
+        return ignoreExceptions.get();
     }
 
     public boolean isTypePoolCacheEnabled() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -40,6 +40,7 @@ import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
 import co.elastic.apm.agent.impl.transaction.Transaction;
+import co.elastic.apm.agent.matcher.WildcardMatcher;
 import co.elastic.apm.agent.metrics.MetricRegistry;
 import co.elastic.apm.agent.objectpool.Allocator;
 import co.elastic.apm.agent.objectpool.ObjectPool;
@@ -357,7 +358,7 @@ public class ElasticApmTracer {
     }
 
     public void captureException(long epochMicros, @Nullable Throwable e, @Nullable TraceContextHolder<?> parent, @Nullable ClassLoader initiatingClassLoader) {
-        if (e != null) {
+        if (e != null && !WildcardMatcher.isAnyMatch(coreConfiguration.getIgnoreExceptions(), e.getClass().getName())) {
             ErrorCapture error = errorPool.createInstance();
             error.withTimestamp(epochMicros);
             error.setException(e);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -358,6 +358,7 @@ public class ElasticApmTracer {
     }
 
     public void captureException(long epochMicros, @Nullable Throwable e, @Nullable TraceContextHolder<?> parent, @Nullable ClassLoader initiatingClassLoader) {
+        // note: if we add inheritance support for exception filtering, caching would be required for performance
         if (e != null && !WildcardMatcher.isAnyMatch(coreConfiguration.getIgnoreExceptions(), e.getClass().getName())) {
             ErrorCapture error = errorPool.createInstance();
             error.withTimestamp(epochMicros);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/matcher/WildcardMatcher.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/matcher/WildcardMatcher.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/matcher/WildcardMatcher.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/matcher/WildcardMatcher.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -134,11 +134,11 @@ public abstract class WildcardMatcher {
     }
 
     /**
-     * Returns the first {@link WildcardMatcher} {@linkplain WildcardMatcher#matches(String) matching} the provided string.
+     * Returns {@code true}, if any of the matchers match the provided string.
      *
      * @param matchers the matchers which should be used to match the provided string
      * @param s        the string to match against
-     * @return the first matching {@link WildcardMatcher}, or {@code null} if none match.
+     * @return {@code true}, if any of the matchers match the provided string
      */
     @Nullable
     public static boolean isAnyMatch(List<WildcardMatcher> matchers, @Nullable String s) {
@@ -146,11 +146,11 @@ public abstract class WildcardMatcher {
     }
 
     /**
-     * Returns {@code true}, if any of the matchers match the provided string.
+     * Returns the first {@link WildcardMatcher} {@linkplain WildcardMatcher#matches(String) matching} the provided string.
      *
      * @param matchers the matchers which should be used to match the provided string
      * @param s        the string to match against
-     * @return {@code true}, if any of the matchers match the provided string
+     * @return the first matching {@link WildcardMatcher}, or {@code null} if none match.
      */
     @Nullable
     public static WildcardMatcher anyMatch(List<WildcardMatcher> matchers, @Nullable String s) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/SpyConfiguration.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/SpyConfiguration.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/SpyConfiguration.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/SpyConfiguration.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *   http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -57,7 +57,7 @@ public class SpyConfiguration {
      * <p>
      * That way, the default configuration values are returned but can be overridden by {@link org.mockito.Mockito#when(Object)}
      *
-     * @return a syp configuration registry
+     * @return a spy configuration registry
      * @param configurationSource
      */
     public static ConfigurationRegistry createSpyConfig(ConfigurationSource configurationSource) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -180,18 +180,6 @@ class ElasticApmTracerTest {
     }
 
     @Test
-    void testDoesNotIgnoreExceptionsWithEmptyWildcards(){
-        DummyException1 exception = new DummyException1();
-
-        when(config.getConfig(CoreConfiguration.class).getIgnoreExceptions())
-            .thenReturn(Lists.emptyList());
-
-        tracerImpl.captureException(exception, getClass().getClassLoader());
-        assertThat(reporter.getErrors()).hasSize(1);
-        assertThat(reporter.getFirstError().getException()).isEqualTo(exception);
-    }
-
-    @Test
     void testDoesNotRecordIgnoredExceptions() {
         List<WildcardMatcher> wildcardList = Stream.of(
             "co.elastic.apm.agent.impl.ElasticApmTracerTest$DummyException1",

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -72,6 +72,7 @@ Click on a key to get more information.
 ** <<config-sanitize-field-names>>
 ** <<config-disable-instrumentations>>
 ** <<config-unnest-exceptions>>
+** <<config-ignore-exceptions>>
 ** <<config-global-labels>>
 ** <<config-trace-methods>>
 ** <<config-trace-methods-duration-threshold>>
@@ -402,6 +403,27 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 |============
 | Java System Properties      | Property file   | Environment
 | `elastic.apm.unnest_exceptions` | `unnest_exceptions` | `ELASTIC_APM_UNNEST_EXCEPTIONS`
+|============
+
+[float]
+[[config-ignore-exceptions]]
+==== `ignore_exceptions` (added[1.11.0])
+
+A list of exceptions that should be ignored and not reported as errors.
+This allows to ignore exceptions thrown in regular control flow that are not actual errors
+
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `<none>` | List | true
+|============
+
+
+[options="header"]
+|============
+| Java System Properties      | Property file   | Environment
+| `elastic.apm.ignore_exceptions` | `ignore_exceptions` | `ELASTIC_APM_IGNORE_EXCEPTIONS`
 |============
 
 [float]
@@ -1576,6 +1598,15 @@ The default unit for this option is `ms`
 # Default value: (?-i)*Nested*Exception
 #
 # unnest_exceptions=(?-i)*Nested*Exception
+
+# A list of exceptions that should be ignored and not reported as errors.
+# This allows to ignore exceptions thrown in regular control flow that are not actual errors
+#
+# This setting can be changed at runtime
+# Type: comma separated list
+# Default value: 
+#
+# ignore_exceptions=
 
 # Labels added to all events, with the format `key=value[,key=value[,...]]`.
 # Any labels set by application via the API will override global labels with the same keys.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -211,11 +211,14 @@ If the service name is set explicitly, it overrides all of the above.
 [[config-service-node-name]]
 ==== `service_node_name` (added[1.11.0])
 
-If set, this name is used to distinguish between different nodes of a service, therefore it should be unique for each JVM within a service.
-If not set, data aggregations will be done based on a container ID (where valid) or on the reported hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>).
+If set, this name is used to distinguish between different nodes of a service, 
+therefore it should be unique for each JVM within a service. 
+If not set, data aggregations will be done based on a container ID (where valid) or on the reported 
+hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>). 
 
-NOTE: JVM metrics views rely on aggregations that are based on the service node name.
-If you have multiple JVMs installed on the same host reporting data for the same service name, you must set a unique node name for each in order to view metrics at the JVM level.
+NOTE: JVM metrics views rely on aggregations that are based on the service node name. 
+If you have multiple JVMs installed on the same host reporting data for the same service name, 
+you must set a unique node name for each in order to view metrics at the JVM level.
 
 NOTE: Metrics views can utilize this configuration since APM Server 7.5
 
@@ -225,6 +228,7 @@ NOTE: Metrics views can utilize this configuration since APM Server 7.5
 | Default                          | Type                | Dynamic
 | `<none>` | String | false
 |============
+
 
 [options="header"]
 |============

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -412,6 +412,10 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 A list of exceptions that should be ignored and not reported as errors.
 This allows to ignore exceptions thrown in regular control flow that are not actual errors
 
+This list supports wildcards patterns, thus using exception class qualified name is not required
+For example `com.mycompany.ExceptionToIgnore` could be shortened to `*ExceptionToIgnore`.
+NOTE: Exception inheritance is not supported, thus you have to explicitly list all the thrown exception types
+
 
 [options="header"]
 |============
@@ -1601,6 +1605,10 @@ The default unit for this option is `ms`
 
 # A list of exceptions that should be ignored and not reported as errors.
 # This allows to ignore exceptions thrown in regular control flow that are not actual errors
+# 
+# This list supports wildcards patterns, thus using exception class qualified name is not required
+# For example `com.mycompany.ExceptionToIgnore` could be shortened to `*ExceptionToIgnore`.
+# NOTE: Exception inheritance is not supported, thus you have to explicitly list all the thrown exception types
 #
 # This setting can be changed at runtime
 # Type: comma separated list

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -412,8 +412,17 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 A list of exceptions that should be ignored and not reported as errors.
 This allows to ignore exceptions thrown in regular control flow that are not actual errors
 
-This list supports wildcards patterns, thus using exception class qualified name is not required
-For example `com.mycompany.ExceptionToIgnore` could be shortened to `*ExceptionToIgnore`.
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive by default.
+Prepending an element with `(?-i)` makes the matching case sensitive.
+
+Examples:
+
+ - `com.mycompany.ExceptionToIgnore`: using fully qualified name
+ - `*ExceptionToIgnore`: using wildcard to avoid package name
+ - `*exceptiontoignore`: case-insensitive by default
+
 NOTE: Exception inheritance is not supported, thus you have to explicitly list all the thrown exception types
 
 
@@ -1606,8 +1615,17 @@ The default unit for this option is `ms`
 # A list of exceptions that should be ignored and not reported as errors.
 # This allows to ignore exceptions thrown in regular control flow that are not actual errors
 # 
-# This list supports wildcards patterns, thus using exception class qualified name is not required
-# For example `com.mycompany.ExceptionToIgnore` could be shortened to `*ExceptionToIgnore`.
+# This option supports the wildcard `*`, which matches zero or more characters.
+# Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+# Matching is case insensitive by default.
+# Prepending an element with `(?-i)` makes the matching case sensitive.
+# 
+# Examples:
+# 
+#  - `com.mycompany.ExceptionToIgnore`: using fully qualified name
+#  - `*ExceptionToIgnore`: using wildcard to avoid package name
+#  - `*exceptiontoignore`: case-insensitive by default
+# 
 # NOTE: Exception inheritance is not supported, thus you have to explicitly list all the thrown exception types
 #
 # This setting can be changed at runtime


### PR DESCRIPTION
closes elastic/apm-agent-java#762

Adds a new configuration parameter `ignore_exceptions` that contains a list of wildcard patterns of exceptions that should be ignored by the agent and not considered as errors.

### Checklist

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Update [CHANGELOG.md](CHANGELOG.md)
- [ ] ~~Update [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- [x] Added an API method or config option? Document in which version this will be introduced.
