### PR TITLE
Exclude Quartz 1 from instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,9 @@ endif::[]
 ===== Bug fixes
 * When Servlet-related Exceptions are handled through exception handlers that return a 200 status code, agent
 shouldn't override with 500 - {pull}1103[#1103]
+* Exclude Quartz 1 from instrumentation to avoid
+  `IncompatibleClassChangeError: Found class org.quartz.JobExecutionContext, but interface was expected` - {pull}1108[#1108]
+
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameInstrumentation.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,6 +39,7 @@ import java.util.Collection;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPackage;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -61,7 +62,8 @@ public class JobTransactionNameInstrumentation extends ElasticApmInstrumentation
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        return named("execute").or(named("executeInternal")).and(takesArgument(0, named("org.quartz.JobExecutionContext")));
+        return named("execute").or(named("executeInternal"))
+            .and(takesArgument(0, named("org.quartz.JobExecutionContext").and(isInterface())));
     }
 
     @Override

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -333,7 +333,7 @@ When using a scheduling framework a transaction for every execution will be crea
 |1.6.0
 
 |Quartz
-|
+|2.0+
 |The agent instruments the `execute` method of any class implementing `org.quartz.Job`, as well as the `executeInternal` method of any class extending `org.springframework.scheduling.quartz.QuartzJobBean`, and creates a transaction with the type `scheduled`, representing the job execution 
 
 NOTE: only classes from packages configured in <<config-application-packages>>  will be instrumented.


### PR DESCRIPTION
To avoid IncompatibleClassChangeError: Found class org.quartz.JobExecutionContext, but interface was expected