### PR TITLE
Automatic tracing for Jobs defined in quartz-jobs dependency

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ This is not a breaking change, so former
 * Adds <<config-span-min-duration,`span_min_duration`>> option to exclude fast executing spans.
   When set together with one of the more specific thresholds - `trace_methods_duration_threshold` or `profiling_inferred_spans_min_duration`,
   the higher threshold will determine which spans will be discarded.
+* Automatically instrument quartz jobs from the quartz-jobs artifact {pull}1170[#1170]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-quartz-job-plugin/pom.xml
+++ b/apm-agent-plugins/apm-quartz-job-plugin/pom.xml
@@ -29,6 +29,13 @@
             <version>${version.spring}</version>
             <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.quartz-scheduler</groupId>
+            <artifactId>quartz-jobs</artifactId>
+            <version>${version.quartz}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameInstrumentation.java
@@ -40,6 +40,7 @@ import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPa
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
@@ -56,6 +57,7 @@ public class JobTransactionNameInstrumentation extends ElasticApmInstrumentation
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
         return isInAnyPackage(applicationPackages, ElementMatchers.<NamedElement>none())
+            .or(nameStartsWith("org.quartz.job"))
             .and(hasSuperType(named("org.quartz.Job")))
             .and(declaresMethod(getMethodMatcher()));
     }

--- a/apm-agent-plugins/apm-quartz-job-plugin/src/test/java/co/elastic/apm/agent/quartz/job/JobTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-quartz-job-plugin/src/test/java/co/elastic/apm/agent/quartz/job/JobTransactionNameInstrumentationTest.java
@@ -24,14 +24,16 @@
  */
 package co.elastic.apm.agent.quartz.job;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.TracerInternalApiUtils;
 import co.elastic.apm.agent.impl.transaction.Transaction;
-import org.awaitility.Awaitility;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.quartz.Job;
@@ -45,11 +47,9 @@ import org.quartz.SimpleScheduleBuilder;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
 import org.quartz.impl.StdSchedulerFactory;
+import org.quartz.jobs.DirectoryScanJob;
+import org.quartz.jobs.DirectoryScanListener;
 import org.springframework.scheduling.quartz.QuartzJobBean;
-
-import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -159,6 +159,27 @@ class JobTransactionNameInstrumentationTest extends AbstractInstrumentationTest 
         assertThat(reporter.getTransactions().get(0).getResult()).isEqualTo("this is the result");
     }
 
+    @Test
+    void testDirectoryScan() throws SchedulerException, IOException {
+        Path directoryScanTest = Files.createTempDirectory("DirectoryScanTest");
+
+        Trigger trigger = TriggerBuilder
+            .newTrigger()
+            .withIdentity("myTrigger")
+            .withSchedule(
+                SimpleScheduleBuilder.repeatSecondlyForTotalCount(1, 1))
+            .build();
+        final JobDetail job = JobBuilder.newJob(DirectoryScanJob.class)
+            .withIdentity("dummyJobName")
+            .usingJobData(DirectoryScanJob.DIRECTORY_NAME, directoryScanTest.toAbsolutePath().toString())
+            .usingJobData(DirectoryScanJob.DIRECTORY_SCAN_LISTENER_NAME, TestDirectoryScanListener.class.getSimpleName())
+            .build();
+
+        scheduler.getContext().put(TestDirectoryScanListener.class.getSimpleName(), new TestDirectoryScanListener());
+        scheduler.scheduleJob(job, trigger);
+        verifyJobDetails(job);
+    }
+
     public static class TestJob implements Job {
         @Override
         public void execute(JobExecutionContext context) throws JobExecutionException {
@@ -200,5 +221,12 @@ class JobTransactionNameInstrumentationTest extends AbstractInstrumentationTest 
         protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
         }
 
+    }
+
+    public static class TestDirectoryScanListener implements DirectoryScanListener {
+
+        @Override
+        public void filesUpdatedOrAdded(File[] files) {
+        }
     }
 }

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -336,7 +336,7 @@ When using a scheduling framework a transaction for every execution will be crea
 |2.0+
 |The agent instruments the `execute` method of any class implementing `org.quartz.Job`, as well as the `executeInternal` method of any class extending `org.springframework.scheduling.quartz.QuartzJobBean`, and creates a transaction with the type `scheduled`, representing the job execution
 
