### PR TITLE
Refactor plugin versions & cleanup pom.xml

### DIFF
--- a/apm-agent-api/pom.xml
+++ b/apm-agent-api/pom.xml
@@ -1,8 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <properties>
-        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
-    </properties>
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>apm-agent-parent</artifactId>
+        <groupId>co.elastic.apm</groupId>
+        <version>1.11.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>apm-agent-api</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <licenses>
         <license>
@@ -11,15 +18,9 @@
         </license>
     </licenses>
 
-    <parent>
-        <artifactId>apm-agent-parent</artifactId>
-        <groupId>co.elastic.apm</groupId>
-        <version>1.11.1-SNAPSHOT</version>
-    </parent>
-    <modelVersion>4.0.0</modelVersion>
-
-    <artifactId>apm-agent-api</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
+    <properties>
+        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
+    </properties>
 
     <build>
         <resources>

--- a/apm-agent-api/pom.xml
+++ b/apm-agent-api/pom.xml
@@ -37,7 +37,6 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>
@@ -51,7 +50,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${version.plugin.jar}</version>
                 <configuration>

--- a/apm-agent-api/pom.xml
+++ b/apm-agent-api/pom.xml
@@ -39,7 +39,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>generate-source-jar</id>
@@ -52,7 +51,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/apm-agent-attach/pom.xml
+++ b/apm-agent-attach/pom.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-agent-attach</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <licenses>
         <license>
@@ -18,9 +22,6 @@
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
         <version.jna>5.3.1</version.jna>
     </properties>
-
-    <artifactId>apm-agent-attach</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>
@@ -177,4 +178,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/apm-agent-attach/pom.xml
+++ b/apm-agent-attach/pom.xml
@@ -45,7 +45,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>generate-source-jar</id>
@@ -57,7 +56,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <dependencies>
                     <dependency>
@@ -91,7 +92,6 @@
             <plugin>
                 <groupId>com.coderplus.maven.plugins</groupId>
                 <artifactId>copy-rename-maven-plugin</artifactId>
-                <version>1.0</version>
                 <executions>
                     <execution>
                         <id>copy-file</id>
@@ -108,7 +108,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>without-jna</id>

--- a/apm-agent-attach/pom.xml
+++ b/apm-agent-attach/pom.xml
@@ -43,7 +43,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>
@@ -107,7 +106,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.1.0</version>
                 <executions>

--- a/apm-agent-benchmarks/pom.xml
+++ b/apm-agent-benchmarks/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
@@ -9,8 +10,20 @@
 
     <artifactId>apm-agent-benchmarks</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
-    <packaging>jar</packaging>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jmh.version>1.21</jmh.version>
+        <javac.target>1.8</javac.target>
+        <uberjar.name>benchmarks</uberjar.name>
+        <maven.compiler.target>9</maven.compiler.target>
+        <maven.compiler.testTarget>9</maven.compiler.testTarget>
+        <maven.compiler.showWarnings>false</maven.compiler.showWarnings>
+        <maven.compiler.errorprone>false</maven.compiler.errorprone>
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
+        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -105,20 +118,6 @@
             <version>0.3.0</version>
         </dependency>
     </dependencies>
-
-    <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jmh.version>1.21</jmh.version>
-        <javac.target>1.8</javac.target>
-        <uberjar.name>benchmarks</uberjar.name>
-        <maven.compiler.target>9</maven.compiler.target>
-        <maven.compiler.testTarget>9</maven.compiler.testTarget>
-        <maven.compiler.showWarnings>false</maven.compiler.showWarnings>
-        <maven.compiler.errorprone>false</maven.compiler.errorprone>
-        <animal.sniffer.skip>true</animal.sniffer.skip>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
-        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
-    </properties>
 
     <build>
         <plugins>

--- a/apm-agent-benchmarks/pom.xml
+++ b/apm-agent-benchmarks/pom.xml
@@ -123,7 +123,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.2</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -157,46 +156,6 @@
                 </executions>
             </plugin>
         </plugins>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.5</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>${version.plugin.jar}</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.0</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.6</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
     </build>
 
 </project>

--- a/apm-agent-benchmarks/pom.xml
+++ b/apm-agent-benchmarks/pom.xml
@@ -123,7 +123,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>2.2</version>
                 <executions>

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -143,9 +143,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
-        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
-    </properties>
 
     <parent>
         <groupId>co.elastic.apm</groupId>
@@ -15,44 +11,10 @@
     <artifactId>apm-agent-core</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.jsonschema2pojo</groupId>
