### PR TITLE
Adding class exclusion from instrumentation config

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ endif::[]
 There will always be one history file `${log_file}.1`.
 * Add <<config-log-format-sout>> and <<config-log-format-file>> with the options `PLAIN_TEXT` and `JSON`.
 The latter uses https://github.com/elastic/ecs-logging-java[ecs-logging-java] to format the logs.
+* Exposing <<config-classes-excluded-from-instrumentation>> config - {pull}1187[#1187]
 
 
 [float]

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -397,8 +397,6 @@ public class ElasticApmAgent {
     }
 
     private static AgentBuilder getAgentBuilder(final ByteBuddy byteBuddy, final CoreConfiguration coreConfiguration, Logger logger, AgentBuilder.DescriptionStrategy descriptionStrategy, boolean premain) {
-        final List<WildcardMatcher> classesExcludedFromInstrumentation = coreConfiguration.getClassesExcludedFromInstrumentation();
-
         AgentBuilder.LocationStrategy locationStrategy = AgentBuilder.LocationStrategy.ForClassLoader.WEAK;
         if (agentJarFile != null) {
             try {
@@ -472,7 +470,13 @@ public class ElasticApmAgent {
             .or(new ElementMatcher.Junction.AbstractBase<TypeDescription>() {
                 @Override
                 public boolean matches(TypeDescription target) {
-                    return WildcardMatcher.anyMatch(classesExcludedFromInstrumentation, target.getName()) != null;
+                    return WildcardMatcher.anyMatch(coreConfiguration.getDefaultClassesExcludedFromInstrumentation(), target.getName()) != null;
+                }
+            })
+            .or(new ElementMatcher.Junction.AbstractBase<TypeDescription>() {
+                @Override
+                public boolean matches(TypeDescription target) {
+                    return WildcardMatcher.anyMatch(coreConfiguration.getClassesExcludedFromInstrumentation(), target.getName()) != null;
                 }
             })
             .disableClassFormatChanges();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -334,11 +334,22 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)
         .key("classes_excluded_from_instrumentation")
         .configurationCategory(CORE_CATEGORY)
+        .description("Use to exclude specific classes from being instrumented. In order to exclude entire packages, \n" +
+            "use wildcards, as in: `com.project.exclude.*`" +
+            "\n" +
+            WildcardMatcher.DOCUMENTATION)
+        .dynamic(false)
+        .buildWithDefault(Collections.<WildcardMatcher>emptyList());
+
+    private final ConfigurationOption<List<WildcardMatcher>> defaultClassesExcludedFromInstrumentation = ConfigurationOption
+        .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)
+        .key("default_classes_excluded_from_instrumentation")
+        .configurationCategory(CORE_CATEGORY)
         .tags("internal")
         .description("\n" +
             "\n" +
             WildcardMatcher.DOCUMENTATION)
-        .dynamic(true)
+        .dynamic(false)
         .buildWithDefault(Arrays.asList(
             WildcardMatcher.valueOf("(?-i)org.infinispan*"),
             WildcardMatcher.valueOf("(?-i)org.apache.xerces*"),
@@ -636,6 +647,10 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
 
     public List<WildcardMatcher> getClassesExcludedFromInstrumentation() {
         return classesExcludedFromInstrumentation.get();
+    }
+
+    public List<WildcardMatcher> getDefaultClassesExcludedFromInstrumentation() {
+        return defaultClassesExcludedFromInstrumentation.get();
     }
 
     public List<WildcardMatcher> getMethodsExcludedFromInstrumentation() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -343,7 +343,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
 
     private final ConfigurationOption<List<WildcardMatcher>> defaultClassesExcludedFromInstrumentation = ConfigurationOption
         .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)
-        .key("default_classes_excluded_from_instrumentation")
+        .key("classes_excluded_from_instrumentation_default")
         .configurationCategory(CORE_CATEGORY)
         .tags("internal")
         .description("\n" +

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
@@ -129,6 +129,15 @@ public class MockTracer {
         );
     }
 
+    public static synchronized void resetTracer() {
+        ElasticApmTracer tracer = ElasticApmInstrumentation.tracer;
+        if (tracer != null) {
+            ElasticApmAgent.reset();
+            tracer.stop();
+            ElasticApmInstrumentation.tracer = null;
+        }
+    }
+
     /**
      * Like {@link #create(ConfigurationRegistry)} but with a {@link SpyConfiguration#createSpyConfig() mocked ConfigurationRegistry}.
      *

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/BodyProcessorTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/BodyProcessorTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,7 +36,7 @@ import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import static co.elastic.apm.agent.impl.context.AbstractContext.REDACTED_CONTEXT_STRING;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doReturn;
 
 class BodyProcessorTest {
 
@@ -54,7 +54,7 @@ class BodyProcessorTest {
 
     @Test
     void processBeforeReport_Transaction_EventTypeAll() {
-        when(config.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ALL);
+        doReturn(CoreConfiguration.EventType.ALL).when(config).getCaptureBody();
 
         final Transaction transaction = processTransaction();
 
@@ -64,7 +64,7 @@ class BodyProcessorTest {
 
     @Test
     void processBeforeReport_Transaction_EventTypeTransaction() {
-        when(config.getCaptureBody()).thenReturn(CoreConfiguration.EventType.TRANSACTIONS);
+        doReturn(CoreConfiguration.EventType.TRANSACTIONS).when(config).getCaptureBody();
 
         final Transaction transaction = processTransaction();
 
@@ -74,7 +74,7 @@ class BodyProcessorTest {
 
     @Test
     void processBeforeReport_Transaction_EventTypeError() {
-        when(config.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ERRORS);
+        doReturn(CoreConfiguration.EventType.ERRORS).when(config).getCaptureBody();
 
         final Transaction transaction = processTransaction();
 
@@ -84,7 +84,7 @@ class BodyProcessorTest {
 
     @Test
     void processBeforeReport_Transaction_EventTypeOff() {
-        when(config.getCaptureBody()).thenReturn(CoreConfiguration.EventType.OFF);
+        doReturn(CoreConfiguration.EventType.OFF).when(config).getCaptureBody();
 
         final Transaction transaction = processTransaction();
 
@@ -94,7 +94,7 @@ class BodyProcessorTest {
 
     @Test
     void processBeforeReport_Error_EventTypeAll() {
-        when(config.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ALL);
+        doReturn(CoreConfiguration.EventType.ALL).when(config).getCaptureBody();
 
         final ErrorCapture error = processError();
 
@@ -104,7 +104,7 @@ class BodyProcessorTest {
 
     @Test
     void processBeforeReport_Error_EventTypeTransaction() {
-        when(config.getCaptureBody()).thenReturn(CoreConfiguration.EventType.TRANSACTIONS);
+        doReturn(CoreConfiguration.EventType.TRANSACTIONS).when(config).getCaptureBody();
 
         final ErrorCapture error = processError();
 
@@ -114,7 +114,7 @@ class BodyProcessorTest {
 
     @Test
     void processBeforeReport_Error_EventTypeError() {
-        when(config.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ERRORS);
+        doReturn(CoreConfiguration.EventType.ERRORS).when(config).getCaptureBody();
 
         final ErrorCapture error = processError();
 
@@ -124,7 +124,7 @@ class BodyProcessorTest {
 
     @Test
     void processBeforeReport_Error_EventTypeOff() {
-        when(config.getCaptureBody()).thenReturn(CoreConfiguration.EventType.OFF);
+        doReturn(CoreConfiguration.EventType.OFF).when(config).getCaptureBody();
 
         final ErrorCapture error = processError();
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcContextHeadersTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcContextHeadersTest.java
@@ -92,7 +92,7 @@ public abstract class AbstractGrpcContextHeadersTest extends AbstractInstrumenta
         Transaction transaction2 = transactions.stream()
             .filter((t) -> !t.equals(transaction1))
             .findFirst()
-            .orElseThrow();
+            .orElseThrow(() -> null);
 
         Span span = reporter.getFirstSpan();
 

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/JmsInstrumentationIT.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/JmsInstrumentationIT.java
@@ -79,6 +79,7 @@ import static co.elastic.apm.agent.configuration.MessagingConfiguration.Strategy
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 @RunWith(Parameterized.class)
@@ -125,7 +126,7 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
         startAndActivateTransaction(null);
         brokerFacade.beforeTest();
         noopQ = brokerFacade.createQueue("NOOP");
-        when(coreConfiguration.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ALL);
+        doReturn(CoreConfiguration.EventType.ALL).when(coreConfiguration).getCaptureBody();
     }
 
     private void startAndActivateTransaction(@Nullable Sampler sampler) {

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyClientIT.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyClientIT.java
@@ -60,11 +60,12 @@ import java.util.UUID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 /**
  * This test is disabled because may fail on CI, maybe because of running in parallel to the current client test.
- * It is still useful to be ran locally to test the legacy client.
+ * It is still useful to run locally to test the legacy client.
  * <p>
  * Each test sends a message to a request topic and waits on a reply message. This serves two purposes:
  * 1.  reduce waits to a minimum within tests
@@ -210,7 +211,7 @@ public class KafkaLegacyClientIT extends AbstractInstrumentationTest {
 
     @Test
     public void testBodyCaptureEnabled() {
-        when(coreConfiguration.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ALL);
+        doReturn(CoreConfiguration.EventType.ALL).when(coreConfiguration).getCaptureBody();
         testScenario = TestScenario.BODY_CAPTURE_ENABLED;
         consumerThread.setIterationMode(RecordIterationMode.ITERABLE_FOR);
         sendTwoRecordsAndConsumeReplies();

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaIT.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaIT.java
@@ -68,6 +68,7 @@ import java.util.UUID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 /**
@@ -230,7 +231,7 @@ public class KafkaIT extends AbstractInstrumentationTest {
 
     @Test
     public void testBodyCaptureEnabled() {
-        when(coreConfiguration.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ALL);
+        doReturn(CoreConfiguration.EventType.ALL).when(coreConfiguration).getCaptureBody();
         testScenario = TestScenario.BODY_CAPTURE_ENABLED;
         consumerThread.setIterationMode(RecordIterationMode.ITERABLE_FOR);
         sendTwoRecordsAndConsumeReplies();

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyBrokerIT.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyBrokerIT.java
@@ -63,12 +63,13 @@ import java.util.UUID;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 /**
  * Tests newer client with a 0.10.2.2 version.
  * This test is disabled because may fail on CI, maybe because of running in parallel to the current broker test.
- * It is still useful to be ran locally to test the legacy broker.
+ * It is still useful to run locally to test the legacy broker.
  * <p>
  * Each test sends a message to a request topic and waits on a reply message. This serves two purposes:
  * 1.  reduce waits to a minimum within tests
@@ -214,7 +215,7 @@ public class KafkaLegacyBrokerIT extends AbstractInstrumentationTest {
 
     @Test
     public void testBodyCaptureEnabled() {
-        when(coreConfiguration.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ALL);
+        doReturn(CoreConfiguration.EventType.ALL).when(coreConfiguration).getCaptureBody();
         testScenario = TestScenario.BODY_CAPTURE_ENABLED;
         consumerThread.setIterationMode(RecordIterationMode.ITERABLE_FOR);
         sendTwoRecordsAndConsumeReplies();

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/TestRequestBodyCapturing.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/TestRequestBodyCapturing.java
@@ -61,6 +61,7 @@ import java.util.stream.Stream;
 
 import static co.elastic.apm.agent.impl.context.AbstractContext.REDACTED_CONTEXT_STRING;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
 class TestRequestBodyCapturing extends AbstractInstrumentationTest {
@@ -231,7 +232,7 @@ class TestRequestBodyCapturing extends AbstractInstrumentationTest {
 
     @Test
     void testTrackPostParams() throws IOException, ServletException {
-        when(coreConfiguration.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ALL);
+        doReturn(CoreConfiguration.EventType.ALL).when(coreConfiguration).getCaptureBody();
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/foo/bar");
         request.addParameter("foo", "bar");
         request.addParameter("baz", "qux", "quux");

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/TestRequestBodyCapturing.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/TestRequestBodyCapturing.java
@@ -95,7 +95,7 @@ class TestRequestBodyCapturing extends AbstractInstrumentationTest {
     void setUp() {
         webConfiguration = tracer.getConfig(WebConfiguration.class);
         coreConfiguration = tracer.getConfig(CoreConfiguration.class);
-        when(coreConfiguration.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ALL);
+        doReturn(CoreConfiguration.EventType.ALL).when(coreConfiguration).getCaptureBody();
         filterChain = new MockFilterChain(new HttpServlet() {
             @Override
             protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
@@ -134,7 +134,7 @@ class TestRequestBodyCapturing extends AbstractInstrumentationTest {
 
     @Test
     void testCaptureBodyOff() throws Exception {
-        when(coreConfiguration.getCaptureBody()).thenReturn(CoreConfiguration.EventType.OFF);
+        doReturn(CoreConfiguration.EventType.OFF).when(coreConfiguration).getCaptureBody();
         executeRequest(filterChain, "foo".getBytes(StandardCharsets.UTF_8), "text/plain");
 
         final Object body = reporter.getFirstTransaction().getContext().getRequest().getBody();
@@ -147,7 +147,7 @@ class TestRequestBodyCapturing extends AbstractInstrumentationTest {
     void testCaptureBodyNotOff(CoreConfiguration.EventType eventType) throws Exception {
         streamCloser = is -> { throw new RuntimeException(); };
 
-        when(coreConfiguration.getCaptureBody()).thenReturn(eventType);
+        doReturn(eventType).when(coreConfiguration).getCaptureBody();
         executeRequest(filterChain, "foo".getBytes(StandardCharsets.UTF_8), "text/plain");
 
         final Transaction transaction = reporter.getFirstTransaction();
@@ -247,7 +247,7 @@ class TestRequestBodyCapturing extends AbstractInstrumentationTest {
 
     @Test
     void testTrackPostParamsDisabled() throws IOException, ServletException {
-        when(coreConfiguration.getCaptureBody()).thenReturn(CoreConfiguration.EventType.ALL);
+        doReturn(CoreConfiguration.EventType.ALL).when(coreConfiguration).getCaptureBody();
         when(webConfiguration.getCaptureContentTypes()).thenReturn(Collections.emptyList());
         MockHttpServletRequest request = new MockHttpServletRequest("POST", "/foo/bar");
         request.addParameter("foo", "bar");

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -114,6 +114,7 @@ Click on a key to get more information.
 ** <<config-capture-body>>
 ** <<config-capture-headers>>
 ** <<config-global-labels>>
+** <<config-classes-excluded-from-instrumentation>>
 ** <<config-trace-methods>>
 ** <<config-trace-methods-duration-threshold>>
 ** <<config-boot-delegation-packages>>
@@ -846,6 +847,34 @@ NOTE: This feature requires APM Server 7.2+
 |============
 | Java System Properties      | Property file   | Environment
 | `elastic.apm.global_labels` | `global_labels` | `ELASTIC_APM_GLOBAL_LABELS`
+|============
+
+// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
+[float]
+[[config-classes-excluded-from-instrumentation]]
+==== `classes_excluded_from_instrumentation`
+
+Use to exclude specific classes from being instrumented. In order to exclude entire packages, 
+use wildcards, as in: `com.project.exclude.*`
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive by default.
+Prepending an element with `(?-i)` makes the matching case sensitive.
+
+
+
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `<none>` | List | false
+|============
+
+
+[options="header"]
+|============
+| Java System Properties      | Property file   | Environment
+| `elastic.apm.classes_excluded_from_instrumentation` | `classes_excluded_from_instrumentation` | `ELASTIC_APM_CLASSES_EXCLUDED_FROM_INSTRUMENTATION`
 |============
 
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
@@ -2593,6 +2622,19 @@ The default unit for this option is `ms`.
 # Default value: 
 #
 # global_labels=
+
+# Use to exclude specific classes from being instrumented. In order to exclude entire packages, 
+# use wildcards, as in: `com.project.exclude.*`
+# This option supports the wildcard `*`, which matches zero or more characters.
+# Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+# Matching is case insensitive by default.
+# Prepending an element with `(?-i)` makes the matching case sensitive.
+#
+# This setting can not be changed at runtime. Changes require a restart of the application.
+# Type: comma separated list
+# Default value: 
+#
+# classes_excluded_from_instrumentation=
 
 # A list of methods for which to create a transaction or span.
 # 


### PR DESCRIPTION
Adding (and exposing) the ability to exclude classes from instrumentation without having to override the default excluded classes. 
For example - https://discuss.elastic.co/t/how-to-ignore-certain-spans/232625