### PR TITLE
Work around JULI deadlock

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
@@ -79,6 +79,7 @@ public class ApmServerClient {
     }
 
     public ApmServerClient(ReporterConfiguration reporterConfiguration, List<URL> shuffledUrls) {
+        initHttpUrlConnectionClass();
         this.reporterConfiguration = reporterConfiguration;
         this.healthChecker = new ApmServerHealthChecker(this);
         this.reporterConfiguration.getServerUrlsOption().addChangeListener(new ConfigurationOption.ChangeListener<List<URL>>() {
@@ -91,6 +92,19 @@ public class ApmServerClient {
             }
         });
         setServerUrls(Collections.unmodifiableList(shuffledUrls));
+    }
+
+    /**
+     * A noop method for the sole purpose of loading the HttpUrlConnection class as a side effect, on the main thread,
+     * in order to work around the JULI deadlock reported at https://github.com/elastic/apm-agent-java/issues/954
+     */
+    private void initHttpUrlConnectionClass() {
+        try {
+            new URL("http://localhost:11111").openConnection();
+            new URL("https://localhost:11111").openConnection();
+        } catch (IOException e) {
+            //ignore
+        }
     }
 
     private void setServerUrls(List<URL> serverUrls) {


### PR DESCRIPTION
Fixes #954 

Not the most elegant or generic way to work around this deadlock.
There are multiple ways to work around it, but I wouldn't want to synchronize the healthcheck with the JMX tracker intialization, as this could block the main thread waiting for the healthcheck to be done, which defeats the purpose of doing it on a separate thread. 
If we want to invest more time on it, we can move the JMX tracker initialization to another thread and then sync with the healthcheck, but this requires a bit of effort due to listening on the JMX configuration.
So, in order to provide a quick fix without investing too much effort- this should be good enough.