### PR TITLE
Lettuce javadoc fix- take II

### DIFF
--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce34Instrumentation.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce34Instrumentation.java
@@ -42,7 +42,7 @@ public abstract class Lettuce34Instrumentation extends ElasticApmInstrumentation
     public static final WeakConcurrentMap<RedisCommand, Span> commandToSpan = new WeakConcurrentMap.WithInlinedExpunction<RedisCommand, Span>();
 
     /**
-     * We don't support Lettuce <= 3.3, as the {@code RedisCommand#getType()} method is missing
+     * We don't support Lettuce up to version 3.3, as the {@link RedisCommand#getType()} method is missing
      */
     @Override
     public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce34Instrumentation.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce34Instrumentation.java
@@ -42,7 +42,7 @@ public abstract class Lettuce34Instrumentation extends ElasticApmInstrumentation
     public static final WeakConcurrentMap<RedisCommand, Span> commandToSpan = new WeakConcurrentMap.WithInlinedExpunction<RedisCommand, Span>();
 
     /**
-     * We don't support Lettuce <= 3.3, as the {@link RedisCommand#getType()} method is missing
+     * We don't support Lettuce <= 3.3, as the {@code RedisCommand#getType()} method is missing
      */
     @Override
     public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {


### PR DESCRIPTION
Wasn't the `@link` probably, the `<=` may bother the javadoc plugin...