### PR TITLE
Report exception cause to backend

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorPayload.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorPayload.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,7 +39,10 @@ import java.util.List;
  * Errors payload
  * <p>
  * List of errors wrapped in an object containing some other attributes normalized away from the errors themselves
+ *
+ * @deprecated part of v1 intake protocol
  */
+@Deprecated
 public class ErrorPayload extends Payload {
 
     /**

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/Payload.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/Payload.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -28,6 +28,10 @@ import co.elastic.apm.agent.objectpool.Recyclable;
 
 import java.util.List;
 
+/**
+ * @deprecated part of v1 intake protocol
+ */
+@Deprecated
 public abstract class Payload implements Recyclable {
     /**
      * Service

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/TransactionPayload.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/TransactionPayload.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -37,7 +37,10 @@ import java.util.List;
  * Transactions payload
  * <p>
  * List of transactions wrapped in an object containing some other attributes normalized away from the transactions themselves
+ *
+ * @deprecated part of v1 intake protocol
  */
+@Deprecated
 public class TransactionPayload extends Payload {
 
     /**

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -310,7 +310,7 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
             writeStringValue(exception.getClass().getName());
 
             Throwable cause = exception.getCause();
-            if(cause != null) {
+            if (cause != null) {
                 jw.writeByte(COMMA);
                 writeFieldName("cause");
                 jw.writeByte(ARRAY_START);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -143,21 +143,6 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
     }
 
     @Override
-    public void serializePayload(final OutputStream os, final Payload payload) {
-        if (logger.isTraceEnabled()) {
-            logger.trace(toJsonString(payload));
-        }
-        jw.reset(os);
-        if (payload instanceof TransactionPayload) {
-            serializeTransactionPayload((TransactionPayload) payload);
-        } else if (payload instanceof ErrorPayload) {
-            serializeErrorPayload((ErrorPayload) payload);
-        }
-        jw.flush();
-        jw.reset();
-    }
-
-    @Override
     public void serializeMetaDataNdJson(MetaData metaData) {
         jw.writeByte(JsonWriter.OBJECT_START);
         writeFieldName("metadata");
@@ -244,6 +229,7 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
         metricRegistry.report(this);
     }
 
+    @Deprecated
     private void serializeErrorPayload(ErrorPayload payload) {
         jw.writeByte(JsonWriter.OBJECT_START);
         serializeService(payload.getService());
@@ -369,6 +355,7 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
         return jw.toString();
     }
 
+    @Deprecated
     private void serializeTransactionPayload(final TransactionPayload payload) {
         jw.writeByte(JsonWriter.OBJECT_START);
         serializeService(payload.getService());
@@ -382,6 +369,7 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
         jw.writeByte(JsonWriter.OBJECT_END);
     }
 
+    @Deprecated
     private void serializeTransactions(final TransactionPayload payload) {
         writeFieldName("transactions");
         jw.writeByte(ARRAY_START);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -298,11 +298,25 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
 
     private void serializeException(@Nullable Throwable exception) {
         writeFieldName("exception");
+        recursiveSerializeException(exception);
+    }
+
+    private void recursiveSerializeException(@Nullable Throwable exception) {
         jw.writeByte(JsonWriter.OBJECT_START);
         if (exception != null) {
             writeField("message", String.valueOf(exception.getMessage()));
             serializeStacktrace(exception.getStackTrace());
-            writeLastField("type", exception.getClass().getName());
+            writeFieldName("type");
+            writeStringValue(exception.getClass().getName());
+
+            Throwable cause = exception.getCause();
+            if(cause != null) {
+                jw.writeByte(COMMA);
+                writeFieldName("cause");
+                jw.writeByte(ARRAY_START);
+                recursiveSerializeException(cause);
+                jw.writeByte(ARRAY_END);
+            }
         }
         jw.writeByte(JsonWriter.OBJECT_END);
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -98,9 +98,9 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
     private static final byte NEW_LINE = (byte) '\n';
     private static final Logger logger = LoggerFactory.getLogger(DslJsonSerializer.class);
     private static final String[] DISALLOWED_IN_LABEL_KEY = new String[]{".", "*", "\""};
+    private static final Collection<String> excludedStackFrames = Arrays.asList("java.lang.reflect", "com.sun", "sun.", "jdk.internal.");
     // visible for testing
     final JsonWriter jw;
-    private final Collection<String> excludedStackFrames = Arrays.asList("java.lang.reflect", "com.sun", "sun.", "jdk.internal.");
     private final StringBuilder replaceBuilder = new StringBuilder(MAX_LONG_STRING_VALUE_LENGTH + 1);
     private final StacktraceConfiguration stacktraceConfiguration;
     private final ApmServerClient apmServerClient;
@@ -687,7 +687,7 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
         }
     }
 
-    private boolean isExcluded(StackTraceElement stackTraceElement) {
+    private static boolean isExcluded(StackTraceElement stackTraceElement) {
         // file name is a required field
         if (stackTraceElement.getFileName() == null) {
             return true;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/PayloadSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/PayloadSerializer.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,8 +35,6 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 public interface PayloadSerializer {
-
-    void serializePayload(OutputStream os, Payload payload) throws IOException;
 
     /**
      * Sets the output stream which the {@code *NdJson} methods should write to.

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -203,6 +203,10 @@ public class MockReporter implements Reporter {
         return errors.iterator().next();
     }
 
+    /**
+     * @deprecated part of v1 intake protocol
+     */
+    @Deprecated
     public String generateTransactionPayloadJson() {
         TransactionPayload payload = PayloadUtils.createTransactionPayload();
         payload.getTransactions().addAll(transactions);
@@ -210,6 +214,10 @@ public class MockReporter implements Reporter {
         return dslJsonSerializer.toJsonString(payload);
     }
 
+    /**
+     * @deprecated part of v1 intake protocol
+     */
+    @Deprecated
     public String generateErrorPayloadJson() {
         ErrorPayload errorPayload = PayloadUtils.createErrorPayload();
         errorPayload.getErrors().addAll(errors);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/PayloadUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/PayloadUtils.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -29,9 +29,14 @@ import co.elastic.apm.agent.TransactionUtils;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.error.ErrorPayload;
 import co.elastic.apm.agent.impl.transaction.Transaction;
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 
 import static org.mockito.Mockito.mock;
 
+/**
+ * @deprecated part of v1 intake protocol
+ */
+@Deprecated
 public class PayloadUtils {
 
     private static final Service SERVICE;


### PR DESCRIPTION
Fixes elastic/apm-agent-java#705 

Implement implement "chained exceptions" reporting to backend server (part of https://github.com/elastic/apm/issues/40)

In Java, each exception has at most one "cause" exception, thus the 'cause' array has at most one element.

### Checklist

- [x] Implement code
- [x] Add tests
- [ ] ~~Update documentation~~
- [ ] ~~Update [CHANGELOG.md](CHANGELOG.md)~~
- [ ] ~~Update [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- [ ] ~~Added an API method or config option? Document in which version this will be introduced.~~
- [x] Manual test with latest `master` branch of backend that supports this feature.