### PR TITLE
Allow logs to be redirected to /dev/null

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,6 +45,7 @@ This is not a breaking change, so former
 * Fix flaky gRPC server instrumentation {pull}1122[#1122]
 * Fix side effect of calling `Statement.getUpdateCount` more than once {pull}1139[#1139]
 * Stop capturing JDBC affected rows count using `Statement.getUpdateCount` to prevent unreliable side-effects {pull}1147[#1147]
+* Allow logs to be redirected to `/dev/null` {pull}1154[#1154]
 
 
 [[release-notes-1.x]]

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
@@ -34,6 +34,9 @@ import org.stagemonitor.configuration.source.ConfigurationSource;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 
 /**
@@ -169,11 +172,17 @@ public class LoggingConfiguration extends ConfigurationOptionProvider {
         if (!logDir.exists()) {
             logDir.mkdir();
         }
-        if (!logDir.canWrite()) {
+
+        final Path logFilePath = Paths.get(logFile);
+        if (Files.exists(logFilePath) && !Files.isWritable(logFilePath) || !Files.exists(logFilePath) && !logDir.canWrite()) {
             System.err.println("Log file " + logFile + " is not writable. Falling back to System.out.");
             return SYSTEM_OUT;
         }
-        System.out.println("Writing Elastic APM logs to " + logFile);
+
+        if(!logFile.equalsIgnoreCase("/dev/null")) {
+            System.out.println("Writing Elastic APM logs to " + logFile);
+        }
+
         return logFile;
     }
 


### PR DESCRIPTION
<!--
A few suggestions about filling out this PR

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR at least one of the following labels, depending on the scope of your change:
- type:new-feature, which adds new behavior
- type:bug fix
- type:enhancement, which modifies existing behavior
- type:breaking-change
4. Remove those recommended/optional sections if you don't need them. Only "What does this PR do" and "Checklist" are mandatory.
5. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
6. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!
-->

## What does this PR do?
<!-- _(Mandatory)_
Replace this comment with a description of what's being changed by this PR. Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
-->
The documentation of the APM agent states that [the logging output can be redirected to a file](https://www.elastic.co/guide/en/apm/agent/java/master/config-logging.html#config-log-file). Currently, this does not work when specifying `/dev/null` to silence the APM logs completely. When trying to do so, the agent complains with

```
Log file /dev/null is not writable. Falling back to System.out.
```

## Checklist
<!-- _(Mandatory)_
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes it easier to review.
-->
- [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing for details.
-->
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [ ] ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- [ ] ~~Added an API method or config option? Document in which version this will be introduced~~
- [ ] ~~Added an instrumentation plugin? How did you make sure that old, non-supported versions are not instrumented by accident?~~

## Author's Checklist
<!-- _(Recommended)_
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
dir exists | dir writeable | file exists | file writeable | action
---------- | ---           | ---         | ---            | ---
false      | -             | -           | -              | Create directory and file
true       | false         | false       | -              | Print error, fallback to STDOUT
true       | false         | true        | false          | Print error, fallback to STDOUT
true       | false         | true        | true           | Use given file (e.g. `/dev/null`)
true       | true          | false       | -              | Create new file
true       | true          | true        | false          | Print error, fallback to STDOUT
true       | true          | true        | true           | Use given file

## Related issues
<!-- _(Recommended)_
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->
* https://github.com/elastic/apm-agent-java/issues/550
* https://github.com/elastic/apm-agent-java/issues/442#issuecomment-602042731

## Use cases
<!-- _(Recommended)_
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.
If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->
There are companies that have very strict requirements regarding application logs/log formats which may prevent the usage of Elastic APM agent, because there is currently no way, to configure/alter the log format, for example to output JSON.

As a workaround, it should be possible to silence the APM agent by redirecting its logs to `/dev/null`.

## Screenshots
<!-- _(Optional)_
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