-                <artifactId>jsonschema2pojo-maven-plugin</artifactId>
-                <version>0.5.1</version>
-                <configuration>
-                    <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
-                    <targetPackage>co.elastic.apm.agent.impl.intake</targetPackage>
-                    <usePrimitives>true</usePrimitives>
-                    <useLongIntegers>true</useLongIntegers>
-                    <includeAdditionalProperties>false</includeAdditionalProperties>
-                    <formatDateTimes>true</formatDateTimes>
-                    <generateBuilders>true</generateBuilders>
-                    <skip>true</skip>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>generate</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <properties>
+        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
+        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -155,4 +117,44 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jsonschema2pojo</groupId>
+                <artifactId>jsonschema2pojo-maven-plugin</artifactId>
+                <version>0.5.1</version>
+                <configuration>
+                    <sourceDirectory>${basedir}/src/main/resources/schema</sourceDirectory>
+                    <targetPackage>co.elastic.apm.agent.impl.intake</targetPackage>
+                    <usePrimitives>true</usePrimitives>
+                    <useLongIntegers>true</useLongIntegers>
+                    <includeAdditionalProperties>false</includeAdditionalProperties>
+                    <formatDateTimes>true</formatDateTimes>
+                    <generateBuilders>true</generateBuilders>
+                    <skip>true</skip>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${version.plugin.jar}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-apache-httpclient-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-apache-httpclient-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>
@@ -40,6 +41,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/apm-agent-plugins/apm-api-plugin/pom.xml
+++ b/apm-agent-plugins/apm-api-plugin/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
@@ -22,4 +23,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>apm-asynchttpclient-plugin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/apm-agent-plugins/apm-error-logging-plugin/pom.xml
+++ b/apm-agent-plugins/apm-error-logging-plugin/pom.xml
@@ -8,11 +8,11 @@
         <version>1.11.1-SNAPSHOT</version>
     </parent>
 
+    <artifactId>apm-error-logging-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-error-logging-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
 </project>

--- a/apm-agent-plugins/apm-error-logging-plugin/pom.xml
+++ b/apm-agent-plugins/apm-error-logging-plugin/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/pom.xml
@@ -52,4 +52,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/pom.xml
@@ -16,23 +16,6 @@
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
     <dependencies>
         <!-- Elasticsearch rest client -->
         <dependency>
@@ -71,4 +54,22 @@
         </dependency>
 
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${version.plugin.jar}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/pom.xml
@@ -58,9 +58,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_1/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_1/pom.xml
@@ -61,4 +61,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/pom.xml
@@ -46,4 +46,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/pom.xml
@@ -33,9 +33,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-es-restclient-plugin</artifactId>
     <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
@@ -19,7 +24,5 @@
         <module>apm-es-restclient-plugin-7_1</module>
     </modules>
 
-    <artifactId>apm-es-restclient-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
 </project>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-hibernate-search-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>apm-hibernate-search-plugin-5_x</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-hibernate-search-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>apm-hibernate-search-plugin-6_x</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-hibernate-search-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>apm-hibernate-search-plugin-common</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
@@ -38,4 +39,5 @@
             </plugin>
         </plugins>
     </build>
+
 </project>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
@@ -26,9 +26,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/pom.xml
@@ -1,12 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-hibernate-search-plugin</artifactId>
     <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
@@ -17,8 +22,5 @@
         <module>apm-hibernate-search-plugin-6_x</module>
         <module>apm-hibernate-search-plugin-common</module>
     </modules>
-
-    <artifactId>apm-hibernate-search-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
 </project>

--- a/apm-agent-plugins/apm-httpclient-core/pom.xml
+++ b/apm-agent-plugins/apm-httpclient-core/pom.xml
@@ -18,9 +18,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apm-agent-plugins/apm-httpclient-core/pom.xml
+++ b/apm-agent-plugins/apm-httpclient-core/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-httpclient-core</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-httpclient-core</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <build>
         <plugins>

--- a/apm-agent-plugins/apm-java-concurrent-plugin/pom.xml
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-java-concurrent-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-java-concurrent-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-agent-plugins/apm-jaxrs-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jaxrs-plugin/pom.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>apm-jaxrs-plugin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <version.jersey>2.27</version.jersey>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>

--- a/apm-agent-plugins/apm-jaxws-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jaxws-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-jaxws-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-jaxws-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>
@@ -22,6 +23,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/apm-agent-plugins/apm-jdbc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jdbc-plugin/pom.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-jdbc-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
 
-    <artifactId>apm-jdbc-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -120,4 +122,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-jms-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jms-plugin/pom.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-jms-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
@@ -13,9 +17,6 @@
         <activemq.version>5.15.9</activemq.version>
         <artemis.version>2.8.1</artemis.version>
     </properties>
-
-    <artifactId>apm-jms-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-agent-plugins/apm-jmx-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jmx-plugin/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>apm-jmx-plugin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>

--- a/apm-agent-plugins/apm-jsf-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jsf-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-jsf-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-jsf-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-agent-plugins/apm-mule4-plugin/pom.xml
+++ b/apm-agent-plugins/apm-mule4-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-mule4-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-mule4-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-agent-plugins/apm-okhttp-plugin/pom.xml
+++ b/apm-agent-plugins/apm-okhttp-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-okhttp-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-okhttp-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>
@@ -46,6 +47,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/apm-agent-plugins/apm-opentracing-plugin/pom.xml
+++ b/apm-agent-plugins/apm-opentracing-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-opentracing-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-opentracing-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-agent-plugins/apm-quartz-job-plugin/pom.xml
+++ b/apm-agent-plugins/apm-quartz-job-plugin/pom.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-quartz-job-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
         <version.quartz>2.3.1</version.quartz>
     </properties>
