### PR TITLE
Adding Destination fields

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,9 +28,9 @@ endif::[]
 
 * Add support for <<supported-databases, Redis Lettuce client>>
 * Add `context.message.age.ms` field for JMS message receiving spans and transactions - {pull}970[#970]
-* Instrument log4j Logger#error(String, Throwable) ({pull}919[#919])
-  Automatically captures exceptions when calling `logger.error("message", exception)`
+* Instrument log4j Logger#error(String, Throwable) ({pull}919[#919]) Automatically captures exceptions when calling `logger.error("message", exception)`
 * Add instrumentation for external process execution through `java.lang.Process` and Apache `commons-exec` - {pull}903[#903]
+* Add `destination` fields to exit span contexts - {pull}976[#976]
 
 [float]
 ===== Bug Fixes

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
@@ -1,0 +1,96 @@
+package co.elastic.apm.agent.impl.context;
+
+import co.elastic.apm.agent.objectpool.Recyclable;
+
+import javax.annotation.Nullable;
+
+/**
+ * Context information about a destination of outgoing calls.
+ */
+public class Destination implements Recyclable {
+    /**
+     * Information about the service related to this destination.
+     */
+    private final Service service = new Service();
+
+    public Service getService() {
+        return service;
+    }
+
+    public boolean hasContent() {
+        return service.hasContent();
+    }
+
+    @Override
+    public void resetState() {
+        service.resetState();
+    }
+
+    /**
+     * Context information required for service maps.
+     */
+    public static class Service implements Recyclable {
+        /**
+         * Used for detecting unique destinations from each service.
+         * For HTTP, this is the address, with the port (even when it's the default port), without any scheme.
+         * For other types of connections, it's just the {@code span.subtype} (kafka, elasticsearch etc.).
+         * For messaging, we additionally add the queue name (eg jms/myQueue).
+         */
+        private final StringBuilder resource = new StringBuilder();
+
+        /**
+         * Used for detecting “sameness” of services and then the display name of a service in the Service Map.
+         * In other words, the {@link Service#resource} is used to query data for ALL destinations. However,
+         * some `resources` may be nodes of the same cluster, in which case we also want to be aware.
+         * Eventually, we may decide to actively fetch a cluster name or similar and we could use that to detect "sameness".
+         * For now, for HTTP we use scheme, host, and non-default port. For anything else, we use {@code span.subtype}
+         * (for example- postgresql, elasticsearch).
+         */
+        private final StringBuilder name = new StringBuilder();
+
+        /**
+         * For displaying icons or similar. Currently, this should be equal to the {@code span.type}.
+         */
+        @Nullable
+        private String type;
+
+        public Service withResource(String resource) {
+            this.resource.append(resource);
+            return this;
+        }
+
+        public StringBuilder getResource() {
+            return resource;
+        }
+
+        public Service withName(String name) {
+            this.name.append(name);
+            return this;
+        }
+
+        public StringBuilder getName() {
+            return name;
+        }
+
+        public Service withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        @Nullable
+        public String getType() {
+            return type;
+        }
+
+        public boolean hasContent() {
+            return resource.length() > 0 || name.length() > 0 || type != null;
+        }
+
+        @Override
+        public void resetState() {
+            resource.setLength(0);
+            name.setLength(0);
+            type = null;
+        }
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
@@ -43,8 +43,8 @@ public class Destination implements Recyclable {
      */
     private int port;
 
-    public Destination withAddress(CharSequence address) {
-        if (address.length() > 0) {
+    public Destination withAddress(@Nullable CharSequence address) {
+        if (address != null && address.length() > 0) {
             // remove square brackets for IPv6 addresses
             int startIndex = 0;
             if (address.charAt(0) == '[') {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
@@ -32,6 +32,46 @@ import javax.annotation.Nullable;
  * Context information about a destination of outgoing calls.
  */
 public class Destination implements Recyclable {
+
+    /**
+     * An IP (v4 or v6) or a host/domain name.
+     */
+    private final StringBuilder address = new StringBuilder();
+
+    /**
+     * The destination's port used within this context.
+     */
+    private int port;
+
+    public Destination withAddress(CharSequence address) {
+        if (address.length() > 0) {
+            // remove square brackets for IPv6 addresses
+            int startIndex = 0;
+            if (address.charAt(0) == '[') {
+                startIndex = 1;
+            }
+            int endIndex = address.length();
+            if (address.charAt(endIndex - 1) == ']') {
+                endIndex--;
+            }
+            this.address.append(address, startIndex, endIndex);
+        }
+        return this;
+    }
+
+    public StringBuilder getAddress() {
+        return address;
+    }
+
+    public Destination withPort(int port) {
+        this.port = port;
+        return this;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
     /**
      * Information about the service related to this destination.
      */
@@ -42,11 +82,13 @@ public class Destination implements Recyclable {
     }
 
     public boolean hasContent() {
-        return service.hasContent();
+        return address.length() > 0 || port > 0 || service.hasContent();
     }
 
     @Override
     public void resetState() {
+        address.setLength(0);
+        port = -1;
         service.resetState();
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.impl.context;
 
 import co.elastic.apm.agent.objectpool.Recyclable;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/SpanContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/SpanContext.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -42,6 +42,11 @@ public class SpanContext extends AbstractContext {
     private final Http http = new Http();
 
     /**
+     * An object containing contextual data for service maps
+     */
+    private final Destination destination = new Destination();
+
+    /**
      * An object containing contextual data for database spans
      */
     public Db getDb() {
@@ -55,14 +60,22 @@ public class SpanContext extends AbstractContext {
         return http;
     }
 
+    /**
+     * An object containing contextual data for service maps
+     */
+    public Destination getDestination() {
+        return destination;
+    }
+
     @Override
     public void resetState() {
         super.resetState();
         db.resetState();
         http.resetState();
+        destination.resetState();
     }
 
     public boolean hasContent() {
-        return super.hasContent() || db.hasContent() || http.hasContent();
+        return super.hasContent() || db.hasContent() || http.hasContent() || destination.hasContent();
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
@@ -188,16 +188,16 @@ public abstract class AbstractSpan<T extends AbstractSpan> extends TraceContextH
      * as the underlying {@link StringBuilder} instance will be reused.
      * </p>
      *
-     * @param s the string to append to the name
+     * @param cs the char sequence to append to the name
      * @return {@code this}, for chaining
      */
-    public T appendToName(String s) {
-        return appendToName(s, PRIO_DEFAULT);
+    public T appendToName(CharSequence cs) {
+        return appendToName(cs, PRIO_DEFAULT);
     }
 
-    public T appendToName(String s, int priority) {
+    public T appendToName(CharSequence cs, int priority) {
         if (priority >= namePriority) {
-            this.name.append(s);
+            this.name.append(cs);
             this.namePriority = priority;
         }
         return (T) this;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -26,6 +26,7 @@ package co.elastic.apm.agent.report.serialize;
 
 import co.elastic.apm.agent.impl.MetaData;
 import co.elastic.apm.agent.impl.context.AbstractContext;
+import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.context.Message;
 import co.elastic.apm.agent.impl.context.Request;
 import co.elastic.apm.agent.impl.context.Response;
@@ -728,12 +729,34 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
         serializeMessageContext(context.getMessage());
         serializeDbContext(context.getDb());
         serializeHttpContext(context.getHttp());
+        serializeDestination(context.getDestination());
 
         writeFieldName("tags");
         serializeLabels(context);
 
         jw.writeByte(OBJECT_END);
         jw.writeByte(COMMA);
+    }
+
+    private void serializeDestination(Destination destination) {
+        if (destination.hasContent()) {
+            writeFieldName("destination");
+            jw.writeByte(OBJECT_START);
+            serializeService(destination.getService());
+            jw.writeByte(OBJECT_END);
+            jw.writeByte(COMMA);
+        }
+    }
+
+    private void serializeService(Destination.Service service) {
+        if (service.hasContent()) {
+            writeFieldName("service");
+            jw.writeByte(OBJECT_START);
+            writeField("name", service.getName());
+            writeField("resource", service.getResource());
+            writeLastField("type", service.getType());
+            jw.writeByte(OBJECT_END);
+        }
     }
 
     private void serializeMessageContext(final Message message) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -742,6 +742,12 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
         if (destination.hasContent()) {
             writeFieldName("destination");
             jw.writeByte(OBJECT_START);
+            if (destination.getAddress().length() > 0) {
+                writeField("address", destination.getAddress());
+            }
+            if (destination.getPort() > 0) {
+                writeField("port", destination.getPort());
+            }
             serializeService(destination.getService());
             jw.writeByte(OBJECT_END);
             jw.writeByte(COMMA);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -280,9 +280,11 @@ class DslJsonSerializerTest {
             .withMethod("GET")
             .withStatusCode(523)
             .withUrl("http://whatever.com/path");
-        span.getContext().getDestination().getService().withName("http://whatever.com");
-        span.getContext().getDestination().getService().withResource("whatever.com:80");
-        span.getContext().getDestination().getService().withType("external");
+        span.getContext().getDestination().withAddress("whatever.com").withPort(80)
+            .getService()
+            .withName("http://whatever.com")
+            .withResource("whatever.com:80")
+            .withType("external");
 
         JsonNode spanJson = readJsonString(serializer.toJsonString(span));
         JsonNode context = spanJson.get("context");
@@ -293,6 +295,8 @@ class DslJsonSerializerTest {
         assertThat(http.get("status_code").intValue()).isEqualTo(523);
         JsonNode destination = context.get("destination");
         assertThat(destination).isNotNull();
+        assertThat("whatever.com").isEqualTo(destination.get("address").textValue());
+        assertThat(80).isEqualTo(destination.get("port").intValue());
         JsonNode service = destination.get("service");
         assertThat(service).isNotNull();
         assertThat("http://whatever.com").isEqualTo(service.get("name").textValue());

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -280,6 +280,9 @@ class DslJsonSerializerTest {
             .withMethod("GET")
             .withStatusCode(523)
             .withUrl("http://whatever.com/path");
+        span.getContext().getDestination().getService().withName("http://whatever.com");
+        span.getContext().getDestination().getService().withResource("whatever.com:80");
+        span.getContext().getDestination().getService().withType("external");
 
         JsonNode spanJson = readJsonString(serializer.toJsonString(span));
         JsonNode context = spanJson.get("context");
@@ -288,6 +291,13 @@ class DslJsonSerializerTest {
         assertThat(http.get("method").textValue()).isEqualTo("GET");
         assertThat(http.get("url").textValue()).isEqualTo("http://whatever.com/path");
         assertThat(http.get("status_code").intValue()).isEqualTo(523);
+        JsonNode destination = context.get("destination");
+        assertThat(destination).isNotNull();
+        JsonNode service = destination.get("service");
+        assertThat(service).isNotNull();
+        assertThat("http://whatever.com").isEqualTo(service.get("name").textValue());
+        assertThat("whatever.com:80").isEqualTo(service.get("resource").textValue());
+        assertThat("external").isEqualTo(service.get("type").textValue());
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -280,11 +280,6 @@ class DslJsonSerializerTest {
             .withMethod("GET")
             .withStatusCode(523)
             .withUrl("http://whatever.com/path");
-        span.getContext().getDestination().withAddress("whatever.com").withPort(80)
-            .getService()
-            .withName("http://whatever.com")
-            .withResource("whatever.com:80")
-            .withType("external");
 
         JsonNode spanJson = readJsonString(serializer.toJsonString(span));
         JsonNode context = spanJson.get("context");
@@ -293,6 +288,19 @@ class DslJsonSerializerTest {
         assertThat(http.get("method").textValue()).isEqualTo("GET");
         assertThat(http.get("url").textValue()).isEqualTo("http://whatever.com/path");
         assertThat(http.get("status_code").intValue()).isEqualTo(523);
+    }
+
+    @Test
+    void testSpanDestinationContextSerialization() {
+        Span span = new Span(MockTracer.create());
+        span.getContext().getDestination().withAddress("whatever.com").withPort(80)
+            .getService()
+            .withName("http://whatever.com")
+            .withResource("whatever.com:80")
+            .withType("external");
+
+        JsonNode spanJson = readJsonString(serializer.toJsonString(span));
+        JsonNode context = spanJson.get("context");
         JsonNode destination = context.get("destination");
         assertThat(destination).isNotNull();
         assertThat("whatever.com").isEqualTo(destination.get("address").textValue());

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/VersionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/VersionTest.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.util;
 
 import org.junit.jupiter.api.Test;

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpAsyncRequestProducerWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpAsyncRequestProducerWrapper.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,6 +24,7 @@
  */
 package co.elastic.apm.agent.httpclient;
 
+import co.elastic.apm.agent.http.client.HttpClientHelper;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.objectpool.Recyclable;
@@ -81,6 +82,7 @@ public class HttpAsyncRequestProducerWrapper implements HttpAsyncRequestProducer
             String hostname = host.getHostName();
             if (hostname != null) {
                 span.appendToName(hostname);
+                HttpClientHelper.setDestinationServiceDetails(span, host.getSchemeName(), hostname, host.getPort());
             }
         }
 

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AbstractAsyncHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AbstractAsyncHttpClientInstrumentation.java
@@ -38,6 +38,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import org.asynchttpclient.AsyncHandler;
 import org.asynchttpclient.HttpResponseStatus;
 import org.asynchttpclient.Request;
+import org.asynchttpclient.uri.Uri;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -78,7 +79,8 @@ public abstract class AbstractAsyncHttpClientInstrumentation extends ElasticApmI
             }
 
             final TraceContextHolder<?> parent = tracer.getActive();
-            span = HttpClientHelper.startHttpClientSpan(parent, request.getMethod(), request.getUri().toUrl(), request.getUri().getHost());
+            Uri uri = request.getUri();
+            span = HttpClientHelper.startHttpClientSpan(parent, request.getMethod(), uri.toUrl(), uri.getScheme(), uri.getHost(), uri.getPort());
 
             if (span != null) {
                 span.activate();

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_1/src/test/java/co/elastic/apm/agent/es/restclient/v7_1/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_1/src/test/java/co/elastic/apm/agent/es/restclient/v7_1/ElasticsearchRestClientInstrumentationIT.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/es/restclient/ElasticsearchRestClientInstrumentationHelperImpl.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/es/restclient/ElasticsearchRestClientInstrumentationHelperImpl.java
@@ -25,6 +25,7 @@
 package co.elastic.apm.agent.es.restclient;
 
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
 import co.elastic.apm.agent.objectpool.Allocator;
@@ -105,6 +106,7 @@ public class ElasticsearchRestClientInstrumentationHelperImpl implements Elastic
                     }
                 }
             }
+            span.getContext().getDestination().getService().withName(ELASTICSEARCH).withResource(ELASTICSEARCH).withType(SPAN_TYPE);
         }
         return span;
     }

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
@@ -126,6 +126,8 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
 
     private void validateDestinationContextContent(Destination destination) {
         assertThat(destination).isNotNull();
+        assertThat(destination.getAddress().toString()).isEqualTo(container.getContainerIpAddress());
+        assertThat(destination.getPort()).isEqualTo(container.getMappedPort(9200));
         assertThat(destination.getService().getName().toString()).isEqualTo(ELASTICSEARCH);
         assertThat(destination.getService().getResource().toString()).isEqualTo(ELASTICSEARCH);
         assertThat(destination.getService().getType()).isEqualTo(SPAN_TYPE);

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,6 +25,7 @@
 package co.elastic.apm.agent.es.restclient;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.context.Db;
 import co.elastic.apm.agent.impl.context.Http;
@@ -120,6 +121,14 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
     protected void validateSpanContent(Span span, String expectedName, int statusCode, String method) {
         validateSpanContentWithoutContext(span, expectedName, statusCode, method);
         validateHttpContextContent(span.getContext().getHttp(), statusCode, method);
+        validateDestinationContextContent(span.getContext().getDestination());
+    }
+
+    private void validateDestinationContextContent(Destination destination) {
+        assertThat(destination).isNotNull();
+        assertThat(destination.getService().getName().toString()).isEqualTo(ELASTICSEARCH);
+        assertThat(destination.getService().getResource().toString()).isEqualTo(ELASTICSEARCH);
+        assertThat(destination.getService().getType()).isEqualTo(SPAN_TYPE);
     }
 
     private void validateHttpContextContent(Http http, int statusCode, String method) {

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchConstants.java
@@ -30,4 +30,6 @@ public final class HibernateSearchConstants {
 
     public static final String HIBERNATE_SEARCH_ORM_SPAN_NAME = "Hibernate-Search";
 
+    public static final String HIBERNATE_SEARCH_ORM_SPAN_TYPE = "db";
+
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
@@ -51,14 +51,18 @@ public final class HibernateSearchHelper {
 
             span = active.createSpan().activate();
 
-            span.withType("db")
-                .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                .withAction(methodName);
+            span.withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_TYPE)
+                    .withSubtype(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                    .withAction(methodName);
             span.getContext().getDb()
-                .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                .withStatement(query);
+                    .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                    .withStatement(query);
             span.withName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME)
-                .appendToName(" ").appendToName(methodName).appendToName("()");
+                    .appendToName(" ").appendToName(methodName).appendToName("()");
+            span.getContext().getDestination().getService()
+                    .withName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                    .withResource(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
+                    .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_TYPE);
         }
         return span;
     }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/main/java/co/elastic/apm/agent/hibernate/search/HibernateSearchHelper.java
@@ -59,10 +59,6 @@ public final class HibernateSearchHelper {
                     .withStatement(query);
             span.withName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_NAME)
                     .appendToName(" ").appendToName(methodName).appendToName("()");
-            span.getContext().getDestination().getService()
-                    .withName(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                    .withResource(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE)
-                    .withType(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_TYPE);
         }
         return span;
     }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -25,6 +25,7 @@
 package co.elastic.apm.agent.hibernate.search;
 
 import co.elastic.apm.agent.MockReporter;
+import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.transaction.Span;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -40,9 +41,13 @@ public final class HibernateSearchAssertionHelper {
         final Span span = reporter.getFirstSpan();
         assertThat(span.getSubtype()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
         assertThat(span.getContext().getDb().getStatement()).isEqualTo(expectedQuery);
-        assertThat(span.getType()).isEqualTo("db");
+        assertThat(span.getType()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_TYPE);
         assertThat(span.getAction()).isEqualTo(searchMethod);
         assertThat(span.getNameAsString()).isEqualTo(buildSpanName(searchMethod));
+        Destination.Service service = span.getContext().getDestination().getService();
+        assertThat(service.getName().toString()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
+        assertThat(service.getResource().toString()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
+        assertThat(service.getType()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_TYPE);
     }
 
     private static String buildSpanName(final String methodName) {

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/src/test/java/co/elastic/apm/agent/hibernate/search/HibernateSearchAssertionHelper.java
@@ -44,10 +44,6 @@ public final class HibernateSearchAssertionHelper {
         assertThat(span.getType()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_TYPE);
         assertThat(span.getAction()).isEqualTo(searchMethod);
         assertThat(span.getNameAsString()).isEqualTo(buildSpanName(searchMethod));
-        Destination.Service service = span.getContext().getDestination().getService();
-        assertThat(service.getName().toString()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
-        assertThat(service.getResource().toString()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
-        assertThat(service.getType()).isEqualTo(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_SPAN_TYPE);
     }
 
     private static String buildSpanName(final String methodName) {

--- a/apm-agent-plugins/apm-httpclient-core/src/main/java/co/elastic/apm/agent/http/client/HttpClientHelper.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/main/java/co/elastic/apm/agent/http/client/HttpClientHelper.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,6 +25,7 @@
 package co.elastic.apm.agent.http.client;
 
 import co.elastic.apm.agent.bci.VisibleForAdvice;
+import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
 
@@ -37,13 +38,25 @@ public class HttpClientHelper {
 
     @Nullable
     @VisibleForAdvice
-    public static Span startHttpClientSpan(TraceContextHolder<?> parent, String method, @Nullable URI uri, String hostName) {
-        return startHttpClientSpan(parent, method, uri != null ? uri.toString() : null, hostName);
+    public static Span startHttpClientSpan(TraceContextHolder<?> parent, String method, @Nullable URI uri, @Nullable String hostName) {
+        String uriString = null;
+        String scheme = null;
+        int port = -1;
+        if (uri != null) {
+            uriString = uri.toString();
+            scheme = uri.getScheme();
+            port = uri.getPort();
+            if (hostName == null) {
+                hostName = uri.getHost();
+            }
+        }
+        return startHttpClientSpan(parent, method, uriString, scheme, hostName, port);
     }
 
     @Nullable
     @VisibleForAdvice
-    public static Span startHttpClientSpan(TraceContextHolder<?> parent, String method, @Nullable String uri, String hostName) {
+    public static Span startHttpClientSpan(TraceContextHolder<?> parent, String method, @Nullable String uri,
+                                           String scheme, String hostName, int port) {
         Span span = parent.createExitSpan();
         if (span != null) {
             span.withType(EXTERNAL_TYPE)
@@ -53,7 +66,42 @@ public class HttpClientHelper {
             if (uri != null) {
                 span.getContext().getHttp().withUrl(uri);
             }
+            setDestinationServiceDetails(span, scheme, hostName, port);
         }
         return span;
+    }
+
+    @VisibleForAdvice
+    public static void setDestinationServiceDetails(Span span, @Nullable String scheme, @Nullable String host, int port) {
+        if (scheme == null || host == null) {
+            return;
+        }
+
+        boolean isDefaultPort = false;
+        if ("http".equals(scheme)) {
+            if (port < 0) {
+                port = 80;
+            }
+            if (port == 80) {
+                isDefaultPort = true;
+            }
+        } else if ("https".equals(scheme)) {
+            if (port < 0) {
+                port = 443;
+            }
+            if (port == 443) {
+                isDefaultPort = true;
+            }
+        } else {
+            return;
+        }
+
+        Destination destination = span.getContext().getDestination();
+        destination.getService().getResource().append(host).append(":").append(port);
+        destination.getService().getName().append(scheme).append("://").append(host);
+        if (!isDefaultPort) {
+            destination.getService().getName().append(":").append(port);
+        }
+        destination.getService().withType(EXTERNAL_TYPE);
     }
 }

--- a/apm-agent-plugins/apm-httpclient-core/src/main/java/co/elastic/apm/agent/http/client/HttpClientHelper.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/main/java/co/elastic/apm/agent/http/client/HttpClientHelper.java
@@ -38,7 +38,7 @@ public class HttpClientHelper {
 
     @Nullable
     @VisibleForAdvice
-    public static Span startHttpClientSpan(TraceContextHolder<?> parent, String method, @Nullable URI uri, @Nullable String hostName) {
+    public static Span startHttpClientSpan(TraceContextHolder<?> parent, String method, @Nullable URI uri, @Nullable CharSequence hostName) {
         String uriString = null;
         String scheme = null;
         int port = -1;
@@ -56,7 +56,7 @@ public class HttpClientHelper {
     @Nullable
     @VisibleForAdvice
     public static Span startHttpClientSpan(TraceContextHolder<?> parent, String method, @Nullable String uri,
-                                           String scheme, String hostName, int port) {
+                                           String scheme, CharSequence hostName, int port) {
         Span span = parent.createExitSpan();
         if (span != null) {
             span.withType(EXTERNAL_TYPE)
@@ -72,8 +72,8 @@ public class HttpClientHelper {
     }
 
     @VisibleForAdvice
-    public static void setDestinationServiceDetails(Span span, @Nullable String scheme, @Nullable String host, int port) {
-        if (scheme == null || host == null) {
+    public static void setDestinationServiceDetails(Span span, @Nullable String scheme, @Nullable CharSequence host, int port) {
+        if (scheme == null || host == null || host.length() == 0) {
             return;
         }
 

--- a/apm-agent-plugins/apm-httpclient-core/src/main/java/co/elastic/apm/agent/http/client/HttpClientHelper.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/main/java/co/elastic/apm/agent/http/client/HttpClientHelper.java
@@ -96,7 +96,7 @@ public class HttpClientHelper {
             return;
         }
 
-        Destination destination = span.getContext().getDestination();
+        Destination destination = span.getContext().getDestination().withAddress(host).withPort(port);
         destination.getService().getResource().append(host).append(":").append(port);
         destination.getService().getName().append(scheme).append("://").append(host);
         if (!isDefaultPort) {

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/http/client/HttpClientHelperTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/http/client/HttpClientHelperTest.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.http.client;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/http/client/HttpClientHelperTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/http/client/HttpClientHelperTest.java
@@ -66,6 +66,8 @@ class HttpClientHelperTest extends AbstractInstrumentationTest {
         assertThat(destination.getService().getName().toString()).isEqualTo("http://testing.local:1234");
         assertThat(destination.getService().getResource().toString()).isEqualTo("testing.local:1234");
         assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+        assertThat(destination.getAddress().toString()).isEqualTo("testing.local");
+        assertThat(destination.getPort()).isEqualTo(1234);
     }
 
     @Test
@@ -79,6 +81,8 @@ class HttpClientHelperTest extends AbstractInstrumentationTest {
         assertThat(destination.getService().getName().toString()).isEqualTo("https://www.elastic.co");
         assertThat(destination.getService().getResource().toString()).isEqualTo("www.elastic.co:443");
         assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+        assertThat(destination.getAddress().toString()).isEqualTo("www.elastic.co");
+        assertThat(destination.getPort()).isEqualTo(443);
     }
 
     @Test
@@ -92,6 +96,8 @@ class HttpClientHelperTest extends AbstractInstrumentationTest {
         assertThat(destination.getService().getName().toString()).isEqualTo("https://www.elastic.co");
         assertThat(destination.getService().getResource().toString()).isEqualTo("www.elastic.co:443");
         assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+        assertThat(destination.getAddress().toString()).isEqualTo("www.elastic.co");
+        assertThat(destination.getPort()).isEqualTo(443);
     }
 
     @Test
@@ -105,6 +111,8 @@ class HttpClientHelperTest extends AbstractInstrumentationTest {
         assertThat(destination.getService().getName().toString()).isEqualTo("https://151.101.114.217");
         assertThat(destination.getService().getResource().toString()).isEqualTo("151.101.114.217:443");
         assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+        assertThat(destination.getAddress().toString()).isEqualTo("151.101.114.217");
+        assertThat(destination.getPort()).isEqualTo(443);
     }
 
     @Test
@@ -118,5 +126,7 @@ class HttpClientHelperTest extends AbstractInstrumentationTest {
         assertThat(destination.getService().getName().toString()).isEqualTo("http://[2001:db8:a0b:12f0::1]");
         assertThat(destination.getService().getResource().toString()).isEqualTo("[2001:db8:a0b:12f0::1]:80");
         assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+        assertThat(destination.getAddress().toString()).isEqualTo("2001:db8:a0b:12f0::1");
+        assertThat(destination.getPort()).isEqualTo(80);
     }
 }

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/http/client/HttpClientHelperTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/http/client/HttpClientHelperTest.java
@@ -1,0 +1,98 @@
+package co.elastic.apm.agent.http.client;
+
+import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.impl.context.Destination;
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import static co.elastic.apm.agent.http.client.HttpClientHelper.EXTERNAL_TYPE;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("ConstantConditions")
+class HttpClientHelperTest extends AbstractInstrumentationTest {
+
+    @BeforeEach
+    void beforeTest() {
+        tracer.startTransaction(TraceContext.asRoot(), null, null)
+            .withName("Test HTTP client")
+            .withType("test")
+            .activate();
+    }
+
+    @AfterEach
+    void afterTest() {
+        tracer.currentTransaction().deactivate().end();
+        reporter.reset();
+    }
+
+    @Test
+    void testNonDefaultPort() throws URISyntaxException {
+        HttpClientHelper.startHttpClientSpan(tracer.getActive(), "GET", new URI("http://user:pass@testing.local:1234/path?query"), null)
+            .end();
+        assertThat(reporter.getSpans()).hasSize(1);
+        Span httpSpan = reporter.getFirstSpan();
+        assertThat(httpSpan.getContext().getHttp().getUrl()).isEqualTo("http://testing.local:1234/path?query");
+        Destination destination = httpSpan.getContext().getDestination();
+        assertThat(destination.getService().getName().toString()).isEqualTo("http://testing.local:1234");
+        assertThat(destination.getService().getResource().toString()).isEqualTo("testing.local:1234");
+        assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+    }
+
+    @Test
+    void testDefaultExplicitPort() throws URISyntaxException {
+        HttpClientHelper.startHttpClientSpan(tracer.getActive(), "GET", new URI("https://www.elastic.co:443/products/apm"), null)
+            .end();
+        assertThat(reporter.getSpans()).hasSize(1);
+        Span httpSpan = reporter.getFirstSpan();
+        assertThat(httpSpan.getContext().getHttp().getUrl()).isEqualTo("https://www.elastic.co:443/products/apm");
+        Destination destination = httpSpan.getContext().getDestination();
+        assertThat(destination.getService().getName().toString()).isEqualTo("https://www.elastic.co");
+        assertThat(destination.getService().getResource().toString()).isEqualTo("www.elastic.co:443");
+        assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+    }
+
+    @Test
+    void testDefaultImplicitPort() throws URISyntaxException {
+        HttpClientHelper.startHttpClientSpan(tracer.getActive(), "GET", new URI("https://www.elastic.co/products/apm"), null)
+            .end();
+        assertThat(reporter.getSpans()).hasSize(1);
+        Span httpSpan = reporter.getFirstSpan();
+        assertThat(httpSpan.getContext().getHttp().getUrl()).isEqualTo("https://www.elastic.co/products/apm");
+        Destination destination = httpSpan.getContext().getDestination();
+        assertThat(destination.getService().getName().toString()).isEqualTo("https://www.elastic.co");
+        assertThat(destination.getService().getResource().toString()).isEqualTo("www.elastic.co:443");
+        assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+    }
+
+    @Test
+    void testDefaultImplicitPortWithIpv4() throws URISyntaxException {
+        HttpClientHelper.startHttpClientSpan(tracer.getActive(), "GET", new URI("https://151.101.114.217/index.html"), null)
+            .end();
+        assertThat(reporter.getSpans()).hasSize(1);
+        Span httpSpan = reporter.getFirstSpan();
+        assertThat(httpSpan.getContext().getHttp().getUrl()).isEqualTo("https://151.101.114.217/index.html");
+        Destination destination = httpSpan.getContext().getDestination();
+        assertThat(destination.getService().getName().toString()).isEqualTo("https://151.101.114.217");
+        assertThat(destination.getService().getResource().toString()).isEqualTo("151.101.114.217:443");
+        assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+    }
+
+    @Test
+    void testDefaultImplicitPortWithIpv6() throws URISyntaxException {
+        HttpClientHelper.startHttpClientSpan(tracer.getActive(), "GET", new URI("http://[2001:db8:a0b:12f0::1]/index.html"), null)
+            .end();
+        assertThat(reporter.getSpans()).hasSize(1);
+        Span httpSpan = reporter.getFirstSpan();
+        assertThat(httpSpan.getContext().getHttp().getUrl()).isEqualTo("http://[2001:db8:a0b:12f0::1]/index.html");
+        Destination destination = httpSpan.getContext().getDestination();
+        assertThat(destination.getService().getName().toString()).isEqualTo("http://[2001:db8:a0b:12f0::1]");
+        assertThat(destination.getService().getResource().toString()).isEqualTo("[2001:db8:a0b:12f0::1]:80");
+        assertThat(destination.getService().getType()).isEqualTo(EXTERNAL_TYPE);
+    }
+}

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -123,6 +123,10 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         assertThat(span.getSubtype()).isEqualTo("http");
         assertThat(span.getAction()).isNull();
         Destination destination = span.getContext().getDestination();
+        int addressStartIndex = (host.startsWith("[")) ? 1 : 0;
+        int addressEndIndex = (host.endsWith("]")) ? host.length() - 1 : host.length();
+        assertThat(destination.getAddress().toString()).isEqualTo(host.substring(addressStartIndex, addressEndIndex));
+        assertThat(destination.getPort()).isEqualTo(wireMockRule.port());
         assertThat(destination.getService().getName().toString()).isEqualTo(baseUrl);
         assertThat(destination.getService().getResource().toString()).isEqualTo(host + ":" + wireMockRule.port());
         assertThat(destination.getService().getType()).isEqualTo("external");

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,6 +25,8 @@
 package co.elastic.apm.agent.httpclient;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.impl.context.Destination;
+import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
@@ -87,14 +89,36 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         verifyHttpSpan("/");
     }
 
+    @Test
+    public void testHttpCallWithIpv4() throws Exception {
+        performGet("http://127.0.0.1:" + wireMockRule.port() + "/");
+        verifyHttpSpan("http", "127.0.0.1", wireMockRule.port(), "/");
+    }
+
+    @Test
+    public void testHttpCallWithIpv6() throws Exception {
+        performGet("http://[::1]:" + wireMockRule.port() + "/");
+        verifyHttpSpan("http", "[::1]", wireMockRule.port(), "/");
+    }
+
     protected void verifyHttpSpan(String path) throws Exception {
+        verifyHttpSpan("http", "localhost", wireMockRule.port(), path);
+    }
+
+    protected void verifyHttpSpan(String scheme, String host, int port, String path) throws Exception {
         assertThat(reporter.getFirstSpan(500)).isNotNull();
         assertThat(reporter.getSpans()).hasSize(1);
-        assertThat(reporter.getSpans().get(0).getContext().getHttp().getUrl()).isEqualTo(getBaseUrl() + path);
-        assertThat(reporter.getSpans().get(0).getContext().getHttp().getStatusCode()).isEqualTo(200);
-        assertThat(reporter.getSpans().get(0).getType()).isEqualTo("external");
-        assertThat(reporter.getSpans().get(0).getSubtype()).isEqualTo("http");
-        assertThat(reporter.getSpans().get(0).getAction()).isNull();
+        Span span = reporter.getSpans().get(0);
+        String baseUrl = scheme + "://" + host + ":" + port;
+        assertThat(span.getContext().getHttp().getUrl()).isEqualTo(baseUrl + path);
+        assertThat(span.getContext().getHttp().getStatusCode()).isEqualTo(200);
+        assertThat(span.getType()).isEqualTo("external");
+        assertThat(span.getSubtype()).isEqualTo("http");
+        assertThat(span.getAction()).isNull();
+        Destination destination = span.getContext().getDestination();
+        assertThat(destination.getService().getName().toString()).isEqualTo(baseUrl);
+        assertThat(destination.getService().getResource().toString()).isEqualTo(host + ":" + wireMockRule.port());
+        assertThat(destination.getService().getType()).isEqualTo("external");
 
         final String traceParentHeader = reporter.getFirstSpan().getTraceContext().getOutgoingTraceParentHeader().toString();
         verify(anyRequestedFor(urlPathEqualTo(path))

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -97,8 +97,15 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
 
     @Test
     public void testHttpCallWithIpv6() throws Exception {
+        if (!isIpv6Supported()) {
+            return;
+        }
         performGet("http://[::1]:" + wireMockRule.port() + "/");
         verifyHttpSpan("http", "[::1]", wireMockRule.port(), "/");
+    }
+
+    protected boolean isIpv6Supported() {
+        return true;
     }
 
     protected void verifyHttpSpan(String path) throws Exception {

--- a/apm-agent-plugins/apm-jdbc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jdbc-plugin/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
+        <testcontainers-version>1.12.0</testcontainers-version>
     </properties>
 
     <dependencies>
@@ -33,22 +34,45 @@
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
+            <artifactId>jdbc</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
+            <version>${testcontainers-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
+            <version>${testcontainers-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mariadb</artifactId>
+            <version>${testcontainers-version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mssqlserver</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>db2</artifactId>
+            <version>${testcontainers-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>oracle-xe</artifactId>
+            <version>${testcontainers-version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -75,6 +99,18 @@
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
             <version>6.4.0.jre9</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.ibm.db2.jcc</groupId>
+            <artifactId>db2jcc</artifactId>
+            <version>db2jcc4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.ojdbc</groupId>
+            <artifactId>ojdbc8</artifactId>
+            <version>19.3.0.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/StatementInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/StatementInstrumentation.java
@@ -70,8 +70,7 @@ public abstract class StatementInstrumentation extends ElasticApmInstrumentation
         this.methodMatcher = methodMatcher;
         jdbcHelperManager = HelperClassManager.ForSingleClassLoader.of(tracer,
             "co.elastic.apm.agent.jdbc.helper.JdbcHelperImpl",
-            "co.elastic.apm.agent.jdbc.helper.JdbcHelperImpl$1",
-            "co.elastic.apm.agent.jdbc.helper.JdbcHelperImpl$ConnectionMetaData");
+            "co.elastic.apm.agent.jdbc.helper.JdbcHelperImpl$1");
     }
 
     @Override

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaData.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaData.java
@@ -1,0 +1,434 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.jdbc.helper;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConnectionMetaData {
+
+    private static final Logger logger = LoggerFactory.getLogger(ConnectionMetaData.class);
+
+    private static final Map<String, ConnectionUrlParser> parsers = new HashMap<>();
+
+    static {
+        for (ConnectionUrlParser parser : ConnectionUrlParser.values()) {
+            parsers.put(parser.dbVendor, parser);
+        }
+    }
+
+    /**
+     * Creates a DB metadata based on the connection URL.
+     *
+     * @param connectionUrl the connection URL obtained from the JDBC connection
+     * @param user          DB user
+     * @return metadata of a JDBC connection
+     */
+    public static ConnectionMetaData create(String connectionUrl, String user) {
+        String dbVendor = "unknown";
+
+        // trimming a temp copy, keeping the original for logging purposes
+        String tmpUrl = connectionUrl;
+
+        // Connection URLs have a common prefix, starting with "jdbc:", followed by the vendor name and a colon.
+        // The rest is vendor specific.
+        //
+        // Examples:
+        // jdbc:postgresql://hostname/db?user=jdo&password=pass
+        // jdbc:sqlserver://localhost:32958;sslProtocol=TLS;jaasConfigurationName=SQLJDBCDriver
+        // jdbc:oracle:oci:root/secret@localhost:1521:testdb
+        // jdbc:derby:memory:testdb
+        // jdbc:h2:mem:test
+        int indexOfJdbc = tmpUrl.indexOf("jdbc:");
+
+        if (indexOfJdbc != -1) {
+            tmpUrl = tmpUrl.substring(indexOfJdbc + 5);
+            int indexOfNextColon = tmpUrl.indexOf(":");
+            if (indexOfNextColon != -1) {
+                dbVendor = tmpUrl.substring(0, indexOfNextColon);
+                tmpUrl = tmpUrl.substring(indexOfNextColon + 1);
+            }
+        }
+
+        // Further parsing needs to be vendor specific.
+        ConnectionMetaData ret = null;
+        ConnectionUrlParser connectionUrlParser = parsers.get(dbVendor);
+        if (connectionUrlParser != null) {
+            try {
+                ret = connectionUrlParser.parse(tmpUrl, user);
+            } catch (Exception e) {
+                logger.error("Failed to parse connection URL", e);
+            }
+        } else {
+            // Doesn't hurt to try...
+            ret = ConnectionUrlParser.defaultParse(connectionUrl, dbVendor, -1, user);
+        }
+
+        if (ret == null) {
+            ret = new ConnectionMetaData(dbVendor, null, -1, user);
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("Based on the connection URL {}, parsed metadata is: {}", connectionUrl, ret);
+        }
+        return ret;
+    }
+
+    private final String dbVendor;
+    @Nullable
+    private final String host;
+    private final int port;
+    private final String user;
+
+    private ConnectionMetaData(String dbVendor, @Nullable String host, int port, String user) {
+        this.dbVendor = dbVendor;
+        this.host = host;
+        this.port = port;
+        this.user = user;
+    }
+
+    public String getDbVendor() {
+        return dbVendor;
+    }
+
+    @Nullable
+    public String getHost() {
+        return host;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    @Override
+    public String toString() {
+        return "ConnectionMetaData{" +
+            "dbVendor='" + dbVendor + '\'' +
+            ", host='" + host + '\'' +
+            ", port=" + port +
+            ", user='" + user + '\'' +
+            '}';
+    }
+
+    @SuppressWarnings("unused")
+    private enum ConnectionUrlParser {
+        ORACLE("oracle") {
+            public static final int DEFAULT_PORT = 1521;
+
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                // Examples:
+                // jdbc:oracle:thin:scott/tiger@//myhost:1521/myinstance
+                // jdbc:oracle:thin:scott/tiger@127.0.0.1:666:myinstance
+                // jdbc:oracle:thin:scott/tiger@localhost:myinstance
+                // jdbc:oracle:oci:scott/tiger/@
+                // jdbc:oracle:thin:@ldap://ldap.acme.com:7777/sales,cn=OracleContext,dc=com
+                int indexOfUserDetailsEnd = connectionUrl.indexOf('@');
+                if (indexOfUserDetailsEnd > 0) {
+                    if (connectionUrl.length() > indexOfUserDetailsEnd + 1) {
+                        connectionUrl = connectionUrl.substring(indexOfUserDetailsEnd + 1);
+                    } else {
+                        // jdbc:oracle:oci:scott/tiger/@
+                        return new ConnectionMetaData(dbVendor, null, DEFAULT_PORT, user);
+                    }
+                }
+
+                String host = null;
+                int port = DEFAULT_PORT;
+
+                // try looking for a //host:port/instance pattern
+                HostPort hostPort = parseHostPort(connectionUrl);
+                if (hostPort.host != null) {
+                    host = hostPort.host;
+                    if (hostPort.port > 0) {
+                        port = hostPort.port;
+                    }
+                } else {
+                    // Thin driver host:port:sid syntax:
+                    // myhost:666:instance
+                    // myhost:instance
+                    // thin:myhost:port:instance
+                    if (connectionUrl.startsWith("thin:")) {
+                        connectionUrl = connectionUrl.substring("thin:".length());
+                    }
+
+                    String[] parts = connectionUrl.split(":");
+                    if (parts.length > 0) {
+                        host = parts[0];
+                    }
+                    if (parts.length > 1) {
+                        try {
+                            port = Integer.parseInt(parts[1]);
+                        } catch (NumberFormatException e) {
+                            // apparently not a port...
+                        }
+                    }
+                }
+
+                return new ConnectionMetaData(dbVendor, host, port, user);
+            }
+        },
+
+        POSTGRESQL("postgresql") {
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                return ConnectionUrlParser.defaultParse(connectionUrl, dbVendor, 5432, user);
+            }
+        },
+
+        MYSQL("mysql") {
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                return ConnectionUrlParser.defaultParse(connectionUrl, dbVendor, 3306, user);
+            }
+        },
+
+        DB2("db2") {
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                return ConnectionUrlParser.defaultParse(connectionUrl, dbVendor, 50000, user);
+            }
+        },
+
+        H2("h2") {
+            // Actually behaves like the default, but better have it explicit
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                return ConnectionUrlParser.defaultParse(connectionUrl, dbVendor, -1, user);
+            }
+        },
+
+        DERBY("derby") {
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                return ConnectionUrlParser.defaultParse(connectionUrl, dbVendor, 1527, user);
+            }
+        },
+
+        HSQLDB("hsqldb") {
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                return ConnectionUrlParser.defaultParse(connectionUrl, dbVendor, 9001, user);
+            }
+        },
+
+        MARIADB("mariadb") {
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                // just like MySQL
+                String host = "localhost";
+                int port = 3306;
+                HostPort hostPort = parseHostPort(connectionUrl);
+                if (hostPort.host == null) {
+                    // but may also allow a non-proper URL format, like jdbc:mariadb:myhost:666
+                    hostPort = parseAuthority(connectionUrl);
+                }
+                if (hostPort.host != null) {
+                    host = hostPort.host;
+                    if (hostPort.port > 0) {
+                        port = hostPort.port;
+                    }
+                }
+                return new ConnectionMetaData(dbVendor, host, port, user);
+            }
+        },
+
+        SQLSERVER("sqlserver") {
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                // just like MySQL
+                String host = "localhost";
+                int port = 1433;
+                int indexOfProperties = connectionUrl.indexOf(';');
+                if (indexOfProperties > 0) {
+                    if (connectionUrl.length() > indexOfProperties + 1) {
+                        String propertiesPart = connectionUrl.substring(indexOfProperties + 1);
+                        String[] properties = propertiesPart.split(";");
+                        for (String property : properties) {
+                            String[] parts = property.split("=");
+                            if (parts.length == 2 && parts[0].equals("serverName")) {
+                                host = parts[1];
+                            }
+                        }
+                    }
+                    connectionUrl = connectionUrl.substring(0, indexOfProperties);
+                }
+                HostPort hostPort = parseHostPort(connectionUrl);
+
+                if (hostPort.host != null) {
+                    host = hostPort.host;
+                    if (hostPort.port > 0) {
+                        port = hostPort.port;
+                    }
+                }
+
+                // remove the instance part of the host
+                int indexOfInstance = host.indexOf('\\');
+                if (indexOfInstance > 0) {
+                    host = host.substring(0, indexOfInstance);
+                }
+                return new ConnectionMetaData(dbVendor, host, port, user);
+            }
+        },
+
+        UNKNOWN("unknown") {
+            @Override
+            ConnectionMetaData parse(String connectionUrl, String user) {
+                return new ConnectionMetaData(dbVendor, null, -1, user);
+            }
+        };
+
+        ConnectionUrlParser(String dbVendor) {
+            this.dbVendor = dbVendor;
+        }
+
+        final String dbVendor;
+
+        abstract ConnectionMetaData parse(String connectionUrl, String user);
+
+        static ConnectionMetaData defaultParse(String connectionUrl, String dbVendor, int defaultPort, String user) {
+            // Examples:
+            // database
+            // /
+            // //host:666/database
+            // //host/database
+            // //host:666/
+            // //host/
+            // //host:666/database?prop1=val1&prop2=val2
+            // //host:666/database;prop1=val1;prop2=val2
+
+            // try remove properties appended with semicolon
+            int indexOfProperties = connectionUrl.indexOf(';');
+            if (indexOfProperties > 0) {
+                connectionUrl = connectionUrl.substring(0, indexOfProperties);
+            }
+
+            String host = "localhost";
+            int port = -1;
+            HostPort hostPort = parseHostPort(connectionUrl);
+            if (hostPort.host != null) {
+                host = hostPort.host;
+                if (hostPort.port > 0) {
+                    port = hostPort.port;
+                } else {
+                    port = defaultPort;
+                }
+            }
+            return new ConnectionMetaData(dbVendor, host, port, user);
+        }
+
+        /**
+         * Expects a URL structure, from which the authority component is extracted to get host and port.
+         *
+         * @param url expected structure: "[...//]host[:port][/[instance/database]]
+         * @return extracted host and port
+         */
+        static HostPort parseHostPort(String url) {
+            if (url.length() > 0) {
+                int indexOfDoubleSlash = url.indexOf("//");
+                if (indexOfDoubleSlash >= 0 && url.length() > indexOfDoubleSlash + 2) {
+                    url = url.substring(indexOfDoubleSlash + 2);
+                    if (url.length() == 1) {
+                        // for urls such as: jdbc:mysql:///
+                        return new HostPort("localhost", -1);
+                    }
+                    return parseAuthority(url);
+                }
+            }
+            return new HostPort(null, -1);
+        }
+
+        static HostPort parseAuthority(String url) {
+            // Examples:
+            // myhost:666/myinstance
+            // myhost:666/myinstance?arg1=val1&arg2=val2
+            // myhost/instance
+            // myhost/instance?arg1=val1&arg2=val2
+            // myhost:666
+            // myhost:666?arg1=val1&arg2=val2
+            // myhost
+            // myhost?arg1=val1&arg2=val2
+            int indexOrProperties = url.indexOf('?');
+            if (indexOrProperties > 0) {
+                url = url.substring(0, indexOrProperties);
+            }
+
+            String hostPort;
+            int indexOfSlash = url.indexOf('/');
+            if (indexOfSlash > 0) {
+                hostPort = url.substring(0, indexOfSlash);
+            } else {
+                hostPort = url;
+            }
+
+            String host;
+            int port = -1;
+            int indexOfColon = hostPort.indexOf(':');
+            if (indexOfColon > 0) {
+                // check if IPv6
+                int lastIndexOfColon = hostPort.lastIndexOf(':');
+                if (indexOfColon != lastIndexOfColon) {
+                    // IPv6 - [::1] or ::1 or [::1]:666
+                    int indexOfIpv6End = hostPort.indexOf(']');
+                    if (indexOfIpv6End > 0 && hostPort.length() > indexOfIpv6End + 1) {
+                        indexOfColon = indexOfIpv6End + 1;
+                    } else {
+                        // no port specified
+                        indexOfColon = -1;
+                    }
+                }
+            }
+
+            if (indexOfColon > 0) {
+                host = hostPort.substring(0, indexOfColon);
+                if (hostPort.length() > indexOfColon + 1) {
+                    port = Integer.parseInt(hostPort.substring(indexOfColon + 1));
+                }
+            } else {
+                host = hostPort;
+            }
+
+            return new HostPort(host, port);
+        }
+
+        static class HostPort {
+            @Nullable
+            String host;
+            int port;
+
+            public HostPort(@Nullable String host, int port) {
+                this.host = host;
+                this.port = port;
+            }
+        }
+    }
+}

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelperImpl.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelperImpl.java
@@ -25,6 +25,7 @@
 package co.elastic.apm.agent.jdbc.helper;
 
 import co.elastic.apm.agent.bci.VisibleForAdvice;
+import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
@@ -72,39 +73,23 @@ public class JdbcHelperImpl extends JdbcHelper {
         span.withType(DB_SPAN_TYPE);
         try {
             final ConnectionMetaData connectionMetaData = getConnectionMetaData(connection);
-            span.withSubtype(connectionMetaData.dbVendor)
+            span.withSubtype(connectionMetaData.getDbVendor())
                 .withAction(DB_SPAN_ACTION);
             span.getContext().getDb()
-                .withUser(connectionMetaData.user)
+                .withUser(connectionMetaData.getUser())
                 .withStatement(sql)
                 .withType("sql");
-            span.getContext().getDestination().getService()
-                .withName(connectionMetaData.dbVendor)
-                .withResource(connectionMetaData.dbVendor)
+            Destination destination = span.getContext().getDestination()
+                .withAddress(connectionMetaData.getHost())
+                .withPort(connectionMetaData.getPort());
+            destination.getService()
+                .withName(connectionMetaData.getDbVendor())
+                .withResource(connectionMetaData.getDbVendor())
                 .withType(DB_SPAN_TYPE);
         } catch (SQLException e) {
             logger.warn("Ignored exception", e);
         }
         return span;
-    }
-
-    @Nullable
-    private String getMethod(@Nullable String sql) {
-        if (sql == null) {
-            return null;
-        }
-        // don't allocate objects for the common case
-        if (sql.startsWith("SELECT") || sql.startsWith("select")) {
-            return "SELECT";
-        }
-        sql = sql.trim();
-        final int indexOfWhitespace = sql.indexOf(' ');
-        if (indexOfWhitespace > 0) {
-            return sql.substring(0, indexOfWhitespace).toUpperCase();
-        } else {
-            // for example COMMIT
-            return sql.toUpperCase();
-        }
     }
 
     /*
@@ -121,42 +106,14 @@ public class JdbcHelperImpl extends JdbcHelper {
         return parentSpan.getType() != null && parentSpan.getType().equals(DB_SPAN_TYPE);
     }
 
-
     private ConnectionMetaData getConnectionMetaData(Connection connection) throws SQLException {
         ConnectionMetaData connectionMetaData = metaDataMap.get(connection);
         if (connectionMetaData == null) {
             final DatabaseMetaData metaData = connection.getMetaData();
-            String dbVendor = getDbVendor(metaData.getURL());
-            connectionMetaData = new ConnectionMetaData(dbVendor, metaData.getUserName());
+            connectionMetaData = ConnectionMetaData.create(metaData.getURL(), metaData.getUserName());
             metaDataMap.put(connection, connectionMetaData);
         }
         return connectionMetaData;
 
-    }
-
-    private String getDbVendor(String url) {
-        // jdbc:h2:mem:test
-        //     ^
-        int indexOfJdbc = url.indexOf("jdbc:");
-        if (indexOfJdbc != -1) {
-            // h2:mem:test
-            String urlWithoutJdbc = url.substring(indexOfJdbc + 5);
-            int indexOfColonAfterVendor = urlWithoutJdbc.indexOf(":");
-            if (indexOfColonAfterVendor != -1) {
-                // h2
-                return urlWithoutJdbc.substring(0, indexOfColonAfterVendor);
-            }
-        }
-        return "unknown";
-    }
-
-    private static class ConnectionMetaData {
-        final String dbVendor;
-        final String user;
-
-        private ConnectionMetaData(String dbVendor, String user) {
-            this.dbVendor = dbVendor;
-            this.user = user;
-        }
     }
 }

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelperImpl.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelperImpl.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -78,6 +78,10 @@ public class JdbcHelperImpl extends JdbcHelper {
                 .withUser(connectionMetaData.user)
                 .withStatement(sql)
                 .withType("sql");
+            span.getContext().getDestination().getService()
+                .withName(connectionMetaData.dbVendor)
+                .withResource(connectionMetaData.dbVendor)
+                .withType(DB_SPAN_TYPE);
         } catch (SQLException e) {
             logger.warn("Ignored exception", e);
         }

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
@@ -168,6 +168,7 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         boolean nullForLargeBatch = isKnownDatabase("MySQL", "5.7");
         nullForLargeBatch = nullForLargeBatch || isKnownDatabase("MySQL", "10."); // mariadb
         nullForLargeBatch = nullForLargeBatch || isKnownDatabase("Microsoft SQL Server", "14.");
+        nullForLargeBatch = nullForLargeBatch || isKnownDatabase("Oracle", "");
         if (isLargeBatch && nullForLargeBatch) {
             // we might actually test for a bug or driver implementation detail here
             assertThat(updates).isNull();
@@ -248,7 +249,7 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
                 long[] batchUpdates = statement.executeLargeBatch();
                 System.arraycopy(batchUpdates, 0, updates, 0, batchUpdates.length);
             });
-            if(!supported){
+            if (!supported) {
                 // ignore unsupported feature
                 return;
             }
@@ -258,8 +259,8 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         }
 
         long expectedAffected = 2;
-        if (isKnownDatabase("MySQL", "10.")) {
-            // for an unknown reason mariadb 10 has unexpected but somehow consistent behavior here
+        if (isKnownDatabase("MySQL", "10.") || isKnownDatabase("Oracle", "")) {
+            // for an unknown reason mariadb 10 and Oracle express have unexpected but somehow consistent behavior here
             assertThat(updates).containsExactly(-2, -2);
             expectedAffected = -4;
         } else {
@@ -277,9 +278,11 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         assertThat(reporter.getSpans()).hasSize(1);
         Db db = reporter.getFirstSpan().getContext().getDb();
         assertThat(db.getStatement()).isEqualTo(insert);
-        assertThat(db.getAffectedRowsCount())
-            .isEqualTo(statement.getUpdateCount())
-            .isEqualTo(1);
+        if (!isKnownDatabase("Oracle", "")) {
+            assertThat(db.getAffectedRowsCount())
+                .isEqualTo(statement.getUpdateCount())
+                .isEqualTo(1);
+        }
     }
 
     private void assertQuerySucceededAndSpanRecorded(ResultSet resultSet, String rawSql, boolean preparedStatement) throws SQLException {
@@ -305,14 +308,23 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
 
         Db db = jdbcSpan.getContext().getDb();
         assertThat(db.getStatement()).isEqualTo(rawSql);
-        assertThat(db.getUser()).isEqualToIgnoringCase(connection.getMetaData().getUserName());
+        DatabaseMetaData metaData = connection.getMetaData();
+        assertThat(db.getUser()).isEqualToIgnoringCase(metaData.getUserName());
         assertThat(db.getType()).isEqualToIgnoringCase("sql");
 
         assertThat(db.getAffectedRowsCount())
             .describedAs("unexpected affected rows count for statement %s", rawSql)
             .isEqualTo(expectedAffectedRows);
 
-        Destination.Service service = jdbcSpan.getContext().getDestination().getService();
+        Destination destination = jdbcSpan.getContext().getDestination();
+        assertThat(destination.getAddress().toString()).isEqualTo("localhost");
+        if (expectedDbVendor.equals("h2")) {
+            assertThat(destination.getPort()).isEqualTo(-1);
+        } else {
+            assertThat(destination.getPort()).isGreaterThan(0);
+        }
+
+        Destination.Service service = destination.getService();
         assertThat(service.getName().toString()).isEqualTo(expectedDbVendor);
         assertThat(service.getResource().toString()).isEqualTo(expectedDbVendor);
         assertThat(service.getType()).isEqualTo(DB_SPAN_TYPE);

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
@@ -26,6 +26,7 @@ package co.elastic.apm.agent.jdbc;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.impl.context.Db;
+import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
@@ -310,6 +311,11 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         assertThat(db.getAffectedRowsCount())
             .describedAs("unexpected affected rows count for statement %s", rawSql)
             .isEqualTo(expectedAffectedRows);
+
+        Destination.Service service = jdbcSpan.getContext().getDestination().getService();
+        assertThat(service.getName().toString()).isEqualTo(expectedDbVendor);
+        assertThat(service.getResource().toString()).isEqualTo(expectedDbVendor);
+        assertThat(service.getType()).isEqualTo(DB_SPAN_TYPE);
     }
 
     private static long[] toLongArray(int[] a) {

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
@@ -49,6 +49,8 @@ public class JdbcDbIT extends AbstractJdbcInstrumentationTest {
             {"jdbc:tc:postgresql:10://hostname/databasename", "postgresql"},
             {"jdbc:tc:mariadb:10://hostname/databasename", "mariadb"},
             {"jdbc:tc:sqlserver:2017-CU12://hostname/databasename", "sqlserver"},
+            {"jdbc:tc:db2:11.5.0.0a://hostname/databasename", "db2"},
+            {"jdbc:tc:oracle://hostname/databasename", "oracle"},
         });
     }
 

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
@@ -49,8 +49,7 @@ public class JdbcDbIT extends AbstractJdbcInstrumentationTest {
             {"jdbc:tc:postgresql:10://hostname/databasename", "postgresql"},
             {"jdbc:tc:mariadb:10://hostname/databasename", "mariadb"},
             {"jdbc:tc:sqlserver:2017-CU12://hostname/databasename", "sqlserver"},
-            {"jdbc:tc:db2:11.5.0.0a://hostname/databasename", "db2"},
-//            {"jdbc:tc:oracle://hostname/databasename", "oracle"},
+            {"jdbc:tc:db2:11.5.0.0a://hostname/databasename", "db2"}
         });
     }
 

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
@@ -50,7 +50,7 @@ public class JdbcDbIT extends AbstractJdbcInstrumentationTest {
             {"jdbc:tc:mariadb:10://hostname/databasename", "mariadb"},
             {"jdbc:tc:sqlserver:2017-CU12://hostname/databasename", "sqlserver"},
             {"jdbc:tc:db2:11.5.0.0a://hostname/databasename", "db2"},
-            {"jdbc:tc:oracle://hostname/databasename", "oracle"},
+//            {"jdbc:tc:oracle://hostname/databasename", "oracle"},
         });
     }
 

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaDataTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaDataTest.java
@@ -1,0 +1,203 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.jdbc.helper;
+
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ConnectionMetaDataTest {
+    @Test
+    void testOracle() {
+        // https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm#BEIJFHHB
+        testUrl("jdbc:oracle:thin:scott/tiger@//myhost:666/myinstance", "oracle", "myhost", 666);
+        testUrl("jdbc:oracle:thin:scott/tiger@//myhost/myinstance", "oracle", "myhost", 1521);
+        testUrl("jdbc:oracle:thin:scott/tiger@//myhost:666", "oracle", "myhost", 666);
+        testUrl("jdbc:oracle:thin:scott/tiger@//myhost", "oracle", "myhost", 1521);
+        testUrl("jdbc:oracle:thin:scott/tiger@myhost:666:myinstance", "oracle", "myhost", 666);
+        testUrl("jdbc:oracle:thin:scott/tiger@myhost:myinstance", "oracle", "myhost", 1521);
+        testUrl("jdbc:oracle:thin:scott/tiger@myhost:666", "oracle", "myhost", 666);
+        testUrl("jdbc:oracle:thin:scott/tiger@myhost", "oracle", "myhost", 1521);
+        testUrl("jdbc:oracle:thin:scott/tiger@", "oracle", null, 1521);
+        testUrl("jdbc:oracle:thin:myhost:666:myinstance", "oracle", "myhost", 666);
+        testUrl("jdbc:oracle:thin:myhost:myinstance", "oracle", "myhost", 1521);
+        testUrl("jdbc:oracle:thin:myhost:666", "oracle", "myhost", 666);
+        testUrl("jdbc:oracle:thin:myhost", "oracle", "myhost", 1521);
+    }
+
+    @Test
+    void testPostgresql() {
+        // https://jdbc.postgresql.org/documentation/head/connect.html
+        testUrl("jdbc:postgresql://myhost:666/database", "postgresql", "myhost", 666);
+        testUrl("jdbc:postgresql://myhost/database", "postgresql", "myhost", 5432);
+        testUrl("jdbc:postgresql://myhost:666/", "postgresql", "myhost", 666);
+        testUrl("jdbc:postgresql://myhost/", "postgresql", "myhost", 5432);
+        testUrl("jdbc:postgresql://127.0.0.1/", "postgresql", "127.0.0.1", 5432);
+        testUrl("jdbc:postgresql://::1/", "postgresql", "::1", 5432);
+        testUrl("jdbc:postgresql://[::1]/", "postgresql", "[::1]", 5432);
+        testUrl("jdbc:postgresql://[::1]:666/", "postgresql", "[::1]", 666);
+
+        testUrl("jdbc:postgresql:database", "postgresql", "localhost", -1);
+        testUrl("jdbc:postgresql:/", "postgresql", "localhost", -1);
+    }
+
+    @Test
+    void testMysql() {
+        // https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html
+        // Single host:
+        testUrl("jdbc:mysql://myhost:666/database", "mysql", "myhost", 666);
+        testUrl("jdbc:mysql://myhost/database", "mysql", "myhost", 3306);
+        testUrl("jdbc:mysql://myhost:666/", "mysql", "myhost", 666);
+        testUrl("jdbc:mysql://myhost/", "mysql", "myhost", 3306);
+        testUrl("jdbc:mysql://127.0.0.1/", "mysql", "127.0.0.1", 3306);
+        testUrl("jdbc:mysql://::1/", "mysql", "::1", 3306);
+        testUrl("jdbc:mysql://[::1]/", "mysql", "[::1]", 3306);
+        testUrl("jdbc:mysql://[::1]:666/", "mysql", "[::1]", 666);
+
+        testUrl("jdbc:mysql://myhost", "mysql", "myhost", 3306);
+        testUrl("jdbc:mysql://myhost:666/database?prop1=val1&prop2=val2", "mysql", "myhost", 666);
+        testUrl("jdbc:mysql://myhost:666?prop1=val1&prop2=val2", "mysql", "myhost", 666);
+    }
+
+    @Test
+    void testMariadb() {
+        // https://mariadb.com/kb/en/about-mariadb-connector-j/#connection-strings
+        // Just like MySQL, but although not documented, seems to also allow the form: jdbc:mariadb:myhost:666/database
+        testUrl("jdbc:mariadb://myhost:666/database", "mariadb", "myhost", 666);
+        testUrl("jdbc:mariadb://myhost/database", "mariadb", "myhost", 3306);
+        testUrl("jdbc:mariadb://myhost:666/", "mariadb", "myhost", 666);
+        testUrl("jdbc:mariadb://myhost/", "mariadb", "myhost", 3306);
+        testUrl("jdbc:mariadb://127.0.0.1/", "mariadb", "127.0.0.1", 3306);
+        testUrl("jdbc:mariadb://::1/", "mariadb", "::1", 3306);
+        testUrl("jdbc:mariadb://[::1]/", "mariadb", "[::1]", 3306);
+        testUrl("jdbc:mariadb://[::1]:666/", "mariadb", "[::1]", 666);
+
+        testUrl("jdbc:mariadb://myhost", "mariadb", "myhost", 3306);
+        testUrl("jdbc:mariadb://myhost:666/database?prop1=val1&prop2=val2", "mariadb", "myhost", 666);
+        testUrl("jdbc:mariadb://myhost:666?prop1=val1&prop2=val2", "mariadb", "myhost", 666);
+
+        testUrl("jdbc:mariadb:myhost:666/database", "mariadb", "myhost", 666);
+        testUrl("jdbc:mariadb:myhost:666/database?prop1=val1&prop2=val2", "mariadb", "myhost", 666);
+        testUrl("jdbc:mariadb:myhost/database", "mariadb", "myhost", 3306);
+        testUrl("jdbc:mariadb:myhost/database?prop1=val1&prop2=val2", "mariadb", "myhost", 3306);
+        testUrl("jdbc:mariadb:myhost:666", "mariadb", "myhost", 666);
+        testUrl("jdbc:mariadb:myhost:666?prop1=val1&prop2=val2", "mariadb", "myhost", 666);
+        testUrl("jdbc:mariadb:myhost", "mariadb", "myhost", 3306);
+        testUrl("jdbc:mariadb:myhost?prop1=val1&prop2=val2", "mariadb", "myhost", 3306);
+    }
+
+    @Test
+    void testSqlserver() {
+        // https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15
+        testUrl("jdbc:sqlserver://myhost\\instance:666", "sqlserver", "myhost", 666);
+        testUrl("jdbc:sqlserver://myhost\\instance:666;prop1=val1;prop2=val2", "sqlserver", "myhost", 666);
+        testUrl("jdbc:sqlserver://myhost:666", "sqlserver", "myhost", 666);
+        testUrl("jdbc:sqlserver://myhost:666;prop1=val1;prop2=val2", "sqlserver", "myhost", 666);
+        testUrl("jdbc:sqlserver://myhost\\instance", "sqlserver", "myhost", 1433);
+        testUrl("jdbc:sqlserver://myhost\\instance;prop1=val1;prop2=val2", "sqlserver", "myhost", 1433);
+        testUrl("jdbc:sqlserver://myhost", "sqlserver", "myhost", 1433);
+        testUrl("jdbc:sqlserver://myhost;prop1=val1;prop2=val2", "sqlserver", "myhost", 1433);
+        testUrl("jdbc:sqlserver://", "sqlserver", "localhost", 1433);
+        testUrl("jdbc:sqlserver://;prop1=val1;prop2=val2", "sqlserver", "localhost", 1433);
+        testUrl("jdbc:sqlserver://;", "sqlserver", "localhost", 1433);
+        testUrl("jdbc:sqlserver://;serverName=myhost", "sqlserver", "myhost", 1433);
+        testUrl("jdbc:sqlserver://;prop1=val1;serverName=myhost", "sqlserver", "myhost", 1433);
+        testUrl("jdbc:sqlserver://;serverName=myhost;prop1=val1", "sqlserver", "myhost", 1433);
+        testUrl("jdbc:sqlserver://;serverName=myhost\\instance;prop1=val1", "sqlserver", "myhost", 1433);
+        testUrl("jdbc:sqlserver://;serverName=3ffe:8311:eeee:f70f:0:5eae:10.203.31.9\\instance;prop1=val1",
+            "sqlserver", "3ffe:8311:eeee:f70f:0:5eae:10.203.31.9", 1433);
+    }
+
+    @Test
+    void testDb2() {
+        // https://www.ibm.com/support/knowledgecenter/SSEPGG_11.5.0/com.ibm.db2.luw.apdv.java.doc/src/tpc/imjcc_tjvjcccn.html
+        testUrl("jdbc:db2://myhost:666/mydb:user=dbadm;password=dbadm;", "db2", "myhost", 666);
+        testUrl("jdbc:db2://[::1]:666/mydb:user=dbadm;password=dbadm;", "db2", "[::1]", 666);
+        testUrl("jdbc:db2://127.0.0.1:666/mydb:user=dbadm;password=dbadm;", "db2", "127.0.0.1", 666);
+        testUrl("jdbc:db2://myhost/mydb:user=dbadm;password=dbadm;", "db2", "myhost", 50000);
+        testUrl("jdbc:db2://myhost;", "db2", "myhost", 50000);
+        testUrl("jdbc:db2://my.host;", "db2", "my.host", 50000);
+        testUrl("jdbc:db2://myhost", "db2", "myhost", 50000);
+    }
+
+    @Test
+    void testH2() {
+        // http://www.h2database.com/html/features.html#database_url
+        testUrl("jdbc:h2:file:/data/sample", "h2", "localhost", -1);
+        testUrl("jdbc:h2:mem:", "h2", "localhost", -1);
+        testUrl("jdbc:h2:mem:test_mem", "h2", "localhost", -1);
+        testUrl("jdbc:h2:tcp://localhost/mem:test", "h2", "localhost", -1);
+        testUrl("jdbc:h2:tcp://dbserv:8084/~/sample", "h2", "dbserv", 8084);
+        testUrl("jdbc:h2:ssl://dbserv:8085/~/sample;", "h2", "dbserv", 8085);
+        testUrl("jdbc:h2:ssl://dbserv:8085/~/sample;prop1=val1;prop2=val2", "h2", "dbserv", 8085);
+    }
+
+    @Test
+    void testUnknown() {
+        testUrl("jdbc:arbitrary://myhost:666/mydb;user=dbadm;password=dbadm;", "arbitrary", "myhost", 666);
+        testUrl("jdbc:arbitrary://[::1]:666/mydb?user=dbadm&password=dbadm;", "arbitrary", "[::1]", 666);
+        testUrl("jdbc:arbitrary://127.0.0.1:666/mydb;user=dbadm;password=dbadm;", "arbitrary", "127.0.0.1", 666);
+        testUrl("jdbc:arbitrary://myhost/mydb;user=dbadm;password=dbadm;", "arbitrary", "myhost", -1);
+        testUrl("jdbc:arbitrary://myhost;", "arbitrary", "myhost", -1);
+        testUrl("jdbc:arbitrary://my.host;", "arbitrary", "my.host", -1);
+        testUrl("jdbc:arbitrary://myhost", "arbitrary", "myhost", -1);
+    }
+
+    @Test
+    void testDerby() {
+        testUrl("jdbc:derby://my.host/memory:mydb;prop1=val1;prop2=val2", "derby", "my.host", 1527);
+        testUrl("jdbc:derby://my.host/memory:mydb;prop1=val1;prop2=val2", "derby", "my.host", 1527);
+        testUrl("jdbc:derby://my.host:666/memory:mydb;prop1=val1;prop2=val2", "derby", "my.host", 666);
+        testUrl("jdbc:derby:jar:/mydb;prop1=val1;prop2=val2", "derby", "localhost", -1);
+        testUrl("jjdbc:derby:memory:mydb", "derby", "localhost", -1);
+        testUrl("jjdbc:derby:mydb", "derby", "localhost", -1);
+    }
+
+    @Test
+    void testHsqldb() {
+        // http://hsqldb.org/doc/2.0/guide/dbproperties-chapt.html
+        testUrl("jdbc:hsqldb:file:~/mydb", "hsqldb", "localhost", -1);
+        testUrl("jdbc:hsqldb:file:enrolments;user=aUserName;ifexists=true", "hsqldb", "localhost", -1);
+        testUrl("jdbc:hsqldb:hsql://localhost/enrolments;close_result=true", "hsqldb", "localhost", 9001);
+        testUrl("jdbc:hsqldb:hsql://my.host/enrolments;close_result=true", "hsqldb", "my.host", 9001);
+        testUrl("jdbc:hsqldb:http://192.0.0.10:9500", "hsqldb", "192.0.0.10", 9500);
+        testUrl("jdbc:hsqldb:http://dbserver.somedomain.com", "hsqldb", "dbserver.somedomain.com", 9001);
+        testUrl("jdbc:hsqldb:mem:", "hsqldb", "localhost", -1);
+    }
+
+    @Test
+    void testInvalid() {
+        testUrl("postgresql://myhost:666/database", "unknown", null, -1);
+    }
+
+    private void testUrl(String url, String expectedVendor, @Nullable String expectedHost, int expectedPort) {
+        ConnectionMetaData metadata = ConnectionMetaData.create(url, "TEST_USER");
+        assertEquals(metadata.getDbVendor(), expectedVendor);
+        assertEquals(metadata.getHost(), expectedHost);
+        assertEquals(metadata.getPort(), expectedPort);
+    }
+}

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/resources/container-license-acceptance.txt
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/resources/container-license-acceptance.txt
@@ -1,3 +1,4 @@
 # The EULA allows for testing purposes:
 # You may install and use copies of the software [...] to design, develop, test and demonstrate your programs.
 mcr.microsoft.com/mssql/server:2017-CU12
+ibmcom/db2:11.5.0.0a

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/resources/testcontainers.properties
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/resources/testcontainers.properties
@@ -1,1 +1,1 @@
-oracle.container.image=wnameless/oracle-xe-11g-r2
+

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/resources/testcontainers.properties
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+oracle.container.image=wnameless/oracle-xe-11g-r2

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsInstrumentationHelperImpl.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsInstrumentationHelperImpl.java
@@ -98,7 +98,12 @@ public class JmsInstrumentationHelperImpl implements JmsInstrumentationHelper<De
         try {
             if (span.isSampled()) {
                 message.setStringProperty(JMS_TRACE_PARENT_PROPERTY, span.getTraceContext().getOutgoingTraceParentHeader().toString());
+                span.getContext().getDestination().getService()
+                    .withName("jms")
+                    .withResource("jms")
+                    .withType(MESSAGING_TYPE);
                 if (destinationName != null) {
+                    span.getContext().getDestination().getService().getResource().append("/").append(destinationName);
                     span.withName("JMS SEND to ");
                     addDestinationDetails(null, destination, destinationName, span);
                     if (isDestinationNameComputed) {

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/JmsInstrumentationIT.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/JmsInstrumentationIT.java
@@ -345,6 +345,7 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
         assertThat(sendSpan.getTraceContext().getTraceId()).isEqualTo(currentTraceId);
         assertThat(sendSpan.getContext().getMessage().getTopicName()).isNull();
         assertThat(sendSpan.getContext().getMessage().getQueueName()).isEqualTo(queue.getQueueName());
+        verifySendSpanDestinationDetails(sendSpan, queue.getQueueName());
 
         Id receiveTraceId = receiveSpan.getTraceContext().getTraceId();
         List<Transaction> receiveTransactions = reporter.getTransactions().stream().filter(transaction -> transaction.getTraceContext().getTraceId().equals(receiveTraceId)).collect(Collectors.toList());
@@ -367,7 +368,14 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
             assertThat(sendToNoopSpan.getTraceContext().getParentId()).isEqualTo(receiveTransaction.getTraceContext().getId());
             assertThat(sendToNoopSpan.getContext().getMessage().getTopicName()).isNull();
             assertThat(sendToNoopSpan.getContext().getMessage().getQueueName()).isEqualTo("NOOP");
+            verifySendSpanDestinationDetails(sendToNoopSpan, "NOOP");
         }
+    }
+
+    private void verifySendSpanDestinationDetails(Span sendSpan, String destinationName) {
+        assertThat(sendSpan.getContext().getDestination().getService().getName().toString()).isEqualTo("jms");
+        assertThat(sendSpan.getContext().getDestination().getService().getResource().toString()).isEqualTo("jms/" + destinationName);
+        assertThat(sendSpan.getContext().getDestination().getService().getType()).isEqualTo(MESSAGING_TYPE);
     }
 
     // tests transaction creation following a receive
@@ -398,6 +406,7 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
             assertThat(sendSpan.getContext().getMessage().getTopicName()).isEqualTo(destinationName);
         }
         assertThat(sendSpan.getContext().getMessage().getAge()).isEqualTo(-1L);
+        verifySendSpanDestinationDetails(sendSpan, destinationName);
 
         //noinspection ConstantConditions
         Id currentTraceId = tracer.currentTransaction().getTraceContext().getTraceId();
@@ -470,6 +479,7 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
             assertThat(sendInitialMessageSpan.getContext().getMessage().getTopicName()).isEqualTo(destinationName);
         }
         assertThat(sendInitialMessageSpan.getContext().getMessage().getAge()).isEqualTo(-1L);
+        verifySendSpanDestinationDetails(sendInitialMessageSpan, destinationName);
 
         //noinspection ConstantConditions
         Id currentTraceId = tracer.currentTransaction().getTraceContext().getTraceId();
@@ -508,6 +518,7 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
             // If both polling and handling transactions are captured, handling transaction would come second
             assertThat(sendNoopSpan.getTraceContext().getParentId()).isEqualTo(transactionId);
             assertThat(sendNoopSpan.getContext().getMessage().getQueueName()).isEqualTo("NOOP");
+            verifySendSpanDestinationDetails(sendNoopSpan, "NOOP");
         }
     }
 

--- a/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionAdvice.java
+++ b/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionAdvice.java
@@ -62,16 +62,18 @@ public class ConnectionAdvice {
 
         span.withType("db").withSubtype("mongodb")
             .appendToName(database).getContext().getDb().withType("mongodb");
+        span.getContext().getDestination().getService()
+            .withName("mongodb").withResource("mongodb").withType("db");
         try {
             String cmd =
                 // try to determine main commands in a garbage free way
-                command.containsKey("find")    ? "find"    :
-                command.containsKey("insert")  ? "insert"  :
-                command.containsKey("count")   ? "count"   :
-                command.containsKey("drop")    ? "drop"    :
-                command.containsKey("update")  ? "update"  :
-                command.containsKey("delete")  ? "delete"  :
-                command.containsKey("create")  ? "create"  :
+                command.containsKey("find") ? "find" :
+                    command.containsKey("insert") ? "insert" :
+                        command.containsKey("count") ? "count" :
+                            command.containsKey("drop") ? "drop" :
+                                command.containsKey("update") ? "update" :
+                                    command.containsKey("delete") ? "delete" :
+                                        command.containsKey("create") ? "create" :
                 command.containsKey("getMore") ? "getMore" :
                 // fall back to getting the first key which is the command name
                 // by allocating a key set and an iterator

--- a/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionAdvice.java
+++ b/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionAdvice.java
@@ -76,12 +76,12 @@ public class ConnectionAdvice {
             String cmd =
                 // try to determine main commands in a garbage free way
                 command.containsKey("find") ? "find" :
-                    command.containsKey("insert") ? "insert" :
-                        command.containsKey("count") ? "count" :
-                            command.containsKey("drop") ? "drop" :
-                                command.containsKey("update") ? "update" :
-                                    command.containsKey("delete") ? "delete" :
-                                        command.containsKey("create") ? "create" :
+                command.containsKey("insert") ? "insert" :
+                command.containsKey("count") ? "count" :
+                command.containsKey("drop") ? "drop" :
+                command.containsKey("update") ? "update" :
+                command.containsKey("delete") ? "delete" :
+                command.containsKey("create") ? "create" :
                 command.containsKey("getMore") ? "getMore" :
                 // fall back to getting the first key which is the command name
                 // by allocating a key set and an iterator

--- a/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionAdvice.java
+++ b/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionAdvice.java
@@ -28,6 +28,8 @@ import co.elastic.apm.agent.bci.ElasticApmInstrumentation;
 import co.elastic.apm.agent.bci.VisibleForAdvice;
 import co.elastic.apm.agent.impl.transaction.Span;
 import com.mongodb.MongoNamespace;
+import com.mongodb.ServerAddress;
+import com.mongodb.connection.Connection;
 import net.bytebuddy.asm.Advice;
 import org.bson.BsonDocument;
 import org.bson.BsonValue;
@@ -43,7 +45,9 @@ public class ConnectionAdvice {
 
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    public static Span onEnter(@Advice.Argument(0) Object databaseOrMongoNamespace, @Advice.Argument(1) BsonDocument command) {
+    public static Span onEnter(@Advice.This Connection thiz,
+                               @Advice.Argument(0) Object databaseOrMongoNamespace,
+                               @Advice.Argument(1) BsonDocument command) {
         Span span = ElasticApmInstrumentation.createExitSpan();
 
         if (span == null) {
@@ -64,6 +68,10 @@ public class ConnectionAdvice {
             .appendToName(database).getContext().getDb().withType("mongodb");
         span.getContext().getDestination().getService()
             .withName("mongodb").withResource("mongodb").withType("db");
+        ServerAddress serverAddress = thiz.getDescription().getServerAddress();
+        span.getContext().getDestination()
+            .withAddress(serverAddress.getHost())
+            .withPort(serverAddress.getPort());
         try {
             String cmd =
                 // try to determine main commands in a garbage free way

--- a/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionInstrumentation.java
@@ -85,6 +85,8 @@ public class ConnectionInstrumentation extends MongoClientInstrumentation {
 
         span.withType("db").withSubtype("mongodb")
             .getContext().getDb().withType("mongodb");
+        span.getContext().getDestination().getService()
+            .withName("mongodb").withResource("mongodb").withType("db");
         String command = methodName;
         if (methodName.equals("query")) {
             // if the method name is query, that corresponds to the find command

--- a/apm-agent-plugins/apm-mongoclient-plugin/src/test/java/co/elastic/apm/agent/mongoclient/AbstractMongoClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-mongoclient-plugin/src/test/java/co/elastic/apm/agent/mongoclient/AbstractMongoClientInstrumentationTest.java
@@ -205,7 +205,10 @@ public abstract class AbstractMongoClientInstrumentationTest extends AbstractIns
 
     private void verifyDestinationDetails(List<Span> spanList) {
         for (Span span : spanList) {
-            Destination.Service service = span.getContext().getDestination().getService();
+            Destination destination = span.getContext().getDestination();
+            assertThat(destination.getAddress().toString()).isEqualTo("localhost");
+            assertThat(destination.getPort()).isEqualTo(container.getMappedPort(27017));
+            Destination.Service service = destination.getService();
             assertThat(service.getName().toString()).isEqualTo("mongodb");
             assertThat(service.getResource().toString()).isEqualTo("mongodb");
             assertThat(service.getType()).isEqualTo("db");

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentation.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,6 +39,7 @@ import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.HttpUrl;
 import okhttp3.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,7 +94,8 @@ public class OkHttp3ClientAsyncInstrumentation extends ElasticApmInstrumentation
             final TraceContextHolder<?> parent = tracer.getActive();
 
             okhttp3.Request request = originalRequest;
-            span = HttpClientHelper.startHttpClientSpan(parent, request.method(), request.url().toString(), request.url().host());
+            HttpUrl url = request.url();
+            span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.scheme(), url.host(), url.port());
             if (span != null) {
                 span.activate();
                 originalRequest = originalRequest.newBuilder().addHeader(TraceContext.TRACE_PARENT_HEADER, span.getTraceContext().getOutgoingTraceParentHeader().toString()).build();

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentation.java
@@ -95,7 +95,8 @@ public class OkHttp3ClientAsyncInstrumentation extends ElasticApmInstrumentation
 
             okhttp3.Request request = originalRequest;
             HttpUrl url = request.url();
-            span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.scheme(), url.host(), url.port());
+            span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.scheme(),
+                OkHttpClientHelper.computeHostName(url.host()), url.port());
             if (span != null) {
                 span.activate();
                 originalRequest = originalRequest.newBuilder().addHeader(TraceContext.TRACE_PARENT_HEADER, span.getTraceContext().getOutgoingTraceParentHeader().toString()).build();

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentation.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -35,6 +35,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
+import okhttp3.HttpUrl;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -69,7 +70,8 @@ public class OkHttp3ClientInstrumentation extends ElasticApmInstrumentation {
 
             if (originalRequest instanceof okhttp3.Request) {
                 okhttp3.Request request = (okhttp3.Request) originalRequest;
-                span = HttpClientHelper.startHttpClientSpan(parent, request.method(), request.url().toString(), request.url().host());
+                HttpUrl url = request.url();
+                span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.scheme(), url.host(), url.port());
                 if (span != null) {
                     span.activate();
                     originalRequest = ((okhttp3.Request) originalRequest).newBuilder().addHeader(TraceContext.TRACE_PARENT_HEADER, span.getTraceContext().getOutgoingTraceParentHeader().toString()).build();

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentation.java
@@ -71,7 +71,8 @@ public class OkHttp3ClientInstrumentation extends ElasticApmInstrumentation {
             if (originalRequest instanceof okhttp3.Request) {
                 okhttp3.Request request = (okhttp3.Request) originalRequest;
                 HttpUrl url = request.url();
-                span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.scheme(), url.host(), url.port());
+                span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.scheme(),
+                    OkHttpClientHelper.computeHostName(url.host()), url.port());
                 if (span != null) {
                     span.activate();
                     originalRequest = ((okhttp3.Request) originalRequest).newBuilder().addHeader(TraceContext.TRACE_PARENT_HEADER, span.getTraceContext().getOutgoingTraceParentHeader().toString()).build();

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentation.java
@@ -94,7 +94,8 @@ public class OkHttpClientAsyncInstrumentation extends ElasticApmInstrumentation 
 
             Request request = originalRequest;
             URL url = request.url();
-            span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.getProtocol(), url.getHost(), url.getPort());
+            span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.getProtocol(),
+                OkHttpClientHelper.computeHostName(url.getHost()), url.getPort());
             if (span != null) {
                 span.activate();
                 originalRequest = originalRequest.newBuilder().addHeader(TraceContext.TRACE_PARENT_HEADER, span.getTraceContext().getOutgoingTraceParentHeader().toString()).build();

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentation.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -92,7 +93,8 @@ public class OkHttpClientAsyncInstrumentation extends ElasticApmInstrumentation 
             final TraceContextHolder<?> parent = tracer.getActive();
 
             Request request = originalRequest;
-            span = HttpClientHelper.startHttpClientSpan(parent, request.method(), request.url().toString(), request.url().getHost());
+            URL url = request.url();
+            span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.getProtocol(), url.getHost(), url.getPort());
             if (span != null) {
                 span.activate();
                 originalRequest = originalRequest.newBuilder().addHeader(TraceContext.TRACE_PARENT_HEADER, span.getTraceContext().getOutgoingTraceParentHeader().toString()).build();

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientHelper.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientHelper.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2019 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.okhttp;
 
 import co.elastic.apm.agent.bci.VisibleForAdvice;

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientHelper.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientHelper.java
@@ -41,6 +41,13 @@ public class OkHttpClientHelper {
         }
     };
 
+    /**
+     * NOTE: this method returns a StringBuilder instance that is kept as this class's ThreadLocal. Callers of this
+     * method MAY NOT KEEP A REFERENCE TO THE RETURNED OBJECT, only copy its contents.
+     *
+     * @param originalHostName the original host name retrieved from the OkHttp client
+     * @return a StringBuilder instance that is kept as a ThreadLocal
+     */
     @VisibleForAdvice
     @Nullable
     public static CharSequence computeHostName(@Nullable String originalHostName) {

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientHelper.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientHelper.java
@@ -1,0 +1,33 @@
+package co.elastic.apm.agent.okhttp;
+
+import co.elastic.apm.agent.bci.VisibleForAdvice;
+
+import javax.annotation.Nullable;
+
+@VisibleForAdvice
+public class OkHttpClientHelper {
+
+    /**
+     * Used to avoid allocations when calculating destination host name.
+     */
+    private static final ThreadLocal<StringBuilder> destinationHostName = new ThreadLocal<StringBuilder>() {
+        @Override
+        protected StringBuilder initialValue() {
+            return new StringBuilder();
+        }
+    };
+
+    @VisibleForAdvice
+    @Nullable
+    public static CharSequence computeHostName(@Nullable String originalHostName) {
+        CharSequence hostName = originalHostName;
+        // okhttp represents IPv6 addresses without square brackets, as opposed to all others, so we should add them
+        if (originalHostName != null && originalHostName.contains(":") && !originalHostName.startsWith("[")) {
+            StringBuilder sb = destinationHostName.get();
+            sb.setLength(0);
+            sb.append("[").append(originalHostName).append("]");
+            hostName = sb;
+        }
+        return hostName;
+    }
+}

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentation.java
@@ -70,7 +70,8 @@ public class OkHttpClientInstrumentation extends ElasticApmInstrumentation {
             if (originalRequest instanceof com.squareup.okhttp.Request) {
                 com.squareup.okhttp.Request request = (com.squareup.okhttp.Request) originalRequest;
                 HttpUrl httpUrl = request.httpUrl();
-                span = HttpClientHelper.startHttpClientSpan(parent, request.method(), httpUrl.toString(), httpUrl.scheme(), httpUrl.host(), httpUrl.port());
+                span = HttpClientHelper.startHttpClientSpan(parent, request.method(), httpUrl.toString(), httpUrl.scheme(),
+                    OkHttpClientHelper.computeHostName(httpUrl.host()), httpUrl.port());
                 if (span != null) {
                     span.activate();
                     originalRequest = ((com.squareup.okhttp.Request) originalRequest).newBuilder().addHeader(TraceContext.TRACE_PARENT_HEADER,

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentation.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,6 +30,7 @@ import co.elastic.apm.agent.http.client.HttpClientHelper;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.TraceContextHolder;
+import com.squareup.okhttp.HttpUrl;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -68,7 +69,8 @@ public class OkHttpClientInstrumentation extends ElasticApmInstrumentation {
 
             if (originalRequest instanceof com.squareup.okhttp.Request) {
                 com.squareup.okhttp.Request request = (com.squareup.okhttp.Request) originalRequest;
-                span = HttpClientHelper.startHttpClientSpan(parent, request.method(), request.httpUrl().toString(), request.httpUrl().host());
+                HttpUrl httpUrl = request.httpUrl();
+                span = HttpClientHelper.startHttpClientSpan(parent, request.method(), httpUrl.toString(), httpUrl.scheme(), httpUrl.host(), httpUrl.port());
                 if (span != null) {
                     span.activate();
                     originalRequest = ((com.squareup.okhttp.Request) originalRequest).newBuilder().addHeader(TraceContext.TRACE_PARENT_HEADER,

--- a/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentationTest.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -67,5 +67,10 @@ public class OkHttpClientAsyncInstrumentationTest extends AbstractHttpClientInst
 
     }
 
+    @Override
+    protected boolean isIpv6Supported() {
+        // See https://github.com/square/okhttp/issues/2618
+        return false;
+    }
 }
 

--- a/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -47,5 +47,10 @@ public class OkHttpClientInstrumentationTest extends AbstractHttpClientInstrumen
         client.newCall(request).execute().body().close();
     }
 
+    @Override
+    protected boolean isIpv6Supported() {
+        // see https://github.com/square/okhttp/issues/2618
+        return false;
+    }
 }
 

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/main/java/co/elastic/apm/agent/redis/jedis/JedisInstrumentation.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/main/java/co/elastic/apm/agent/redis/jedis/JedisInstrumentation.java
@@ -30,7 +30,9 @@ import co.elastic.apm.agent.redis.RedisSpanUtils;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
+import redis.clients.jedis.BinaryJedis;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
@@ -46,8 +48,13 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 public class JedisInstrumentation extends ElasticApmInstrumentation {
 
     @Advice.OnMethodEnter(suppress = Throwable.class)
-    private static void beforeSendCommand(@Advice.Local("span") Span span, @Advice.Origin("#m") String method) {
-       span = RedisSpanUtils.createRedisSpan(method);
+    private static void beforeSendCommand(@Advice.This(typing = Assigner.Typing.DYNAMIC) BinaryJedis thiz,
+                                          @Advice.Local("span") Span span,
+                                          @Advice.Origin("#m") String method) {
+        span = RedisSpanUtils.createRedisSpan(method);
+        span.getContext().getDestination()
+            .withAddress(thiz.getClient().getHost())
+            .withPort(thiz.getClient().getPort());
     }
 
     @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
@@ -63,9 +70,7 @@ public class JedisInstrumentation extends ElasticApmInstrumentation {
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
         return named("redis.clients.jedis.Jedis")
-            .or(named("redis.clients.jedis.BinaryJedis"))
-            .or(named("redis.clients.jedis.ShardedJedis"))
-            .or(named("redis.clients.jedis.BinaryShardedJedis"));
+            .or(named("redis.clients.jedis.BinaryJedis"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-3-tests/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce3InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-3-tests/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce3InstrumentationTest.java
@@ -60,4 +60,9 @@ public class Lettuce3InstrumentationTest extends AbstractRedisInstrumentationTes
     public void tearDownLettuce() throws ExecutionException, InterruptedException {
         connection.close();
     }
+
+    @Override
+    protected boolean destinationAddressSupported() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-3-tests/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce3InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-3-tests/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce3InstrumentationTest.java
@@ -45,6 +45,7 @@ public class Lettuce3InstrumentationTest extends AbstractRedisInstrumentationTes
     public void setUpLettuce() {
         client = new RedisClient("localhost", redisPort);
         connection = client.connect();
+        reporter.disableDestinationAddressCheck();
     }
 
     @Test

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce4InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce4InstrumentationTest.java
@@ -81,4 +81,9 @@ public class Lettuce4InstrumentationTest extends AbstractRedisInstrumentationTes
     public void tearDownLettuce() {
         connection.close();
     }
+
+    @Override
+    protected boolean destinationAddressSupported() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce4InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce4InstrumentationTest.java
@@ -46,6 +46,7 @@ public class Lettuce4InstrumentationTest extends AbstractRedisInstrumentationTes
     public void setUpLettuce() {
         client = RedisClient.create("redis://localhost:" + redisPort);
         connection = client.connect();
+        reporter.disableDestinationAddressCheck();
     }
 
     @Test

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce5InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce5InstrumentationTest.java
@@ -109,4 +109,9 @@ public class Lettuce5InstrumentationTest extends AbstractRedisInstrumentationTes
     public void tearDownLettuce() {
         connection.close();
     }
+
+    @Override
+    protected boolean destinationAddressSupported() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce5InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce5InstrumentationTest.java
@@ -51,6 +51,7 @@ public class Lettuce5InstrumentationTest extends AbstractRedisInstrumentationTes
     public void setUpLettuce() {
         RedisClient client = RedisClient.create(RedisURI.create("localhost", redisPort));
         connection = client.connect();
+        reporter.disableDestinationAddressCheck();
     }
 
     @Test

--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/main/java/co/elastic/apm/agent/redis/RedisSpanUtils.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/main/java/co/elastic/apm/agent/redis/RedisSpanUtils.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,11 +39,16 @@ public class RedisSpanUtils {
                 if (activeSpan.isExit()) {
                     return null;
                 }
-                return activeSpan.createSpan()
+                Span span = activeSpan.createSpan()
                     .withName(command)
                     .withType("db")
                     .withSubtype("redis")
-                    .withAction("query")
+                    .withAction("query");
+                span.getContext().getDestination().getService()
+                    .withName("redis")
+                    .withResource("redis")
+                    .withType("db");
+                return span
                     .asExit()
                     .activate();
             }

--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
@@ -25,7 +25,9 @@
 package co.elastic.apm.agent.redis;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.transaction.Span;
+import org.assertj.core.api.Java6Assertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.jupiter.api.AfterEach;
@@ -36,6 +38,7 @@ import javax.net.ServerSocketFactory;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.ServerSocket;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -74,5 +77,15 @@ public abstract class AbstractRedisInstrumentationTest extends AbstractInstrumen
         assertThat(reporter.getSpans().stream().map(Span::getSubtype).distinct()).containsExactly("redis");
         assertThat(reporter.getSpans().stream().map(Span::getAction).distinct()).containsExactly("query");
         assertThat(reporter.getSpans().stream().map(Span::isExit).distinct()).containsExactly(true);
+        verifyDestinationDetails(reporter.getSpans());
+    }
+
+    private void verifyDestinationDetails(List<Span> spanList) {
+        for (Span span : spanList) {
+            Destination.Service service = span.getContext().getDestination().getService();
+            Java6Assertions.assertThat(service.getName().toString()).isEqualTo("redis");
+            Java6Assertions.assertThat(service.getResource().toString()).isEqualTo("redis");
+            Java6Assertions.assertThat(service.getType()).isEqualTo("db");
+        }
     }
 }

--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
@@ -82,10 +82,19 @@ public abstract class AbstractRedisInstrumentationTest extends AbstractInstrumen
 
     private void verifyDestinationDetails(List<Span> spanList) {
         for (Span span : spanList) {
-            Destination.Service service = span.getContext().getDestination().getService();
+            Destination destination = span.getContext().getDestination();
+            if (destinationAddressSupported()) {
+                assertThat(destination.getAddress().toString()).isEqualTo("localhost");
+                assertThat(destination.getPort()).isEqualTo(redisPort);
+            }
+            Destination.Service service = destination.getService();
             Java6Assertions.assertThat(service.getName().toString()).isEqualTo("redis");
             Java6Assertions.assertThat(service.getResource().toString()).isEqualTo("redis");
             Java6Assertions.assertThat(service.getType()).isEqualTo("db");
         }
+    }
+
+    protected boolean destinationAddressSupported() {
+        return true;
     }
 }

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -82,7 +82,7 @@ public abstract class HttpUrlConnectionInstrumentation extends ElasticApmInstrum
             span = inFlightSpans.get(thiz);
             if (span == null && !connected) {
                 final URL url = thiz.getURL();
-                span = HttpClientHelper.startHttpClientSpan(tracer.getActive(), thiz.getRequestMethod(), url.toString(), url.getHost());
+                span = HttpClientHelper.startHttpClientSpan(tracer.getActive(), thiz.getRequestMethod(), url.toString(), url.getProtocol(), url.getHost(), url.getPort());
                 if (span != null) {
                     if (thiz.getRequestProperty(TraceContext.TRACE_PARENT_HEADER) == null) {
                         thiz.addRequestProperty(TraceContext.TRACE_PARENT_HEADER, span.getTraceContext().getOutgoingTraceParentHeader().toString());


### PR DESCRIPTION
Closes elastic/apm-agent-java#934  
Closes elastic/apm-agent-java#957
Closes elastic/apm-agent-java#969 

Some technology-specific info:
- Hibernate search is not supported as it seems a low ROI, especially since only relevant for usage with remote data stores.
- Databases support is largely based on online research. It is not documented whether the URL we would get from the actual connection is exactly the same as the one used to configure the data source. I tested where and what possible, but since our integration tests rely on testcontainers, we cannot test all syntaxes.
For example- the [Oracle](https://docs.oracle.com/cd/B28359_01/java.111/b31224/urls.htm#BEIJFHHB) address list parenthesis syntax or [MySQL's](https://dev.mysql.com/doc/connector-j/8.0/en/connector-j-reference-jdbc-url-format.html) multiple host configuration. If those are required, we can add them in the future.
- JMS doesn't offer a standard API to retrieve the broker address, so this needs to be implemented for each JMS client. Since the address and port are not required for the service map, I excluded it from this already big enough PR. We can implement that in a later time. Examples for getting the address in the two clients we have integration tests for:
   - ActiveMQ: `((ActiveMQMessageProducer) producer).session.getConnection().getTransport().getRemoteAddress()` returns a String that we can use to create a URI, from which host and port can be extracted.
   - ActiveMQ Artemis:`((TopologyMember)((ActiveMQMessageProducer)producer).connection.getSessionFactory().getServerLocator().getTopology().getMembers().toArray()[0]).toURI()` returns a String that we can use to create a URI, from which host and port **of one broker node** can be extracted. If multiple destinations are configured, this is not enough to get the actual address used for a specific connection.
- Redis (requires @felixbarny's input):
   - Jedis: it seems like the Sharded client instrumentation is redundant, as this client first finds a shard and then calls the already instrumented Jedis. The integration tests work without those. Am I missing something here?
   - Lettuce: I couldn't find an elegant way to locate the address and port. We can instrument the Client construction and keep mapping from Connections to the Client, then instrument the Connections and map created Commands to Connections and use those eventually (although there are differences between versions). Based on your experience, can you think of a better way? Unless you can think of something, we will keep Lettuce unsupported and if required create a separate issue.

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [x] Update [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
