### PR TITLE
provide standalone grpc test applications

### DIFF
--- a/apm-agent-plugins/apm-grpc/README.md
+++ b/apm-agent-plugins/apm-grpc/README.md
@@ -35,3 +35,14 @@ apm-grpc                   -> agent plugin itself + common test infrastructure
  |--apm-grpc-test-1.6.1    -> test app for gRPC 1.6.1 with generated code
  \--apm-grpc-test-latest   -> test app for gRPC latest with generated code
 ```
+
+## Test applications
+
+Standalone gRPC test applications are available for testing as executable jars.
+It allows testing application behavior with/without agent outside of unit/integration tests.
+
+There is one version per test submodule
+```
+java -jar apm-grpc-test-1.6.1/target/testapp.jar
+java -jar apm-grpc-test-latest/target/testapp.jar
+```

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/Main.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/Main.java
@@ -1,0 +1,76 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.grpc.testapp;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
+
+public class Main {
+
+    private static final int SLEEP = 200;
+
+    protected static void doMain(GrpcApp app) {
+        try {
+            app.start();
+
+            HelloClient<?, ?> client = app.getClient();
+
+            for (int i = 1; i <= 3; i++) {
+                System.out.println(String.format("---- run %d ----", i));
+
+                System.out.println(client.sayHello("bob", i));
+                Thread.sleep(SLEEP);
+
+                System.out.println(client.sayHelloMany("alice", i));
+                Thread.sleep(1000);
+
+                System.out.println(client.sayManyHello(Arrays.asList("bob", "alice", "oscar"), i));
+                Thread.sleep(1000);
+
+                System.out.println(client.sayHelloManyMany(Arrays.asList("joe", "oscar"), i));
+                Thread.sleep(1000);
+
+                System.out.println(client.saysHelloAsync("async-user", i).get());
+                Thread.sleep(1000);
+            }
+
+
+            app.stop();
+        } catch (IOException | InterruptedException | ExecutionException e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected static int parsePort(String[] args) {
+        int port = 4242;
+        try {
+            port = Integer.parseInt(args[0]);
+        } catch (RuntimeException e) {
+            // silently ignored
+        }
+        return port;
+    }
+}

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/pom.xml
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/pom.xml
@@ -21,6 +21,35 @@
         <protobuf.version>3.3.0</protobuf.version>
     </properties>
 
+    <build>
+        <plugins>
+            <!-- provide a standalone test app to use for testing -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <finalName>testapp</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <archive>
+                        <manifest>
+                            <mainClass>co.elastic.apm.agent.grpc.v1_6_1.testapp.MainImpl</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptors>
+                        <descriptor>${project.basedir}/../assembly-testapp.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>co.elastic.apm</groupId>

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/MainImpl.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/MainImpl.java
@@ -1,0 +1,34 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.grpc.v1_6_1.testapp;
+
+import co.elastic.apm.agent.grpc.testapp.Main;
+
+public class MainImpl extends Main {
+
+    public static void main(String[] args) {
+        doMain(GrpcAppProviderImpl.INSTANCE.getGrpcApp("localhost", parsePort(args)));
+    }
+}

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/pom.xml
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/pom.xml
@@ -21,6 +21,35 @@
         <protobuf.version>3.11.0</protobuf.version>
     </properties>
 
+    <build>
+        <plugins>
+            <!-- provide a standalone test app to use for testing -->
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <finalName>testapp-grpc</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                    <archive>
+                        <manifest>
+                            <mainClass>co.elastic.apm.agent.grpc.latest.testapp.MainImpl</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptors>
+                        <descriptor>${project.basedir}/../assembly-testapp.xml</descriptor>
+                    </descriptors>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>co.elastic.apm</groupId>

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/MainImpl.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/MainImpl.java
@@ -1,0 +1,34 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.grpc.latest.testapp;
+
+import co.elastic.apm.agent.grpc.testapp.Main;
+
+public class MainImpl extends Main {
+
+    public static void main(String[] args) {
+        doMain(GrpcAppProviderImpl.INSTANCE.getGrpcApp("localhost", parsePort(args)));
+    }
+}

--- a/apm-agent-plugins/apm-grpc/assembly-testapp.xml
+++ b/apm-agent-plugins/apm-grpc/assembly-testapp.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.0.0 http://maven.apache.org/xsd/assembly-2.0.0.xsd">
+
+    <id>executable-test-jar</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <useTransitiveDependencies>true</useTransitiveDependencies>
+            <unpack>true</unpack>
+            <scope>test</scope>
+            <excludes>
+                <!-- needs to be explicitly excluded otherwise we have grpc plugin in app classpath -->
+                <exclude>co.elastic.apm:apm-grpc-plugin:jar:</exclude>
+                <!-- agent and its dependencies -->
+                <exclude>co.elastic.apm:apm-agent-core</exclude>
+                <exclude>com.lmax</exclude>
+                <exclude>org.jctools</exclude>
+                <exclude>com.blogspot.mydailyjava</exclude>
+                <exclude>org.stagemonitor</exclude>
+                <exclude>net.bytebuddy</exclude>
+                <exclude>org.hdrhistogram</exclude>
+                <exclude>com.dslplatform</exclude>
+            </excludes>
+        </dependencySet>
+    </dependencySets>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/test-classes</directory>
+            <outputDirectory>/</outputDirectory>
+            <includes>
+                <include>**/*.class</include>
+            </includes>
+            <useDefaultExcludes>true</useDefaultExcludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -412,7 +412,7 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -411,6 +411,10 @@
             <!-- pin and set plugin versions at parent project level -->
             <plugins>
                 <plugin>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>2.5.5</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.2.0</version>
                 </plugin>


### PR DESCRIPTION
## What does this PR do?

This PR provides standalone test applications for gRPC.

This allows to quickly test gRPC support and effects with/without agent outside of any integration / unit test.

Those simple applications execute a set of known RPC calls to an embedded server within the same JVM, and use exactly the same endpoints as unit tests.

## Checklist
- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
- ~~I have made corresponding changes to the documentation~~
- ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
- ~~I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)~~
- ~~I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)~~
- ~~Added an API method or config option? Document in which version this will be introduced~~
- ~~Added an instrumentation plugin? How did you make sure that old, non-supported versions are not instrumented by accident?~~

## Author's Checklist
- [x] manual testing without agent
- [x] manual testing with elastic agent
