### PR TITLE
Add @Traced annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
  * Added `ElasticApmAttacher.attach(String propertiesLocation)` to specify a custom properties location
  * Logs message when `transaction_max_spans` has been exceeded (#849)
  * Report the number of affected rows by a SQL statement (UPDATE,DELETE,INSERT) in 'affected_rows' span attribute (#707)
+ * Add [`@Traced`](https://www.elastic.co/guide/en/apm/agent/java/master/public-api.html#api-traced) annotation which either creates a span or a transaction, depending on the context
 
 ## Bug Fixes
  * JMS creates polling transactions even when the API invocations return without a message

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/Traced.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/Traced.java
@@ -1,0 +1,87 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotating a method with {@code @}{@link Traced} creates a {@link Span} as the child of the currently active span or transaction
+ * ({@link ElasticApm#currentSpan()}).
+ * <p>
+ * When there is no current span,
+ * a {@link Transaction} will be created instead.
+ * </p>
+ * <p>
+ * Use this annotation over {@link CaptureSpan} or {@link CaptureTransaction} if a method can both be an entry point (a {@link Transaction})
+ * or a unit of work within a transaction (a {@link Span}).
+ * </p>
+ * <p>
+ * Note: it is required to configure the {@code application_packages}, otherwise this annotation will be ignored.
+ * </p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Traced {
+
+    /**
+     * The name of the {@link Span} or {@link Transaction}.
+     * Defaults to the {@code ClassName#methodName}
+     */
+    String value() default "";
+
+    /**
+     * <p>
+     * Sets the general type of the captured span or transaction, used to group similar spans together, for example: `db`. Though there are no naming
+     * restrictions for the general types, the following are standardized across all Elastic APM agents: `app`, `db`, `cache`,
+     * `template`, and `ext`.
+     * </p>
+     * <p>
+     * Defaults to {@code request} for transactions and {@code app} for spans
+     * </p>
+     */
+    String type() default "";
+
+    /**
+     * <p>
+     * Sets the subtype of the captured span, used to group similar spans together, for example: `mysql`.
+     * </p>
+     * <p>
+     * NOTE: has no effect when a transaction is created
+     * </p>
+     */
+    String subtype() default "";
+    /**
+     * <p>
+     * Sets the action of the captured span, used to group similar spans together, for example: `query`.
+     * </p>
+     * <p>
+     * NOTE: has no effect when a transaction is created
+     * </p>
+     */
+    String action() default "";
+}

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/TracedInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/TracedInstrumentation.java
@@ -1,0 +1,139 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.plugin.api;
+
+import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
+import co.elastic.apm.agent.bci.VisibleForAdvice;
+import co.elastic.apm.agent.bci.bytebuddy.AnnotationValueOffsetMappingFactory;
+import co.elastic.apm.agent.bci.bytebuddy.SimpleMethodSignatureOffsetMappingFactory;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
+import co.elastic.apm.agent.impl.transaction.Transaction;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.matcher.ElementMatchers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPackage;
+import static co.elastic.apm.agent.impl.transaction.AbstractSpan.PRIO_METHOD_SIGNATURE;
+import static co.elastic.apm.agent.impl.transaction.AbstractSpan.PRIO_USER_SUPPLIED;
+import static co.elastic.apm.agent.plugin.api.ElasticApmApiInstrumentation.PUBLIC_API_INSTRUMENTATION_GROUP;
+import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
+import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public class TracedInstrumentation extends ElasticApmInstrumentation {
+
+    private final StacktraceConfiguration config;
+
+    public TracedInstrumentation(ElasticApmTracer tracer) {
+        config = tracer.getConfig(StacktraceConfiguration.class);
+    }
+
+    @Advice.OnMethodEnter(suppress = Throwable.class)
+    public static void onMethodEnter(
+        @Advice.Origin Class<?> clazz,
+        @SimpleMethodSignatureOffsetMappingFactory.SimpleMethodSignature String signature,
+        @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.Traced", method = "value") String spanName,
+        @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.Traced", method = "type") String type,
+        @Nullable @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.Traced", method = "subtype") String subtype,
+        @Nullable @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.Traced", method = "action") String action,
+        @Advice.Local("span") AbstractSpan abstractSpan) {
+
+        if (tracer != null) {
+            final TraceContextHolder<?> parent = tracer.getActive();
+            if (parent != null) {
+                Span span = parent.createSpan();
+                span.withType(type.isEmpty() ? "app" : type);
+                span.withSubtype(subtype);
+                span.withAction(action);
+                span.withName(spanName.isEmpty() ? signature : spanName)
+                    .activate();
+                abstractSpan = span;
+            } else {
+                Transaction transaction = tracer.startTransaction(TraceContext.asRoot(), null, clazz.getClassLoader());
+                if (spanName.isEmpty()) {
+                    transaction.withName(signature, PRIO_METHOD_SIGNATURE);
+                } else {
+                    transaction.withName(spanName, PRIO_USER_SUPPLIED);
+                }
+                transaction.withType(type.isEmpty() ? Transaction.TYPE_REQUEST : type)
+                    .activate();
+                abstractSpan = transaction;
+            }
+        }
+
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
+    public static void onMethodExit(@Nullable @Advice.Local("span") AbstractSpan span,
+                                    @Advice.Thrown Throwable t) {
+        if (span != null) {
+            span.captureException(t)
+                .deactivate();
+            span.end();
+        }
+    }
+
+    @Override
+    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
+        return classLoaderCanLoadClass("co.elastic.apm.api.Traced");
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return isInAnyPackage(config.getApplicationPackages(), ElementMatchers.<NamedElement>none())
+            .and(declaresMethod(getMethodMatcher()));
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return isAnnotatedWith(named("co.elastic.apm.api.Traced"));
+    }
+
+    @Override
+    public boolean includeWhenInstrumentationIsDisabled() {
+        return false;
+    }
+
+    @Override
+    public final Collection<String> getInstrumentationGroupNames() {
+        return Arrays.asList(PUBLIC_API_INSTRUMENTATION_GROUP, "annotations");
+    }
+
+}

--- a/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
@@ -27,6 +27,7 @@ co.elastic.apm.agent.plugin.api.CaptureExceptionInstrumentation
 co.elastic.apm.agent.plugin.api.ApiScopeInstrumentation
 co.elastic.apm.agent.plugin.api.CaptureTransactionInstrumentation
 co.elastic.apm.agent.plugin.api.CaptureSpanInstrumentation
+co.elastic.apm.agent.plugin.api.TracedInstrumentation
 # legacy
 co.elastic.apm.agent.plugin.api.LegacySpanInstrumentation$SetNameInstrumentation
 co.elastic.apm.agent.plugin.api.LegacySpanInstrumentation$SetTypeInstrumentation

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationApiTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationApiTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -93,6 +93,31 @@ class AnnotationApiTest extends AbstractInstrumentationTest {
         assertThat(internalSpan.getAction()).isEqualTo("okhttp");
     }
 
+    @Test
+    void testTracedTransactionAndSpan() {
+        TracedAnnotationTest.tracedTransaction();
+        assertThat(reporter.getTransactions()).hasSize(1);
+        assertThat(reporter.getSpans()).hasSize(1);
+
+        assertThat(reporter.getFirstTransaction().getNameAsString()).isEqualTo("TracedAnnotationTest#tracedTransaction");
+        assertThat(reporter.getFirstTransaction().getType()).isEqualTo("type");
+
+        assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("TracedAnnotationTest#tracedSpanOrTransaction");
+        assertThat(reporter.getFirstSpan().getType()).isEqualTo("app");
+        assertThat(reporter.getFirstSpan().getSubtype()).isEqualTo("subtype");
+        assertThat(reporter.getFirstSpan().getAction()).isEqualTo("action");
+    }
+
+    @Test
+    void testTracedTransaction() {
+        TracedAnnotationTest.tracedSpanOrTransaction();
+        assertThat(reporter.getTransactions()).hasSize(1);
+        assertThat(reporter.getSpans()).hasSize(0);
+
+        assertThat(reporter.getFirstTransaction().getNameAsString()).isEqualTo("TracedAnnotationTest#tracedSpanOrTransaction");
+        assertThat(reporter.getFirstTransaction().getType()).isEqualTo("request");
+    }
+
     public static class AnnotationTestClass {
 
         @CaptureTransaction
@@ -143,6 +168,17 @@ class AnnotationApiTest extends AbstractInstrumentationTest {
         @CaptureSpan(value = "spanWithMissingSubtype", type = "ext.http", action = "okhttp")
         private static void spanWithMissingSubtype() {
 
+        }
+    }
+
+    static class TracedAnnotationTest {
+        @Traced(type = "type")
+        static void tracedTransaction() {
+            tracedSpanOrTransaction();
+        }
+
+        @Traced(subtype = "subtype", action = "action")
+        static void tracedSpanOrTransaction() {
         }
     }
 }

--- a/docs/public-api.asciidoc
+++ b/docs/public-api.asciidoc
@@ -231,6 +231,27 @@ method. It also implicitly ends it and deactivates it before exiting the annotat
 See <<api-span-start-span, `startSpan()`>>, <<api-span-start-span-with-type, `startSpan(String, String, String)`>>,
 <<api-transaction-activate, `span.activate()`>> and <<api-span-end, `span.end()`>>
 
+[float]
+[[api-traced]]
+==== `@Traced`  added[1.11.0]
+Annotating a method with `@Traced` creates a span as the child of the currently active span or transaction.
+
+When there is no current span,
+a transaction will be created instead.
+
+Use this annotation over <<api-capture-span>> or <<api-capture-transaction>> if a method can both be an entry point (a transaction)
+or a unit of work within a transaction (a span).
+
+* `value`: The name of the span or transaction. Defaults to `ClassName#methodName`
+* `type`: The type of the span or transaction. Defaults to `request` for transactions and `app` for spans
+* `subtype`: The subtype of the span, e.g. `mysql` for DB span. Defaults to empty string. Has no effect when a transaction is created.
+* `action`: The action related to the span, e.g. `query` for DB spans. Defaults to empty string. Has no effect when a transaction is created.
+
+NOTE: Using this annotation implicitly creates a span or transaction and activates it when entering the annotated
+method. It also implicitly ends it and deactivates it before exiting the annotated method.
+See <<api-span-start-span, `startSpan()`>>, <<api-span-start-span-with-type, `startSpan(String, String, String)`>>,
+<<api-transaction-activate, `span.activate()`>> and <<api-span-end, `span.end()`>>
+
 //----------------------------
 [float]
 [[api-transaction]]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -320,7 +320,7 @@ If you are seeing gaps in the span timeline and want to include certain methods,
 |Wrong usage of the API may lead to invalid traces (scope leaks).
 
 |Annotations
-|Annotate any method with <<api-capture-span, `@CaptureSpan`>> or <<api-capture-transaction, `@CaptureTransaction`>>.
+|Annotate any method with <<api-capture-span, `@CaptureSpan`>>, <<api-capture-transaction, `@CaptureTransaction`>> or <<api-traced, `@Traced`>>.
 |Easier and more robust as there's nothing you can do wrong like forgetting to end a span or close a scope.
  It's also a bit more performant than the programmatic way.
 |Less flexible on it's own but can be combined with the API.


### PR DESCRIPTION
Similar to trace_methods, creates either a transaction or a span, depending on the context

closes elastic/apm-agent-java#904


<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.

-->


<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update documentation
- [x] Update [CHANGELOG.md](CHANGELOG.md)
- [x] Update [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)
- [x] Added an API method or config option? Document in which version this will be introduced.