### PR TITLE
Set default test logging to INFO

### DIFF
--- a/apm-agent-core/src/test/resources/elasticapm.properties
+++ b/apm-agent-core/src/test/resources/elasticapm.properties
@@ -1,4 +1,4 @@
-log_level=DEBUG
+log_level=INFO
 log_file=System.out
 # incubating instrumentations should be active in tests
 disable_instrumentations=


### PR DESCRIPTION
This sets the default test logging to the `INFO` level instead of `DEBUG`. 

In doing so, this prevents us from logging environment variables during tests and just in general makes the test output easier to read and errors and warnings much easier to spot.