### PR TITLE
make gRPC less flaky (again)

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/impl/BookkeeperObjectPool.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/impl/BookkeeperObjectPool.java
@@ -25,6 +25,8 @@
 package co.elastic.apm.agent.objectpool.impl;
 
 import co.elastic.apm.agent.objectpool.ObjectPool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -39,6 +41,8 @@ import java.util.concurrent.atomic.AtomicInteger;
  * @param <T> pooled object type
  */
 public class BookkeeperObjectPool<T> implements ObjectPool<T> {
+
+    private static final Logger logger = LoggerFactory.getLogger(BookkeeperObjectPool.class);
 
     private final ObjectPool<T> pool;
     private final Set<T> toReturn = Collections.<T>newSetFromMap(new IdentityHashMap<T, Boolean>());
@@ -65,13 +69,16 @@ public class BookkeeperObjectPool<T> implements ObjectPool<T> {
         T instance = pool.createInstance();
         toReturn.add(instance);
         objectCounter.incrementAndGet();
+        logger.debug("creating pooled object: " + instance);
         return instance;
     }
 
     @Override
     public void recycle(T obj) {
+        logger.debug("recycling pooled object: " + obj);
+
         if (!toReturn.contains(obj)) {
-            throw new IllegalStateException("trying to recycle object that has not been taken from this pool or has already been returned");
+            throw new IllegalStateException("trying to recycle object that has not been taken from this pool or has already been returned " + obj);
         }
         pool.recycle(obj);
         toReturn.remove(obj);

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelper.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelper.java
@@ -53,7 +53,7 @@ public interface GrpcHelper {
     @Nullable
     Transaction enterServerListenerMethod(ServerCall.Listener<?> listener);
 
-    void exitServerListenerMethod(Throwable thrown, ServerCall.Listener<?> listener, Transaction transaction, boolean isLastMethod);
+    void exitServerListenerMethod(@Nullable Throwable thrown, ServerCall.Listener<?> listener, Transaction transaction, boolean isLastMethod);
 
     // client part
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelperImpl.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/helper/GrpcHelperImpl.java
@@ -139,7 +139,7 @@ public class GrpcHelperImpl implements GrpcHelper {
 
     @Override
     public void endTransaction(Status status, @Nullable Throwable thrown, ServerCall<?, ?> serverCall) {
-        Transaction transaction = inFlightTransactions.get(serverCall);
+        Transaction transaction = inFlightTransactions.remove(serverCall);
         if (transaction == null) {
             return;
         }


### PR DESCRIPTION
## What does this PR do?

Fix #1146 

- `cancel` gRPC can be called out of order when transaction is already terminated, which caused some concurrency
- using lambdas to assert span/transaction state produces unreliable results (but I don't know why exactly).

## Checklist
- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- ~~I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)~~
- ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- ~~Added an API method or config option? Document in which version this will be introduced~~
- ~~Added an instrumentation plugin? How did you make sure that old, non-supported versions are not instrumented by accident?~~

## Author's Checklist
- [x] run flaky tests for ~30min and 16k executions without any failure

## Related issues
- Closes #1146 