-
-    <artifactId>apm-quartz-job-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-2-tests/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-2-tests/pom.xml
@@ -1,34 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <artifactId>apm-jedis-2-tests</artifactId>
+
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>
@@ -58,4 +43,22 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${version.plugin.jar}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-2-tests/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-2-tests/pom.xml
@@ -8,8 +8,8 @@
         <version>1.11.1-SNAPSHOT</version>
     </parent>
 
-    <name>${project.groupId}:${project.artifactId}</name>
     <artifactId>apm-jedis-2-tests</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
@@ -47,9 +47,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-3-tests/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-3-tests/pom.xml
@@ -8,8 +8,8 @@
         <version>1.11.1-SNAPSHOT</version>
     </parent>
 
-    <name>${project.groupId}:${project.artifactId}</name>
     <artifactId>apm-jedis-3-tests</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-3-tests/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-3-tests/pom.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <name>${project.groupId}:${project.artifactId}</name>
     <artifactId>apm-jedis-3-tests</artifactId>
+
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
@@ -48,6 +50,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/pom.xml
@@ -40,9 +40,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/pom.xml
@@ -1,34 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>apm-jedis-plugin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 
     <dependencies>
         <dependency>
@@ -52,5 +37,21 @@
         </dependency>
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${version.plugin.jar}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/pom.xml
@@ -18,9 +18,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/pom.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>apm-redis-common</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
+
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
@@ -29,6 +31,5 @@
             </plugin>
         </plugins>
     </build>
-
 
 </project>

--- a/apm-agent-plugins/apm-redis-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/pom.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>apm-redis-plugin</artifactId>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
+    </properties>
+
     <modules>
         <module>apm-jedis-2-tests</module>
         <module>apm-jedis-3-tests</module>
         <module>apm-jedis-plugin</module>
         <module>apm-redis-common</module>
     </modules>
-
-    <properties>
-        <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
-    </properties>
 
     <dependencies>
         <dependency>

--- a/apm-agent-plugins/apm-scheduled-annotation-plugin/pom.xml
+++ b/apm-agent-plugins/apm-scheduled-annotation-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-scheduled-annotation-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-scheduled-annotation-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-agent-plugins/apm-servlet-plugin/pom.xml
+++ b/apm-agent-plugins/apm-servlet-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-servlet-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-servlet-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>
@@ -51,6 +52,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/apm-agent-plugins/apm-slf4j-plugin/pom.xml
+++ b/apm-agent-plugins/apm-slf4j-plugin/pom.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-slf4j-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
 
-    <artifactId>apm-slf4j-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
     <dependencies>
         <!--simple-logger does not have a working MDC implementation, logback does-->
         <dependency>
@@ -22,6 +24,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/apm-agent-plugins/apm-spring-resttemplate-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-resttemplate-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-spring-resttemplate-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-spring-resttemplate-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/pom.xml
@@ -1,18 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-spring-webmvc-plugin</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-spring-webmvc-plugin</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>
@@ -104,6 +105,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/apm-agent-plugins/apm-urlconnection-plugin/pom.xml
+++ b/apm-agent-plugins/apm-urlconnection-plugin/pom.xml
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
+
+    <artifactId>apm-urlconnection-plugin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
-    <modelVersion>4.0.0</modelVersion>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
 
-    <artifactId>apm-urlconnection-plugin</artifactId>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-httpclient-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-httpclient-core</artifactId>
@@ -28,4 +29,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-web-plugin/pom.xml
+++ b/apm-agent-plugins/apm-web-plugin/pom.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
-    <properties>
-        <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
-    </properties>
 
     <artifactId>apm-web-plugin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
 
+    <properties>
+        <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
+    </properties>
 
 </project>

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -61,15 +61,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <pluginManagement>
-            <plugins>
-                <!-- use 2.4 version, TODO see if using common version is fine -->
-                <plugin>
-                    <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
 </project>

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -60,4 +60,16 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- use 2.4 version, TODO see if using common version is fine -->
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>2.4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+    </build>
 </project>

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -1,12 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-agent-plugins</artifactId>
     <packaging>pom</packaging>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
+        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
+    </properties>
+
     <modules>
         <module>apm-jaxrs-plugin</module>
         <module>apm-jdbc-plugin</module>
@@ -35,14 +45,6 @@
         <module>apm-jmx-plugin</module>
         <module>apm-mule4-plugin</module>
     </modules>
-
-    <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
-        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
-    </properties>
-
-    <artifactId>apm-agent-plugins</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-opentracing/pom.xml
+++ b/apm-opentracing/pom.xml
@@ -1,11 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>apm-opentracing</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <licenses>
         <license>
@@ -17,9 +21,6 @@
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>apm-opentracing</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/apm-opentracing/pom.xml
+++ b/apm-opentracing/pom.xml
@@ -64,9 +64,7 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>generate-source-jar</id>
@@ -78,9 +76,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <configuration>
                     <archive>
                         <manifestEntries>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -1,179 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <properties>
