### PR TITLE
Set classname instead of filename when connected to APM Server 7.6

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchers.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchers.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -140,14 +140,14 @@ public class CustomElementMatchers {
              *
              * @param protectionDomain a {@link ProtectionDomain} from which to look for the manifest file
              * @return true if version parsed from the manifest file is lower than or equals to the matcher's version
-             * 
+             *
              * NOTE: MAY RETURN FALSE POSITIVES - returns true if matching fails, logging a warning message
              */
             @Override
             public boolean matches(@Nullable ProtectionDomain protectionDomain) {
                 try {
                     Version pdVersion = readImplementationVersionFromManifest(protectionDomain);
-                    Version limitVersion = new Version(version);
+                    Version limitVersion = Version.of(version);
                     if (pdVersion != null) {
                         return pdVersion.compareTo(limitVersion) <= 0;
                     }
@@ -182,7 +182,7 @@ public class CustomElementMatchers {
                         if (manifest != null) {
                             String implementationVersion = manifest.getMainAttributes().getValue("Implementation-Version");
                             if (implementationVersion != null) {
-                                version = new Version(implementationVersion);
+                                version = Version.of(implementationVersion);
                             }
                         }
                     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
@@ -68,7 +68,6 @@ public class ApmServerClient {
     private static final Logger logger = LoggerFactory.getLogger(ApmServerClient.class);
     private static final String USER_AGENT = "elasticapm-java/" + VersionUtils.getAgentVersion();
     private static final Version VERSION_6_7 = Version.of("6.7.0");
-    private static final Version VERSION_7_6 = Version.of("7.6.0");
     private final ReporterConfiguration reporterConfiguration;
     private volatile List<URL> serverUrls;
     private volatile Future<Version> apmServerVersion;
@@ -288,10 +287,6 @@ public class ApmServerClient {
 
     public boolean supportsNonStringLabels() {
         return isAtLeast(VERSION_6_7);
-    }
-
-    public boolean supportsStacktraceClassname() {
-        return isAtLeast(VERSION_7_6);
     }
 
     public boolean isAtLeast(Version apmServerVersion) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
@@ -67,7 +67,8 @@ public class ApmServerClient {
 
     private static final Logger logger = LoggerFactory.getLogger(ApmServerClient.class);
     private static final String USER_AGENT = "elasticapm-java/" + VersionUtils.getAgentVersion();
-    private static final Version APM_SERVER_NON_STRING_LABEL_SUPPORT = new Version("6.7.0");
+    private static final Version VERSION_6_7 = Version.of("6.7.0");
+    private static final Version VERSION_7_6 = Version.of("7.6.0");
     private final ReporterConfiguration reporterConfiguration;
     private volatile List<URL> serverUrls;
     private volatile Future<Version> apmServerVersion;
@@ -286,7 +287,11 @@ public class ApmServerClient {
     }
 
     public boolean supportsNonStringLabels() {
-        return isAtLeast(APM_SERVER_NON_STRING_LABEL_SUPPORT);
+        return isAtLeast(VERSION_6_7);
+    }
+
+    public boolean supportsStacktraceClassname() {
+        return isAtLeast(VERSION_7_6);
     }
 
     public boolean isAtLeast(Version apmServerVersion) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
@@ -104,7 +104,7 @@ public class ApmServerHealthChecker implements Callable<Version> {
                             if (logger.isDebugEnabled()) {
                                 logger.debug("APM server {} version is: {}", connection.getURL(), versionString);
                             }
-                            return new Version(versionString);
+                            return Version.of(versionString);
                         } catch (Exception e) {
                             logger.warn("Failed to parse version of APM server {}: {}", connection.getURL(), e.getMessage());
                         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -693,11 +693,8 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
 
     private void serializeStackTraceElement(StackTraceElement stacktrace) {
         jw.writeByte(OBJECT_START);
-        if (apmServerClient.supportsStacktraceClassname()) {
-            writeField("classname", stacktrace.getClassName());
-        } else {
-            writeField("filename", stacktrace.getFileName());
-        }
+        writeField("filename", stacktrace.getFileName());
+        writeField("classname", stacktrace.getClassName());
         writeField("function", stacktrace.getMethodName());
         writeField("library_frame", isLibraryFrame(stacktrace.getClassName()));
         writeField("lineno", stacktrace.getLineNumber());

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -26,6 +26,8 @@ package co.elastic.apm.agent.report.serialize;
 
 import co.elastic.apm.agent.impl.MetaData;
 import co.elastic.apm.agent.impl.context.AbstractContext;
+import co.elastic.apm.agent.impl.context.Db;
+import co.elastic.apm.agent.impl.context.Http;
 import co.elastic.apm.agent.impl.context.Message;
 import co.elastic.apm.agent.impl.context.Request;
 import co.elastic.apm.agent.impl.context.Response;
@@ -47,8 +49,6 @@ import co.elastic.apm.agent.impl.payload.Service;
 import co.elastic.apm.agent.impl.payload.SystemInfo;
 import co.elastic.apm.agent.impl.payload.TransactionPayload;
 import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
-import co.elastic.apm.agent.impl.context.Db;
-import co.elastic.apm.agent.impl.context.Http;
 import co.elastic.apm.agent.impl.transaction.Id;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.SpanCount;
@@ -693,7 +693,11 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
 
     private void serializeStackTraceElement(StackTraceElement stacktrace) {
         jw.writeByte(OBJECT_START);
-        writeField("filename", stacktrace.getFileName());
+        if (apmServerClient.supportsStacktraceClassname()) {
+            writeField("classname", stacktrace.getClassName());
+        } else {
+            writeField("filename", stacktrace.getFileName());
+        }
         writeField("function", stacktrace.getMethodName());
         writeField("library_frame", isLibraryFrame(stacktrace.getClassName()));
         writeField("lineno", stacktrace.getLineNumber());

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/Version.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/Version.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -31,7 +31,11 @@ package co.elastic.apm.agent.util;
 public class Version implements Comparable<Version> {
     private final int[] numbers;
 
-    public Version(String version) {
+    public static Version of(String version) {
+        return new Version(version);
+    }
+
+    private Version(String version) {
         final String[] parts = version.split("\\-")[0].split("\\.");
         numbers = new int[parts.length];
         for (int i = 0; i < parts.length; i++) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientTest.java
@@ -185,8 +185,8 @@ public class ApmServerClientTest {
 
     @Test
     public void testApmServerVersion() throws IOException {
-        assertThat(apmServerClient.isAtLeast(new Version("6.7.0"))).isTrue();
-        assertThat(apmServerClient.isAtLeast(new Version("6.7.1"))).isFalse();
+        assertThat(apmServerClient.isAtLeast(Version.of("6.7.0"))).isTrue();
+        assertThat(apmServerClient.isAtLeast(Version.of("6.7.1"))).isFalse();
         assertThat(apmServerClient.supportsNonStringLabels()).isTrue();
         apmServer1.stubFor(get(urlEqualTo("/")).willReturn(okForJson(Map.of("version", "6.6.1"))));
         config.save("server_urls", new URL("http", "localhost", apmServer1.port(), "/").toString(), SpyConfiguration.CONFIG_SOURCE_NAME);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -130,25 +130,6 @@ class DslJsonSerializerTest {
     }
 
     @Test
-    void testErrorSerializationWithClassname() {
-        when(apmServerClient.supportsStacktraceClassname()).thenReturn(true);
-
-        ErrorCapture error = new ErrorCapture(MockTracer.create());
-        error.setException(new Exception("test"));
-
-        JsonNode errorTree = readJsonString(serializer.toJsonString(error));
-
-        JsonNode jsonStackTrace = errorTree.get("exception").get("stacktrace");
-        assertThat(jsonStackTrace.getNodeType()).isEqualTo(JsonNodeType.ARRAY);
-        assertThat(jsonStackTrace).isNotNull();
-
-        for (JsonNode stackTraceElement : jsonStackTrace) {
-            assertThat(stackTraceElement.get("filename")).isNull();
-            assertThat(stackTraceElement.get("classname")).isNotNull();
-        }
-    }
-
-    @Test
     void testErrorSerializationOutsideTrace() {
         MockReporter reporter = new MockReporter();
         ElasticApmTracer tracer = MockTracer.createRealTracer(reporter);
@@ -209,6 +190,7 @@ class DslJsonSerializerTest {
 
         for (JsonNode stackTraceElement : jsonStackTrace) {
             assertThat(stackTraceElement.get("filename")).isNotNull();
+            assertThat(stackTraceElement.get("classname")).isNotNull();
             assertThat(stackTraceElement.get("function")).isNotNull();
             assertThat(stackTraceElement.get("library_frame")).isNotNull();
             assertThat(stackTraceElement.get("lineno")).isNotNull();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/VersionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/VersionTest.java
@@ -1,0 +1,14 @@
+package co.elastic.apm.agent.util;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VersionTest {
+
+    @Test
+    void testVersion() {
+        assertThat(Version.of("1.2.3")).isGreaterThan(Version.of("1.2.2"));
+        assertThat(Version.of("1.2.3-SNAPSHOT")).isGreaterThan(Version.of("1.2.2"));
+    }
+}


### PR DESCRIPTION
<!--

Replace this comment with a description of what's being changed by this PR.

If this PR should close an issue, please add one of the magic keywords
(e.g. Fixes) followed by the issue number. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/

If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.

-->

See https://github.com/elastic/kibana/issues/49467

### Checklist

<!-- Potential tasks related to a new PR. Remove tasks that are not relevant -->

- [x] Implement code
- [x] Add tests
- [ ] ~Update documentation~
- [ ] Update [CHANGELOG.asciidoc](CHANGELOG.asciidoc). Not sure if that's worth mentioning?
- [ ] ~Update [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~
- [ ] ~Added an API method or config option? Document in which version this will be introduced.~
- [ ] ~Added an instrumentation plugin? How did you make sure that old, non-supported versions are not instrumented by accident?~
