### PR TITLE
Disable agent on early Java 8 versions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ endif::[]
 
 [float]
 ===== Features
+* Gracefully abort agent init when running on a known Java 8 buggy JVM {pull}1075[#1075].
 
 [float]
 ===== Bug fixes

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
@@ -76,7 +76,7 @@ public class AgentMain {
         String javaVersion = System.getProperty("java.version");
         if (!isJavaVersionSupported(javaVersion)) {
             // gracefully abort agent startup is better than unexpected failure down the road
-            System.err.println(String.format("Failed ot start agent - JVM version not supported: %s", javaVersion));
+            System.err.println(String.format("Failed to start agent - JVM version not supported: %s", javaVersion));
             return;
         }
 
@@ -125,7 +125,13 @@ public class AgentMain {
             if (updateIndex <= 0) {
                 return false;
             } else {
-                String updateVersion = javaVersion.substring(updateIndex + 1);
+                int versionSuffixIndex = javaVersion.indexOf('-', updateIndex + 1);
+                String updateVersion;
+                if(versionSuffixIndex <= 0) {
+                    updateVersion = javaVersion.substring(updateIndex + 1);
+                } else {
+                    updateVersion = javaVersion.substring(updateIndex + 1, versionSuffixIndex);
+                }
                 try {
                     return Integer.parseInt(updateVersion) >= 40;
                 } catch (NumberFormatException e) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
@@ -133,7 +133,7 @@ public class AgentMain {
             // non-hotspot JVMs are not concerned (yet)
             return true;
         } else {
-            // java 8
+            // HotSpot 8
             int updateIndex = version.lastIndexOf("_");
             if (updateIndex <= 0) {
                 // GA release '1.8.0'

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/AgentMainTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/AgentMainTest.java
@@ -26,85 +26,121 @@ package co.elastic.apm.agent.bci;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AgentMainTest {
 
+    private static String HOTSPOT_VM_NAME = "Java HotSpot(TM) 64-Bit Server VM";
+
     @Test
     void java6AndEarlierNotSupported() {
-        checkNotSupported("1.5.0");
-        checkNotSupported("1.5.0-hello");
-        checkNotSupported("1.5.0_1");
-        checkNotSupported("1.5.0_1-hello");
-        checkNotSupported("1.6.0");
-        checkNotSupported("1.6.0-hello");
-        checkNotSupported("1.6.0_42");
-        checkNotSupported("1.6.0_42-hello");
+        checkNotSupported("", Stream.of(
+            "1.5.0",
+            "1.5.0-hello",
+            "1.5.0_1",
+            "1.5.0_1-hello",
+            "1.6.0",
+            "1.6.0-hello",
+            "1.6.0_42",
+            "1.6.0_42-hello"
+        ));
     }
 
     @Test
     void java7AllVersionsSupported() {
-        checkSupported("1.7.0");
-        checkSupported("1.7.0-hello");
-        checkSupported("1.7.0_1");
-        checkSupported("1.7.0_1-hello");
-        checkSupported("1.7.0_241");
-        checkSupported("1.7.0_241-hello");
+        checkSupported("", Stream.of(
+            "1.7.0",
+            "1.7.0-hello",
+            "1.7.0_1",
+            "1.7.0_1-hello",
+            "1.7.0_241",
+            "1.7.0_241-hello"
+        ));
     }
 
     @Test
-    void java8OnlySupportedAfterUpdate40() {
-        checkNotSupported("1.8.0");
-        checkNotSupported("1.8.0-hello");
-        checkNotSupported("1.8.0_1");
-        checkNotSupported("1.8.0_1-hello");
-        checkNotSupported("1.8.0_39");
-        checkNotSupported("1.8.0_39-hello");
-        checkSupported("1.8.0_40");
-        checkSupported("1.8.0_40-hello");
-        checkSupported("1.8.0_241");
-        checkSupported("1.8.0_241-hello");
+    void java8HotspotOnlySupportedAfterUpdate40() {
+
+        // non-hotspot JVM will be supported by default
+        checkSupported("", hotspotJava8NotSupported());
+        checkSupported("", hotspotJava8supported());
+
+        checkNotSupported(HOTSPOT_VM_NAME, hotspotJava8NotSupported());
+        checkSupported(HOTSPOT_VM_NAME, hotspotJava8supported());
+    }
+
+    private Stream<String> hotspotJava8NotSupported() {
+        return Stream.of(
+            "1.8.0",
+            "1.8.0-hello",
+            "1.8.0_1",
+            "1.8.0_1-hello",
+            "1.8.0_39",
+            "1.8.0_39-hello"
+        );
+    }
+
+    private Stream<String> hotspotJava8supported() {
+        return Stream.of(
+            "1.8.0_40",
+            "1.8.0_40-hello",
+            "1.8.0_241",
+            "1.8.0_241-hello"
+        );
     }
 
     @Test
     void java9AndLaterAllVersionsSupported() {
-        checkSupported("9");
-        checkSupported("9.0.1");
-        checkSupported("9.0.4");
-        checkSupported("10");
-        checkSupported("10.0.1");
-        checkSupported("10.0.2");
-        checkSupported("11");
-        checkSupported("11.0.1");
-        checkSupported("11.0.2");
-        checkSupported("11.0.3");
-        checkSupported("11.0.4");
-        checkSupported("11.0.5");
-        checkSupported("11.0.6");
-        checkSupported("12");
-        checkSupported("12.0.1");
-        checkSupported("12.0.2");
-        checkSupported("13");
-        checkSupported("13.0.1");
-        checkSupported("13.0.2");
-        checkSupported("14");
+        checkSupported("", Stream.of(
+            "9",
+            "9.0.1",
+            "9.0.4",
+            "10",
+            "10.0.1",
+            "10.0.2",
+            "11",
+            "11.0.1",
+            "11.0.2",
+            "11.0.3",
+            "11.0.4",
+            "11.0.5",
+            "11.0.6",
+            "12",
+            "12.0.1",
+            "12.0.2",
+            "13",
+            "13.0.1",
+            "13.0.2",
+            "14")
+        );
     }
 
     @Test
-    void notSupportedwithGarbage() {
-        checkNotSupported("1.8.0_aaa");
+    void shouldBeSupportedInCaseOfParsingError() {
+        checkSupported(HOTSPOT_VM_NAME, Stream.of(
+            "1.8.0_",
+            "1.8.0_aaa"
+        ));
     }
 
-    private static void checkSupported(String version) {
-        assertThat(AgentMain.isJavaVersionSupported(version))
-            .describedAs("java.version = %s should be supported", version)
-            .isTrue();
+    private static void checkSupported(String vmName, Stream<String> versions) {
+        versions.forEach((v) -> {
+            boolean supported = AgentMain.isJavaVersionSupported(v, vmName);
+            assertThat(supported)
+                .describedAs("java.version = '%s' java.vm.name = '%s' should be supported", v, vmName)
+                .isTrue();
+        });
     }
 
-    private static void checkNotSupported(String version) {
-        assertThat(AgentMain.isJavaVersionSupported(version))
-            .describedAs("java.version = %s should not be supported", version)
-            .isFalse();
+    private static void checkNotSupported(String vmName, Stream<String> versions) {
+        versions.forEach((v) -> {
+            boolean supported = AgentMain.isJavaVersionSupported(v, vmName);
+            assertThat(supported)
+                .describedAs("java.version = '%s' java.vm.name = '%s' should not be supported", v, vmName)
+                .isFalse();
+        });
     }
 
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/AgentMainTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/AgentMainTest.java
@@ -33,23 +33,37 @@ class AgentMainTest {
     @Test
     void java6AndEarlierNotSupported() {
         checkNotSupported("1.5.0");
-        checkNotSupported("1.6.0"); // 211
+        checkNotSupported("1.5.0-hello");
+        checkNotSupported("1.5.0_1");
+        checkNotSupported("1.5.0_1-hello");
+        checkNotSupported("1.6.0");
+        checkNotSupported("1.6.0-hello");
+        checkNotSupported("1.6.0_42");
+        checkNotSupported("1.6.0_42-hello");
     }
 
     @Test
     void java7AllVersionsSupported() {
         checkSupported("1.7.0");
+        checkSupported("1.7.0-hello");
         checkSupported("1.7.0_1");
+        checkSupported("1.7.0_1-hello");
         checkSupported("1.7.0_241");
+        checkSupported("1.7.0_241-hello");
     }
 
     @Test
     void java8OnlySupportedAfterUpdate40() {
         checkNotSupported("1.8.0");
+        checkNotSupported("1.8.0-hello");
         checkNotSupported("1.8.0_1");
+        checkNotSupported("1.8.0_1-hello");
         checkNotSupported("1.8.0_39");
+        checkNotSupported("1.8.0_39-hello");
         checkSupported("1.8.0_40");
+        checkSupported("1.8.0_40-hello");
         checkSupported("1.8.0_241");
+        checkSupported("1.8.0_241-hello");
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/AgentMainTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/AgentMainTest.java
@@ -1,0 +1,72 @@
+package co.elastic.apm.agent.bci;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AgentMainTest {
+
+    @Test
+    void java6AndEarlierNotSupported() {
+        checkNotSupported("1.5.0");
+        checkNotSupported("1.6.0"); // 211
+    }
+
+    @Test
+    void java7AllVersionsSupported() {
+        checkSupported("1.7.0");
+        checkSupported("1.7.0_1");
+        checkSupported("1.7.0_241");
+    }
+
+    @Test
+    void java8OnlySupportedAfterUpdate40() {
+        checkNotSupported("1.8.0");
+        checkNotSupported("1.8.0_1");
+        checkNotSupported("1.8.0_39");
+        checkSupported("1.8.0_40");
+        checkSupported("1.8.0_241");
+    }
+
+    @Test
+    void java9AndLaterAllVersionsSupported() {
+        checkSupported("9");
+        checkSupported("9.0.1");
+        checkSupported("9.0.4");
+        checkSupported("10");
+        checkSupported("10.0.1");
+        checkSupported("10.0.2");
+        checkSupported("11");
+        checkSupported("11.0.1");
+        checkSupported("11.0.2");
+        checkSupported("11.0.3");
+        checkSupported("11.0.4");
+        checkSupported("11.0.5");
+        checkSupported("11.0.6");
+        checkSupported("12");
+        checkSupported("12.0.1");
+        checkSupported("12.0.2");
+        checkSupported("13");
+        checkSupported("13.0.1");
+        checkSupported("13.0.2");
+        checkSupported("14");
+    }
+
+    @Test
+    void notSupportedwithGarbage() {
+        checkNotSupported("1.8.0_aaa");
+    }
+
+    private static void checkSupported(String version) {
+        assertThat(AgentMain.isJavaVersionSupported(version))
+            .describedAs("java.version = %s should be supported", version)
+            .isTrue();
+    }
+
+    private static void checkNotSupported(String version) {
+        assertThat(AgentMain.isJavaVersionSupported(version))
+            .describedAs("java.version = %s should not be supported", version)
+            .isFalse();
+    }
+
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/AgentMainTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/AgentMainTest.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.bci;
 
 import org.junit.jupiter.api.Test;

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -39,6 +39,10 @@ the agent does not capture transactions.
 [[supported-java-versions]]
 === Java versions
 
+Early Java 8 versions before update 40 are *not supported* because they have
+several bugs that might result in JVM crashes when a java agent is active,
+thus agent *will not start* on those versions.
+
 |===
 |Vendor |Supported versions | Notes
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -39,10 +39,6 @@ the agent does not capture transactions.
 [[supported-java-versions]]
 === Java versions
 
-Early Java 8 versions before update 40 are *not supported* because they have
-several bugs that might result in JVM crashes when a java agent is active,
-thus agent *will not start* on those versions.
-
 |===
 |Vendor |Supported versions | Notes
 
@@ -57,6 +53,15 @@ thus agent *will not start* on those versions.
 |IBM J9 VM
 |8
 |
+
+NOTE: Early Java 8 versions before update 40 are *not supported* because they have
+several bugs that might result in JVM crashes when a java agent is active,
+thus agent *will not start* on those versions.
+
+Here is an example of the message displayed when this happens.
+```
+Failed ot start agent - JVM version not supported: 1.8.0_31
+```
 
 |===
 


### PR DESCRIPTION
# What does this PR do?

Early Java 8 versions are known to have bugs that are triggered when used with an agent doing instrumentation. Of course, those flaws might not be visible without the agent, thus agent becomes the obvious culprit whereas in practice we can't really work around those.

As a result, using our agent with one of those JVMs will likely result in:
- a crashed JVM
- likely some angry ops, because killing, even if it's a computer process is a bad thing.
- a lot of back & forth with user/customer and support trying to debug a core dump
- unmet expectations: Java 8 is officially supported.

## Checklist
- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)

## Author's Checklist
- [x]  run integration tests to make sure none of our docker images is using one of those JVMs
- [x]  test manually on working / not buggy versions

