### PR TITLE
add workaround to disable emulated attach

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ endif::[]
 * Deprecating the `incubating` tag in favour of the `experimental` tag.
 This is not a breaking change, so former
 <<config-disable-instrumentations,`disable_instrumentation`>> configuration containing the `incubating` tag will still be respected - {pull}1123[#1123]
+* Add a `--without-emulated-attach` option for runtime attachment to allow disabling this feature as a workaround.
 
 [float]
 ===== Bug fixes

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,6 +36,7 @@ import java.math.BigInteger;
 import java.security.DigestInputStream;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -53,14 +54,6 @@ public class ElasticApmAttacher {
      * this can even lead to segfaults.
      */
     private static final String TEMP_PROPERTIES_FILE_KEY = "c";
-    private static final ByteBuddyAgent.AttachmentProvider ATTACHMENT_PROVIDER = new ByteBuddyAgent.AttachmentProvider.Compound(
-        ByteBuddyAgent.AttachmentProvider.ForEmulatedAttachment.INSTANCE,
-        ByteBuddyAgent.AttachmentProvider.ForModularizedVm.INSTANCE,
-        ByteBuddyAgent.AttachmentProvider.ForJ9Vm.INSTANCE,
-        new CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider.ForStandardToolsJarVm.JVM_ROOT),
-        new CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider.ForStandardToolsJarVm.JDK_ROOT),
-        new CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider.ForStandardToolsJarVm.MACINTOSH),
-        new CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider.ForUserDefinedToolsJar.INSTANCE));
 
     /**
      * Attaches the Elastic Apm agent to the current JVM.
@@ -163,7 +156,7 @@ public class ElasticApmAttacher {
         File tempFile = createTempProperties(configuration);
         String agentArgs = tempFile == null ? null : TEMP_PROPERTIES_FILE_KEY + "=" + tempFile.getAbsolutePath();
 
-        ByteBuddyAgent.attach(AgentJarFileHolder.INSTANCE.agentJarFile, pid, agentArgs, ATTACHMENT_PROVIDER);
+        ByteBuddyAgent.attach(AgentJarFileHolder.INSTANCE.agentJarFile, pid, agentArgs, ElasticAttachmentProvider.get());
         if (tempFile != null) {
             if (!tempFile.delete()) {
                 tempFile.deleteOnExit();
@@ -180,7 +173,7 @@ public class ElasticApmAttacher {
      */
     @Deprecated
     public static void attach(String pid, String agentArgs) {
-        ByteBuddyAgent.attach(AgentJarFileHolder.INSTANCE.agentJarFile, pid, agentArgs, ATTACHMENT_PROVIDER);
+        ByteBuddyAgent.attach(AgentJarFileHolder.INSTANCE.agentJarFile, pid, agentArgs, ElasticAttachmentProvider.get());
     }
 
     private enum AgentJarFileHolder {

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticAttachmentProvider.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticAttachmentProvider.java
@@ -1,0 +1,72 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.attach;
+
+import net.bytebuddy.agent.ByteBuddyAgent;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+public class ElasticAttachmentProvider {
+
+    private static ByteBuddyAgent.AttachmentProvider provider;
+
+    /**
+     * Initializes attachment provider, this method can only be called once as it loads native code.
+     *
+     * @param useEmulatedAttach {@literal true} to enable emulated attach, {@literal false} to disable
+     */
+    public synchronized static void init(boolean useEmulatedAttach) {
+        if (provider != null) {
+            throw new IllegalStateException("ElasticAttachmentProvider.init() should only be called once");
+        }
+
+        ArrayList<ByteBuddyAgent.AttachmentProvider> providers = new ArrayList<>();
+        if (useEmulatedAttach) {
+            providers.add(ByteBuddyAgent.AttachmentProvider.ForEmulatedAttachment.INSTANCE);
+        }
+        providers.addAll(Arrays.asList(ByteBuddyAgent.AttachmentProvider.ForModularizedVm.INSTANCE,
+            ByteBuddyAgent.AttachmentProvider.ForJ9Vm.INSTANCE,
+            new CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider.ForStandardToolsJarVm.JVM_ROOT),
+            new CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider.ForStandardToolsJarVm.JDK_ROOT),
+            new CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider.ForStandardToolsJarVm.MACINTOSH),
+            new CachedAttachmentProvider(ByteBuddyAgent.AttachmentProvider.ForUserDefinedToolsJar.INSTANCE)));
+
+        provider = new ByteBuddyAgent.AttachmentProvider.Compound(providers);
+    }
+
+    /**
+     * Get (and optionally initialize) attachment provider, will internally call {@link #init(boolean)} if not already called
+     *
+     * @return attachment provider
+     */
+    public synchronized static ByteBuddyAgent.AttachmentProvider get() {
+        if (provider != null) {
+            return provider;
+        }
+        init(true);
+        return provider;
+    }
+}

--- a/docs/setup-attach-cli.asciidoc
+++ b/docs/setup-attach-cli.asciidoc
@@ -181,6 +181,14 @@ See <<configuration>> for all available configuration options.
 NOTE: This option cannot be used in conjunction with `--pid` and `--config`
 --
 
+*-w, --without-emulated-attach*::
++
+--
+Disables using emulated attach feature provided by byte-buddy, this should be used as a workaround on some JDK/JREs
+when runtime attachment fails.
+--
+
+
 
 [float]
 [[setup-attach-cli-docker]]

--- a/docs/setup-attach-cli.asciidoc
+++ b/docs/setup-attach-cli.asciidoc
@@ -184,7 +184,7 @@ NOTE: This option cannot be used in conjunction with `--pid` and `--config`
 *-w, --without-emulated-attach*::
 +
 --
-Disables using emulated attach feature provided by byte-buddy, this should be used as a workaround on some JDK/JREs
+Disables using emulated attach feature provided by Byte Buddy, this should be used as a workaround on some JDK/JREs
 when runtime attachment fails.
 --
 


### PR DESCRIPTION
## What does this PR do?

Adds a workaround option for remote attach that allows to disable emulated attach.

## Checklist
- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
- [x] I have made corresponding changes to the documentation
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- [x] Added an API method or config option? Document in which version this will be introduced
- ~~Added an instrumentation plugin? How did you make sure that old, non-supported versions are not instrumented by accident?~~

## Author's Checklist
- [x] manually testing feature locally to ensure that it still works with JRE/JDK installation when disabled

## Use cases

Workaround when remote attachment fails, should be used quite rarely.
