### PR TITLE
Remove calls to Statement.getUpdateCount

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ This is not a breaking change, so former
 * Fix breakdown metrics span sub-types {pull}1113[#1113]
 * Fix flaky gRPC server instrumentation {pull}1122[#1122]
 * Fix side effect of calling `Statement.getUpdateCount` more than once {pull}1139[#1139]
+* Stop capturing JDBC affected rows count using `Statement.getUpdateCount` to prevent unreliable side-effects {pull}1147[#1147]
 
 
 [[release-notes-1.x]]

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelper.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelper.java
@@ -69,24 +69,4 @@ public abstract class JdbcHelper {
     @Nullable
     public abstract Span createJdbcSpan(@Nullable String sql, Object statement, @Nullable TraceContextHolder<?> parent, boolean preparedStatement);
 
-    /**
-     * Safely wraps calls to {@link java.sql.Statement#getUpdateCount()} and stores last result.
-     * <p>
-     * getUpdateCount javadoc indicates that this method should be called only once.
-     * In practice, adding this extra call seem to not have noticeable side effects on most databases but Oracle.
-     * </p>
-     *
-     * @param statement {@code java.sql.Statement} instance
-     * @return {@link Integer#MIN_VALUE} if statement does not support this feature, returned value otherwise
-     */
-    public abstract int getAndStoreUpdateCount(Object statement);
-
-    /**
-     * Get and clears stored update count (if any) for a given statement.
-     *
-     * @param statement {@code java.sql.Statement} instance
-     * @return {@link Integer#MIN_VALUE} if there is no stored value for this statement
-     */
-    public abstract int getAndClearStoredUpdateCount(Object statement);
-
 }

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelperImpl.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelperImpl.java
@@ -192,6 +192,8 @@ public class JdbcHelperImpl extends JdbcHelper {
 
     @Override
     public int getAndStoreUpdateCount(Object statement) {
+        return Integer.MIN_VALUE;
+        /*
         int result = Integer.MIN_VALUE;
         if (!(statement instanceof Statement)) {
             return result;
@@ -227,15 +229,20 @@ public class JdbcHelperImpl extends JdbcHelper {
             markNotSupported(updateCountSupported, type, e);
         }
         return result;
+
+         */
     }
 
     @Override
     public int getAndClearStoredUpdateCount(Object statement) {
+        return Integer.MIN_VALUE;
+        /*
         Integer value = null;
         if (Boolean.FALSE == idempotentGetUpdateCount.get(statement.getClass())) {
             value = statementsUpdateCount.remove(statement);
         }
         return value != null ? value : Integer.MIN_VALUE;
+         */
     }
 
     @Nullable

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelperImpl.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/JdbcHelperImpl.java
@@ -52,15 +52,8 @@ public class JdbcHelperImpl extends JdbcHelper {
     // have the expected behavior, thus, any direct reference to `JdbcHelperImpl` should only be obtained from the
     // HelperClassManager<JdbcHelper> instance.
     private final WeakConcurrentMap<Connection, ConnectionMetaData> metaDataMap = DataStructures.createWeakConcurrentMapWithCleanerThread();
-    private final WeakConcurrentMap<Class<?>, Boolean> updateCountSupported = new WeakConcurrentMap.WithInlinedExpunction<Class<?>, Boolean>();
     private final WeakConcurrentMap<Class<?>, Boolean> metadataSupported = new WeakConcurrentMap.WithInlinedExpunction<Class<?>, Boolean>();
     private final WeakConcurrentMap<Class<?>, Boolean> connectionSupported = new WeakConcurrentMap.WithInlinedExpunction<Class<?>, Boolean>();
-
-    // keeps track of non-idempotent implementations of getUpdateCount
-    private final WeakConcurrentMap<Class<?>, Boolean> idempotentGetUpdateCount = new WeakConcurrentMap.WithInlinedExpunction<Class<?>, Boolean>();
-
-    // stores statements update count to avoid side-effects of calling Statement.getUpdateCount()
-    private final WeakConcurrentMap<Object, Integer> statementsUpdateCount = new WeakConcurrentMap.WithInlinedExpunction<>();
 
     @VisibleForAdvice
     public final ThreadLocal<SignatureParser> SIGNATURE_PARSER_THREAD_LOCAL = new ThreadLocal<SignatureParser>() {
@@ -73,10 +66,8 @@ public class JdbcHelperImpl extends JdbcHelper {
     @Override
     public void clearInternalStorage() {
         metaDataMap.clear();
-        updateCountSupported.clear();
         metadataSupported.clear();
         connectionSupported.clear();
-        statementsUpdateCount.clear();
     }
 
     @Override
@@ -187,62 +178,6 @@ public class JdbcHelperImpl extends JdbcHelper {
         }
 
         return connection;
-    }
-
-
-    @Override
-    public int getAndStoreUpdateCount(Object statement) {
-        return Integer.MIN_VALUE;
-        /*
-        int result = Integer.MIN_VALUE;
-        if (!(statement instanceof Statement)) {
-            return result;
-        }
-
-        Class<?> type = statement.getClass();
-        Boolean supported = isSupported(updateCountSupported, type);
-        if (supported == Boolean.FALSE) {
-            return result;
-        }
-
-        try {
-            result = ((Statement) statement).getUpdateCount();
-            if (supported == null) {
-                markSupported(updateCountSupported, type);
-            }
-
-            // in order to minimize allocation, we keep track of implementation classes that are not idempotent,
-            // that allows avoiding extra work for the most common idempotent case.
-            Boolean isIdempotent = isSupported(idempotentGetUpdateCount, type);
-            if (isIdempotent == null) {
-                int secondResult = ((Statement) statement).getUpdateCount();
-                isIdempotent = (secondResult == result) ? Boolean.TRUE : Boolean.FALSE;
-                idempotentGetUpdateCount.put(type, isIdempotent);
-            }
-
-            if (isIdempotent != Boolean.TRUE) {
-                // save the value to be restored for the next call to getUpdateCount()
-                statementsUpdateCount.put(statement, result);
-            }
-
-        } catch (SQLException e) {
-            markNotSupported(updateCountSupported, type, e);
-        }
-        return result;
-
-         */
-    }
-
-    @Override
-    public int getAndClearStoredUpdateCount(Object statement) {
-        return Integer.MIN_VALUE;
-        /*
-        Integer value = null;
-        if (Boolean.FALSE == idempotentGetUpdateCount.get(statement.getClass())) {
-            value = statementsUpdateCount.remove(statement);
-        }
-        return value != null ? value : Integer.MIN_VALUE;
-         */
     }
 
     @Nullable

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.bci.ElasticApmInstrumentation
@@ -5,4 +5,3 @@ co.elastic.apm.agent.jdbc.StatementInstrumentation$ExecuteUpdateNoQueryInstrumen
 co.elastic.apm.agent.jdbc.StatementInstrumentation$AddBatchInstrumentation
 co.elastic.apm.agent.jdbc.StatementInstrumentation$ExecuteBatchInstrumentation
 co.elastic.apm.agent.jdbc.StatementInstrumentation$ExecutePreparedStatementInstrumentation
-co.elastic.apm.agent.jdbc.StatementInstrumentation$GetUpdateCountInstrumentation

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
@@ -115,7 +115,7 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
     public void test() throws SQLException {
         executeTest(this::testStatement);
         executeTest(this::testUpdateStatement);
-        executeTest(this::testStatementNotSupportingUpdateCount);
+//        executeTest(this::testStatementNotSupportingUpdateCount);
         executeTest(this::testStatementNotSupportingConnection);
         executeTest(this::testStatementWithoutConnectionMetadata);
 
@@ -399,11 +399,12 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         assertThat(reporter.getSpans()).hasSize(1);
         Db db = reporter.getFirstSpan().getContext().getDb();
         assertThat(db.getStatement()).isEqualTo(insert);
-        if (!isKnownDatabase("Oracle", "")) {
-            assertThat(db.getAffectedRowsCount())
-                .isEqualTo(statement.getUpdateCount())
-                .isEqualTo(1);
-        }
+//        // TODO : looks suspicious, why do we have oracle DB excluded here ?
+//        if (!isKnownDatabase("Oracle", "")) {
+//            assertThat(db.getAffectedRowsCount())
+//                .isEqualTo(statement.getUpdateCount())
+//                .isEqualTo(1);
+//        }
     }
 
     private void assertQuerySucceededAndSpanRecorded(ResultSet resultSet, String rawSql, boolean preparedStatement) throws SQLException {
@@ -433,9 +434,9 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         assertThat(db.getUser()).isEqualToIgnoringCase(metaData.getUserName());
         assertThat(db.getType()).isEqualToIgnoringCase("sql");
 
-        assertThat(db.getAffectedRowsCount())
-            .describedAs("unexpected affected rows count for statement %s", rawSql)
-            .isEqualTo(expectedAffectedRows);
+//        assertThat(db.getAffectedRowsCount())
+//            .describedAs("unexpected affected rows count for statement %s", rawSql)
+//            .isEqualTo(expectedAffectedRows);
 
         Destination destination = jdbcSpan.getContext().getDestination();
         assertThat(destination.getAddress().toString()).isEqualTo("localhost");
@@ -468,9 +469,9 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         assertThat(db.getUser()).isNull();
         assertThat(db.getType()).isEqualToIgnoringCase("sql");
 
-        assertThat(db.getAffectedRowsCount())
-            .describedAs("unexpected affected rows count for statement %s", rawSql)
-            .isEqualTo(expectedAffectedRows);
+//        assertThat(db.getAffectedRowsCount())
+//            .describedAs("unexpected affected rows count for statement %s", rawSql)
+//            .isEqualTo(expectedAffectedRows);
 
         Destination destination = jdbcSpan.getContext().getDestination();
         assertThat(destination.getAddress()).isNullOrEmpty();

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
@@ -232,7 +232,7 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         assertThat(check.getThrownCount()).isEqualTo(1);
         assertThat(isResultSet).isFalse();
 
-        assertSpanRecordedWithoutConnection(sql, false, 1);
+        assertSpanRecordedWithoutConnection(sql, false, -1);
 
         // try to execute statement again, should not throw again
         statement.execute(sql);

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/TestStatement.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/TestStatement.java
@@ -34,7 +34,6 @@ class TestStatement implements Statement {
     private final Statement delegate;
 
     private boolean isGetConnectionSupported;
-    private boolean isGetUpdateCountSupported;
     private int unsupportedThrownCount;
 
     private Connection connection;
@@ -43,7 +42,6 @@ class TestStatement implements Statement {
         this.delegate = delegate;
         this.unsupportedThrownCount = 0;
         this.isGetConnectionSupported = true;
-        this.isGetUpdateCountSupported = true;
     }
 
     private void unsupportedCheck(boolean isFeatureSupported) throws SQLException {
@@ -57,10 +55,6 @@ class TestStatement implements Statement {
         this.isGetConnectionSupported = supported;
     }
 
-    public void setGetUpdateCountSupported(boolean supported) {
-        this.isGetUpdateCountSupported = supported;
-    }
-
     int getUnsupportedThrownCount(){
         return unsupportedThrownCount;
     }
@@ -68,7 +62,6 @@ class TestStatement implements Statement {
     void setConnection(Connection connection) {
         this.connection = connection;
     }
-
 
     public ResultSet executeQuery(String sql) throws SQLException {
         return delegate.executeQuery(sql);
@@ -135,7 +128,6 @@ class TestStatement implements Statement {
     }
 
     public int getUpdateCount() throws SQLException {
-        unsupportedCheck(isGetUpdateCountSupported);
         return delegate.getUpdateCount();
     }
 


### PR DESCRIPTION
Due to many issues and unexpected side-effects of calling `Statement.getUpdateCount`, we decided to remove calls to this method performed by our agent.

This will partially revert work that has been done for https://github.com/elastic/apm/issues/112 / https://github.com/elastic/apm-agent-java/issues/707

Here is the non-exhaustive list of issues/PR that are related to this simple (but cursed) feature:
- https://github.com/elastic/apm-agent-java/pull/1008 `getUpdateCount` is not supported by all drivers and might throw `SQLException`
- https://github.com/elastic/apm-agent-java/pull/1035 Improvement on #1008 to avoid excessive logging
- https://github.com/elastic/apm-agent-java/pull/1139 Attempt to avoid side effects of non-idempotent implementations (like Oracle).

This will be a two-step process
- quickly remove calls to `getUpdateCount` from the agent
- properly proceed to removal, and make sure that feature is still supported for `Statement.executeUpdate()`, for which we can capture the return value.

