### PR TITLE
Make continuous profiling the default, rename inferred spans config option

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,7 +41,7 @@ endif::[]
 
 [float]
 ===== Potentially breaking changes
-* Renamed some configuration options related to the experimental profiler-inferred spans feature:
+* Renamed some configuration options related to the experimental profiler-inferred spans feature ({pull}1084[#1084]):
 ** `profiling_spans_enabled` -> `profiling_inferred_spans_enabled`
 ** `profiling_sampling_interval` -> `profiling_inferred_spans_sampling_interval`
 ** `profiling_spans_min_duration` -> `profiling_inferred_spans_min_duration`

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,17 @@ endif::[]
 * When JAX-RS-annotated method delegates to another JAX-RS-annotated method, transaction name should include method A - {pull}1062[#1062]
 * Fixed bug that prevented an APM Error from being created when calling `org.slf4j.Logger#error` - {pull}1049[#1049]
 
+[float]
+===== Potentially breaking changes
+* Renamed some configuration options related to the experimental profiler-inferred spans feature:
+** `profiling_spans_enabled` -> `profiling_inferred_spans_enabled`
+** `profiling_sampling_interval` -> `profiling_inferred_spans_sampling_interval`
+** `profiling_spans_min_duration` -> `profiling_inferred_spans_min_duration`
+** `profiling_included_classes` -> `profiling_inferred_spans_included_classes`
+** `profiling_excluded_classes` -> `profiling_inferred_spans_excluded_classes`
+** Removed `profiling_interval` and `profiling_duration` (both are fixed to 5s now)
+
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -369,7 +369,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .description("A list of methods for which to create a transaction or span.\n" +
             "\n" +
             "If you want to monitor a large number of methods,\n" +
-            "use  <<config-profiling-spans-enabled, `profiling_spans_enabled`>> instead.\n" +
+            "use  <<config-profiling-inferred-spans-enabled, `profiling_inferred_spans_enabled`>> instead.\n" +
             "\n" +
             "This works by instrumenting each matching method to include code that creates a span for the method.\n" +
             "While creating a span is quite cheap in terms of performance,\n" +

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -43,31 +43,25 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
     private static final String PROFILING_CATEGORY = "Profiling";
 
     private final ConfigurationOption<Boolean> profilingEnabled = ConfigurationOption.<Boolean>booleanOption()
-        .key("profiling_spans_enabled")
+        .key("profiling_inferred_spans_enabled")
         .configurationCategory(PROFILING_CATEGORY)
         .description("Set to `true` to make the agent create spans for method executions based on\n" +
             "https://github.com/jvm-profiling-tools/async-profiler[async-profiler], a sampling aka statistical profiler.\n" +
             "\n" +
-            "If this is enabled, the agent will start a profiling session every\n" +
-            "<<config-profiling-interval, `profiling_interval`>> which lasts for <<config-profiling-duration, `profiling_duration`>>.\n" +
-            "If a transaction happens within a profiling session,\n" +
-            "the agent creates spans for slow methods.\n" +
-            "\n" +
             "Due to the nature of how sampling profilers work,\n" +
             "the duration of the inferred spans are not exact, but only estimations.\n" +
-            "The <<config-profiling-sampling-interval, `profiling_sampling_interval`>> lets you fine tune the trade-off between accuracy and overhead.\n" +
+            "The <<config-profiling-inferred-spans-sampling-interval, `profiling_inferred_spans_sampling_interval`>> lets you fine tune the trade-off between accuracy and overhead.\n" +
             "\n" +
             "The inferred spans are created after a profiling session has ended.\n" +
             "This means there is a delay between the regular and the inferred spans being visible in the UI.\n" +
             "\n" +
             "NOTE: This feature is not available on Windows")
-        .tags("experimental")
         .dynamic(true)
-        .tags("added[1.14.0]")
+        .tags("added[1.15.0]", "experimental")
         .buildWithDefault(false);
 
     private final ConfigurationOption<TimeDuration> samplingInterval = TimeDurationValueConverter.durationOption("ms")
-        .key("profiling_sampling_interval")
+        .key("profiling_inferred_spans_sampling_interval")
         .configurationCategory(PROFILING_CATEGORY)
         .dynamic(true)
         .description("The frequency at which stack traces are gathered within a profiling session.\n" +
@@ -75,23 +69,23 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
             "This comes at the expense of higher overhead and more spans for potentially irrelevant operations.\n" +
             "The minimal duration of a profiling-inferred span is the same as the value of this setting.")
         .addValidator(isInRange(TimeDuration.of("1ms"), TimeDuration.of("1s")))
-        .tags("added[1.14.0]")
-        .buildWithDefault(TimeDuration.of("20ms"));
+        .tags("added[1.15.0]")
+        .buildWithDefault(TimeDuration.of("50ms"));
 
     private final ConfigurationOption<TimeDuration> inferredSpansMinDuration = TimeDurationValueConverter.durationOption("ms")
-        .key("profiling_spans_min_duration")
+        .key("profiling_inferred_spans_min_duration")
         .configurationCategory(PROFILING_CATEGORY)
         .dynamic(true)
         .description("The minimum duration of an inferred span.\n" +
             "Note that the min duration is also implicitly set by the sampling interval.\n" +
             "However, increasing the sampling interval also decreases the accuracy of the duration of inferred spans.")
-        .tags("added[1.14.0]")
+        .tags("added[1.15.0]")
         .addValidator(min(TimeDuration.of("0ms")))
         .buildWithDefault(TimeDuration.of("0ms"));
 
     private final ConfigurationOption<List<WildcardMatcher>> includedClasses = ConfigurationOption
         .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)
-        .key("profiling_included_classes")
+        .key("profiling_inferred_spans_included_classes")
         .configurationCategory(PROFILING_CATEGORY)
         .description("If set, the agent will only create inferred spans for methods which match this list.\n" +
             "Setting a value may slightly increase performance and can reduce clutter by only creating spans for the classes you are interested in.\n" +
@@ -99,18 +93,18 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
             "\n" +
             WildcardMatcher.DOCUMENTATION)
         .dynamic(true)
-        .tags("added[1.14.0]")
+        .tags("added[1.15.0]")
         .buildWithDefault(WildcardMatcher.matchAllList());
 
     private final ConfigurationOption<List<WildcardMatcher>> excludedClasses = ConfigurationOption
         .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)
-        .key("profiling_excluded_classes")
+        .key("profiling_inferred_spans_excluded_classes")
         .configurationCategory(PROFILING_CATEGORY)
         .description("Excludes classes for which no profiler-inferred spans should be created.\n" +
             "\n" +
             WildcardMatcher.DOCUMENTATION)
         .dynamic(true)
-        .tags("added[1.14.0]")
+        .tags("added[1.15.0]")
         .buildWithDefault(Arrays.asList(
             WildcardMatcher.caseSensitiveMatcher("java.*"),
             WildcardMatcher.caseSensitiveMatcher("javax.*"),
@@ -128,16 +122,16 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
         ));
 
     private final ConfigurationOption<TimeDuration> profilerInterval = TimeDurationValueConverter.durationOption("s")
-        .key("profiling_interval")
+        .key("profiling_inferred_spans_interval")
         .description("The interval at which profiling sessions should be started.")
         .configurationCategory(PROFILING_CATEGORY)
         .addValidator(min(TimeDuration.of("0ms")))
         .dynamic(true)
-        .tags("added[1.14.0]")
-        .buildWithDefault(TimeDuration.of("61s"));
+        .tags("added[1.15.0]", "internal")
+        .buildWithDefault(TimeDuration.of("5s"));
 
     private final ConfigurationOption<TimeDuration> profilingDuration = TimeDurationValueConverter.durationOption("s")
-        .key("profiling_duration")
+        .key("profiling_inferred_spans_duration")
         .description("The duration of a profiling session.\n" +
             "For sampled transactions which fall within a profiling session (they start after and end before the session),\n" +
             "so-called inferred spans will be created.\n" +
@@ -145,12 +139,12 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
             "\n" +
             "NOTE: It is not recommended to set much higher durations as it may fill the activation events file and async-profiler's frame buffer.\n" +
             "Warnings will be logged if the activation events file is full.\n" +
-            "If you want to have more profiling coverage, try decreasing <<config-profiling-interval, `profiling_interval`>>.")
+            "If you want to have more profiling coverage, try decreasing <<config-profiling-inferred-spans-interval, `profiling_inferred_spans_interval`>>.")
         .configurationCategory(PROFILING_CATEGORY)
         .dynamic(true)
-        .addValidator(min(TimeDuration.of("1s")))
-        .tags("added[1.14.0]")
-        .buildWithDefault(TimeDuration.of("10s"));
+        .addValidator(isInRange(TimeDuration.of("1s"), TimeDuration.of("30s")))
+        .tags("added[1.15.0]", "internal")
+        .buildWithDefault(TimeDuration.of("5s"));
 
     public boolean isProfilingEnabled() {
         return profilingEnabled.get();

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -112,13 +112,11 @@ Click on a key to get more information.
 * <<config-messaging>>
 ** <<config-ignore-message-queues>>
 * <<config-profiling>>
-** <<config-profiling-spans-enabled>>
-** <<config-profiling-sampling-interval>>
-** <<config-profiling-spans-min-duration>>
-** <<config-profiling-included-classes>>
-** <<config-profiling-excluded-classes>>
-** <<config-profiling-interval>>
-** <<config-profiling-duration>>
+** <<config-profiling-inferred-spans-enabled>>
+** <<config-profiling-inferred-spans-sampling-interval>>
+** <<config-profiling-inferred-spans-min-duration>>
+** <<config-profiling-inferred-spans-included-classes>>
+** <<config-profiling-inferred-spans-excluded-classes>>
 * <<config-reporter>>
 ** <<config-secret-token>>
 ** <<config-server-urls>>
@@ -774,7 +772,7 @@ NOTE: This feature requires APM Server 7.2+
 A list of methods for which to create a transaction or span.
 
 If you want to monitor a large number of methods,
-use  <<config-profiling-spans-enabled, `profiling_spans_enabled`>> instead.
+use  <<config-profiling-inferred-spans-enabled, `profiling_inferred_spans_enabled`>> instead.
 
 This works by instrumenting each matching method to include code that creates a span for the method.
 While creating a span is quite cheap in terms of performance,
@@ -1450,20 +1448,15 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 === Profiling configuration options
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
-[[config-profiling-spans-enabled]]
-==== `profiling_spans_enabled` (added[1.14.0])
+[[config-profiling-inferred-spans-enabled]]
+==== `profiling_inferred_spans_enabled` (added[1.15.0] experimental)
 
 Set to `true` to make the agent create spans for method executions based on
 https://github.com/jvm-profiling-tools/async-profiler[async-profiler], a sampling aka statistical profiler.
 
-If this is enabled, the agent will start a profiling session every
-<<config-profiling-interval, `profiling_interval`>> which lasts for <<config-profiling-duration, `profiling_duration`>>.
-If a transaction happens within a profiling session,
-the agent creates spans for slow methods.
-
 Due to the nature of how sampling profilers work,
 the duration of the inferred spans are not exact, but only estimations.
-The <<config-profiling-sampling-interval, `profiling_sampling_interval`>> lets you fine tune the trade-off between accuracy and overhead.
+The <<config-profiling-inferred-spans-sampling-interval, `profiling_inferred_spans_sampling_interval`>> lets you fine tune the trade-off between accuracy and overhead.
 
 The inferred spans are created after a profiling session has ended.
 This means there is a delay between the regular and the inferred spans being visible in the UI.
@@ -1481,13 +1474,13 @@ NOTE: This feature is not available on Windows
 [options="header"]
 |============
 | Java System Properties      | Property file   | Environment
-| `elastic.apm.profiling_spans_enabled` | `profiling_spans_enabled` | `ELASTIC_APM_PROFILING_SPANS_ENABLED`
+| `elastic.apm.profiling_inferred_spans_enabled` | `profiling_inferred_spans_enabled` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED`
 |============
 
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
-[[config-profiling-sampling-interval]]
-==== `profiling_sampling_interval` (added[1.14.0])
+[[config-profiling-inferred-spans-sampling-interval]]
+==== `profiling_inferred_spans_sampling_interval` (added[1.15.0])
 
 The frequency at which stack traces are gathered within a profiling session.
 The lower you set it, the more accurate the durations will be.
@@ -1495,26 +1488,26 @@ This comes at the expense of higher overhead and more spans for potentially irre
 The minimal duration of a profiling-inferred span is the same as the value of this setting.
 
 Supports the duration suffixes `ms`, `s` and `m`.
-Example: `20ms`.
+Example: `50ms`.
 The default unit for this option is `ms`.
 
 [options="header"]
 |============
 | Default                          | Type                | Dynamic
-| `20ms` | TimeDuration | true
+| `50ms` | TimeDuration | true
 |============
 
 
 [options="header"]
 |============
 | Java System Properties      | Property file   | Environment
-| `elastic.apm.profiling_sampling_interval` | `profiling_sampling_interval` | `ELASTIC_APM_PROFILING_SAMPLING_INTERVAL`
+| `elastic.apm.profiling_inferred_spans_sampling_interval` | `profiling_inferred_spans_sampling_interval` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_SAMPLING_INTERVAL`
 |============
 
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
-[[config-profiling-spans-min-duration]]
-==== `profiling_spans_min_duration` (added[1.14.0])
+[[config-profiling-inferred-spans-min-duration]]
+==== `profiling_inferred_spans_min_duration` (added[1.15.0])
 
 The minimum duration of an inferred span.
 Note that the min duration is also implicitly set by the sampling interval.
@@ -1534,13 +1527,13 @@ The default unit for this option is `ms`.
 [options="header"]
 |============
 | Java System Properties      | Property file   | Environment
-| `elastic.apm.profiling_spans_min_duration` | `profiling_spans_min_duration` | `ELASTIC_APM_PROFILING_SPANS_MIN_DURATION`
+| `elastic.apm.profiling_inferred_spans_min_duration` | `profiling_inferred_spans_min_duration` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_MIN_DURATION`
 |============
 
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
-[[config-profiling-included-classes]]
-==== `profiling_included_classes` (added[1.14.0])
+[[config-profiling-inferred-spans-included-classes]]
+==== `profiling_inferred_spans_included_classes` (added[1.15.0])
 
 If set, the agent will only create inferred spans for methods which match this list.
 Setting a value may slightly increase performance and can reduce clutter by only creating spans for the classes you are interested in.
@@ -1562,13 +1555,13 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 [options="header"]
 |============
 | Java System Properties      | Property file   | Environment
-| `elastic.apm.profiling_included_classes` | `profiling_included_classes` | `ELASTIC_APM_PROFILING_INCLUDED_CLASSES`
+| `elastic.apm.profiling_inferred_spans_included_classes` | `profiling_inferred_spans_included_classes` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_INCLUDED_CLASSES`
 |============
 
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
-[[config-profiling-excluded-classes]]
-==== `profiling_excluded_classes` (added[1.14.0])
+[[config-profiling-inferred-spans-excluded-classes]]
+==== `profiling_inferred_spans_excluded_classes` (added[1.15.0])
 
 Excludes classes for which no profiler-inferred spans should be created.
 
@@ -1588,62 +1581,7 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 [options="header"]
 |============
 | Java System Properties      | Property file   | Environment
-| `elastic.apm.profiling_excluded_classes` | `profiling_excluded_classes` | `ELASTIC_APM_PROFILING_EXCLUDED_CLASSES`
-|============
-
-// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
-[float]
-[[config-profiling-interval]]
-==== `profiling_interval` (added[1.14.0])
-
-The interval at which profiling sessions should be started.
-
-Supports the duration suffixes `ms`, `s` and `m`.
-Example: `61s`.
-The default unit for this option is `s`.
-
-[options="header"]
-|============
-| Default                          | Type                | Dynamic
-| `61s` | TimeDuration | true
-|============
-
-
-[options="header"]
-|============
-| Java System Properties      | Property file   | Environment
-| `elastic.apm.profiling_interval` | `profiling_interval` | `ELASTIC_APM_PROFILING_INTERVAL`
-|============
-
-// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
-[float]
-[[config-profiling-duration]]
-==== `profiling_duration` (added[1.14.0])
-
-The duration of a profiling session.
-For sampled transactions which fall within a profiling session (they start after and end before the session),
-so-called inferred spans will be created.
-They appear in the trace waterfall view like regular spans.
-
-NOTE: It is not recommended to set much higher durations as it may fill the activation events file and async-profiler's frame buffer.
-Warnings will be logged if the activation events file is full.
-If you want to have more profiling coverage, try decreasing <<config-profiling-interval, `profiling_interval`>>.
-
-Supports the duration suffixes `ms`, `s` and `m`.
-Example: `10s`.
-The default unit for this option is `s`.
-
-[options="header"]
-|============
-| Default                          | Type                | Dynamic
-| `10s` | TimeDuration | true
-|============
-
-
-[options="header"]
-|============
-| Java System Properties      | Property file   | Environment
-| `elastic.apm.profiling_duration` | `profiling_duration` | `ELASTIC_APM_PROFILING_DURATION`
+| `elastic.apm.profiling_inferred_spans_excluded_classes` | `profiling_inferred_spans_excluded_classes` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_EXCLUDED_CLASSES`
 |============
 
 [[config-reporter]]
@@ -2345,7 +2283,7 @@ The default unit for this option is `ms`.
 # A list of methods for which to create a transaction or span.
 # 
 # If you want to monitor a large number of methods,
-# use  <<config-profiling-spans-enabled, `profiling_spans_enabled`>> instead.
+# use  <<config-profiling-inferred-spans-enabled, `profiling_inferred_spans_enabled`>> instead.
 # 
 # This works by instrumenting each matching method to include code that creates a span for the method.
 # While creating a span is quite cheap in terms of performance,
@@ -2791,14 +2729,9 @@ The default unit for this option is `ms`.
 # Set to `true` to make the agent create spans for method executions based on
 # https://github.com/jvm-profiling-tools/async-profiler[async-profiler], a sampling aka statistical profiler.
 # 
-# If this is enabled, the agent will start a profiling session every
-# <<config-profiling-interval, `profiling_interval`>> which lasts for <<config-profiling-duration, `profiling_duration`>>.
-# If a transaction happens within a profiling session,
-# the agent creates spans for slow methods.
-# 
 # Due to the nature of how sampling profilers work,
 # the duration of the inferred spans are not exact, but only estimations.
-# The <<config-profiling-sampling-interval, `profiling_sampling_interval`>> lets you fine tune the trade-off between accuracy and overhead.
+# The <<config-profiling-inferred-spans-sampling-interval, `profiling_inferred_spans_sampling_interval`>> lets you fine tune the trade-off between accuracy and overhead.
 # 
 # The inferred spans are created after a profiling session has ended.
 # This means there is a delay between the regular and the inferred spans being visible in the UI.
@@ -2809,7 +2742,7 @@ The default unit for this option is `ms`.
 # Type: Boolean
 # Default value: false
 #
-# profiling_spans_enabled=false
+# profiling_inferred_spans_enabled=false
 
 # The frequency at which stack traces are gathered within a profiling session.
 # The lower you set it, the more accurate the durations will be.
@@ -2818,11 +2751,11 @@ The default unit for this option is `ms`.
 #
 # This setting can be changed at runtime
 # Type: TimeDuration
-# Supports the duration suffixes ms, s and m. Example: 20ms.
+# Supports the duration suffixes ms, s and m. Example: 50ms.
 # The default unit for this option is ms.
-# Default value: 20ms
+# Default value: 50ms
 #
-# profiling_sampling_interval=20ms
+# profiling_inferred_spans_sampling_interval=50ms
 
 # The minimum duration of an inferred span.
 # Note that the min duration is also implicitly set by the sampling interval.
@@ -2834,7 +2767,7 @@ The default unit for this option is `ms`.
 # The default unit for this option is ms.
 # Default value: 0ms
 #
-# profiling_spans_min_duration=0ms
+# profiling_inferred_spans_min_duration=0ms
 
 # If set, the agent will only create inferred spans for methods which match this list.
 # Setting a value may slightly increase performance and can reduce clutter by only creating spans for the classes you are interested in.
@@ -2849,7 +2782,7 @@ The default unit for this option is `ms`.
 # Type: comma separated list
 # Default value: *
 #
-# profiling_included_classes=*
+# profiling_inferred_spans_included_classes=*
 
 # Excludes classes for which no profiler-inferred spans should be created.
 # 
@@ -2862,34 +2795,7 @@ The default unit for this option is `ms`.
 # Type: comma separated list
 # Default value: (?-i)java.*,(?-i)javax.*,(?-i)sun.*,(?-i)com.sun.*,(?-i)jdk.*,(?-i)org.apache.tomcat.*,(?-i)org.apache.catalina.*,(?-i)org.apache.coyote.*,(?-i)org.jboss.as.*,(?-i)org.glassfish.*,(?-i)org.eclipse.jetty.*,(?-i)com.ibm.websphere.*,(?-i)io.undertow.*
 #
-# profiling_excluded_classes=(?-i)java.*,(?-i)javax.*,(?-i)sun.*,(?-i)com.sun.*,(?-i)jdk.*,(?-i)org.apache.tomcat.*,(?-i)org.apache.catalina.*,(?-i)org.apache.coyote.*,(?-i)org.jboss.as.*,(?-i)org.glassfish.*,(?-i)org.eclipse.jetty.*,(?-i)com.ibm.websphere.*,(?-i)io.undertow.*
-
-# The interval at which profiling sessions should be started.
-#
-# This setting can be changed at runtime
-# Type: TimeDuration
-# Supports the duration suffixes ms, s and m. Example: 61s.
-# The default unit for this option is s.
-# Default value: 61s
-#
-# profiling_interval=61s
-
-# The duration of a profiling session.
-# For sampled transactions which fall within a profiling session (they start after and end before the session),
-# so-called inferred spans will be created.
-# They appear in the trace waterfall view like regular spans.
-# 
-# NOTE: It is not recommended to set much higher durations as it may fill the activation events file and async-profiler's frame buffer.
-# Warnings will be logged if the activation events file is full.
-# If you want to have more profiling coverage, try decreasing <<config-profiling-interval, `profiling_interval`>>.
-#
-# This setting can be changed at runtime
-# Type: TimeDuration
-# Supports the duration suffixes ms, s and m. Example: 10s.
-# The default unit for this option is s.
-# Default value: 10s
-#
-# profiling_duration=10s
+# profiling_inferred_spans_excluded_classes=(?-i)java.*,(?-i)javax.*,(?-i)sun.*,(?-i)com.sun.*,(?-i)jdk.*,(?-i)org.apache.tomcat.*,(?-i)org.apache.catalina.*,(?-i)org.apache.coyote.*,(?-i)org.jboss.as.*,(?-i)org.glassfish.*,(?-i)org.eclipse.jetty.*,(?-i)com.ibm.websphere.*,(?-i)io.undertow.*
 
 ############################################
 # Reporter                                 #

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -418,7 +418,7 @@ If you are seeing gaps in the span timeline and want to include certain methods,
 |Sampling-based profiler (experimental) added[1.14.0]
 |Leverages https://github.com/jvm-profiling-tools/async-profiler[async-profiler]
  to periodically record which methods are running (stack traces).
- Enable by setting <<config-profiling-spans-enabled, `profiling_spans_enabled`>> to `true`.
+ Enable by setting <<config-profiling-inferred-spans-enabled, `profiling_inferred_spans_enabled`>> to `true`.
 |Very low overhead, no code changes required.
  Great to find out which parts of the code make your application slow,
  without having to apply application-specific configuration.

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -415,7 +415,7 @@ If you are seeing gaps in the span timeline and want to include certain methods,
 |Less flexible on it's own but can be combined with the API.
  Just get the <<api-current-span, current span>> on an annotated method and customize the span to your liking.
 
-|Sampling-based profiler (incubating) added[1.14.0]
+|Sampling-based profiler (experimental) added[1.14.0]
 |Leverages https://github.com/jvm-profiling-tools/async-profiler[async-profiler]
  to periodically record which methods are running (stack traces).
  Enable by setting <<config-profiling-spans-enabled, `profiling_spans_enabled`>> to `true`.

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -423,10 +423,8 @@ If you are seeing gaps in the span timeline and want to include certain methods,
  Great to find out which parts of the code make your application slow,
  without having to apply application-specific configuration.
 |Does not work on Windows.
- Only creates spans while a profiling session is ongoing.
- This can be controlled via <<config-profiling-duration, `profiling_duration`>> and <<config-profiling-interval, `profiling_interval`>>.
  The duration of profiler-inferred spans are not exact measurements, only estimates.
- The accuracy depends on <<config-profiling-sampling-interval, `profiling_sampling_interval`>>.
+ The accuracy depends on <<config-profiling-inferred-spans-sampling-interval, `profiling_inferred_spans_sampling_interval`>>.
 
 |Configuration-based method instrumentation
 |Use the <<config-trace-methods, `trace_methods`>> configuration option to specify additional methods to instrument.


### PR DESCRIPTION
Profiling should run continuously in the background, rather than run profiling sessions which run for 10 seconds each minute for the following reasons:
- Transactions that take longer than a profiling session will get inferred spans too
- It's more intuitive: only whether a transaction is sampled or not should decide whether it should have inferred spans
- Consistency in relation to distributed tracing: we don't want to be in a situation where some services within a trace create inferred spans while others do not.

The `profiling_interval` and `profiling_duration` options are removed and are hard-coded to `5s` (down from `10s`). This has the following advantages:
- It takes less time for the inferred spans to appear in the UI
- Processing is faster and more efficient as the file sizes are smaller

Also renames configuration options for consistency (everything is prefixed with `profiling_inferred_spans_`)

The default for the `profiling_inferred_spans_sampling_interval` is increased from `20ms` to `50ms`, which matches the default value for the wall clock mode of async-profiler.

As the inferred spans feature is marked experimental, there's no backwards compatibility with the previous configuration options. When migrating to the new options, it's best to just set both, the old and the new ones.