### PR TITLE
ci: run benchmark on a PR basis if comment

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -217,7 +217,7 @@ pipeline {
                 branch 'master'
                 branch "\\d+\\.\\d+"
                 branch "v\\d?"
-                tag "v\\d+\\.\\d+\\.\\d+*"
+                tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
                 expression { return params.Run_As_Master_Branch }
                 expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?tests(?:\\W+please)?.*')
+    issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:benchmark\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
     string(name: 'MAVEN_CONFIG', defaultValue: '-B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn', description: 'Additional maven options.')
@@ -219,6 +219,7 @@ pipeline {
                 branch "v\\d?"
                 tag "v\\d+\\.\\d+\\.\\d+*"
                 expression { return params.Run_As_Master_Branch }
+                expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
               }
               expression { return params.bench_ci }
             }


### PR DESCRIPTION
## What does this pull request do?

Enable the benchmark stage on a PR basis if using the GH comment `jenkins run the benchmark tests please` or a more minimalistic comment with `jenkins run benchmark tests` or even with `run benchmark tests`

## Why is it important?

Help to run the benchmark on a PR basis using a GitHub comment can facilitate the CI interactions.

## Questions

- [ ] Can we run this stage safely for the PRs? Or will it mess the benchmark data?