### PR TITLE
ci(jenkins): avoid duplicated builds and reduce the polling

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -20,7 +20,7 @@
     script-path: Jenkinsfile
     scm:
     - github:
-        branch-discovery: all
+        branch-discovery: no-pr
         discover-pr-forks-strategy: merge-current
         discover-pr-forks-trust: permission
         discover-pr-origin: merge-current
@@ -54,7 +54,7 @@
         timeout: '15'
         use-author: true
         wipe-workspace: 'True'
-    periodic-folder-trigger: 1d
+    periodic-folder-trigger: 1w
     prune-dead-branches: true
     publishers:
     - email:


### PR DESCRIPTION
## What does this PR do?

no-pr is the way to ensure no build branches that are also filled as PRs. once a week for polling should be enough to avoid consuming the API quota in GitHub, there is already a webhook to create/destroy branches anyway.


## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist
<!-- _(Recommended)_
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## Related issues
n/a

## Use cases

## Screenshots

Originally 

![image](https://user-images.githubusercontent.com/2871786/74418181-e3cd2500-4e3f-11ea-8088-82de90ac8d7b.png)

![image](https://user-images.githubusercontent.com/2871786/74418286-124b0000-4e40-11ea-9df3-558afdd9d6c7.png)


To 

![image](https://user-images.githubusercontent.com/2871786/74418216-f21b4100-4e3f-11ea-957e-b64716be4d78.png)

![image](https://user-images.githubusercontent.com/2871786/74418274-0c551f00-4e40-11ea-9e6e-1317da86a7b1.png)
