### PR TITLE
Restore version 1.14.0-SNAPSHOT

### DIFF
--- a/apm-agent-api/pom.xml
+++ b/apm-agent-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent-api</artifactId>

--- a/apm-agent-attach/pom.xml
+++ b/apm-agent-attach/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent-attach</artifactId>

--- a/apm-agent-benchmarks/pom.xml
+++ b/apm-agent-benchmarks/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent-benchmarks</artifactId>

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>co.elastic.apm</groupId>
         <artifactId>apm-agent-parent</artifactId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent-core</artifactId>

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-apache-httpclient-plugin</artifactId>

--- a/apm-agent-plugins/apm-api-plugin/pom.xml
+++ b/apm-agent-plugins/apm-api-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-asynchttpclient-plugin</artifactId>

--- a/apm-agent-plugins/apm-error-logging-plugin/pom.xml
+++ b/apm-agent-plugins/apm-error-logging-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-error-logging-plugin</artifactId>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-es-restclient-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-es-restclient-plugin-5_6</artifactId>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-es-restclient-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-es-restclient-plugin-6_4</artifactId>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_1/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-es-restclient-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-es-restclient-plugin-7_1</artifactId>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-es-restclient-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-es-restclient-plugin-common</artifactId>

--- a/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-es-restclient-plugin</artifactId>

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>co.elastic.apm</groupId>
         <artifactId>apm-grpc</artifactId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-grpc-plugin</artifactId>

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.27.1/pom.xml
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.27.1/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>co.elastic.apm</groupId>
         <artifactId>apm-grpc</artifactId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-grpc-test-1.27.1</artifactId>

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/pom.xml
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>co.elastic.apm</groupId>
         <artifactId>apm-grpc</artifactId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-grpc-test-1.6.1</artifactId>

--- a/apm-agent-plugins/apm-grpc/pom.xml
+++ b/apm-agent-plugins/apm-grpc/pom.xml
@@ -1,11 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>co.elastic.apm</groupId>
         <artifactId>apm-agent-plugins</artifactId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-grpc</artifactId>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-hibernate-search-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-hibernate-search-plugin-5_x</artifactId>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-hibernate-search-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-hibernate-search-plugin-6_x</artifactId>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-hibernate-search-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-hibernate-search-plugin-common</artifactId>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-hibernate-search-plugin</artifactId>

--- a/apm-agent-plugins/apm-httpclient-core/pom.xml
+++ b/apm-agent-plugins/apm-httpclient-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-httpclient-core</artifactId>

--- a/apm-agent-plugins/apm-java-concurrent-plugin/pom.xml
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-java-concurrent-plugin</artifactId>

--- a/apm-agent-plugins/apm-jaxrs-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jaxrs-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jaxrs-plugin</artifactId>

--- a/apm-agent-plugins/apm-jaxws-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jaxws-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jaxws-plugin</artifactId>

--- a/apm-agent-plugins/apm-jdbc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jdbc-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jdbc-plugin</artifactId>

--- a/apm-agent-plugins/apm-jms-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jms-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jms-plugin</artifactId>

--- a/apm-agent-plugins/apm-jmx-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jmx-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jmx-plugin</artifactId>

--- a/apm-agent-plugins/apm-jsf-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jsf-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jsf-plugin</artifactId>

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/pom.xml
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apm-kafka-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/pom.xml
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>apm-kafka-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-kafka-plugin/pom.xml
+++ b/apm-agent-plugins/apm-kafka-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-log-correlation-plugin/pom.xml
+++ b/apm-agent-plugins/apm-log-correlation-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-log-correlation-plugin</artifactId>

--- a/apm-agent-plugins/apm-mongoclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-mongoclient-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-mule4-plugin/pom.xml
+++ b/apm-agent-plugins/apm-mule4-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-mule4-plugin</artifactId>

--- a/apm-agent-plugins/apm-okhttp-plugin/pom.xml
+++ b/apm-agent-plugins/apm-okhttp-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-okhttp-plugin</artifactId>

--- a/apm-agent-plugins/apm-opentracing-plugin/pom.xml
+++ b/apm-agent-plugins/apm-opentracing-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-opentracing-plugin</artifactId>

--- a/apm-agent-plugins/apm-process-plugin/pom.xml
+++ b/apm-agent-plugins/apm-process-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-profiling-plugin/pom.xml
+++ b/apm-agent-plugins/apm-profiling-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-profiling-plugin</artifactId>

--- a/apm-agent-plugins/apm-quartz-job-plugin/pom.xml
+++ b/apm-agent-plugins/apm-quartz-job-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-quartz-job-plugin</artifactId>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-2-tests/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-2-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jedis-2-tests</artifactId>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-3-tests/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-3-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jedis-3-tests</artifactId>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-jedis-plugin</artifactId>

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-3-tests/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-3-tests/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-redis-common</artifactId>

--- a/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-redis-plugin</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-redisson-plugin</artifactId>

--- a/apm-agent-plugins/apm-redis-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-redis-plugin</artifactId>