-        <elastic.apm.agent>co.elastic.apm.agent.bci.AgentMain</elastic.apm.agent>
-        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
-    </properties>
 
     <parent>
         <groupId>co.elastic.apm</groupId>
         <artifactId>apm-agent-parent</artifactId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <packaging>jar</packaging>
 
     <artifactId>elastic-apm-agent</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>generate-source-jar</id>
-                        <phase>prepare-package</phase>
-                        <goals>
-                            <goal>jar-no-fork</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>com.coderplus.maven.plugins</groupId>
-                <artifactId>copy-rename-maven-plugin</artifactId>
-                <version>1.0</version>
-                <executions>
-                    <execution>
-                        <id>copy-file</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <configuration>
-                            <sourceFile>${apm-agent-parent.base.dir}/NOTICE</sourceFile>
-                            <destinationFile>target/classes/META-INF/NOTICE</destinationFile>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <createSourcesJar>true</createSourcesJar>
-                            <shadeSourcesContent>true</shadeSourcesContent>
-                            <shadedArtifactAttached>false</shadedArtifactAttached>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <exclude>**/module-info.class</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.hdrhistogram:HdrHistogram</artifact>
-                                    <!--
-                                    Currently, we only need this single class.
-                                    We need to be careful not to use others.
-                                    But even if we did, the integration tests should catch that there's a missing class.
-                                    -->
-                                    <includes>
-                                        <include>org/HdrHistogram/WriterReaderPhaser.class</include>
-                                    </includes>
-                                </filter>
-                            </filters>
-                            <relocations>
-                                <relocation>
-                                    <pattern>net.bytebuddy</pattern>
-                                    <shadedPattern>co.elastic.apm.agent.shaded.bytebuddy</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.dslplatform</pattern>
-                                    <shadedPattern>co.elastic.apm.agent.shaded.dslplatform</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.lmax</pattern>
-                                    <shadedPattern>co.elastic.apm.agent.shaded.lmax</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.slf4j</pattern>
-                                    <shadedPattern>co.elastic.apm.agent.shaded.slf4j</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.stagemonitor</pattern>
-                                    <shadedPattern>co.elastic.apm.agent.shaded.stagemonitor</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.jctools</pattern>
-                                    <shadedPattern>co.elastic.apm.agent.shaded.jctools</shadedPattern>
-                                </relocation>
-                                <!--
-                                Makes sure that the relocated slf4j simple does not look for a simplelogger.properties
-                                Although this is not a package but a string constant, it does work
-                                -->
-                                <relocation>
-                                    <pattern>simplelogger.properties</pattern>
-                                    <shadedPattern>elasticapmlogger.properties</shadedPattern>
-                                </relocation>
-                                <!-- See javadoc of co.elastic.apm.agent.logging.JulBridgeLogger -->
-                                <relocation>
-                                    <pattern>java.util.logging.Logger</pattern>
-                                    <shadedPattern>co.elastic.apm.agent.logging.JulBridgeLogger</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>com.blogspot.mydailyjava.weaklockfree</pattern>
-                                    <shadedPattern>co.elastic.apm.agent.shaded.weaklockfree</shadedPattern>
-                                </relocation>
-                                <relocation>
-                                    <pattern>org.HdrHistogram</pattern>
-                                    <shadedPattern>co.elastic.apm.agent.shaded.HdrHistogram</shadedPattern>
-                                </relocation>
-                            </relocations>
-                            <transformers>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <manifestEntries>
-                                        <Premain-Class>${elastic.apm.agent}</Premain-Class>
-                                        <Agent-Class>${elastic.apm.agent}</Agent-Class>
-                                        <Can-Redefine-Classes>true</Can-Redefine-Classes>
-                                        <Can-Retransform-Classes>true</Can-Retransform-Classes>
-                                        <Can-Set-Native-Method-Prefix>true</Can-Set-Native-Method-Prefix>
-                                        <Automatic-Module-Name>${project.groupId}.agent</Automatic-Module-Name>
-                                    </manifestEntries>
-                                </transformer>
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
-                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
-                                    <resource>META-INF/LICENSE</resource>
-                                    <file>${apm-agent-parent.base.dir}/LICENSE</file>
-                                </transformer>
-                            </transformers>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${version.plugin.javadoc}</version>
-                <configuration>
-                    <additionalOptions>-html5</additionalOptions>
-                </configuration>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <includeDependencySources>true</includeDependencySources>
-                            <dependencySourceIncludes>
-                                <dependencySourceInclude>${project.groupId}:apm-agent-api</dependencySourceInclude>
-                                <dependencySourceInclude>${project.groupId}:apm-agent-core</dependencySourceInclude>
-                            </dependencySourceIncludes>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+    <properties>
+        <elastic.apm.agent>co.elastic.apm.agent.bci.AgentMain</elastic.apm.agent>
+        <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -349,4 +190,164 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.0.1</version>
+                <executions>
+                    <execution>
+                        <id>generate-source-jar</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.coderplus.maven.plugins</groupId>
+                <artifactId>copy-rename-maven-plugin</artifactId>
+                <version>1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-file</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <configuration>
+                            <sourceFile>${apm-agent-parent.base.dir}/NOTICE</sourceFile>
+                            <destinationFile>target/classes/META-INF/NOTICE</destinationFile>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <shadedArtifactAttached>false</shadedArtifactAttached>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>**/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
+                                    <artifact>org.hdrhistogram:HdrHistogram</artifact>
+                                    <!--
+                                    Currently, we only need this single class.
+                                    We need to be careful not to use others.
+                                    But even if we did, the integration tests should catch that there's a missing class.
+                                    -->
+                                    <includes>
+                                        <include>org/HdrHistogram/WriterReaderPhaser.class</include>
+                                    </includes>
+                                </filter>
+                            </filters>
+                            <relocations>
+                                <relocation>
+                                    <pattern>net.bytebuddy</pattern>
+                                    <shadedPattern>co.elastic.apm.agent.shaded.bytebuddy</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.dslplatform</pattern>
+                                    <shadedPattern>co.elastic.apm.agent.shaded.dslplatform</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.lmax</pattern>
+                                    <shadedPattern>co.elastic.apm.agent.shaded.lmax</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.slf4j</pattern>
+                                    <shadedPattern>co.elastic.apm.agent.shaded.slf4j</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.stagemonitor</pattern>
+                                    <shadedPattern>co.elastic.apm.agent.shaded.stagemonitor</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.jctools</pattern>
+                                    <shadedPattern>co.elastic.apm.agent.shaded.jctools</shadedPattern>
+                                </relocation>
+                                <!--
+                                Makes sure that the relocated slf4j simple does not look for a simplelogger.properties
+                                Although this is not a package but a string constant, it does work
+                                -->
+                                <relocation>
+                                    <pattern>simplelogger.properties</pattern>
+                                    <shadedPattern>elasticapmlogger.properties</shadedPattern>
+                                </relocation>
+                                <!-- See javadoc of co.elastic.apm.agent.logging.JulBridgeLogger -->
+                                <relocation>
+                                    <pattern>java.util.logging.Logger</pattern>
+                                    <shadedPattern>co.elastic.apm.agent.logging.JulBridgeLogger</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>com.blogspot.mydailyjava.weaklockfree</pattern>
+                                    <shadedPattern>co.elastic.apm.agent.shaded.weaklockfree</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>org.HdrHistogram</pattern>
+                                    <shadedPattern>co.elastic.apm.agent.shaded.HdrHistogram</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <manifestEntries>
+                                        <Premain-Class>${elastic.apm.agent}</Premain-Class>
+                                        <Agent-Class>${elastic.apm.agent}</Agent-Class>
+                                        <Can-Redefine-Classes>true</Can-Redefine-Classes>
+                                        <Can-Retransform-Classes>true</Can-Retransform-Classes>
+                                        <Can-Set-Native-Method-Prefix>true</Can-Set-Native-Method-Prefix>
+                                        <Automatic-Module-Name>${project.groupId}.agent</Automatic-Module-Name>
+                                    </manifestEntries>
+                                </transformer>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/LICENSE</resource>
+                                    <file>${apm-agent-parent.base.dir}/LICENSE</file>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${version.plugin.javadoc}</version>
+                <configuration>
+                    <additionalOptions>-html5</additionalOptions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                        <configuration>
+                            <includeDependencySources>true</includeDependencySources>
+                            <dependencySourceIncludes>
+                                <dependencySourceInclude>${project.groupId}:apm-agent-api</dependencySourceInclude>
+                                <dependencySourceInclude>${project.groupId}:apm-agent-core</dependencySourceInclude>
+                            </dependencySourceIncludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -19,7 +19,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>3.0.1</version>
                 <executions>
