### PR TITLE
Fix request body recycling

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Request.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Request.java
@@ -27,8 +27,8 @@ package co.elastic.apm.agent.impl.context;
 import co.elastic.apm.agent.objectpool.Allocator;
 import co.elastic.apm.agent.objectpool.ObjectPool;
 import co.elastic.apm.agent.objectpool.Recyclable;
-import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
 import co.elastic.apm.agent.objectpool.Resetter;
+import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
 import co.elastic.apm.agent.report.serialize.DslJsonSerializer;
 import co.elastic.apm.agent.util.PotentiallyMultiValuedMap;
 import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
@@ -296,6 +296,7 @@ public class Request implements Recyclable {
             charBufferPool.recycle(bodyBuffer);
             bodyBuffer = null;
         }
+        rawBody = null;
     }
 
     public void copyFrom(Request other) {
@@ -314,6 +315,7 @@ public class Request implements Recyclable {
             }
             ((Buffer) thisBuffer).flip();
         }
+        this.rawBody = other.rawBody;
     }
 
     public boolean hasContent() {

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/TestRequestBodyCapturing.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/TestRequestBodyCapturing.java
@@ -26,12 +26,13 @@ package co.elastic.apm.agent.servlet;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
+import co.elastic.apm.agent.impl.context.web.WebConfiguration;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.report.serialize.DslJsonSerializer;
 import co.elastic.apm.agent.util.PotentiallyMultiValuedMap;
-import co.elastic.apm.agent.impl.context.web.WebConfiguration;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -108,6 +109,15 @@ class TestRequestBodyCapturing extends AbstractInstrumentationTest {
         streamConsumer = is -> is.readLine(BUFFER, 0, BUFFER.length);
         streamCloser = InputStream::close;
 
+    }
+
+    @AfterEach
+    void tearDown() {
+        Transaction transaction = reporter.getFirstTransaction();
+        reporter.assertRecycledAfterDecrementingReferences();
+        assertThat(transaction.getContext().getRequest().getRawBody()).isNull();
+        assertThat(transaction.getContext().getRequest().getBody()).isNull();
+        assertThat((CharSequence) transaction.getContext().getRequest().getBodyBufferForSerialization()).isNull();
     }
 
     @ParameterizedTest


### PR DESCRIPTION
When the Content-Type header doesn't match the configured ones, we set `[REDACTED]` as the request body.
To reduce the memory allocations in the agent, we reuse transaction objects. That requires resetting all the values after a transaction is reported.

This fixes a bug where the `rawBody` field is not reset which prevents `rawBody=[REDACTED]` to be leaked to other transactions.