### PR TITLE
Fix flaky gRPC server instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ shouldn't override with 500 - {pull}1103[#1103]
 * Exclude Quartz 1 from instrumentation to avoid
   `IncompatibleClassChangeError: Found class org.quartz.JobExecutionContext, but interface was expected` - {pull}1108[#1108]
 * Fix breakdown metrics span sub-types {pull}1113[#1113]
+* Fix flaky gRPC server instrumentation {pull}1122[#1122]
 
 
 [[release-notes-1.x]]

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/AbstractInstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/AbstractInstrumentationTest.java
@@ -65,13 +65,15 @@ public abstract class AbstractInstrumentationTest {
         ElasticApmAgent.reset();
     }
 
-    public static void staticReset() {
+    public static synchronized void staticReset() {
         SpyConfiguration.reset(config);
         reporter.reset();
 
         // resume tracer in case it has been paused
         // otherwise the 1st test that pauses tracer will have side effects on others
-        TracerInternalApiUtils.resumeTracer(tracer);
+        if (!tracer.isRunning()) {
+            TracerInternalApiUtils.resumeTracer(tracer);
+        }
     }
 
     public static ElasticApmTracer getTracer() {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
@@ -196,16 +196,15 @@ public class MockReporter implements Reporter {
         return getFirstTransaction();
     }
 
-    public void assertNoTransaction(){
+    public void assertNoTransaction() {
         assertThat(getTransactions())
             .describedAs("no transaction expected")
             .isEmpty();
     }
 
-    public void assertNoTransaction(long timeoutMs){
+    public void assertNoTransaction(long timeoutMs) {
         awaitTimeout(timeoutMs)
-            .untilAsserted(() -> assertThat(getTransactions()).isEmpty());
-        assertNoTransaction();
+            .untilAsserted(this::assertNoTransaction);
     }
 
     public void awaitUntilAsserted(long timeoutMs, ThrowingRunnable assertion){
@@ -215,7 +214,7 @@ public class MockReporter implements Reporter {
 
     private static ConditionFactory awaitTimeout(long timeoutMs) {
         return await()
-            .pollDelay(5, TimeUnit.MILLISECONDS)
+            .pollInterval(1, TimeUnit.MILLISECONDS)
             .timeout(timeoutMs, TimeUnit.MILLISECONDS);
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
@@ -95,7 +95,7 @@ public class MockTracer {
         ElasticApmTracer tracer = ElasticApmInstrumentation.tracer;
         if (tracer == null || tracer.getState() == ElasticApmTracer.TracerState.STOPPED ||
             !(tracer.getReporter() instanceof MockReporter) || !(tracer.getObjectPoolFactory() instanceof TestObjectPoolFactory)) {
-            
+
             // use an object pool that does bookkeeping to allow for extra usage checks
             TestObjectPoolFactory objectPoolFactory = new TestObjectPoolFactory();
 
@@ -115,7 +115,9 @@ public class MockTracer {
                 .build();
         } else {
             ElasticApmAgent.reset();
-            TracerInternalApiUtils.resumeTracer(tracer);
+            if (!tracer.isRunning()) {
+                TracerInternalApiUtils.resumeTracer(tracer);
+            }
             ((MockReporter) tracer.getReporter()).reset();
             SpyConfiguration.reset(tracer.getConfigurationRegistry());
         }

--- a/apm-agent-core/src/test/resources/elasticapm.properties
+++ b/apm-agent-core/src/test/resources/elasticapm.properties
@@ -5,6 +5,3 @@ disable_instrumentations=
 # in unit tests, the agent is loaded by the system class loader so we can't instrument bootstrap classes
 classes_excluded_from_instrumentation=java.*,com.sun.*,sun.*
 application_packages=co.elastic.apm
-
-# circuit breaker should be disabled by default, otherwise it is triggered while tests execute
-circuit_breaker_enabled=false

--- a/apm-agent-core/src/test/resources/elasticapm.properties
+++ b/apm-agent-core/src/test/resources/elasticapm.properties
@@ -5,3 +5,6 @@ disable_instrumentations=
 # in unit tests, the agent is loaded by the system class loader so we can't instrument bootstrap classes
 classes_excluded_from_instrumentation=java.*,com.sun.*,sun.*
 application_packages=co.elastic.apm
+
+# circuit breaker should be disabled by default, otherwise it is triggered while tests execute
+circuit_breaker_enabled=false

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallInstrumentation.java
@@ -70,7 +70,9 @@ public class ServerCallInstrumentation extends BaseInstrumentation {
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
-    private static void onExit(@Advice.Thrown @Nullable Throwable thrown, @Advice.Argument(0) Status status) {
+    private static void onExit(@Advice.Thrown @Nullable Throwable thrown,
+                               @Advice.This ServerCall<?,?> serverCall,
+                               @Advice.Argument(0) Status status) {
 
         if (tracer == null || grpcHelperManager == null) {
             return;
@@ -78,7 +80,7 @@ public class ServerCallInstrumentation extends BaseInstrumentation {
 
         GrpcHelper helper = grpcHelperManager.getForClassLoaderOfClass(ServerCall.class);
         if (helper != null) {
-            helper.endTransaction(status, thrown, tracer.currentTransaction());
+            helper.endTransaction(status, thrown, serverCall);
         }
     }
 }

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelper.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelper.java
@@ -43,9 +43,17 @@ public interface GrpcHelper {
 
     // server part
 
-    void startTransaction(ElasticApmTracer tracer, ClassLoader cl, ServerCall<?, ?> serverCall, Metadata headers);
+    @Nullable
+    Transaction startTransaction(ElasticApmTracer tracer, ClassLoader cl, ServerCall<?, ?> serverCall, Metadata headers);
 
-    void endTransaction(Status status, @Nullable Throwable thrown, @Nullable Transaction transaction);
+    void registerTransactionAndDeactivate(@Nullable Transaction transaction, ServerCall<?, ?> serverCall, ServerCall.Listener<?> listener);
+
+    void endTransaction(Status status, @Nullable Throwable thrown, ServerCall<?, ?> serverCall);
+
+    @Nullable
+    Transaction enterServerListenerMethod(ServerCall.Listener<?> listener);
+
+    void exitServerListenerMethod(Throwable thrown, ServerCall.Listener<?> listener, Transaction transaction, boolean isLastMethod);
 
     // client part
 
@@ -61,4 +69,5 @@ public interface GrpcHelper {
     void captureListenerException(ClientCall.Listener<?> responseListener, @Nullable Throwable thrown);
 
     void enrichSpanContext(ClientCall<?, ?> clientCall, @Nullable String authority);
+
 }

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelperImpl.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelperImpl.java
@@ -37,8 +37,6 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.Status;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -51,8 +49,6 @@ import javax.annotation.Nullable;
  */
 @SuppressWarnings("unused")
 public class GrpcHelperImpl implements GrpcHelper {
-
-    private static final Logger logger = LoggerFactory.getLogger(GrpcHelperImpl.class);
 
     /**
      * Map of all in-flight spans, is only used by client part.
@@ -112,8 +108,6 @@ public class GrpcHelperImpl implements GrpcHelper {
             return null;
         }
 
-        logger.debug("startTransaction ---- {} ", transaction);
-
         transaction.withName(methodDescriptor.getFullMethodName())
             .withType("request")
             .activate();
@@ -126,8 +120,6 @@ public class GrpcHelperImpl implements GrpcHelper {
         if (null == transaction) {
             return;
         }
-
-        logger.debug("registerTransactionAndDeactivate ---- {}", transaction);
 
         inFlightTransactions.put(serverCall, transaction);
         inFlightServerListeners.put(listener, serverCall);

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelperImpl.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelperImpl.java
@@ -37,6 +37,8 @@ import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
 import io.grpc.ServerCall;
 import io.grpc.Status;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -50,29 +52,45 @@ import javax.annotation.Nullable;
 @SuppressWarnings("unused")
 public class GrpcHelperImpl implements GrpcHelper {
 
+    private static final Logger logger = LoggerFactory.getLogger(GrpcHelperImpl.class);
+
     /**
      * Map of all in-flight spans, is only used by client part.
-     * Key is {@link ClientCall}, value is {@link Span}
+     * Key is {@link ClientCall}, value is {@link Span}.
      */
-    private static final WeakConcurrentMap<ClientCall<?, ?>, Span> inFlightSpans;
+    private static final WeakConcurrentMap<ClientCall<?, ?>, Span> inFlightClientSpans;
     /**
-     * Map of all in-flight {@link ClientCall instances} with the {@link ClientCall.Listener} instance that have been used to
-     * start them as key.
+     * Map of all in-flight {@link ClientCall} instances with the {@link ClientCall.Listener} instance as key
      */
-    private static final WeakConcurrentMap<ClientCall.Listener<?>, ClientCall<?,?>> inFlightListeners;
+    private static final WeakConcurrentMap<ClientCall.Listener<?>, ClientCall<?, ?>> inFlightClientListeners;
+
+    /**
+     * Map of all in-flight transactions, is only used by server part.
+     * Key is {@link ServerCall}, value is {@link Transaction}.
+     */
+    private static final WeakConcurrentMap<ServerCall<?, ?>, Transaction> inFlightTransactions;
+    /**
+     * Map of all in-flight {@link ServerCall} instances with the {@link ServerCall.Listener} instance as key
+     */
+    private static final WeakConcurrentMap<ServerCall.Listener<?>, ServerCall<?, ?>> inFlightServerListeners;
+
 
     /**
      * gRPC header cache used to minimize allocations
      */
-    private static final WeakConcurrentMap.WithInlinedExpunction<String, Metadata.Key<String>> headerCache ;
+    private static final WeakConcurrentMap.WithInlinedExpunction<String, Metadata.Key<String>> headerCache;
 
     private static final TextHeaderSetter<Metadata> headerSetter;
     private static final TextHeaderGetter<Metadata> headerGetter;
 
     static {
-        inFlightListeners = new WeakConcurrentMap.WithInlinedExpunction<ClientCall.Listener<?>, ClientCall<?, ?>>();
-        inFlightSpans = new WeakConcurrentMap.WithInlinedExpunction<ClientCall<?, ?>, Span>();
-        headerCache = new WeakConcurrentMap.WithInlinedExpunction<String,Metadata.Key<String>>();
+        inFlightClientListeners = new WeakConcurrentMap.WithInlinedExpunction<ClientCall.Listener<?>, ClientCall<?, ?>>();
+        inFlightClientSpans = new WeakConcurrentMap.WithInlinedExpunction<ClientCall<?, ?>, Span>();
+
+        inFlightServerListeners = new WeakConcurrentMap.WithInlinedExpunction<ServerCall.Listener<?>, ServerCall<?, ?>>();
+        inFlightTransactions = new WeakConcurrentMap.WithInlinedExpunction<ServerCall<?, ?>, Transaction>();
+
+        headerCache = new WeakConcurrentMap.WithInlinedExpunction<String, Metadata.Key<String>>();
 
         headerSetter = new GrpcHeaderSetter();
         headerGetter = new GrpcHeaderGetter();
@@ -81,27 +99,64 @@ public class GrpcHelperImpl implements GrpcHelper {
     // transaction management (server part)
 
     @Override
-    public void startTransaction(ElasticApmTracer tracer, ClassLoader cl, ServerCall<?, ?> serverCall, Metadata headers) {
+    public Transaction startTransaction(ElasticApmTracer tracer, ClassLoader cl, ServerCall<?, ?> serverCall, Metadata headers) {
         MethodDescriptor<?, ?> methodDescriptor = serverCall.getMethodDescriptor();
 
         // ignore non-unary method calls for now
         if (methodDescriptor.getType() != MethodDescriptor.MethodType.UNARY) {
-            return;
+            return null;
         }
 
         Transaction transaction = tracer.startChildTransaction(headers, headerGetter, cl);
         if (transaction == null) {
-            return;
+            return null;
         }
+
+        logger.debug("startTransaction ---- {} ", transaction);
 
         transaction.withName(methodDescriptor.getFullMethodName())
             .withType("request")
             .activate();
+
+        return transaction;
     }
 
     @Override
-    public void endTransaction(Status status, @Nullable Throwable thrown, @Nullable Transaction transaction) {
-        if (transaction == null || transaction.getResult() != null) {
+    public void registerTransactionAndDeactivate(@Nullable Transaction transaction, ServerCall<?, ?> serverCall, ServerCall.Listener<?> listener) {
+        if (null == transaction) {
+            return;
+        }
+
+        logger.debug("registerTransactionAndDeactivate ---- {}", transaction);
+
+        inFlightTransactions.put(serverCall, transaction);
+        inFlightServerListeners.put(listener, serverCall);
+
+        transaction.deactivate();
+    }
+
+    @Nullable
+    private Transaction getTransactionFromListener(ServerCall.Listener<?> listener) {
+        ServerCall<?, ?> serverCall = inFlightServerListeners.get(listener);
+        Transaction transaction = null;
+        if (null != serverCall) {
+            transaction = inFlightTransactions.get(serverCall);
+        }
+        return transaction;
+    }
+
+    @Override
+    public void endTransaction(Status status, @Nullable Throwable thrown, ServerCall<?, ?> serverCall) {
+        Transaction transaction = inFlightTransactions.get(serverCall);
+        if (transaction == null) {
+            return;
+        }
+
+        endTransaction(status, thrown, transaction);
+    }
+
+    private void endTransaction(Status status, @Nullable Throwable thrown, Transaction transaction) {
+        if (transaction.getResult() != null) {
             return;
         }
 
@@ -110,8 +165,38 @@ public class GrpcHelperImpl implements GrpcHelper {
         transaction
             .withResult(status.getCode().name())
             .captureException(thrown)
-            .deactivate()
             .end();
+    }
+
+    @Nullable
+    @Override
+    public Transaction enterServerListenerMethod(ServerCall.Listener<?> listener) {
+        Transaction transaction = getTransactionFromListener(listener);
+        if (transaction != null) {
+            transaction.activate();
+        }
+        return transaction;
+    }
+
+    @Override
+    public void exitServerListenerMethod(@Nullable Throwable thrown, ServerCall.Listener<?> listener, @Nullable Transaction transaction, boolean isLastMethod) {
+        if (transaction == null) {
+            return;
+        }
+
+        transaction.deactivate();
+
+        if (null != thrown) {
+            // when there is a runtime exception thrown in one of the listener methods the calling code will catch it
+            // and set 'unknown' status, we just replicate this behavior as we don't instrument the part that does this
+            endTransaction(Status.UNKNOWN, thrown, transaction);
+
+            // listener won't be called anymore
+            inFlightServerListeners.remove(listener);
+        } else if (isLastMethod) {
+            // last method of listener, listener won't be called anymore
+            inFlightServerListeners.remove(listener);
+        }
     }
 
     // exit span management (client part)
@@ -119,7 +204,6 @@ public class GrpcHelperImpl implements GrpcHelper {
     @Nullable
     @Override
     public Span createExitSpanAndActivate(@Nullable Transaction transaction, @Nullable MethodDescriptor<?, ?> method) {
-        Span span;
         if (null == transaction) {
             return null;
         }
@@ -129,7 +213,7 @@ public class GrpcHelperImpl implements GrpcHelper {
             return null;
         }
 
-        span = transaction.createExitSpan();
+        Span span = transaction.createExitSpan();
         if (span == null) {
             // as it's an external call, we only need a single span for nested calls
             return null;
@@ -144,7 +228,7 @@ public class GrpcHelperImpl implements GrpcHelper {
     @Override
     public void registerSpanAndDeactivate(@Nullable Span span, ClientCall<?, ?> clientCall) {
         if (span != null) {
-            inFlightSpans.put(clientCall, span);
+            inFlightClientSpans.put(clientCall, span);
             span.deactivate();
         }
     }
@@ -152,21 +236,21 @@ public class GrpcHelperImpl implements GrpcHelper {
     @Override
     public void startSpan(ClientCall<?, ?> clientCall, ClientCall.Listener<?> responseListener, Metadata headers) {
         // span should already have been registered
-        Span span = inFlightSpans.get(clientCall);
+        Span span = inFlightClientSpans.get(clientCall);
         if (span == null) {
             return;
         }
 
-        inFlightListeners.put(responseListener, clientCall);
+        inFlightClientListeners.put(responseListener, clientCall);
         span.getTraceContext().setOutgoingTraceContextHeaders(headers, headerSetter);
     }
 
     @Override
     public void endSpan(ClientCall.Listener<?> responseListener, @Nullable Throwable thrown) {
-        ClientCall<?, ?> clientCall = inFlightListeners.get(responseListener);
+        ClientCall<?, ?> clientCall = inFlightClientListeners.get(responseListener);
         Span span = null;
         if (clientCall != null) {
-            span = inFlightSpans.get(clientCall);
+            span = inFlightClientSpans.get(clientCall);
         }
         if (span == null) {
             return;
@@ -175,8 +259,8 @@ public class GrpcHelperImpl implements GrpcHelper {
         span.captureException(thrown)
             .end();
 
-        inFlightListeners.remove(responseListener);
-        inFlightSpans.remove(clientCall);
+        inFlightClientListeners.remove(responseListener);
+        inFlightClientSpans.remove(clientCall);
     }
 
     @Override
@@ -195,7 +279,7 @@ public class GrpcHelperImpl implements GrpcHelper {
             return;
         }
 
-        Span span = inFlightSpans.get(clientCall);
+        Span span = inFlightClientSpans.get(clientCall);
         if (span == null) {
             return;
         }
@@ -211,10 +295,10 @@ public class GrpcHelperImpl implements GrpcHelper {
 
     @Nullable
     private Span getSpanFromListener(ClientCall.Listener<?> responseListener) {
-        ClientCall<?, ?> clientCall = inFlightListeners.get(responseListener);
+        ClientCall<?, ?> clientCall = inFlightClientListeners.get(responseListener);
         Span span = null;
         if (clientCall != null) {
-            span = inFlightSpans.get(clientCall);
+            span = inFlightClientSpans.get(clientCall);
         }
         return span;
     }

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
@@ -1,5 +1,6 @@
 # gRPC server part
-co.elastic.apm.agent.grpc.ServerCallListenerInstrumentation
+co.elastic.apm.agent.grpc.ServerCallListenerInstrumentation$FinalMethodCall
+co.elastic.apm.agent.grpc.ServerCallListenerInstrumentation$NonFinalMethodCall
 co.elastic.apm.agent.grpc.ServerCallHandlerInstrumentation
 co.elastic.apm.agent.grpc.ServerCallInstrumentation
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
@@ -31,7 +31,6 @@ import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,10 +54,13 @@ public abstract class AbstractGrpcClientInstrumentationTest extends AbstractInst
         app = GrpcTest.getApp(getAppProvider());
         app.start();
 
-        tracer.startRootTransaction(AbstractGrpcClientInstrumentationTest.class.getClassLoader())
-            .withName("Test gRPC client")
-            .withType("test")
-            .activate();
+        Transaction transaction = tracer.startRootTransaction(AbstractGrpcClientInstrumentationTest.class.getClassLoader());
+
+        if (transaction != null) {
+            transaction.withName("Test gRPC client")
+                .withType("test")
+                .activate();
+        }
     }
 
     @AfterEach

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcServerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcServerInstrumentationTest.java
@@ -80,8 +80,8 @@ public abstract class AbstractGrpcServerInstrumentationTest extends AbstractInst
             .isEqualTo("nested(1)->hello(bob)");
 
         await()
-            .pollDelay(1, TimeUnit.MILLISECONDS)
-            .timeout(100, TimeUnit.MILLISECONDS)
+            .pollInterval(1, TimeUnit.MILLISECONDS)
+            .timeout(200, TimeUnit.MILLISECONDS)
             .untilAsserted(() -> {
                 List<Transaction> transactions = getReporter().getTransactions();
                 assertThat(transactions).hasSize(2);
@@ -132,7 +132,7 @@ public abstract class AbstractGrpcServerInstrumentationTest extends AbstractInst
     }
 
     @Test
-    void serverStreamingBasicSupport() {
+    void serverStreamingShouldBeIgnored() {
         String s = app.sayHelloServerStreaming("joe", 4);
         assertThat(s)
             .describedAs("we should not break expected app behavior")


### PR DESCRIPTION
## What does this PR do?

A test was qualified as flaky, whereas in practice the implementation was the culprit.

gRPC server instrumentation was relying on the fact that transaction processing stayed on the same thread. However, even if it is the case most of the time, it is not an absolute truth and produces random failures.

Thus, I've reworked gRPC server instrumentation to store in-flight transaction within helper class in-memory storage (a hash-map), in a similar way as it was done for client instrumentation.

## Checklist
- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- ~~Added an API method or config option? Document in which version this will be introduced~~
- ~~Added an instrumentation plugin? How did you make sure that old, non-supported versions are not instrumented by accident?~~

## Author's Checklist
- [x] Run the tests locally continuously for 10min without any failure

## Related issues

- Closes #1106 