@@ -51,7 +50,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.2.1</version>
                 <executions>
@@ -154,7 +152,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${version.plugin.javadoc}</version>
                 <configuration>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -226,7 +226,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -328,7 +327,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${version.plugin.javadoc}</version>
                 <configuration>
                     <additionalOptions>-html5</additionalOptions>
                 </configuration>

--- a/integration-tests/application-server-integration-tests/pom.xml
+++ b/integration-tests/application-server-integration-tests/pom.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
-    <properties>
-        <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
-    </properties>
 
     <artifactId>application-server-integration-tests</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
+    </properties>
 
     <dependencies>
         <dependency>

--- a/integration-tests/jsf-app/jsf-app-standalone/pom.xml
+++ b/integration-tests/jsf-app/jsf-app-standalone/pom.xml
@@ -1,19 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>jsf-app</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jsf-app-standalone</artifactId>
+    <packaging>war</packaging>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>jsf-app-standalone</artifactId>
-    <packaging>war</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
 
@@ -36,4 +37,5 @@
             <scope>runtime</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/integration-tests/jsf-app/pom.xml
+++ b/integration-tests/jsf-app/pom.xml
@@ -1,23 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jsf-app</artifactId>
+    <packaging>pom</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
 
-    <artifactId>jsf-app</artifactId>
-    <packaging>pom</packaging>
-    <name>${project.groupId}:${project.artifactId}</name>
-
     <modules>
         <module>jsf-app-dependent</module>
         <module>jsf-app-standalone</module>
     </modules>
