### PR TITLE
Fix currentTransaction() for async spans

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -323,19 +323,8 @@ public class ElasticApmTracer {
 
     @Nullable
     public Transaction currentTransaction() {
-        Deque<AbstractSpan<?>> stack = activeStack.get();
-        final AbstractSpan<?> bottomOfStack = stack.peekLast();
-        if (bottomOfStack instanceof Transaction) {
-            return (Transaction) bottomOfStack;
-        } else if (bottomOfStack != null) {
-            for (Iterator<AbstractSpan<?>> it = stack.descendingIterator(); it.hasNext(); ) {
-                AbstractSpan<?> context = it.next();
-                if (context instanceof Transaction) {
-                    return (Transaction) context;
-                }
-            }
-        }
-        return null;
+        final AbstractSpan<?> bottomOfStack = activeStack.get().peekLast();
+        return bottomOfStack != null ? bottomOfStack.getTransaction() : null;
     }
 
     /**

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
@@ -98,6 +98,9 @@ public abstract class AbstractSpan<T extends AbstractSpan<T>> implements Recycla
         return discardRequested && getTraceContext().isDiscardable();
     }
 
+    @Nullable
+    public abstract Transaction getTransaction();
+
     private static class ChildDurationTimer implements Recyclable {
 
         private AtomicInteger activeChildren = new AtomicInteger();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
@@ -306,6 +306,7 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
     }
 
     @Nullable
+    @Override
     public Transaction getTransaction() {
         return transaction;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -95,6 +95,11 @@ public class Transaction extends AbstractSpan<Transaction> {
 
     private int maxSpans;
 
+    @Override
+    public Transaction getTransaction() {
+        return this;
+    }
+
     public Transaction(ElasticApmTracer tracer) {
         super(tracer);
     }


### PR DESCRIPTION
When activating a span on another thread,
ElasticApmTracer#currentTransaction returns null.
This fixes that by returning the transaction reference stored in the
span instead.

It also makes currentTransaction() more efficient because the stack
doesn't have to be traversed.