### PR TITLE
More logging in MBean listiner

### DIFF
--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
@@ -196,6 +196,8 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
                                 register(Collections.singletonList(jmxMetric), server);
                             }
                         }
+                    } else {
+                        logger.debug("Received a notification that is not an instance of MBeanServerNotification");
                     }
                 } catch (Exception e) {
                     logger.error(e.getMessage(), e);

--- a/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,6 +36,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import javax.management.MBeanServer;
+import javax.management.MBeanServerFactory;
 import javax.management.ObjectName;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;


### PR DESCRIPTION
A user reported issues with MBeans added later at runtime on JBoss EAP: https://discuss.elastic.co/t/no-jmx-metrics-in-jboss-eap-7-3-0/238438

This PR adds trace logging each time the `NotificationListener` method is called. It also caches and logs exceptions in that listener.