### PR TITLE
Exclude Contrast Security agent classes from instrumentation

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -478,6 +478,7 @@ public class ElasticApmAgent {
             .or(nameStartsWith("org.glowroot."))
             .or(nameStartsWith("com.compuware."))
             .or(nameStartsWith("io.sqreen."))
+            .or(nameStartsWith("com.contrastsecurity."))
             .or(nameContains("javassist"))
             .or(nameContains(".asm."))
             .or(anyMatch(coreConfiguration.getDefaultClassesExcludedFromInstrumentation()))


### PR DESCRIPTION
Reported through [the forum](https://discuss.elastic.co/t/error-on-instrumenting-weblogic-server-with-apm-agent-client-1-16-0/238990)