+
 </project>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>integration-tests</artifactId>
     <packaging>pom</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
+
     <modules>
         <module>simple-webapp</module>
         <module>jsf-app</module>
@@ -19,6 +21,7 @@
         <module>soap-test</module>
         <module>cdi-app</module>
     </modules>
+
     <properties>
         <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>

--- a/integration-tests/simple-webapp/pom.xml
+++ b/integration-tests/simple-webapp/pom.xml
@@ -1,21 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
-
-    <properties>
-        <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
-    </properties>
 
     <artifactId>simple-webapp</artifactId>
     <packaging>war</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
+    </properties>
 
     <build>
         <finalName>simple-webapp</finalName>

--- a/integration-tests/soap-test/pom.xml
+++ b/integration-tests/soap-test/pom.xml
@@ -1,19 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
     <artifactId>soap-test</artifactId>
+    <packaging>war</packaging>
+
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
-
-    <packaging>war</packaging>
 
     <build>
         <finalName>soap-test</finalName>
@@ -32,6 +34,5 @@
             <version>${project.version}</version>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/integration-tests/spring-boot-1-5/pom.xml
+++ b/integration-tests/spring-boot-1-5/pom.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>spring-boot-1-5</artifactId>
+
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>

--- a/integration-tests/spring-boot-2/pom.xml
+++ b/integration-tests/spring-boot-2/pom.xml
@@ -1,22 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>spring-boot-2</artifactId>
     <packaging>pom</packaging>
+
     <name>${project.groupId}:${project.artifactId}</name>
+
     <modules>
         <module>spring-boot-2-base</module>
         <module>spring-boot-2-jetty</module>
         <module>spring-boot-2-tomcat</module>
         <module>spring-boot-2-undertow</module>
     </modules>
-
 
     <properties>
         <version.spring-boot>2.1.8.RELEASE</version.spring-boot>

--- a/integration-tests/spring-boot-2/spring-boot-2-base/pom.xml
+++ b/integration-tests/spring-boot-2/spring-boot-2-base/pom.xml
@@ -1,25 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>spring-boot-2</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-boot-2-base</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
 
-    <name>${project.groupId}:${project.artifactId}</name>
-    <artifactId>spring-boot-2-base</artifactId>
-
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>${version.plugin.jar}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -60,6 +60,5 @@
             <version>${version.byte-buddy}</version>
         </dependency>
     </dependencies>
-
 
 </project>

--- a/integration-tests/spring-boot-2/spring-boot-2-jetty/pom.xml
+++ b/integration-tests/spring-boot-2/spring-boot-2-jetty/pom.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>spring-boot-2</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-boot-2-jetty</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
-
-    <name>${project.groupId}:${project.artifactId}</name>
-    <artifactId>spring-boot-2-jetty</artifactId>
 
     <dependencies>
         <dependency>

--- a/integration-tests/spring-boot-2/spring-boot-2-tomcat/pom.xml
+++ b/integration-tests/spring-boot-2/spring-boot-2-tomcat/pom.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>spring-boot-2</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-boot-2-tomcat</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>spring-boot-2-tomcat</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/integration-tests/spring-boot-2/spring-boot-2-undertow/pom.xml
+++ b/integration-tests/spring-boot-2/spring-boot-2-undertow/pom.xml
@@ -1,18 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <artifactId>spring-boot-2</artifactId>
         <groupId>co.elastic.apm</groupId>
         <version>1.11.1-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>spring-boot-2-undertow</artifactId>
+
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
-
-    <artifactId>spring-boot-2-undertow</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,13 @@
 
     <groupId>co.elastic.apm</groupId>
     <artifactId>apm-agent-parent</artifactId>
-    <name>${project.groupId}:${project.artifactId}</name>
     <version>1.11.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
+    <name>${project.groupId}:${project.artifactId}</name>
+
     <inceptionYear>2018</inceptionYear>
+
     <organization>
         <name>Elastic Inc.</name>
         <url>https://www.elastic.co</url>
@@ -40,7 +42,30 @@
         </developer>
     </developers>
 
+    <distributionManagement>
+        <snapshotRepository>
+            <id>sonatype-nexus-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>sonatype-nexus-staging</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+    <modules>
+        <module>apm-agent-core</module>
+        <module>elastic-apm-agent</module>
+        <module>apm-agent-benchmarks</module>
+        <module>apm-agent-plugins</module>
+        <module>apm-agent-api</module>
+        <module>apm-opentracing</module>
+        <module>integration-tests</module>
+        <module>apm-agent-attach</module>
+    </modules>
+
     <properties>
+
         <maven.compiler.target>7</maven.compiler.target>
         <maven.compiler.testTarget>9</maven.compiler.testTarget>
         <animal.sniffer.skip>false</animal.sniffer.skip>
