### PR TITLE
Fix IndexOutOfBoundsException when handling deactivation events

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,9 @@ The latter uses https://github.com/elastic/ecs-logging-java[ecs-logging-java] to
 
 [float]
 ===== Bug fixes
+* Fixes `IndexOutOfBoundsException` that can occur when profiler-inferred spans are enabled.
+  This also makes the profiler more resilient by just removing the call tree related to the exception (which might be in an invalid state)
+  as opposed to stopping the profiler when an exception occurs.
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/collections/LongList.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/collections/LongList.java
@@ -126,4 +126,8 @@ public class LongList {
     public long[] toArray() {
         return Arrays.copyOfRange(longs, 0, size);
     }
+
+    public boolean isEmpty() {
+        return size == 0;
+    }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/collections/LongListTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/collections/LongListTest.java
@@ -42,7 +42,9 @@ class LongListTest {
 
     @Test
     void testAdd() {
+        assertThat(longList.isEmpty()).isTrue();
         longList.add(42);
+        assertThat(longList.isEmpty()).isFalse();
         assertThat(longList.getSize()).isEqualTo(1);
         assertThat(longList.get(0)).isEqualTo(42);
     }

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/CallTree.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/CallTree.java
@@ -282,7 +282,7 @@ public class CallTree implements Recyclable {
                 // that needs to be transferred to this call tree node
                 // in the above example, 1's child id would be first transferred from a to b and then from b to c
                 // this ensures that the UI knows that c is the parent of 1
-                parent.stealLastChildId(this);
+                parent.giveLastChildIdTo(this);
             }
 
             List<CallTree> callTrees = getChildren();
@@ -484,7 +484,7 @@ public class CallTree implements Recyclable {
      * <p>
      * We would add the id of span {@code 1} to {@code b}'s {@link #maybeChildIds}.
      * But after seeing the next frame,
-     * we realize the {@code b} has already ended and that we should {@link #stealMaybeChildIds} from {@code b} and give it to {@code a}.
+     * we realize the {@code b} has already ended and that we should {@link #giveMaybeChildIdsTo} from {@code b} and give it to {@code a}.
      * This logic is implemented in {@link CallTree.Root#addStackTrace}.
      * After seeing another frame of {@code a}, we know that {@code 1} is really the child of {@code a}, so we {@link #transferMaybeChildIdsToChildIds()}.
      * </p>
@@ -514,11 +514,11 @@ public class CallTree implements Recyclable {
         for (int i = 0, childrenSize = children.size(); i < childrenSize; i++) {
             children.get(i).recursiveGiveChildIdsTo(giveTo);
         }
-        stealChildIds(giveTo);
-        stealMaybeChildIds(giveTo);
+        giveChildIdsTo(giveTo);
+        giveMaybeChildIdsTo(giveTo);
     }
 
-    void stealChildIds(CallTree giveTo) {
+    void giveChildIdsTo(CallTree giveTo) {
         if (this.childIds == null) {
             return;
         }
@@ -531,13 +531,13 @@ public class CallTree implements Recyclable {
     }
 
 
-    private void stealLastChildId(CallTree giveTo) {
+    void giveLastChildIdTo(CallTree giveTo) {
         if (childIds != null && !childIds.isEmpty()) {
             giveTo.addChildId(childIds.remove(childIds.getSize() - 1));
         }
     }
 
-    void stealMaybeChildIds(CallTree giveTo) {
+    void giveMaybeChildIdsTo(CallTree giveTo) {
         if (this.maybeChildIds == null) {
             return;
         }
@@ -669,7 +669,7 @@ public class CallTree implements Recyclable {
             if (firstFrameAfterActivation && previousTopOfStack != topOfStack && previousTopOfStack != null && previousTopOfStack.hasChildIds()) {
                 if (!topOfStack.isSuccessor(previousTopOfStack)) {
                     CallTree commonAncestor = findCommonAncestor(previousTopOfStack, topOfStack);
-                    previousTopOfStack.stealMaybeChildIds(commonAncestor != null ? commonAncestor : topOfStack);
+                    previousTopOfStack.giveMaybeChildIdsTo(commonAncestor != null ? commonAncestor : topOfStack);
                 }
             }
         }

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/CallTree.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/CallTree.java
@@ -532,7 +532,7 @@ public class CallTree implements Recyclable {
 
 
     private void stealLastChildId(CallTree giveTo) {
-        if (childIds != null) {
+        if (childIds != null && !childIds.isEmpty()) {
             giveTo.addChildId(childIds.remove(childIds.getSize() - 1));
         }
     }

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/CallTreeTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/CallTreeTest.java
@@ -117,6 +117,23 @@ class CallTreeTest {
     }
 
     @Test
+    void testGiveEmptyChildIdsTo() {
+        CallTree rich = new CallTree();
+        rich.addChildId(42);
+        CallTree robinHood = new CallTree();
+        CallTree poor = new CallTree();
+
+        rich.giveLastChildIdTo(robinHood);
+        robinHood.giveLastChildIdTo(poor);
+        // list is not null but empty, expecting no exception
+        robinHood.giveLastChildIdTo(rich);
+
+        assertThat(rich.hasChildIds()).isFalse();
+        assertThat(robinHood.hasChildIds()).isFalse();
+        assertThat(poor.hasChildIds()).isTrue();
+    }
+
+    @Test
     void testTwoDistinctInvocationsOfMethodBShouldNotBeFoldedIntoOne() throws Exception {
         assertCallTree(new String[]{
             " bb bb",


### PR DESCRIPTION
Fixes `IndexOutOfBoundsException` that can occur when profiler-inferred spans are enabled.

This also makes the profiler more resilient by just removing the call tree related to the exception (which might be in an invalid state) as opposed to stopping the profiler when an exception occurs.

## Checklist
<!-- _(Mandatory)_
List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->
- [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
- [x] I have added tests that would fail without this fix