-NOTE: only classes from packages configured in <<config-application-packages>>  will be instrumented.
+NOTE: only classes from the quartz-jobs dependency will be instrumented automatically. For the instrumentation of other jobs the package must be added to the <<config-application-packages>> parameter.
 |1.8.0
 |===
 


### PR DESCRIPTION
<!--
A few suggestions about filling out this PR

1. Use a descriptive title for the PR.
2. If this pull request is work in progress, create a draft PR instead of prefixing the title with WIP.
3. Please label this PR at least one of the following labels, depending on the scope of your change:
- type:new-feature, which adds new behavior
- type:bug fix
- type:enhancement, which modifies existing behavior
- type:breaking-change
4. Remove those recommended/optional sections if you don't need them. Only "What does this PR do" and "Checklist" are mandatory.
5. Submit the pull request: Push your local changes to your forked copy of the repository and submit a pull request (https://help.github.com/articles/using-pull-requests).
6. Please be patient. We might not be able to review your code as fast as we would like to, but we'll do our best to dedicate to it the attention it deserves. Your effort is much appreciated!
-->

## What does this PR do?
<!-- _(Mandatory)_
Replace this comment with a description of what's being changed by this PR. Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
-->

While going through our traced Quartz schedules I noticed that the directory scanning schedules are missing which we implement via [quartz-jobs](https://github.com/quartz-scheduler/quartz/tree/master/quartz-jobs) artifact of the quartz project.  
In this use case we do not implement a quartz job but only a callback interface the job will call. As described in the documentation I would have to add the `org.quartz.jobs` package currently to the `application_packages` to make this work.  

In my opinion it would be more user friendly when the jobs provided by the quartz project would work without extra configuration.

This PR add's the instrumentation of the job from the `quartz-jobs` dependency. I decided to not add the package name to the `applicationPackages` collection because the collection we get is immutable.

## Checklist
<!-- _(Mandatory)_
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
- [x] My code follows the [style guidelines of this project](CONTRIBUTING.md#java-language-formatting-guidelines)
- [x] I have rebased my changes on top of the latest master branch
<!--
Update your local repository with the most recent code from the main repo, and rebase your branch on top of the latest master branch. We prefer your initial changes to be squashed into a single commit. Later, if we ask you to make changes, add them as separate commits. This makes them easier to review.
-->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
<!--
Run the test suite to make sure that nothing is broken. See https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing for details.
-->
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [x] I have updated [supported-technologies.asciidoc](docs/supported-technologies.asciidoc)

## Author's Checklist
<!-- _(Recommended)_
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## Related issues
<!-- _(Recommended)_
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it. For more info see:
https://help.github.com/articles/closing-issues-using-keywords/
- Closes #ISSUE_ID
- Relates #ISSUE_ID
- Requires #ISSUE_ID
- Supersedes #ISSUE_ID
-->

## Use cases
<!-- _(Recommended)_
Explain here the different behaviors that this PR introduces or modifies in this project, user roles, environment configuration, etc.
If you are familiar with Gherkin test scenarios, we recommend its usage: https://cucumber.io/docs/gherkin/reference/
-->

The `quartz-jobs` dependency provides ready to use jobs for the following use-cases

- Scanning directories for changed files via lastModified date
- Scanning files for changes via lastModified date
- Executing native executables
- Sending mails
- Invoke JMX
- Sending messages to JMS
- Invoke EJB

## Screenshots
<!-- _(Optional)_
Add here screenshots about how the project will be changed after the PR is applied. They could be related to web pages, terminal, etc, or any other image you consider important to be shared with the team.
