### PR TITLE
Add ElasticApmAttacher.attach(String classpathLocation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
    that is not exposed in the properties file by default.  
  * Send IP obtained through `javax.servlet.ServletRequest#getRemoteAddr()` in `context.request.socket.remote_address` 
    instead of parsing from headers (#889)
+ * Added `ElasticApmAttacher.attach(String propertiesLocation)` to specify a custom properties location
 
 ## Bug Fixes
  * JMS creates polling transactions even when the API invocations return without a message

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
@@ -67,17 +67,34 @@ public class ElasticApmAttacher {
      * <p>
      * This method may only be invoked once.
      * </p>
+     * <p>
+     * Tries to load {@code elasticapm.properties} from the classpath, if exists.
+     * </p>
      *
      * @throws IllegalStateException if there was a problem while attaching the agent to this VM
      */
     public static void attach() {
-        attach(loadProperties());
+        attach(loadProperties("elasticapm.properties"));
     }
 
-    private static Map<String, String> loadProperties() {
+    /**
+     * Attaches the Elastic Apm agent to the current JVM.
+     * <p>
+     * This method may only be invoked once.
+     * </p>
+     *
+     * @throws IllegalStateException if there was a problem while attaching the agent to this VM
+     * @param propertiesLocation the location within the classpath which contains the agent configuration properties file
+     * @since 1.11.0
+     */
+    public static void attach(String propertiesLocation) {
+        attach(loadProperties(propertiesLocation));
+    }
+
+    private static Map<String, String> loadProperties(String propertiesLocation) {
         Map<String, String> propertyMap = new HashMap<>();
         final Properties props = new Properties();
-        try (InputStream resourceStream = ElasticApmAttacher.class.getClassLoader().getResourceAsStream("elasticapm.properties")) {
+        try (InputStream resourceStream = ElasticApmAttacher.class.getClassLoader().getResourceAsStream(propertiesLocation)) {
             if (resourceStream != null) {
                 props.load(resourceStream);
                 for (String propertyName : props.stringPropertyNames()) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -443,8 +443,10 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .tags("added[1.8.0]")
         .configurationCategory(CORE_CATEGORY)
         .description("Sets the path of the agent config file.\n" +
-            "The special value `_AGENT_HOME_` is a placeholder for the folder the elastic-apm-agent.jar is in.\n" +
-            "The location can either be in the classpath of the application (when using the attacher API) or on the file system.\n" +
+            "The special value `_AGENT_HOME_` is a placeholder for the folder the `elastic-apm-agent.jar` is in.\n" +
+            "The file has to be on the file system.\n" +
+            "You can not refer to classpath locations.\n" +
+            "\n" +
             "NOTE: this option can only be set via system properties, environment variables or the attacher options.")
         .buildWithDefault(DEFAULT_CONFIG_FILE);
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilder.java
@@ -179,7 +179,7 @@ public class ElasticApmTracerBuilder {
             }
         });
         String configFileLocation = CoreConfiguration.getConfigFileLocation(result);
-        if (configFileLocation != null && PropertyFileConfigurationSource.isPresent(configFileLocation)) {
+        if (configFileLocation != null && PropertyFileConfigurationSource.getFromFileSystem(configFileLocation) != null) {
             result.add(new PropertyFileConfigurationSource(configFileLocation));
         }
         // looks if we can find a elasticapm.properties on the classpath

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -672,8 +672,10 @@ Disables the collection of breakdown metrics (`span.self_time`)
 ==== `config_file` (added[1.8.0])
 
 Sets the path of the agent config file.
-The special value `_AGENT_HOME_` is a placeholder for the folder the elastic-apm-agent.jar is in.
-The location can either be in the classpath of the application (when using the attacher API) or on the file system.
+The special value `_AGENT_HOME_` is a placeholder for the folder the `elastic-apm-agent.jar` is in.
+The file has to be on the file system.
+You can not refer to classpath locations.
+
 NOTE: this option can only be set via system properties, environment variables or the attacher options.
 
 
@@ -1809,8 +1811,10 @@ The default unit for this option is `ms`
 # breakdown_metrics=true
 
 # Sets the path of the agent config file.
-# The special value `_AGENT_HOME_` is a placeholder for the folder the elastic-apm-agent.jar is in.
-# The location can either be in the classpath of the application (when using the attacher API) or on the file system.
+# The special value `_AGENT_HOME_` is a placeholder for the folder the `elastic-apm-agent.jar` is in.
+# The file has to be on the file system.
+# You can not refer to classpath locations.
+# 
 # NOTE: this option can only be set via system properties, environment variables or the attacher options.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.


### PR DESCRIPTION
Also, clarify that config_file can't be on the classpath

The idea was that when using the attacher, the properties file could be read from the classpath.
However, that never really worked as Spring Boot creates a different class loader for the applicaiton when not started from the IDE.

<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.

-->

relates to https://discuss.elastic.co/t/apm-config-file-location/203887

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] ~Add tests~
- [x] Update documentation
- [x] Update [CHANGELOG.md](CHANGELOG.md)
- [x] ~Update [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~
- [x] ~Added an API method or config option? Document in which version this will be introduced.~