### PR TITLE
[docs] Update 1.13.0 release notes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,7 +35,7 @@ endif::[]
 * Add instrumentation for external process execution through `java.lang.Process` and Apache `commons-exec` - {pull}903[#903]
 * Add `destination` fields to exit span contexts - {pull}976[#976]
 * Removed `context.message.topic.name` field - {pull}993[#993]
-* Add Kafka support, currently marked as `incubating` (off by default), until binary traceparent header is implemented - {pull}981[#981]
+* Add support for Kafka clients - {pull}981[#981]
 * Add support for binary `traceparent` header format (see the https://github.com/elastic/apm/blob/master/docs/agent-development.md#Binary-Fields[spec]
 for more details) - {pull}1009[#1009]
 * Add support for log correlation for log4j and log4j2, even when not used in combination with slf4j.

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,7 +24,7 @@ endif::[]
 === Java Agent version 1.x
 
 [[release-notes-1.13.0]]
-==== 1.13.0 (Next)
+==== 1.13.0 - 2020/02/11
 
 [float]
 ===== Features
@@ -34,7 +34,7 @@ endif::[]
 * Instrument log4j Logger#error(String, Throwable) ({pull}919[#919]) Automatically captures exceptions when calling `logger.error("message", exception)`
 * Add instrumentation for external process execution through `java.lang.Process` and Apache `commons-exec` - {pull}903[#903]
 * Add `destination` fields to exit span contexts - {pull}976[#976]
-* Removed `context.message.topic.name` field. - {pull}993[#993]
+* Removed `context.message.topic.name` field - {pull}993[#993]
 * Add Kafka support, currently marked as `incubating` (off by default), until binary traceparent header is implemented - {pull}981[#981]
 * Add support for binary `traceparent` header format (see the https://github.com/elastic/apm/blob/master/docs/agent-development.md#Binary-Fields[spec]
 for more details) - {pull}1009[#1009]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,6 +20,9 @@ endif::[]
 
 === Unreleased
 
+[[release-notes-1.x]]
+=== Java Agent version 1.x
+
 [[release-notes-1.13.0]]
 ==== 1.13.0 (Next)
 
@@ -45,9 +48,6 @@ for more details) - {pull}1009[#1009]
 * Workaround for `java.util.logging` deadlock {pull}965[#965]
 * JMS should propagate traceparent header when transactions are not sampled {pull}999[#999]
 * Spans are not closed if JDBC implementation does not support `getUpdateCount` {pull}1008[#1008]
-
-[[release-notes-1.x]]
-=== Java Agent version 1.x
 
 [[release-notes-1.12.0]]
 ==== 1.12.0 - 2019/11/21


### PR DESCRIPTION
Moves the `1.13.0` release notes under the `1.x` subheading.