@@ -80,29 +105,10 @@
         <version.plugin.animal-sniffer>1.17</version.plugin.animal-sniffer>
 
         <apm-agent-parent.base.dir>${project.basedir}</apm-agent-parent.base.dir>
+
+        <skip.integration.test>false</skip.integration.test>
+        <skip.unit.test>false</skip.unit.test>
     </properties>
-
-    <modules>
-        <module>apm-agent-core</module>
-        <module>elastic-apm-agent</module>
-        <module>apm-agent-benchmarks</module>
-        <module>apm-agent-plugins</module>
-        <module>apm-agent-api</module>
-        <module>apm-opentracing</module>
-        <module>integration-tests</module>
-        <module>apm-agent-attach</module>
-    </modules>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <profiles>
         <!--
@@ -530,4 +536,5 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,28 +81,26 @@
         -->
         <maven-deploy-plugin.skip>false</maven-deploy-plugin.skip>
 
+        <!-- -dependencies versions -->
         <version.error_prone>2.2.0</version.error_prone>
         <version.h2>1.4.196</version.h2>
         <version.jackson>[2.10.0,)</version.jackson>
         <version.junit-jupiter>5.4.2</version.junit-jupiter>
         <version.junit.vintage>4.12</version.junit.vintage>
+        <version.junit-vintage-engine>5.3.2</version.junit-vintage-engine>
         <version.logback>1.2.3</version.logback>
         <version.okhttp>3.9.1</version.okhttp>
         <version.slf4j>1.7.25</version.slf4j>
         <version.spring>5.0.15.RELEASE</version.spring>
         <version.jetty-server>9.4.11.v20180605</version.jetty-server>
-        <version.junit-vintage-engine>5.3.2</version.junit-vintage-engine>
         <version.json-schema-validator>0.1.19</version.json-schema-validator>
-
-        <version.plugin.compiler>3.7.0</version.plugin.compiler>
-        <version.plugin.jar>3.1.0</version.plugin.jar>
-        <version.plugin.javadoc>3.1.0</version.plugin.javadoc>
-        <version.plugin.surefire>2.19.1</version.plugin.surefire>
         <version.byte-buddy>1.10.1</version.byte-buddy>
+
+        <!-- used both for plugin & annotations dependency -->
+        <version.animal-sniffer>1.17</version.animal-sniffer>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <version.plugin.animal-sniffer>1.17</version.plugin.animal-sniffer>
 
         <apm-agent-parent.base.dir>${project.basedir}</apm-agent-parent.base.dir>
 
@@ -137,14 +135,12 @@
             <plugins>
               <plugin>
                   <artifactId>maven-failsafe-plugin</artifactId>
-                  <version>${version.plugin.surefire}</version>
                   <configuration>
                     <skipTests>${skip.integration.test}</skipTests>
                   </configuration>
               </plugin>
               <plugin>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>${version.plugin.surefire}</version>
                   <configuration>
                       <enableAssertions>true</enableAssertions>
                       <trimStackTrace>false</trimStackTrace>
@@ -165,7 +161,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${version.plugin.compiler}</version>
                         <configuration>
                             <showWarnings>${maven.compiler.showWarnings}</showWarnings>
                             <source>${maven.compiler.target}</source>
@@ -187,7 +182,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-compiler-plugin</artifactId>
-                        <version>${version.plugin.compiler}</version>
                         <configuration>
                             <compilerId>javac-with-errorprone</compilerId>
                             <forceJavacCompilerUse>true</forceJavacCompilerUse>
@@ -237,7 +231,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <phase>verify</phase>
@@ -256,7 +249,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
                 <configuration>
                     <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>gpg</releaseProfiles>
@@ -266,7 +258,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.8.2</version>
                 <configuration>
                     <skip>${maven-deploy-plugin.skip}</skip>
                 </configuration>
@@ -274,7 +265,6 @@
             <!-- The shadowed source files of this module need to be included explicitly to create a javadoc artifact.-->
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${version.plugin.javadoc}</version>
                 <configuration>
                     <additionalOptions>-html5</additionalOptions>
                 </configuration>
@@ -285,24 +275,12 @@
                         </goals>
                     </execution>
                 </executions>
-                <dependencies>
-                    <!--
-                    The transitive dependency has version 3.5,
-                    which is not compatible with Java 10.
-                    TODO Remove this when updating the javadoc plugin version.
-                    -->
-                    <dependency>
-                        <groupId>org.apache.commons</groupId>
-                        <artifactId>commons-lang3</artifactId>
-                        <version>3.7</version>
-                    </dependency>
-                </dependencies>
+
             </plugin>
             <!-- Check that we don't accidentally use features only available in Java 8+ -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>animal-sniffer-maven-plugin</artifactId>
-                <version>${version.plugin.animal-sniffer}</version>
                 <executions>
                     <execution>
                         <id>signature-check</id>
@@ -325,7 +303,6 @@
             </plugin>
             <plugin>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.0.0-M1</version>
                 <executions>
                     <execution>
                         <id>enforce-java</id>
