### PR TITLE
Don't skip Javadoc when building agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
               dir("${BASE_DIR}"){
                 sh """#!/bin/bash
                 set -euxo pipefail
-                ./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true
+                ./mvnw clean install -DskipTests=true
                 ./mvnw license:aggregate-third-party-report -Dlicense.excludedGroups=^co\\.elastic\\.
                 """
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
               dir("${BASE_DIR}"){
                 sh """#!/bin/bash
                 set -euxo pipefail
-                ./mvnw clean install -DskipTests=true
+                ./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true
                 ./mvnw license:aggregate-third-party-report -Dlicense.excludedGroups=^co\\.elastic\\.
                 """
               }
@@ -260,7 +260,7 @@ pipeline {
           }
           when {
             beforeAgent true
-            expression { return params.doc_ci }
+            expression { return env.ONLY_DOCS == "false" }
           }
           steps {
             withGithubNotify(context: 'Javadoc') {


### PR DESCRIPTION
Currently, the Javadoc task gets skipped when building the agent. If there's an error in the Javadoc we only learn that during the release phase which is not ideal.

I'm not sure if there was a reason behind skipping the Javadoc or if it was a leftover from setting up the pipeline.