### PR TITLE
Make grpc test less flaky

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
-public abstract class AbstractSpan<T extends AbstractSpan> extends TraceContextHolder<T> {
+public abstract class AbstractSpan<T extends AbstractSpan<T>> extends TraceContextHolder<T> {
     public static final int PRIO_USER_SUPPLIED = 1000;
     public static final int PRIO_HIGH_LEVEL_FRAMEWORK = 100;
     public static final int PRIO_METHOD_SIGNATURE = 100;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -231,6 +231,7 @@ public class TraceContext extends TraceContextHolder {
      * @see EpochTickClock
      */
     private EpochTickClock clock = new EpochTickClock();
+
     @Nullable
     private String serviceName;
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
@@ -43,6 +43,7 @@ import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.ValidationMessage;
 import org.awaitility.core.ConditionFactory;
+import org.awaitility.core.ThrowingRunnable;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -205,6 +206,11 @@ public class MockReporter implements Reporter {
         awaitTimeout(timeoutMs)
             .untilAsserted(() -> assertThat(getTransactions()).isEmpty());
         assertNoTransaction();
+    }
+
+    public void awaitUntilAsserted(long timeoutMs, ThrowingRunnable assertion){
+        awaitTimeout(timeoutMs)
+            .untilAsserted(assertion);
     }
 
     private static ConditionFactory awaitTimeout(long timeoutMs) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
@@ -209,7 +209,7 @@ public class MockReporter implements Reporter {
 
     private static ConditionFactory awaitTimeout(long timeoutMs) {
         return await()
-            .pollDelay(10, TimeUnit.MILLISECONDS)
+            .pollDelay(5, TimeUnit.MILLISECONDS)
             .timeout(timeoutMs, TimeUnit.MILLISECONDS);
     }
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
@@ -27,11 +27,11 @@ package co.elastic.apm.agent.grpc;
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.grpc.testapp.GrpcApp;
 import co.elastic.apm.agent.grpc.testapp.GrpcAppProvider;
-import co.elastic.apm.agent.impl.transaction.EpochTickClock;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +41,6 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.byLessThan;
 
 public abstract class AbstractGrpcClientInstrumentationTest extends AbstractInstrumentationTest {
 
@@ -126,48 +125,35 @@ public abstract class AbstractGrpcClientInstrumentationTest extends AbstractInst
     @Test
     public void cancelClientCall() throws Exception {
 
-        EpochTickClock clock = new EpochTickClock();
-        clock.init();
-
         CyclicBarrier startProcessing = new CyclicBarrier(2);
         CyclicBarrier endProcessing = new CyclicBarrier(2);
         app.getServer().useBarriersForProcessing(startProcessing, endProcessing);
 
-        long sendMessageStart = clock.getEpochMicros();
         Future<String> msg = app.sayHelloAsync("bob", 0);
 
-        // sending the 1st message takes about 100ms on client side
         startProcessing.await();
-
-        long serverProcessingStart = clock.getEpochMicros();
 
         try {
 
             // span is created somewhere between those two timing events, but we can't exactly when
             // and it varies a lot from one execution to another
 
-            long waitBeforeCancel = 100;
+            long waitBeforeCancel = 20;
 
             Thread.sleep(waitBeforeCancel);
             logger.info("cancel call after waiting {} ms", waitBeforeCancel);
 
             // cancel the future --> should create a span
             assertThat(msg.cancel(true)).isTrue();
-            long cancelTime = clock.getEpochMicros();
 
-            Span span = reporter.getFirstSpan(100);
+
+            Span span = reporter.getFirstSpan(200);
+
+            // we should have a span created and properly terminated, even if the server
+            // thread is still waiting for proper termination.
+            //
+            // we can't reliably do assertions on the actual duration without introducing flaky tests
             checkSpan(span);
-
-            assertThat(span.getTimestamp())
-                .describedAs("span timestamp should be after starting sending message")
-                .isGreaterThanOrEqualTo(sendMessageStart - 50_000);
-
-            assertThat(span.getDuration())
-                .describedAs("span duration should be larger than waited time before cancel")
-                .isGreaterThan(waitBeforeCancel * 1_000L)
-                // we expect an error that is related to the time it took to send the message plus a 5ms margin
-                // this is quite approximate, but we just want to ensure that agent provides something close to reality
-                .isCloseTo(waitBeforeCancel * 1_000L, byLessThan((serverProcessingStart - sendMessageStart) + 5_000L));
 
         } finally {
             // server is still waiting and did not sent response yet

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
@@ -135,9 +135,6 @@ public abstract class AbstractGrpcClientInstrumentationTest extends AbstractInst
 
         try {
 
-            // span is created somewhere between those two timing events, but we can't exactly when
-            // and it varies a lot from one execution to another
-
             long waitBeforeCancel = 20;
 
             Thread.sleep(waitBeforeCancel);

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcContextHeadersTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcContextHeadersTest.java
@@ -78,7 +78,7 @@ public abstract class AbstractGrpcContextHeadersTest extends AbstractInstrumenta
             endRootTransaction(transaction1);
         }
 
-        reporter.awaitUntilAsserted(100, ()->{
+        reporter.awaitUntilAsserted(100, () -> {
             assertThat(reporter.getTransactions())
                 .describedAs("should have 2 transactions: client (root) transaction, and gRPC server transaction")
                 .hasSize(2);
@@ -87,9 +87,12 @@ public abstract class AbstractGrpcContextHeadersTest extends AbstractInstrumenta
         List<Transaction> transactions = reporter.getTransactions();
         assertThat(transactions).hasSize(2);
 
-        assertThat(transactions.get(1)).isSameAs(transaction1);
+        assertThat(transactions).contains(transaction1);
 
-        Transaction transaction2 = transactions.get(0);
+        Transaction transaction2 = transactions.stream()
+            .filter((t) -> !t.equals(transaction1))
+            .findFirst()
+            .orElseThrow();
 
         Span span = reporter.getFirstSpan();
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcContextHeadersTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcContextHeadersTest.java
@@ -78,10 +78,14 @@ public abstract class AbstractGrpcContextHeadersTest extends AbstractInstrumenta
             endRootTransaction(transaction1);
         }
 
+        reporter.awaitUntilAsserted(100, ()->{
+            assertThat(reporter.getTransactions())
+                .describedAs("should have 2 transactions: client (root) transaction, and gRPC server transaction")
+                .hasSize(2);
+        });
+
         List<Transaction> transactions = reporter.getTransactions();
-        assertThat(transactions)
-            .describedAs("should have 2 transactions: client (root) transaction, and gRPC server transaction")
-            .hasSize(2);
+        assertThat(transactions).hasSize(2);
 
         assertThat(transactions.get(1)).isSameAs(transaction1);
 


### PR DESCRIPTION
This PR just removes time-based assertions on grpc tests.

Given those assertions make the test flaky, especially under random high CPU load, we just remove assertions on span start timestamp and duration.