### PR TITLE
Fix configuration exporter test to use UTF-8 encoding

### DIFF
--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporter.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporter.java
@@ -27,6 +27,7 @@ package co.elastic.apm.agent.configuration;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -44,7 +45,7 @@ public class ConfigurationExporter {
         if (!path.toFile().canWrite()) {
             throw new IllegalStateException(path + " does not exist");
         }
-        Files.write(path, renderDocumentation(configurationRegistry).getBytes());
+        Files.write(path, renderDocumentation(configurationRegistry).getBytes(StandardCharsets.UTF_8));
     }
 
 }

--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporterTest.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporterTest.java
@@ -40,6 +40,7 @@ import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -95,10 +96,10 @@ class ConfigurationExporterTest {
     @Test
     void testGeneratedConfigurationDocsAreUpToDate() throws IOException, TemplateException {
         String renderedDocumentation = renderDocumentation(configurationRegistry);
-        String expected = new String(Files.readAllBytes(this.renderedDocumentationPath));
+        String expected = new String(Files.readAllBytes(this.renderedDocumentationPath), StandardCharsets.UTF_8);
 
         // even if this test fails, we want to update the documentation
-        Files.write(renderedDocumentationPath, renderedDocumentation.getBytes());
+        Files.write(renderedDocumentationPath, renderedDocumentation.getBytes(StandardCharsets.UTF_8));
 
         assertThat(renderedDocumentation)
             .withFailMessage("The rendered configuration documentation (/docs/configuration.asciidoc) is not up-to-date.\n" +


### PR DESCRIPTION
On Mac OS X the configuration exporter test can give a false positive, because the code depends on default platform encoding instead of using UTF-8 as specified  by the editorconfig.

### Checklist

- [x] Implement code
