### PR TITLE
Replace underscore with hyphen for OKD pod UID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Bug Fixes
  * JDBC regression- `PreparedStatement#executeUpdate()` and `PreparedStatement#executeLargeUpdate()` are not traced (#918)
+ * When systemd cgroup driver is used, the discovered Kubernetes pod UID contains "_" instead of "-" (#920)
 
 # 1.11.0
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/SystemInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/SystemInfo.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -94,7 +94,7 @@ public class SystemInfo {
         }
         return new SystemInfo(System.getProperty("os.arch"), reportedHostname, System.getProperty("os.name")).findContainerDetails();
     }
-    
+
     public static SystemInfo create() {
         return create(null);
     }
@@ -191,6 +191,7 @@ public class SystemInfo {
                         for (int i = 1; i <= matcher.groupCount(); i++) {
                             String podUid = matcher.group(i);
                             if (podUid != null && !podUid.isEmpty()) {
+                                podUid = podUid.replace('_', '-');
                                 logger.debug("Found Kubernetes pod UID: {}", podUid);
                                 // By default, Kubernetes will set the hostname of the pod containers to the pod name. Users that override
                                 // the name should use the Downward API to override the pod name.

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/ContainerInfoTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/ContainerInfoTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -65,6 +65,15 @@ public class ContainerInfoTest {
         assertContainerId(validLinePrefix + uuid, uuid);
         assertContainerInfoIsNull(validLinePrefix + validId.concat("/"));
         assertContainerId("5:blkio:/system.slice/garden.service/garden/" + validId, validId);
+    }
+
+    @Test
+    void testOkdInfoParsing() {
+        String groupFileLine = "11:pids:/kubepods.slice/kubepods-burstable.slice/" +
+            "kubepods-burstable-pod3f268d6d_0293_11ea_be82_005056938be8.slice/" +
+            "docker-ff4285cc2723440d824a79f530607873a0763da610d94f69070ee3c62459af15.scope";
+        SystemInfo systemInfo = assertContainerId(groupFileLine, "ff4285cc2723440d824a79f530607873a0763da610d94f69070ee3c62459af15");
+        assertKubernetesInfo(systemInfo, "3f268d6d-0293-11ea-be82-005056938be8", "my-host", null, null);
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/ContainerInfoTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/ContainerInfoTest.java
@@ -68,15 +68,6 @@ public class ContainerInfoTest {
     }
 
     @Test
-    void testOkdInfoParsing() {
-        String groupFileLine = "11:pids:/kubepods.slice/kubepods-burstable.slice/" +
-            "kubepods-burstable-pod3f268d6d_0293_11ea_be82_005056938be8.slice/" +
-            "docker-ff4285cc2723440d824a79f530607873a0763da610d94f69070ee3c62459af15.scope";
-        SystemInfo systemInfo = assertContainerId(groupFileLine, "ff4285cc2723440d824a79f530607873a0763da610d94f69070ee3c62459af15");
-        assertKubernetesInfo(systemInfo, "3f268d6d-0293-11ea-be82-005056938be8", "my-host", null, null);
-    }
-
-    @Test
     void testEcsFormat() {
         String id = "7e9139716d9e5d762d22f9f877b87d1be8b1449ac912c025a984750c5dbff157";
         assertContainerId("3:cpuacct:/ecs/eb9d3d0c-8936-42d7-80d8-f82b2f1a629e/" + id, id);
@@ -93,15 +84,16 @@ public class ContainerInfoTest {
         String line = "1:name=systemd:/kubepods/besteffort/pod" + podId + "/" + containerId;
         SystemInfo systemInfo = assertContainerId(line, containerId);
         assertKubernetesInfo(systemInfo, podId, "my-host", null, null);
+    }
 
-        // 1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod90d81341_92de_11e7_8cf2_507b9d4141fa.slice/
-        //                                                      crio-2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63.scope
-        containerId = "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63";
-        podId = "90d81341_92de_11e7_8cf2_507b9d4141fa";
-        line = "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod" + podId + ".slice/crio-" + containerId +
-            ".scope";
-        systemInfo = assertContainerId(line, containerId);
-        assertKubernetesInfo(systemInfo, podId, "my-host", null, null);
+    @Test
+    void testKubernetesInfo_podUid_with_underscores() {
+        // In such cases- underscores should be replaced with hyphens in the pod UID
+        String line = "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/" +
+            "kubepods-burstable-pod90d81341_92de_11e7_8cf2_507b9d4141fa.slice/" +
+            "crio-2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63.scope";
+        SystemInfo systemInfo = assertContainerId(line, "2227daf62df6694645fee5df53c1f91271546a9560e8600a525690ae252b7f63");
+        assertKubernetesInfo(systemInfo, "90d81341-92de-11e7-8cf2-507b9d4141fa", "my-host", null, null);
     }
 
     @Test


### PR DESCRIPTION
Fixes the OKD pod UID discovery error reported through [Discuss](https://discuss.elastic.co/t/infrastructure-ui-kubernetes-apm-traces-integration/207096).

Related to https://github.com/elastic/apm/pull/165

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update [CHANGELOG.md](CHANGELOG.md)
