### PR TITLE
Adding context.message.age.ms field

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,10 +25,13 @@ endif::[]
 
 [float]
 ===== Features
+
 * Add support for <<supported-databases, Redis Lettuce client>>
+* Add `context.message.age.ms` field for JMS message receiving spans and transactions - {pull}970[#970]
 
 [float]
 ===== Bug Fixes
+
 * Fix parsing value of `trace_methods` configuration property {pull}930[#930]
 * Workaround for `java.util.logging` deadlock {pull}965[#965]
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Message.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Message.java
@@ -43,6 +43,12 @@ public class Message implements Recyclable {
     private String body;
 
     /**
+     * Represents the message age in milliseconds. Since 0 is a valid value (can occur due to clock skews between
+     * sender and receiver) - a negative value represents invalid or unavailable age.
+     */
+    private long age = -1L;
+
+    /**
      * A mapping of message headers (in JMS includes properties as well)
      */
     private final NoRandomAccessMap<String, String> headers = new NoRandomAccessMap<>();
@@ -86,6 +92,15 @@ public class Message implements Recyclable {
         return this;
     }
 
+    public long getAge() {
+        return age;
+    }
+
+    public Message withAge(long age) {
+        this.age = age;
+        return this;
+    }
+
     public NoRandomAccessMap<String, String> getHeaders() {
         return headers;
     }
@@ -100,6 +115,7 @@ public class Message implements Recyclable {
         topicName = null;
         body = null;
         headers.resetState();
+        age = -1L;
     }
 
     public void copyFrom(Message other) {
@@ -107,5 +123,6 @@ public class Message implements Recyclable {
         this.topicName = other.getTopicName();
         this.body = other.body;
         this.headers.copyFrom(other.getHeaders());
+        this.age = other.getAge();
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -744,6 +744,14 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
                 writeLongStringField("body", message.getBody());
             }
             serializeMessageHeaders(message);
+            int messageAge = (int) message.getAge();
+            if (messageAge >= 0) {
+                writeFieldName("age");
+                jw.writeByte(OBJECT_START);
+                writeLastField("ms", messageAge);
+                jw.writeByte(OBJECT_END);
+                jw.writeByte(COMMA);
+            }
             if (message.getTopicName() != null) {
                 writeFieldName("topic");
                 jw.writeByte(OBJECT_START);

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsInstrumentationHelper.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsInstrumentationHelper.java
@@ -82,5 +82,7 @@ public interface JmsInstrumentationHelper<D, M, L> {
 
     void addDestinationDetails(M message, D destination, String destinationName, AbstractSpan span);
 
+    void setMessageAge(M message, AbstractSpan span);
+
     void addMessageDetails(@Nullable M message, AbstractSpan span);
 }

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsInstrumentationHelperImpl.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsInstrumentationHelperImpl.java
@@ -185,6 +185,23 @@ public class JmsInstrumentationHelperImpl implements JmsInstrumentationHelper<De
     }
 
     @Override
+    public void setMessageAge(Message message, AbstractSpan span) {
+        try {
+            long messageTimestamp = message.getJMSTimestamp();
+            if (messageTimestamp > 0) {
+                long now = System.currentTimeMillis();
+                if (now > messageTimestamp) {
+                    span.getContext().getMessage().withAge(now - messageTimestamp);
+                } else {
+                    span.getContext().getMessage().withAge(0);
+                }
+            }
+        } catch (JMSException e) {
+            logger.warn("Failed to get message timestamp", e);
+        }
+    }
+
+    @Override
     public void addMessageDetails(@Nullable Message message, AbstractSpan span) {
         if (message == null) {
             return;

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
@@ -175,7 +175,6 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                 String messageSenderContext = null;
                 Destination destination = null;
                 String destinationName = null;
-                long messageAge = 0;
                 boolean discard = false;
                 boolean addDetails = true;
                 if (message != null) {
@@ -185,10 +184,6 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                         if (helper != null) {
                             destinationName = helper.extractDestinationName(message, destination);
                             discard = helper.ignoreDestination(destinationName);
-                        }
-                        long timestamp = message.getJMSTimestamp();
-                        if (timestamp > 0) {
-                            messageAge = System.currentTimeMillis() - timestamp;
                         }
                     } catch (JMSException e) {
                         logger.error("Failed to retrieve meta info from Message", e);
@@ -221,9 +216,7 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                             if (message != null && helper != null && destinationName != null) {
                                 abstractSpan.appendToName(" from ");
                                 helper.addDestinationDetails(message, destination, destinationName, abstractSpan);
-                                if (messageAge > 0) {
-                                    abstractSpan.getContext().getMessage().withAge(messageAge);
-                                }
+                                helper.setMessageAge(message, abstractSpan);
                             }
                             abstractSpan.captureException(throwable);
                         }
@@ -245,9 +238,7 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                         messageHandlingTransaction.appendToName(" from ");
                         helper.addDestinationDetails(message, destination, destinationName, messageHandlingTransaction);
                         helper.addMessageDetails(message, messageHandlingTransaction);
-                        if (messageAge > 0) {
-                            messageHandlingTransaction.getContext().getMessage().withAge(messageAge);
-                        }
+                        helper.setMessageAge(message, messageHandlingTransaction);
                     }
 
                     messageHandlingTransaction.activate();

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
@@ -175,6 +175,7 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                 String messageSenderContext = null;
                 Destination destination = null;
                 String destinationName = null;
+                long messageAge = 0;
                 boolean discard = false;
                 boolean addDetails = true;
                 if (message != null) {
@@ -184,6 +185,10 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                         if (helper != null) {
                             destinationName = helper.extractDestinationName(message, destination);
                             discard = helper.ignoreDestination(destinationName);
+                        }
+                        long timestamp = message.getJMSTimestamp();
+                        if (timestamp > 0) {
+                            messageAge = System.currentTimeMillis() - timestamp;
                         }
                     } catch (JMSException e) {
                         logger.error("Failed to retrieve meta info from Message", e);
@@ -216,6 +221,9 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                             if (message != null && helper != null && destinationName != null) {
                                 abstractSpan.appendToName(" from ");
                                 helper.addDestinationDetails(message, destination, destinationName, abstractSpan);
+                                if (messageAge > 0) {
+                                    abstractSpan.getContext().getMessage().withAge(messageAge);
+                                }
                             }
                             abstractSpan.captureException(throwable);
                         }
@@ -237,6 +245,9 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                         messageHandlingTransaction.appendToName(" from ");
                         helper.addDestinationDetails(message, destination, destinationName, messageHandlingTransaction);
                         helper.addMessageDetails(message, messageHandlingTransaction);
+                        if (messageAge > 0) {
+                            messageHandlingTransaction.getContext().getMessage().withAge(messageAge);
+                        }
                     }
 
                     messageHandlingTransaction.activate();

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
@@ -95,8 +95,10 @@ public class JmsMessageListenerInstrumentation extends BaseJmsInstrumentation {
 
             Destination destination = null;
             String destinationName = null;
+            long timestamp = 0;
             try {
                 destination = message.getJMSDestination();
+                timestamp = message.getJMSTimestamp();
             } catch (JMSException e) {
                 logger.warn("Failed to retrieve message's destination", e);
             }
@@ -134,6 +136,9 @@ public class JmsMessageListenerInstrumentation extends BaseJmsInstrumentation {
                     helper.addDestinationDetails(message, destination, destinationName, transaction.appendToName(" from "));
                 }
                 helper.addMessageDetails(message, transaction);
+                if (timestamp > 0) {
+                    transaction.getContext().getMessage().withAge(System.currentTimeMillis() - timestamp);
+                }
             }
             transaction.activate();
 

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
@@ -136,9 +136,7 @@ public class JmsMessageListenerInstrumentation extends BaseJmsInstrumentation {
                     helper.addDestinationDetails(message, destination, destinationName, transaction.appendToName(" from "));
                 }
                 helper.addMessageDetails(message, transaction);
-                if (timestamp > 0) {
-                    transaction.getContext().getMessage().withAge(System.currentTimeMillis() - timestamp);
-                }
+                helper.setMessageAge(message, transaction);
             }
             transaction.activate();
 

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/ActiveMqArtemisFacade.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/ActiveMqArtemisFacade.java
@@ -125,8 +125,8 @@ public class ActiveMqArtemisFacade implements BrokerFacade {
     }
 
     @Override
-    public void send(Destination destination, Message message) {
-        context.createProducer().send(destination, message);
+    public void send(Destination destination, Message message, boolean disableTimestamp) {
+        context.createProducer().setDisableMessageTimestamp(disableTimestamp).send(destination, message);
     }
 
     @Override

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/ActiveMqFacade.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/ActiveMqFacade.java
@@ -33,6 +33,7 @@ import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
 import javax.jms.MessageListener;
+import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TemporaryQueue;
@@ -108,8 +109,12 @@ class ActiveMqFacade implements BrokerFacade {
     }
 
     @Override
-    public void send(Destination destination, Message message) throws JMSException {
-        session.createProducer(destination).send(message);
+    public void send(Destination destination, Message message, boolean disableTimestamp) throws JMSException {
+        MessageProducer producer = session.createProducer(destination);
+        if (disableTimestamp) {
+            producer.setDisableMessageTimestamp(true);
+        }
+        producer.send(message);
     }
 
     @Override

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/BrokerFacade.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/BrokerFacade.java
@@ -53,6 +53,14 @@ interface BrokerFacade {
 
     TextMessage createTextMessage(String messageText) throws Exception;
 
+    /**
+     * Send the given message to the given destination.
+     *
+     * @param destination      destination to send the message to
+     * @param message          message to be sent
+     * @param disableTimestamp indicates whether the underlying {@link javax.jms.MessageProducer} should disable message timestamp
+     * @throws Exception an internal client error
+     */
     void send(Destination destination, Message message, boolean disableTimestamp) throws Exception;
 
     CompletableFuture<Message> registerConcreteListenerImplementation(Destination destination);

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/BrokerFacade.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/BrokerFacade.java
@@ -53,7 +53,7 @@ interface BrokerFacade {
 
     TextMessage createTextMessage(String messageText) throws Exception;
 
-    void send(Destination destination, Message message) throws Exception;
+    void send(Destination destination, Message message, boolean disableTimestamp) throws Exception;
 
     CompletableFuture<Message> registerConcreteListenerImplementation(Destination destination);
 

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/JmsInstrumentationIT.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/JmsInstrumentationIT.java
@@ -359,7 +359,7 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
         if (disableTimestamp) {
             assertThat(receiveSpan.getContext().getMessage().getAge()).isEqualTo(-1L);
         } else {
-            assertThat(receiveSpan.getContext().getMessage().getAge()).isGreaterThan(0);
+            assertThat(receiveSpan.getContext().getMessage().getAge()).isGreaterThanOrEqualTo(0);
         }
 
         if (sendToNoopSpan != null) {
@@ -417,7 +417,7 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
                 assertThat(receiveTransaction.getContext().getMessage().getTopicName()).isEqualTo(destinationName);
             }
             assertThat(receiveTransaction.getContext().getMessage().getBody()).isEqualTo(message.getText());
-            assertThat(receiveTransaction.getContext().getMessage().getAge()).isGreaterThan(0);
+            assertThat(receiveTransaction.getContext().getMessage().getAge()).isGreaterThanOrEqualTo(0);
             verifyMessageHeaders(message, receiveTransaction);
         }
     }
@@ -497,7 +497,7 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
                 assertThat(receiveTransaction.getContext().getMessage().getTopicName()).isEqualTo(destinationName);
             }
             assertThat(receiveTransaction.getContext().getMessage().getBody()).isEqualTo(message.getText());
-            assertThat(receiveTransaction.getContext().getMessage().getAge()).isGreaterThan(0);
+            assertThat(receiveTransaction.getContext().getMessage().getAge()).isGreaterThanOrEqualTo(0);
             transactionId = receiveTransaction.getTraceContext().getId();
         }
 


### PR DESCRIPTION
Implementing the latest requirement in https://github.com/elastic/apm/issues/143 for the addition of a `context.message.age.ms` field.
 
### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
