### PR TITLE
Don't skip processing traces if there are ongoing transactions

### DIFF
--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
@@ -408,7 +408,7 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
             return;
         }
         long eof = startProcessingActivationEventsFile();
-        if (eof == 0 && activationEventsBuffer.limit() == 0) {
+        if (eof == 0 && activationEventsBuffer.limit() == 0 && profiledThreads.isEmpty()) {
             logger.debug("No activation events during this period. Skip processing stack traces.");
             return;
         }


### PR DESCRIPTION
closes #1088 

If there are no activation events within a profiling session, the agent skips processing the stack traces. However, it should not skip if there are still transactions running we should not skip processing the stack traces. Even if there are no new activation events within a session. 

This only happens for transactions that take longer than 5 seconds and only if the server is not handling any other traffic