### PR TITLE
fix: check that docker is installed

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -5,7 +5,7 @@ JAVA_HOME=$HOME/.java/java10 ./mvnw clean verify \
   --fail-never -q -B \
   -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
-if [ -f "$(command -v docker)" ]; then
+if [ -x "$(command -v docker)" ]; then
   (retry 2 docker pull docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev) \
     && docker tag docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev store/oracle/weblogic:12.2.1.3-dev
 fi

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -5,5 +5,7 @@ JAVA_HOME=$HOME/.java/java10 ./mvnw clean verify \
   --fail-never -q -B \
   -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
-(retry 2 docker pull docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev) \
-  && docker tag docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev store/oracle/weblogic:12.2.1.3-dev
+if [ -f "$(command -v docker)" ]; then
+  (retry 2 docker pull docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev) \
+    && docker tag docker.elastic.co/observability-ci/weblogic:12.2.1.3-dev store/oracle/weblogic:12.2.1.3-dev
+fi


### PR DESCRIPTION
## What does this PR do?

It checks that Docker is installed before run it.

## Why is it important?

Some worker types do not have Docker installed this breaks the packer build.