### PR TITLE
Quick fix flaky Kafka test

### DIFF
--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/pom.xml
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>[2.4.0,)</version>
+            <version>2.4.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
If the Kafka version in KafkaClientVersionsIT is different
than the latest release version, the test fails.
The test fails since yesterday, which is when kafka-clients 2.5.0 has been released.

quickfix for #1140
Doesn't fix the underlying issue