### PR TITLE
ignore jps JVM for runtime attach

### DIFF
--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/JvmDiscoverer.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/JvmDiscoverer.java
@@ -100,7 +100,7 @@ public interface JvmDiscoverer {
             for (String s : jpsOutput.split("\n")) {
                 JvmInfo parse = JvmInfo.parse(s);
                 // ignore jps command that we just started as it's already terminated and not relevant for attachment
-                if(!parse.packageOrPathOrJvmProperties.contains("sun.tools.jps.Jps")){
+                if(!parse.packageOrPathOrJvmProperties.contains(".Jps")){
                     set.add(parse);
                 }
             }

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -130,6 +130,7 @@ public class RemoteAttacher {
                 ElasticApmAttacher.attach(jvmInfo.pid, agentArgs);
                 log("INFO", "Done");
             } catch (Exception e) {
+                log("ERROR", "Unable to attach to JVM with PID = %s", jvmInfo.pid);
                 e.printStackTrace();
             }
         } else {

--- a/apm-agent-attach/src/test/java/co/elastic/apm/attach/JvmDiscovererTest.java
+++ b/apm-agent-attach/src/test/java/co/elastic/apm/attach/JvmDiscovererTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -26,14 +26,31 @@ package co.elastic.apm.attach;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class JvmDiscovererTest {
 
     @Test
     void discoverHotspotJvms() {
-        JvmDiscoverer.ForHotSpotVm hotspotJvmDiscoverer = JvmDiscoverer.ForHotSpotVm.withDefaultTempDir();
-        assertThat(hotspotJvmDiscoverer.isAvailable()).isTrue();
-        assertThat(hotspotJvmDiscoverer.discoverJvms()).contains(new JvmInfo(String.valueOf(ProcessHandle.current().pid()), null));
+        JvmDiscoverer.ForHotSpotVm discoverer = JvmDiscoverer.ForHotSpotVm.withDefaultTempDir();
+        assertThat(discoverer.isAvailable())
+            .describedAs("HotSpot JVM discovery should be available")
+            .isTrue();
+        assertThat(discoverer.discoverJvms()).contains(new JvmInfo(String.valueOf(ProcessHandle.current().pid()), null));
+    }
+
+    @Test
+    void jpsShouldIgnoreJps() throws Exception {
+
+        JvmDiscoverer discoverer = JvmDiscoverer.Jps.INSTANCE;
+        assertThat(discoverer.isAvailable())
+            .describedAs("jps JVM discovery should be available")
+            .isTrue();
+        for (JvmInfo jvm : discoverer.discoverJvms()) {
+            Optional.ofNullable(jvm.packageOrPathOrJvmProperties)
+                .ifPresent((s)-> assertThat(s).doesNotContain("sun.tool.jps.Jps"));
+        }
     }
 }

--- a/apm-agent-attach/src/test/java/co/elastic/apm/attach/JvmDiscovererTest.java
+++ b/apm-agent-attach/src/test/java/co/elastic/apm/attach/JvmDiscovererTest.java
@@ -26,7 +26,11 @@ package co.elastic.apm.attach;
 
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -53,4 +57,29 @@ class JvmDiscovererTest {
                 .ifPresent((s)-> assertThat(s).doesNotContain("sun.tool.jps.Jps"));
         }
     }
+
+    @Test
+    void getJpsPathNoJavaHome() {
+        Properties sysProperties = new Properties();
+        Path path = JvmDiscoverer.Jps.getJpsPath(sysProperties);
+        assertThat(path).asString()
+            .describedAs("should use binary in path as fallback")
+            .isEqualTo("jps");
+    }
+
+    @Test
+    void getJpsPathWindows() {
+        Properties sysProperties = new Properties();
+        sysProperties.put("os.name", "Windows ME"); // the best one ever !
+        Path path = JvmDiscoverer.Jps.getJpsPath(sysProperties);
+        assertThat(path).asString().isEqualTo("jps.exe");
+        // note: we can't really test both windows+java.home set as it relies on absolute path resolution
+    }
+
+    @Test
+    void getJpsPathCurrentJvm() {
+        Path path = JvmDiscoverer.Jps.getJpsPath(System.getProperties());
+        assertThat(Files.isExecutable(path)).isTrue();
+    }
+
 }


### PR DESCRIPTION
When using runtime attach, especially the `--continuous` option, the JVM that is running the `jps` process is always listed, and makes agent output an error message with stack trace because this short-lived JVM is already terminated.

This PR makes JVMs running `jps` ignored when listing, which makes it behave slightly differently than the `jps -lv` command (which always includes itself). Also, it resolves path to `jps` binary using `JAVA_HOME` environment variable in case it's not available in `PATH`.