### PR TITLE
fix: decrease the verbosity of the packer log

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 source /usr/local/bin/bash_standard_lib.sh
 
-JAVA_HOME=$HOME/.java/java10 ./mvnw clean verify --fail-never
+JAVA_HOME=$HOME/.java/java10 ./mvnw clean verify \
+  --fail-never -q -B \
+  -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 (retry 2 docker pull docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev) \
   && docker tag docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev store/oracle/weblogic:12.2.1.3-dev


### PR DESCRIPTION
## What does this PR do?

It adds some settings to maven command used to build the packer cache to reduce the verbosity, the current log has about 60MB 