--- a/apm-agent-plugins/apm-scheduled-annotation-plugin/pom.xml
+++ b/apm-agent-plugins/apm-scheduled-annotation-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-scheduled-annotation-plugin</artifactId>

--- a/apm-agent-plugins/apm-servlet-plugin/pom.xml
+++ b/apm-agent-plugins/apm-servlet-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-servlet-plugin</artifactId>

--- a/apm-agent-plugins/apm-spring-resttemplate-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-resttemplate-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-resttemplate-plugin</artifactId>

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-spring-webmvc-plugin</artifactId>

--- a/apm-agent-plugins/apm-urlconnection-plugin/pom.xml
+++ b/apm-agent-plugins/apm-urlconnection-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-plugins</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-urlconnection-plugin</artifactId>

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-agent-plugins</artifactId>

--- a/apm-opentracing/pom.xml
+++ b/apm-opentracing/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>apm-opentracing</artifactId>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>co.elastic.apm</groupId>
         <artifactId>apm-agent-parent</artifactId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>elastic-apm-agent</artifactId>

--- a/integration-tests/application-server-integration-tests/pom.xml
+++ b/integration-tests/application-server-integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>application-server-integration-tests</artifactId>

--- a/integration-tests/cdi-app/cdi-app-dependent/pom.xml
+++ b/integration-tests/cdi-app/cdi-app-dependent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>cdi-app</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/cdi-app/cdi-app-standalone/pom.xml
+++ b/integration-tests/cdi-app/cdi-app-standalone/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>cdi-app</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/cdi-app/pom.xml
+++ b/integration-tests/cdi-app/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jsf-app/jsf-app-dependent/pom.xml
+++ b/integration-tests/jsf-app/jsf-app-dependent/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>jsf-app</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/integration-tests/jsf-app/jsf-app-standalone/pom.xml
+++ b/integration-tests/jsf-app/jsf-app-standalone/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>jsf-app</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jsf-app-standalone</artifactId>

--- a/integration-tests/jsf-app/pom.xml
+++ b/integration-tests/jsf-app/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>jsf-app</artifactId>

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>apm-agent-parent</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>integration-tests</artifactId>

--- a/integration-tests/simple-webapp/pom.xml
+++ b/integration-tests/simple-webapp/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>simple-webapp</artifactId>

--- a/integration-tests/soap-test/pom.xml
+++ b/integration-tests/soap-test/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>soap-test</artifactId>

--- a/integration-tests/spring-boot-1-5/pom.xml
+++ b/integration-tests/spring-boot-1-5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-boot-1-5</artifactId>

--- a/integration-tests/spring-boot-2/pom.xml
+++ b/integration-tests/spring-boot-2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-tests</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-boot-2</artifactId>

--- a/integration-tests/spring-boot-2/spring-boot-2-base/pom.xml
+++ b/integration-tests/spring-boot-2/spring-boot-2-base/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-boot-2</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-boot-2-base</artifactId>

--- a/integration-tests/spring-boot-2/spring-boot-2-jetty/pom.xml
+++ b/integration-tests/spring-boot-2/spring-boot-2-jetty/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-boot-2</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-boot-2-jetty</artifactId>

--- a/integration-tests/spring-boot-2/spring-boot-2-tomcat/pom.xml
+++ b/integration-tests/spring-boot-2/spring-boot-2-tomcat/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-boot-2</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-boot-2-tomcat</artifactId>

--- a/integration-tests/spring-boot-2/spring-boot-2-undertow/pom.xml
+++ b/integration-tests/spring-boot-2/spring-boot-2-undertow/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-boot-2</artifactId>
         <groupId>co.elastic.apm</groupId>
-        <version>1.15.1-SNAPSHOT</version>
+        <version>1.15.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>spring-boot-2-undertow</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>co.elastic.apm</groupId>
     <artifactId>apm-agent-parent</artifactId>
-    <version>1.15.1-SNAPSHOT</version>
+    <version>1.15.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
The released failed with this message:

```
14:40:19 [INFO] [ERROR] Failed to execute goal org.apache.maven.plugins:maven-deploy-plugin:2.8.2:deploy (default-deploy) on project apm-agent-parent: Failed to deploy artifacts: Could not transfer artifact co.elastic.apm:apm-agent-parent:pom:1.15.0 from/to sonatype-nexus-staging (https://oss.sonatype.org/service/local/staging/deploy/maven2/): Failed to transfer file: https://oss.sonatype.org/service/local/staging/deploy/maven2/co/elastic/apm/apm-agent-parent/1.15.0/apm-agent-parent-1.15.0.pom. Return code is: 504, ReasonPhrase: Gateway Time-out. -> [Help 1]
```

Despite the [sonatype status](https://status.maven.org/) being green, `Staging Operation Duration` indicates some problems:

<img width="893" alt="Screen Shot 2020-03-27 at 15 03 50" src="https://user-images.githubusercontent.com/2163464/77763979-2dfb1600-703c-11ea-856e-dba93a88fa55.png">
