### PR TITLE
Fix ObjectPool PR merge error

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Message.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Message.java
@@ -28,7 +28,7 @@ import co.elastic.apm.agent.objectpool.Allocator;
 import co.elastic.apm.agent.objectpool.ObjectPool;
 import co.elastic.apm.agent.objectpool.Recyclable;
 import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
-import co.elastic.apm.agent.objectpool.impl.Resetter;
+import co.elastic.apm.agent.objectpool.Resetter;
 import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
 
 import javax.annotation.Nullable;

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
@@ -67,8 +67,7 @@ public class JettyIT extends AbstractServletContainerIntegrationTest {
 
     @Override
     public boolean isExpectedStacktrace(String path) {
-        // only from version 9.4 Jetty includes a valid Throwable instance and only in the onComplete
-        return version.equals("9.4") || !path.equals("/async-dispatch-servlet");
+        return !path.equals("/async-dispatch-servlet");
     }
 
     @Override


### PR DESCRIPTION
@SylvainJuge for some reason this invalid import was introduced by merging elastic/apm-agent-java#967 🤷‍♂ 
Not sure what I missed here, but please take a look if this is now as expected.