### PR TITLE
Update render config docs when testing

### DIFF
--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporterTest.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporterTest.java
@@ -41,6 +41,7 @@ import org.stagemonitor.configuration.ConfigurationRegistry;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
@@ -81,9 +82,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 class ConfigurationExporterTest {
 
     private ConfigurationRegistry configurationRegistry;
+    private Path renderedDocumentationPath;
 
     @BeforeEach
     void setUp() {
+        renderedDocumentationPath = Paths.get("../docs/configuration.asciidoc");
         configurationRegistry = ConfigurationRegistry.builder()
             .optionProviders(ServiceLoader.load(ConfigurationOptionProvider.class))
             .build();
@@ -92,9 +95,17 @@ class ConfigurationExporterTest {
     @Test
     void testGeneratedConfigurationDocsAreUpToDate() throws IOException, TemplateException {
         String renderedDocumentation = renderDocumentation(configurationRegistry);
+        String expected = new String(Files.readAllBytes(this.renderedDocumentationPath));
+
+        // even if this test fails, we want to update the documentation
+        Files.write(renderedDocumentationPath, renderDocumentation(configurationRegistry).getBytes());
+
         assertThat(renderedDocumentation)
-            .withFailMessage("The rendered configuration documentation (/docs/configuration.asciidoc) is not up-to-date. Please execute co.elastic.apm.agent.configuration.ConfigurationExporter#main.")
-            .isEqualTo(new String(Files.readAllBytes(Paths.get("../docs/configuration.asciidoc"))));
+            .withFailMessage("The rendered configuration documentation (/docs/configuration.asciidoc) is not up-to-date.\n" +
+                "If you see this error on CI, it means you have to execute the tests locally which will update the rendered docs.\n" +
+                "If you see this error while running the tests locally, there's nothing more to do - the rendered docs have been updated. " +
+                "When you execute this test the next time, it will not fail anymore.")
+            .isEqualTo(expected);
     }
 
     static String renderDocumentation(ConfigurationRegistry configurationRegistry) throws IOException, TemplateException {

--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporterTest.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporterTest.java
@@ -98,11 +98,13 @@ class ConfigurationExporterTest {
         String expected = new String(Files.readAllBytes(this.renderedDocumentationPath));
 
         // even if this test fails, we want to update the documentation
-        Files.write(renderedDocumentationPath, renderDocumentation(configurationRegistry).getBytes());
+        Files.write(renderedDocumentationPath, renderedDocumentation.getBytes());
 
         assertThat(renderedDocumentation)
             .withFailMessage("The rendered configuration documentation (/docs/configuration.asciidoc) is not up-to-date.\n" +
-                "If you see this error on CI, it means you have to execute the tests locally which will update the rendered docs.\n" +
+                "If you see this error on CI, it means you have to execute the tests locally " +
+                "(./mvnw clean test -pl elastic-apm-agent -am -DfailIfNoTests=false -Dtest=ConfigurationExporterTest) " +
+                "which will update the rendered docs.\n" +
                 "If you see this error while running the tests locally, there's nothing more to do - the rendered docs have been updated. " +
                 "When you execute this test the next time, it will not fail anymore.")
             .isEqualTo(expected);


### PR DESCRIPTION
Tests will still fail on CI if the docs are not up-to-date.
But you can bring them up-to-date by executing the tests.
The advantage is that you don't have to execute a main method from within the IDE (easier for drive-by contributions).
Executing the main method via maven is also not trivial for multi-module maven projects.