### PR TITLE
Hanlde corner cases for empty or null service name

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,7 @@ endif::[]
 
 [float]
 ===== Breaking changes
+
 * Ordering of configuration sources has slightly changed, please review <<configuration>>:
 ** `elasticapm.properties` file now has higher priority over java system properties and environment variables, +
 This change allows to change dynamic options values at runtime by editing file, previously values set in java properties
@@ -31,6 +32,7 @@ or environment variables could not be overriden, even if they were dynamic.
 
 [float]
 ===== Features
+
 * Gracefully abort agent init when running on a known Java 8 buggy JVM {pull}1075[#1075].
 * Add support for <<supported-databases, Redis Redisson client>>
 * Makes <<config-instrument>>, <<config-trace-methods>>, and <<config-disable-instrumentations>> dynamic.
@@ -46,6 +48,7 @@ Note that changing these values at runtime can slow down the application tempora
 * Fixed bug that prevented an APM Error from being created when calling `org.slf4j.Logger#error` - {pull}1049[#1049]
 * Wrong address in JDBC spans for Oracle, MySQL and MariaDB when multiple hosts are configured - {pull}1082[#1082]
 * Document and re-order configuration priorities {pull}1087[#1087]
+* Improve heuristic for `service_name` when not set through config {pull}1097[#1097]
 
 [float]
 ===== Potentially breaking changes

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/ServiceNameUtil.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/ServiceNameUtil.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -31,20 +31,28 @@ public class ServiceNameUtil {
     private static final String JAR_VERSION_SUFFIX = "-(\\d+\\.)+(\\d+)(.*)?$";
 
     static String getDefaultServiceName() {
-        String serviceName = null;
-        String sunJavaCommand = System.getProperty("sun.java.command");
-        if (sunJavaCommand != null) {
-            serviceName = parseSunJavaCommand(sunJavaCommand);
+        return getDefaultServiceName(System.getProperty("sun.java.command"));
+    }
+
+    static String getDefaultServiceName(@Nullable String sunJavaCommand) {
+        String serviceName = parseSunJavaCommand(sunJavaCommand);
+        if (serviceName != null) {
+            serviceName = replaceDisallowedChars(serviceName);
+            serviceName = serviceName.trim();
         }
-        if (serviceName == null) {
+        if (serviceName == null || serviceName.isEmpty()) {
             serviceName = "my-service";
         }
         return serviceName;
     }
 
     @Nullable
-    static String parseSunJavaCommand(String command) {
-        String serviceName = getSpecialServiceName(command);
+    private static String parseSunJavaCommand(@Nullable String command) {
+        if (command == null) {
+            return null;
+        }
+        command = command.trim();
+        String serviceName = getContainerServiceName(command);
         if (serviceName != null) {
             return serviceName;
         }
@@ -53,14 +61,11 @@ public class ServiceNameUtil {
         } else {
             serviceName = parseMainClass(command);
         }
-        if (serviceName != null) {
-            return replaceDisallowedChars(serviceName);
-        }
-        return null;
+        return serviceName;
     }
 
     @Nullable
-    private static String getSpecialServiceName(String command) {
+    private static String getContainerServiceName(String command) {
         if (command.startsWith("org.apache.catalina.startup.Bootstrap")) {
             return "tomcat-application";
         } else if (command.startsWith("org.eclipse.jetty")) {
@@ -84,12 +89,14 @@ public class ServiceNameUtil {
     @Nullable
     private static String parseJarCommand(String command) {
         final String[] commandParts = command.split(" ");
+        String result = null;
         for (String commandPart : commandParts) {
             if (commandPart.endsWith(".jar")) {
-                return removeVersionFromJar(removePath(removeJarExtension(commandPart)));
+                result = removeVersionFromJar(removePath(removeJarExtension(commandPart)));
+                break;
             }
         }
-        return null;
+        return result;
     }
 
     @Nonnull

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/ServiceNameUtilTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/ServiceNameUtilTest.java
@@ -68,14 +68,18 @@ class ServiceNameUtilTest {
     @Test
     void parseApplicationServers() {
         assertSoftly(softly -> {
-            softly.assertThat(getDefaultServiceName("org.eclipse.jetty.xml.XmlConfiguration")).isEqualTo("jetty-application");
-            softly.assertThat(getDefaultServiceName("org.apache.catalina.startup.Bootstrap start")).isEqualTo("tomcat-application");
+            softly.assertThat(getDefaultServiceName("org.eclipse.jetty.xml.XmlConfiguration"))
+                .isEqualTo("jetty-application");
+            softly.assertThat(getDefaultServiceName("org.apache.catalina.startup.Bootstrap start"))
+                .isEqualTo("tomcat-application");
             softly.assertThat(getDefaultServiceName("com.sun.enterprise.glassfish.bootstrap.ASMain -upgrade false -read-stdin true -postbootcommandfile /opt/payara5/post-boot-commands.asadmin -domainname domain1 -domaindir /opt/payara5/glassfish/domains/domain1 -asadmin-args --host,,,localhost,,,--port,,,4848,,,--passwordfile,,,/opt/pwdfile,,,--secure=false,,,--terse=false,,,--echo=false,,,--interactive=false,,,start-domain,,,--verbose=false,,,--watchdog=false,,,--debug=false,,,--domaindir,,,/opt/payara5/glassfish/domains,,,domain1 -instancename server -type DAS -verbose false -asadmin-classpath /opt/payara5/glassfish/lib/client/appserver-cli.jar -debug false -asadmin-classname com.sun.enterprise.admin.cli.AdminMain -watchdog false"))
                 .isEqualTo("glassfish-application");
             softly.assertThat(getDefaultServiceName("/opt/ibm/wlp/bin/tools/ws-server.jar defaultServer"))
                 .isEqualTo("websphere-application");
             softly.assertThat(getDefaultServiceName("/opt/jboss/wildfly/jboss-modules.jar -mp /opt/jboss/wildfly/modules org.jboss.as.standalone -Djboss.home.dir=/opt/jboss/wildfly -Djboss.server.base.dir=/opt/jboss/wildfly/standalone -b 0.0.0.0"))
                 .isEqualTo("jboss-application");
+            softly.assertThat(getDefaultServiceName("weblogic.Server"))
+                .isEqualTo("weblogic-application");
 
         });
     }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/ServiceNameUtilTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/ServiceNameUtilTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,45 +26,55 @@ package co.elastic.apm.agent.configuration;
 
 import org.junit.jupiter.api.Test;
 
-import static co.elastic.apm.agent.configuration.ServiceNameUtil.parseSunJavaCommand;
+import static co.elastic.apm.agent.configuration.ServiceNameUtil.getDefaultServiceName;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 class ServiceNameUtilTest {
 
     @Test
-    void testParseSunJavaCommand() {
+    void serviceNameShouldBeNormalizedOrDefaults() {
         assertSoftly(softly -> {
-            softly.assertThat(parseSunJavaCommand("foo.bar.Baz")).isEqualTo("Baz");
-            softly.assertThat(parseSunJavaCommand("foo.bar.Baz$Qux")).isEqualTo("Baz-Qux");
-            softly.assertThat(parseSunJavaCommand("foo.bar.Baz foo")).isEqualTo("Baz");
-            softly.assertThat(parseSunJavaCommand("my-app.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("my-app-4-j.jar bar")).isEqualTo("my-app-4-j");
-            softly.assertThat(parseSunJavaCommand("my-app-2.jar bar")).isEqualTo("my-app-2");
-            softly.assertThat(parseSunJavaCommand("my-app-1.0.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("my-app-1.0.0.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("my-app-1.0.0.0.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("my-app-1.0.0-SNAPSHOT.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("my-app-1.0.0-BUILD-SNAPSHOT.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("my-app-1.0.0.BUILD-SNAPSHOT.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("my-app-1.0.0?and0m.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("my-app-1.0.0-RC1.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("my-app-1.0.0.RC1.jar bar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("foo/my-app-1.0.0-RC1.jar baz")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("C:\\foo\\my-app.jar")).isEqualTo("my-app");
-            softly.assertThat(parseSunJavaCommand("C:\\foo bar\\my-app-1.0.0-BUILD-SNAPSHOT.jar qux")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName(" my-awesome-service ")).isEqualTo("my-awesome-service");
+            softly.assertThat(getDefaultServiceName("")).isEqualTo("my-service");
+            softly.assertThat(getDefaultServiceName("  ")).isEqualTo("my-service");
+            softly.assertThat(getDefaultServiceName(null)).isEqualTo("my-service");
+        });
+    }
+
+    @Test
+    void testDefaultServiceName() {
+        assertSoftly(softly -> {
+            softly.assertThat(getDefaultServiceName("foo.bar.Baz")).isEqualTo("Baz");
+            softly.assertThat(getDefaultServiceName("foo.bar.Baz$Qux")).isEqualTo("Baz-Qux");
+            softly.assertThat(getDefaultServiceName("foo.bar.Baz foo")).isEqualTo("Baz");
+            softly.assertThat(getDefaultServiceName("my-app.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("my-app-4-j.jar bar")).isEqualTo("my-app-4-j");
+            softly.assertThat(getDefaultServiceName("my-app-2.jar bar")).isEqualTo("my-app-2");
+            softly.assertThat(getDefaultServiceName("my-app-1.0.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("my-app-1.0.0.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("my-app-1.0.0.0.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("my-app-1.0.0-SNAPSHOT.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("my-app-1.0.0-BUILD-SNAPSHOT.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("my-app-1.0.0.BUILD-SNAPSHOT.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("my-app-1.0.0?and0m.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("my-app-1.0.0-RC1.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("my-app-1.0.0.RC1.jar bar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("foo/my-app-1.0.0-RC1.jar baz")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("C:\\foo\\my-app.jar")).isEqualTo("my-app");
+            softly.assertThat(getDefaultServiceName("C:\\foo bar\\my-app-1.0.0-BUILD-SNAPSHOT.jar qux")).isEqualTo("my-app");
         });
     }
 
     @Test
     void parseApplicationServers() {
         assertSoftly(softly -> {
-            softly.assertThat(parseSunJavaCommand("org.eclipse.jetty.xml.XmlConfiguration")).isEqualTo("jetty-application");
-            softly.assertThat(parseSunJavaCommand("org.apache.catalina.startup.Bootstrap start")).isEqualTo("tomcat-application");
-            softly.assertThat(parseSunJavaCommand("com.sun.enterprise.glassfish.bootstrap.ASMain -upgrade false -read-stdin true -postbootcommandfile /opt/payara5/post-boot-commands.asadmin -domainname domain1 -domaindir /opt/payara5/glassfish/domains/domain1 -asadmin-args --host,,,localhost,,,--port,,,4848,,,--passwordfile,,,/opt/pwdfile,,,--secure=false,,,--terse=false,,,--echo=false,,,--interactive=false,,,start-domain,,,--verbose=false,,,--watchdog=false,,,--debug=false,,,--domaindir,,,/opt/payara5/glassfish/domains,,,domain1 -instancename server -type DAS -verbose false -asadmin-classpath /opt/payara5/glassfish/lib/client/appserver-cli.jar -debug false -asadmin-classname com.sun.enterprise.admin.cli.AdminMain -watchdog false"))
+            softly.assertThat(getDefaultServiceName("org.eclipse.jetty.xml.XmlConfiguration")).isEqualTo("jetty-application");
+            softly.assertThat(getDefaultServiceName("org.apache.catalina.startup.Bootstrap start")).isEqualTo("tomcat-application");
+            softly.assertThat(getDefaultServiceName("com.sun.enterprise.glassfish.bootstrap.ASMain -upgrade false -read-stdin true -postbootcommandfile /opt/payara5/post-boot-commands.asadmin -domainname domain1 -domaindir /opt/payara5/glassfish/domains/domain1 -asadmin-args --host,,,localhost,,,--port,,,4848,,,--passwordfile,,,/opt/pwdfile,,,--secure=false,,,--terse=false,,,--echo=false,,,--interactive=false,,,start-domain,,,--verbose=false,,,--watchdog=false,,,--debug=false,,,--domaindir,,,/opt/payara5/glassfish/domains,,,domain1 -instancename server -type DAS -verbose false -asadmin-classpath /opt/payara5/glassfish/lib/client/appserver-cli.jar -debug false -asadmin-classname com.sun.enterprise.admin.cli.AdminMain -watchdog false"))
                 .isEqualTo("glassfish-application");
-            softly.assertThat(parseSunJavaCommand("/opt/ibm/wlp/bin/tools/ws-server.jar defaultServer"))
+            softly.assertThat(getDefaultServiceName("/opt/ibm/wlp/bin/tools/ws-server.jar defaultServer"))
                 .isEqualTo("websphere-application");
-            softly.assertThat(parseSunJavaCommand("/opt/jboss/wildfly/jboss-modules.jar -mp /opt/jboss/wildfly/modules org.jboss.as.standalone -Djboss.home.dir=/opt/jboss/wildfly -Djboss.server.base.dir=/opt/jboss/wildfly/standalone -b 0.0.0.0"))
+            softly.assertThat(getDefaultServiceName("/opt/jboss/wildfly/jboss-modules.jar -mp /opt/jboss/wildfly/modules org.jboss.as.standalone -Djboss.home.dir=/opt/jboss/wildfly -Djboss.server.base.dir=/opt/jboss/wildfly/standalone -b 0.0.0.0"))
                 .isEqualTo("jboss-application");
 
         });


### PR DESCRIPTION
## What does this PR do?

This PR tests and improve heuristics to get service name from JVM system properties.
Current implementation might allow to have empty values and did not handled properly values with spaces.

## Checklist

- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
- ~~I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- ~~Added an API method or config option? Document in which version this will be introduced~~
- ~~Added an instrumentation plugin? How did you make sure that old, non-supported versions are not instrumented by accident?~~

## Author's Checklist
- [x] manual testing with Weblogic server
