### PR TITLE
Fix circuit breaker flaky test (race condition)

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/circuitbreaker/CircuitBreakerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/circuitbreaker/CircuitBreakerTest.java
@@ -281,7 +281,7 @@ public class CircuitBreakerTest {
     private static ConditionFactory doAwait() {
         return await()
             .pollInterval(1, TimeUnit.MILLISECONDS)
-            .timeout(50, TimeUnit.MILLISECONDS);
+            .timeout(200, TimeUnit.MILLISECONDS);
 
     }
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
@@ -42,7 +42,7 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**
- * Instruments implementations of {@link io.grpc.ServerCall.Listener} for runtime exceptions & transaction activation
+ * Instruments implementations of {@link io.grpc.ServerCall.Listener} for runtime exceptions and transaction activation
  * <br/>
  * Implementation is split in two classes {@link FinalMethodCall} and {@link NonFinalMethodCall}
  * <ul>


### PR DESCRIPTION
## What does this PR do?

Fixes a race condition only triggered in tests where tracer state isn't properly updated until circuit breaker polling has been run.

## Checklist
- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
- ~~I have made corresponding changes to the documentation~~
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- ~~I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)~~
- ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- ~~Added an API method or config option? Document in which version this will be introduced~~
- ~~Added an instrumentation plugin? How did you make sure that old, non-supported versions are not instrumented by accident?~~

## Author's Checklist
- [x] run the failing for a while (>10k executions without a failure)

## Related issues

Further improvements on changes introduced with #1109 

