### PR TITLE
Fix failing tests due to url-encoded file paths

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/IOUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/IOUtils.java
@@ -32,7 +32,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
-import java.net.URLDecoder;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
@@ -221,11 +220,7 @@ public class IOUtils {
                 throw new IllegalStateException(resource + " not found");
             }
             String hash = md5Hash(IOUtils.class.getResourceAsStream("/" + resource));
-
-            // temp folder might be url-encoded
-            String tempFolder = URLDecoder.decode(System.getProperty("java.io.tmpdir"), StandardCharsets.UTF_8.name());
-
-            File tempFile = new File(tempFolder, tempFileNamePrefix + "-" + hash + tempFileNameExtension);
+            File tempFile = new File(System.getProperty("java.io.tmpdir"), tempFileNamePrefix + "-" + hash + tempFileNameExtension);
             if (!tempFile.exists()) {
                 try (FileOutputStream out = new FileOutputStream(tempFile)) {
                     FileChannel channel = out.getChannel();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ReporterFactoryTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ReporterFactoryTest.java
@@ -42,21 +42,19 @@ import org.eclipse.jetty.util.ssl.SslContextFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-// Jenkins fails with java.lang.IllegalStateException: no valid keystore
-// tbh, I have no clue why
-@DisabledIfEnvironmentVariable(named = "JENKINS_HOME", matches = ".*")
 class ReporterFactoryTest {
 
     private Server server;
@@ -69,7 +67,8 @@ class ReporterFactoryTest {
     void setUp() throws Exception {
         server = new Server();
 
-        final SslContextFactory sslContextFactory = new SslContextFactory(getClass().getResource("/keystore").getPath());
+        Path keyStorePath = Paths.get(ReporterFactoryTest.class.getResource("/keystore").toURI());
+        final SslContextFactory sslContextFactory = new SslContextFactory(keyStorePath.toAbsolutePath().toString());
         sslContextFactory.setKeyStorePassword("password");
         sslContextFactory.getSslContext();
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
@@ -25,27 +25,25 @@
 package co.elastic.apm.agent.util;
 
 import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
+import java.io.IOException;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.Test;
-
-import javax.annotation.Nonnull;
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.CharBuffer;
-import java.nio.charset.Charset;
-import java.util.concurrent.ArrayBlockingQueue;
 
 import static java.nio.charset.StandardCharsets.UTF_16;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -160,7 +158,8 @@ class IOUtilsTest  {
     void exportResourceToTemp() {
         File tmp = IOUtils.exportResourceToTemp("elasticapm.properties", UUID.randomUUID().toString(), "tmp");
         tmp.deleteOnExit();
-        assertThat(tmp).hasSameContentAs(new File(this.getClass().getResource("/elasticapm.properties").getFile()));
+        assertThat(tmp)
+            .hasSameContentAs(new File(this.getClass().getResource("/elasticapm.properties").getFile()));
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
@@ -33,11 +33,11 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.net.URL;
-import java.net.URLDecoder;
+import java.net.URISyntaxException;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -159,17 +159,14 @@ class IOUtilsTest  {
     }
 
     @Test
-    void exportResourceToTemp() throws UnsupportedEncodingException {
+    void exportResourceToTemp() throws UnsupportedEncodingException, URISyntaxException {
         File tmp = IOUtils.exportResourceToTemp("elasticapm.properties", UUID.randomUUID().toString(), "tmp");
         tmp.deleteOnExit();
 
-        URL url = IOUtilsTest.class.getResource("/elasticapm.properties");
-
-        // required because file path may be url-encoded (for example on CI server with spaces in project name)
-        String referenceFile = URLDecoder.decode(url.getFile(), UTF_8);
+        Path referenceFile = Paths.get(IOUtilsTest.class.getResource("/elasticapm.properties").toURI());
 
         assertThat(tmp)
-            .hasSameContentAs(new File(referenceFile));
+            .hasSameContentAs(referenceFile.toFile());
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
@@ -32,6 +32,8 @@ import javax.annotation.Nonnull;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
@@ -155,11 +157,17 @@ class IOUtilsTest  {
     }
 
     @Test
-    void exportResourceToTemp() {
+    void exportResourceToTemp() throws URISyntaxException {
         File tmp = IOUtils.exportResourceToTemp("elasticapm.properties", UUID.randomUUID().toString(), "tmp");
         tmp.deleteOnExit();
+
+        URL url = this.getClass().getResource("/elasticapm.properties");
+        System.out.println("toString " + url.toString());
+        System.out.println("toURI.toASCIIString " + url.toURI().toASCIIString());
+        System.out.println("getFile " + url.getFile());
+
         assertThat(tmp)
-            .hasSameContentAs(new File(this.getClass().getResource("/elasticapm.properties").getFile()));
+            .hasSameContentAs(new File(url.getFile()));
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
@@ -168,7 +168,6 @@ class IOUtilsTest  {
         System.out.println("getFile " + url.getFile());
 
         assertThat(new File(url.toURI().getPath())).exists();
-        assertThat(new File(url.getFile())).doesNotExist();
 
         assertThat(tmp)
             .hasSameContentAs(new File(url.toURI().getPath()));

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
@@ -32,10 +32,12 @@ import javax.annotation.Nonnull;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
-import java.net.URISyntaxException;
+import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.net.URLDecoder;
 import java.nio.CharBuffer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -157,20 +159,17 @@ class IOUtilsTest  {
     }
 
     @Test
-    void exportResourceToTemp() throws URISyntaxException {
+    void exportResourceToTemp() throws UnsupportedEncodingException {
         File tmp = IOUtils.exportResourceToTemp("elasticapm.properties", UUID.randomUUID().toString(), "tmp");
         tmp.deleteOnExit();
 
         URL url = IOUtilsTest.class.getResource("/elasticapm.properties");
-        new File(url.toURI().getPath());
-        System.out.println("toString " + url.toString());
-        System.out.println("toURI.toASCIIString " + url.toURI().toASCIIString());
-        System.out.println("getFile " + url.getFile());
 
-        assertThat(new File(url.toURI().getPath())).exists();
+        // required because file path may be url-encoded (for example on CI server with spaces in project name)
+        String referenceFile = URLDecoder.decode(url.getFile(), UTF_8);
 
         assertThat(tmp)
-            .hasSameContentAs(new File(url.toURI().getPath()));
+            .hasSameContentAs(new File(referenceFile));
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
@@ -161,13 +161,17 @@ class IOUtilsTest  {
         File tmp = IOUtils.exportResourceToTemp("elasticapm.properties", UUID.randomUUID().toString(), "tmp");
         tmp.deleteOnExit();
 
-        URL url = this.getClass().getResource("/elasticapm.properties");
+        URL url = IOUtilsTest.class.getResource("/elasticapm.properties");
+        new File(url.toURI().getPath());
         System.out.println("toString " + url.toString());
         System.out.println("toURI.toASCIIString " + url.toURI().toASCIIString());
         System.out.println("getFile " + url.getFile());
 
+        assertThat(new File(url.toURI().getPath())).exists();
+        assertThat(new File(url.getFile())).doesNotExist();
+
         assertThat(tmp)
-            .hasSameContentAs(new File(url.getFile()));
+            .hasSameContentAs(new File(url.toURI().getPath()));
     }
 
     @Test

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/asyncprofiler/JfrParserTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/asyncprofiler/JfrParserTest.java
@@ -47,7 +47,7 @@ class JfrParserTest {
         // should trigger most edge cases in the buffer being exhausted
         JfrParser jfrParser = new JfrParser(ByteBuffer.allocate(113), ByteBuffer.allocate(113));
 
-        File file = Paths.get(JfrParserTest.class.getResource("recording.jfr").toURI()).toFile();
+        File file = Paths.get(JfrParserTest.class.getClassLoader().getResource("recording.jfr").toURI()).toFile();
 
         jfrParser.parse(file, List.of(), List.of(caseSensitiveMatcher("co.elastic.apm.*")));
         AtomicInteger stackTraces = new AtomicInteger();

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/asyncprofiler/JfrParserTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/asyncprofiler/JfrParserTest.java
@@ -28,10 +28,8 @@ import co.elastic.apm.agent.impl.transaction.StackFrame;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
-import java.net.URL;
-import java.net.URLDecoder;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -48,12 +46,10 @@ class JfrParserTest {
         // using the smallest prime number possible for the buffer
         // should trigger most edge cases in the buffer being exhausted
         JfrParser jfrParser = new JfrParser(ByteBuffer.allocate(113), ByteBuffer.allocate(113));
-        URL url = getClass().getClassLoader().getResource("recording.jfr");
 
-        // URL provides url-encoded path, we have to explicitly decode it otherwise we won't find the file
-        String filePath = URLDecoder.decode(url.getPath(), StandardCharsets.UTF_8.name());
+        File file = Paths.get(JfrParserTest.class.getResource("recording.jfr").toURI()).toFile();
 
-        jfrParser.parse(new File(filePath), List.of(), List.of(caseSensitiveMatcher("co.elastic.apm.*")));
+        jfrParser.parse(file, List.of(), List.of(caseSensitiveMatcher("co.elastic.apm.*")));
         AtomicInteger stackTraces = new AtomicInteger();
         ArrayList<StackFrame> stackFrames = new ArrayList<>();
         jfrParser.consumeStackTraces((threadId, stackTraceId, nanoTime) -> {


### PR DESCRIPTION
Of course, this only fails on internal CI otherwise life is too simple to debug.