### PR TITLE
Set correct Docker namespace

### DIFF
--- a/scripts/jenkins/push_docker.sh
+++ b/scripts/jenkins/push_docker.sh
@@ -39,7 +39,7 @@ readonly CUR_TAG=${CUR_TAG:-$GIT_TAG_DEFAULT}
 
 # 2. Construct the image:tag that we are working with
 # This is roughly <repo>/<namespace>/image
-readonly DOCKER_PUSH_IMAGE="docker.elastic.co/apm/apm-agent-java:$CUR_TAG"
+readonly DOCKER_PUSH_IMAGE="docker.elastic.co/observability/apm-agent-java:$CUR_TAG"
 
 # 3. Proceed with pushing to the registry
 readonly DOCKER_REGISTRY_URL=`echo $DOCKER_PUSH_IMAGE|cut -f1 -d/`


### PR DESCRIPTION
This didn't get updated when we decided to move to the `/observability` namespace, which was preventing the push script from functioning correctly. 