### PR TITLE
Upgrade spring boot 1.5 version

### DIFF
--- a/integration-tests/spring-boot-1-5/pom.xml
+++ b/integration-tests/spring-boot-1-5/pom.xml
@@ -13,7 +13,7 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <version.spring-boot-1.5>1.5.14.RELEASE</version.spring-boot-1.5>
+        <version.spring-boot-1.5>1.5.22.RELEASE</version.spring-boot-1.5>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
 


### PR DESCRIPTION
Snapshot builds fail due to resolving maven dependencies: 
`Could not resolve dependencies for project co.elastic.apm:spring-boot-1-5:jar:1.15.1-SNAPSHOT: Failed to collect dependencies at org.springframework.boot:spring-boot-starter-web:jar:1.5.14.RELEASE: Failed to read artifact descriptor for org.springframework.boot:spring-boot-starter-web:jar:1.5.14.RELEASE: Could not transfer artifact org.springframework.boot:spring-boot-starter-web:pom:1.5.14.RELEASE from/to central (https://repo.maven.apache.org/maven2)
`