### PR TITLE
Fix WebLogic NPE

### DIFF
--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -155,7 +155,11 @@ public class ServletTransactionHelper {
     @VisibleForAdvice
     public void onAfter(Transaction transaction, @Nullable Throwable exception, boolean committed, int status,
                         boolean overrideStatusCodeOnThrowable, String method, @Nullable Map<String, String[]> parameterMap,
-                        String servletPath, @Nullable String pathInfo, @Nullable String contentTypeHeader, boolean deactivate) {
+                        @Nullable String servletPath, @Nullable String pathInfo, @Nullable String contentTypeHeader, boolean deactivate) {
+        if (servletPath == null) {
+            // the servlet path is specified as non-null but WebLogic does return null...
+            servletPath = "";
+        }
         try {
             // thrown the first time a JSP is invoked in order to register it
             if (exception != null && "weblogic.servlet.jsp.AddToMapException".equals(exception.getClass().getName())) {


### PR DESCRIPTION
Spotted in a log, running version 1.15.0:

```
java.lang.NullPointerException
        at co.elastic.apm.agent.matcher.WildcardMatcher$SimpleWildcardMatcher.indexOf(WildcardMatcher.java:387)
        at co.elastic.apm.agent.matcher.WildcardMatcher$SimpleWildcardMatcher.matches(WildcardMatcher.java:376)
        at co.elastic.apm.agent.servlet.ServletTransactionHelper.applyDefaultTransactionName(ServletTransactionHelper.java:194)
        at co.elastic.apm.agent.servlet.ServletTransactionHelper.doOnAfter(ServletTransactionHelper.java:186)
        at co.elastic.apm.agent.servlet.ServletTransactionHelper.onAfter(ServletTransactionHelper.java:164)
        at weblogic.servlet.internal.FilterChainImpl.doFilter(FilterChainImpl.java:79)
```