### PR TITLE
avoid loading application log4j plugins

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ The latter uses https://github.com/elastic/ecs-logging-java[ecs-logging-java] to
 * Fix `NumberFormatException` when parsing Ingres/Actian JDBC connection strings - {pull}1198[#1198]
 * Prevent agent from overriding JVM configured truststore when not using HTTPS for communication with APM server - {pull}1203[#1203]
 * Fix `java.lang.IllegalStateException` with `jps` JVM when using continuous runtime attach - {pull}1205[1205]
+* Fix agent trying to load log4j2 plugins from application {pull}1214[1214]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -342,6 +342,11 @@
                                     <pattern>Log4j-</pattern>
                                     <shadedPattern>ElasticApmLog4j-</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <!-- makes sure that direct link to resources in meta-inf are also relocated, otherwise will load log4j plugins from app -->
+                                    <pattern>META-INF/org/apache/logging</pattern>
+                                    <shadedPattern>META-INF/co/elastic/apm/agent/shaded/logging</shadedPattern>
+                                </relocation>
 
                                 <relocation>
                                     <pattern>org.stagemonitor</pattern>


### PR DESCRIPTION
Found while testing with an application that is using log4j2.

Shaded log4j2 from agent tries to load application plugins, this is due to having hard-coded references to `Log4j2Plugins.dat` within `META-INF` folder (which is not covered by relocation patterns)

Classes that trigger this issue can be found using the following one-liner command within an expanded copy of the agent jar.
```
find . -name '*.class' | xargs grep 'META-INF/org/' -ali 
```

We only have two of them
```
./co/elastic/apm/agent/shaded/apache/logging/log4j/core/config/plugins/processor/PluginProcessor.class
./co/elastic/apm/agent/shaded/apache/logging/log4j/core/config/plugins/util/PluginRegistry.class
```