### PR TITLE
ci(jenkins): reuse agents (2 less agents to be used)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 @Library('apm@current') _
 
 pipeline {
-  agent any
+  agent { label 'linux && immutable' }
   environment {
     REPO = 'apm-agent-java'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
@@ -38,7 +38,6 @@ pipeline {
 
   stages {
     stage('Initializing'){
-      agent { label 'linux && immutable' }
       options { skipDefaultCheckout() }
       environment {
         HOME = "${env.WORKSPACE}"
@@ -46,7 +45,7 @@ pipeline {
         PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
         MAVEN_CONFIG = "${params.MAVEN_CONFIG} ${env.MAVEN_CONFIG}"
       }
-      stages(){
+      stages {
         /**
          Checkout the code and stash it, to use it on other stages.
         */
@@ -92,7 +91,6 @@ pipeline {
           Run only unit test.
         */
         stage('Unit Tests') {
-          agent { label 'linux && immutable' }
           options { skipDefaultCheckout() }
           environment {
             HOME = "${env.WORKSPACE}"


### PR DESCRIPTION
### Highlights
- Let's reuse the top-level agent to reduce the number of fo requested agents and speed up just a bit the builds.
- Reset labels to be `linux && immutable` to help with what kind of OS is required to be used.
- Time improvements per Stage are not significant though but fewer VMs are required which means less overkillling waiting for resources when there are build peaks.