@@ -345,32 +322,13 @@
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>${version.plugin.surefire}</version>
                 <configuration>
                     <enableAssertions>true</enableAssertions>
                     <trimStackTrace>false</trimStackTrace>
                 </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.junit.platform</groupId>
-                        <artifactId>junit-platform-surefire-provider</artifactId>
-                        <version>1.1.1</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.junit.vintage</groupId>
-                        <artifactId>junit-vintage-engine</artifactId>
-                        <version>${version.junit-vintage-engine}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>${version.junit-jupiter}</version>
-                    </dependency>
-                </dependencies>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>${version.plugin.surefire}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -384,7 +342,6 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.2</version>
                 <executions>
                     <execution>
                         <goals>
@@ -404,7 +361,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>license-maven-plugin</artifactId>
-                <version>1.19</version>
                 <configuration>
                     <verbose>false</verbose>
                     <licenseName>apache2_license</licenseName>
@@ -445,6 +401,125 @@
             </plugin>
 
         </plugins>
+
+        <pluginManagement>
+            <!-- pin and set plugin versions at parent project level -->
+            <plugins>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.7.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.19.1</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.junit.platform</groupId>
+                            <artifactId>junit-platform-surefire-provider</artifactId>
+                            <version>1.1.1</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.junit.vintage</groupId>
+                            <artifactId>junit-vintage-engine</artifactId>
+                            <version>${version.junit-vintage-engine}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.junit.jupiter</groupId>
+                            <artifactId>junit-jupiter-engine</artifactId>
+                            <version>${version.junit-jupiter}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.19.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.1.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>2.8</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.1.0</version>
+                    <dependencies>
+                        <!--
+                        The transitive dependency has version 3.5,
+                        which is not compatible with Java 10.
+                        TODO Remove this when updating the javadoc plugin version.
+                        -->
+                        <dependency>
+                            <groupId>org.apache.commons</groupId>
+                            <artifactId>commons-lang3</artifactId>
+                            <version>3.7</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>animal-sniffer-maven-plugin</artifactId>
+                    <version>${version.animal-sniffer}</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.jacoco</groupId>
+                    <artifactId>jacoco-maven-plugin</artifactId>
+                    <version>0.8.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>license-maven-plugin</artifactId>
+                    <version>1.19</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.coderplus.maven.plugins</groupId>
+                    <artifactId>copy-rename-maven-plugin</artifactId>
+                    <version>1.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>3.2.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>2.5</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.4</version> <!-- TODO: see if we can update to latest -->
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>2.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.3</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <dependencyManagement>
@@ -463,7 +538,7 @@
         <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>animal-sniffer-annotations</artifactId>
-            <version>${version.plugin.animal-sniffer}</version>
+            <version>${version.animal-sniffer}</version>
             <optional>true</optional>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -407,11 +407,11 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -440,11 +440,11 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.8</version>
+                    <version>3.1.1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
@@ -460,7 +460,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.1</version>
                     <dependencies>
                         <!--
                         The transitive dependency has version 3.5,
@@ -504,19 +504,19 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.5</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>2.4</version> <!-- TODO: see if we can update to latest -->
+                    <version>3.0.0-M1</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>2.6</version>
+                    <version>3.1.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.8.2</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <name>${project.groupId}:${project.artifactId}</name>
     <version>1.11.1-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <inceptionYear>2018</inceptionYear>
     <organization>
         <name>Elastic Inc.</name>
@@ -129,7 +130,6 @@
           <build>
             <plugins>
               <plugin>
-                  <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-failsafe-plugin</artifactId>
                   <version>${version.plugin.surefire}</version>
                   <configuration>
@@ -158,7 +158,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>${version.plugin.compiler}</version>
                         <configuration>
@@ -181,7 +180,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <version>${version.plugin.compiler}</version>
                         <configuration>
@@ -232,7 +230,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <version>1.6</version>
                         <executions>
@@ -252,7 +249,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <version>2.5.3</version>
                 <configuration>
@@ -263,7 +259,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <version>2.8.2</version>
                 <configuration>
@@ -272,7 +267,6 @@
             </plugin>
             <!-- The shadowed source files of this module need to be included explicitly to create a javadoc artifact.-->
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>${version.plugin.javadoc}</version>
                 <configuration>
@@ -324,7 +318,6 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <version>3.0.0-M1</version>
                 <executions>
@@ -370,7 +363,6 @@
                 </dependencies>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>${version.plugin.surefire}</version>
                 <executions>


### PR DESCRIPTION
## Refactor `pom.xml`
- plugin versions defined at parent module level through `pluginManagement`
- remove default packaging `jar` by default
- remove default `groupId` for plugins `org.apache.maven.plugins`
- dependencies/plugin version properties kept only when used more than once or needs to be kept in sync (spring version, animal sniffer plugin/annotations, ...)
- try to enforce a consistent order of elements in `pom.xml`

### Benefits
- enhanced readeability
- fewer properties
- remove duplication and default values
- same plugin versions used across all modules (might be overloaded locally to a module if needed)

### Risks
- some modules are now built with different plugin versions
- integration tests should ensure that agent is properly packaged and usable


### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code

