### PR TITLE
[1.x][docs] Add placeholder changelog.asciidoc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -1,0 +1,1 @@
+This is a placeholder file. Release notes are published in CHANGELOG.md


### PR DESCRIPTION
In order to build the changelog file to the documentation, the file dependency must be declared in the doc build's `conf.yaml` file. That dependency will be added here: https://github.com/elastic/docs/pull/1459/. The _problem_ is that adding the dependency without it actually existing will cause the doc build to fail. This PR adds a placeholder `CHANGELOG.asciidoc` file to the `1.x` branch. I know you don't typically backport to this branch, but this is the easiest way to ensure that the doc build does not break during the next release. Then, during the next release, this temp file will be overwritten by the up-to-date one in `master`.