### PR TITLE
Remove incubating, introduce experimental

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,12 +27,16 @@ endif::[]
 
 [float]
 ===== Features
+
 * The log correlation feature now adds `error.id` to the MDC. See <<supported-logging-frameworks>> for details. - {pull}1050[#1050]
+* Deprecating the `incubating` tag in favour of the `experimental` tag.
+This is not a breaking change, so former
+<<config-disable-instrumentations,`disable_instrumentation`>> configuration containing the `incubating` tag will still be respected - {pull}1123[#1123]
 
 [float]
 ===== Bug fixes
-* When Servlet-related Exceptions are handled through exception handlers that return a 200 status code, agent
-shouldn't override with 500 - {pull}1103[#1103]
+
+* When Servlet-related Exceptions are handled through exception handlers that return a 200 status code, agent shouldn't override with 500 - {pull}1103[#1103]
 * Exclude Quartz 1 from instrumentation to avoid
   `IncompatibleClassChangeError: Found class org.quartz.JobExecutionContext, but interface was expected` - {pull}1108[#1108]
 * Fix breakdown metrics span sub-types {pull}1113[#1113]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -292,7 +292,7 @@ This requires APM Server 7.2+.
 * Added basic support for JMS- distributed tracing for basic scenarios of `send`, `receive`, `receiveNoWait` and `onMessage`.
 Both Queues and Topics are supported.
 Async `send` APIs are not supported in this version. 
-NOTE: This feature is currently marked as "Incubating" and is disabled by default. In order to enable,
+NOTE: This feature is currently marked as "experimental" and is disabled by default. In order to enable,
 it is required to set the
 https://www.elastic.co/guide/en/apm/agent/java/1.x/config-core.html#config-disable-instrumentations[`disable_instrumentations`] 
 configuration property to an empty string.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -224,7 +224,7 @@ we should think about whether they bring us closer to or further away from those
   Create a configuration option for this new feature and disable it by default.
   One advantage is that less time will be spent rebasing long lasting feature branches.
   Another advantage is that users can try out cutting-edge features by activating a configuration option.
-  Instrumentations can be tagged with `incubating` which makes them being disabled by default.
+  Instrumentations can be tagged with `experimental` which makes them being disabled by default.
 
 ### Architecture overview
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -217,7 +217,11 @@ public class ElasticApmAgent {
     }
 
     private static boolean isIncluded(ElasticApmInstrumentation advice, CoreConfiguration coreConfiguration) {
-        final Collection<String> disabledInstrumentations = coreConfiguration.getDisabledInstrumentations();
+        ArrayList<String> disabledInstrumentations = new ArrayList<>(coreConfiguration.getDisabledInstrumentations());
+        // Supporting the deprecated `incubating` tag for backward compatibility
+        if (disabledInstrumentations.contains("incubating")) {
+            disabledInstrumentations.add("experimental");
+        }
         return !isGroupDisabled(disabledInstrumentations, advice.getInstrumentationGroupNames()) && isInstrumentationEnabled(advice, coreConfiguration);
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -219,12 +219,12 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .configurationCategory(CORE_CATEGORY)
         .description("A list of instrumentations which should be disabled.\n" +
             "Valid options are ${allInstrumentationGroupNames}.\n" +
-            "If you want to try out incubating features, set the value to an empty string.\n" +
+            "If you want to try out experimental features, set the value to an empty string.\n" +
             "\n" +
             "NOTE: Changing this value at runtime can slow down the application temporarily.")
         .dynamic(true)
         .tags("added[1.0.0,Changing this value at runtime is possible since version 1.15.0]")
-        .buildWithDefault(Collections.<String>singleton("incubating"));
+        .buildWithDefault(Collections.<String>singleton("experimental"));
 
     private final ConfigurationOption<List<WildcardMatcher>> unnestExceptions = ConfigurationOption
         .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/circuitbreaker/CircuitBreakerConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/circuitbreaker/CircuitBreakerConfiguration.java
@@ -37,8 +37,7 @@ public class CircuitBreakerConfiguration extends ConfigurationOptionProvider {
 
     private final ConfigurationOption<Boolean> circuitBreakerEnabled = ConfigurationOption.booleanOption()
         .key("circuit_breaker_enabled")
-        .tags("added[1.14.0]")
-        .tags("performance")
+        .tags("added[1.14.0]", "performance",  "experimental")
         .configurationCategory(CIRCUIT_BREAKER_CATEGORY)
         .description("A boolean specifying whether the circuit breaker should be enabled or not. \n" +
             "When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state. \n" +

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -93,6 +93,30 @@ class InstrumentationTest {
     }
 
     @Test
+    void testDefaultDisabledInstrumentation() {
+        final ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
+
+        init(config, List.of(new TestInstrumentation()));
+        assertThat(interceptMe()).isEqualTo("intercepted");
+
+        when(config.getConfig(CoreConfiguration.class).getDisabledInstrumentations()).thenReturn(Collections.singletonList("experimental"));
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
+        assertThat(interceptMe()).isEmpty();
+    }
+
+    @Test
+    void testLegacyDefaultDisabledInstrumentation() {
+        final ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
+
+        init(config, List.of(new TestInstrumentation()));
+        assertThat(interceptMe()).isEqualTo("intercepted");
+
+        when(config.getConfig(CoreConfiguration.class).getDisabledInstrumentations()).thenReturn(Collections.singletonList("incubating"));
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
+        assertThat(interceptMe()).isEmpty();
+    }
+
+    @Test
     void testReInitDisableAllInstrumentations() {
         final ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
         init(config, List.of(new TestInstrumentation()));
@@ -176,7 +200,7 @@ class InstrumentationTest {
 
         @Override
         public Collection<String> getInstrumentationGroupNames() {
-            return Collections.singleton("test");
+            return List.of("test", "experimental");
         }
     }
 

--- a/apm-agent-core/src/test/resources/elasticapm.properties
+++ b/apm-agent-core/src/test/resources/elasticapm.properties
@@ -1,6 +1,6 @@
 log_level=DEBUG
 log_file=System.out
-# incubating instrumentations should be active in tests
+# experimental instrumentations should be active in tests
 disable_instrumentations=
 # in unit tests, the agent is loaded by the system class loader so we can't instrument bootstrap classes
 classes_excluded_from_instrumentation=java.*,com.sun.*,sun.*

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -79,7 +79,7 @@ public class HibernateSearch6Instrumentation extends ElasticApmInstrumentation {
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        return Arrays.asList(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE, "incubating");
+        return Arrays.asList(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE, "experimental");
     }
 
     public static class Hibernate6ExecuteAdvice {

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/main/java/co/elastic/apm/agent/kafka/BaseKafkaInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/main/java/co/elastic/apm/agent/kafka/BaseKafkaInstrumentation.java
@@ -72,7 +72,6 @@ public abstract class BaseKafkaInstrumentation extends ElasticApmInstrumentation
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        // Incubating until we implement traceparent binary format
         return Collections.singletonList("kafka");
     }
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -156,7 +156,9 @@ Click on a key to get more information.
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-circuit-breaker-enabled]]
-==== `circuit_breaker_enabled` (performance)
+==== `circuit_breaker_enabled` (added[1.14.0] performance experimental)
+
+NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
 
 A boolean specifying whether the circuit breaker should be enabled or not. 
 When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state. 
@@ -619,8 +621,8 @@ you should add an additional entry to this list (make sure to also include the d
 ==== `disable_instrumentations` (added[1.0.0,Changing this value at runtime is possible since version 1.15.0])
 
 A list of instrumentations which should be disabled.
-Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `elasticsearch-restclient`, `exception-handler`, `executor`, `hibernate-search`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j`, `logging`, `mongodb-client`, `mule`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `redis`, `redisson`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `slf4j`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `urlconnection`.
-If you want to try out incubating features, set the value to an empty string.
+Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `elasticsearch-restclient`, `exception-handler`, `executor`, `experimental`, `hibernate-search`, `http-client`, `jax-rs`, `jax-ws`, `jdbc`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j`, `logging`, `mongodb-client`, `mule`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `redis`, `redisson`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `slf4j`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `urlconnection`.
+If you want to try out experimental features, set the value to an empty string.
 
 NOTE: Changing this value at runtime can slow down the application temporarily.
 
@@ -628,7 +630,7 @@ NOTE: Changing this value at runtime can slow down the application temporarily.
 [options="header"]
 |============
 | Default                          | Type                | Dynamic
-| `incubating` | Collection | true
+| `experimental` | Collection | true
 |============
 
 
@@ -1135,6 +1137,8 @@ NOTE: All errors that are captured during a request by an ignored user agent are
 [[config-use-path-as-transaction-name]]
 ==== `use_path_as_transaction_name` (experimental)
 
+NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
+
 If set to `true`,
 transaction names of unsupported Servlet API-based frameworks will be in the form of `$method $path` instead of just `$method`.
 
@@ -1473,6 +1477,8 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 [float]
 [[config-profiling-inferred-spans-enabled]]
 ==== `profiling_inferred_spans_enabled` (added[1.15.0] experimental)
+
+NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
 
 Set to `true` to make the agent create spans for method executions based on
 https://github.com/jvm-profiling-tools/async-profiler[async-profiler], a sampling aka statistical profiler.
@@ -2238,16 +2244,16 @@ The default unit for this option is `ms`.
 # sanitize_field_names=password,passwd,pwd,secret,*key,*token*,*session*,*credit*,*card*,authorization,set-cookie
 
 # A list of instrumentations which should be disabled.
-# Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `elasticsearch-restclient`, `exception-handler`, `executor`, `hibernate-search`, `http-client`, `incubating`, `jax-rs`, `jax-ws`, `jdbc`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j`, `logging`, `mongodb-client`, `mule`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `redis`, `redisson`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `slf4j`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `urlconnection`.
-# If you want to try out incubating features, set the value to an empty string.
+# Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `concurrent`, `elasticsearch-restclient`, `exception-handler`, `executor`, `experimental`, `hibernate-search`, `http-client`, `jax-rs`, `jax-ws`, `jdbc`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j`, `logging`, `mongodb-client`, `mule`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `redis`, `redisson`, `render`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-input-stream`, `slf4j`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `urlconnection`.
+# If you want to try out experimental features, set the value to an empty string.
 # 
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: incubating
+# Default value: experimental
 #
-# disable_instrumentations=incubating
+# disable_instrumentations=experimental
 
 # When reporting exceptions,
 # un-nests the exceptions matching the wildcard pattern.

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -29,20 +29,6 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 More detailed information on how the Agent works can be found in the <<faq-how-does-it-work,FAQ>>.
 
 [float]
-[[experimental]]
-=== Experimental features
-
-Some agent features or <<supported-technologies-details,plugins>> are marked as `experimental`, which means:
-
-* They are opt-in (disabled by default).
-* There are no guarantees regarding changes in such features in future releases.
-* In some cases they have special caveats or unknowns that come with them.
-In such cases, the specific feature/plugin documentation should indicate that.
-
-There are cases where we decide to release a feature as `experimental` to be on the safe side and only make it an official feature after we get some feedback about it.
-Any such feedback will be highly appreciated, through a related GitHub issue or through the https://discuss.elastic.co/c/apm[APM discuss forum].
-
-[float]
 [[additional-components]]
 === Additional components
 

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -32,16 +32,15 @@ More detailed information on how the Agent works can be found in the <<faq-how-d
 [[experimental]]
 === Experimental features
 
-Some agent features or <<supported-technologies,plugins>> are marked as `experimental`, which means:
+Some agent features or <<supported-technologies-details,plugins>> are marked as `experimental`, which means:
 
 * They are opt-in (disabled by default).
 * There are no guarantees regarding changes in such features in future releases.
-* In some cases they have special caveats or unknowns that come with them. In such cases, the specific feature/plugin
-documentation should indicate that.
+* In some cases they have special caveats or unknowns that come with them.
+In such cases, the specific feature/plugin documentation should indicate that.
 
-There are cases where we decide to release a feature as `experimental` to be on the safe side and only make it an official
-feature after we get some feedback about it. Any such feedback will be highly appreciated, through a related
-GitHub issue or through the https://discuss.elastic.co/c/apm[APM discuss forum].
+There are cases where we decide to release a feature as `experimental` to be on the safe side and only make it an official feature after we get some feedback about it.
+Any such feedback will be highly appreciated, through a related GitHub issue or through the https://discuss.elastic.co/c/apm[APM discuss forum].
 
 [float]
 [[additional-components]]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -29,6 +29,21 @@ You can then use the APM app in Kibana to gain insight into latency issues and e
 More detailed information on how the Agent works can be found in the <<faq-how-does-it-work,FAQ>>.
 
 [float]
+[[experimental]]
+=== Experimental features
+
+Some agent features or <<supported-technologies,plugins>> are marked as `experimental`, which means:
+
+* They are opt-in (disabled by default).
+* There are no guarantees regarding changes in such features in future releases.
+* In some cases they have special caveats or unknowns that come with them. In such cases, the specific feature/plugin
+documentation should indicate that.
+
+There are cases where we decide to release a feature as `experimental` to be on the safe side and only make it an official
+feature after we get some feedback about it. Any such feedback will be highly appreciated, through a related
+GitHub issue or through the https://discuss.elastic.co/c/apm[APM discuss forum].
+
+[float]
 [[additional-components]]
 === Additional components
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -183,7 +183,7 @@ Other Servlet 3+ compliant servers will most likely work as well.
 |5.x (on by default), 6.x (off by default)
 |The agent automatically creates Hibernate Search spans for queries done through the Hibernate Search API.
 
- *Note:* this feature is marked as incubating for version 6.x, which means it is off by default. In order to enable,
+ *Note:* this feature is marked as experimental for version 6.x, which means it is off by default. In order to enable,
  set the <<config-disable-instrumentations>> config option to an empty string
 |1.9.0
 
@@ -300,7 +300,7 @@ same trace.
 side, the agent reads the context from the Message property through `javax.jms.MessageConsumer#receive`,
 `javax.jms.MessageConsumer#receiveNoWait`, `javax.jms.JMSConsumer#receive`, `javax.jms.JMSConsumer#receiveNoWait` or
 `javax.jms.MessageListener#onMessage` and uses it for enabling distributed tracing.
-|Enabled by default since 1.13.0, added as an incubating plugin in 1.7.0
+|Enabled by default since 1.13.0, added as an experimental plugin in 1.7.0
 
 |Kafka
 | <0.11.0 - without distributed tracing; 0.11.0+ - full support

--- a/docs/tuning-and-overhead.asciidoc
+++ b/docs/tuning-and-overhead.asciidoc
@@ -110,7 +110,7 @@ Disabling <<config-capture-headers>> can save allocations, network bandwidth, an
 
 [float]
 [[circuit-breaker]]
-=== Circuit Breaker
+=== Circuit Breaker (experimental)
 
 When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state.
 If ANY of the monitors detects a stress indication, the agent will become inactive, as if the

--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporterTest.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/configuration/ConfigurationExporterTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -32,7 +32,6 @@ import freemarker.template.Template;
 import freemarker.template.TemplateException;
 import freemarker.template.TemplateExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.stagemonitor.configuration.ConfigurationOption;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
@@ -148,7 +147,7 @@ class ConfigurationExporterTest {
 
     public static String getAllInstrumentationGroupNames() {
         Set<String> instrumentationGroupNames = new TreeSet<>();
-        instrumentationGroupNames.add("incubating");
+        instrumentationGroupNames.add("experimental");
         for (ElasticApmInstrumentation instrumentation : DependencyInjectingServiceLoader.load(ElasticApmInstrumentation.class, MockTracer.create())) {
             instrumentationGroupNames.addAll(instrumentation.getInstrumentationGroupNames());
         }

--- a/elastic-apm-agent/src/test/resources/configuration.asciidoc.ftl
+++ b/elastic-apm-agent/src/test/resources/configuration.asciidoc.ftl
@@ -99,6 +99,10 @@ Click on a key to get more information.
 [[config-${option.key?replace("[^a-z]", "-", "r")}]]
 ==== `${option.key}`${option.tags?has_content?then(" (${option.tags?join(' ')})", '')}
 
+<#if option.tags?seq_contains("experimental")>
+NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
+
+</#if>
 ${option.description}
 
 <#if option.valueType?matches("TimeDuration")>


### PR DESCRIPTION
Removing the `incubating` term from our documentation if favour of `experimental` and add some expectation setting regarding features labeled as `experimental`.
As part of that, the `incubating` instrumentation group is deprecated, but this PR is still maintaining backwards compatibility for `disable_instrumentation` configurations that use it.

## Checklist
- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)

## Related issues
Closes #876 