### PR TITLE
Re-enable non-Scala tests

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/VersionUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/VersionUtilsTest.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.util;
 
 import org.assertj.core.api.Assertions;

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
@@ -42,7 +42,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.30.0)",
+    value = "by gRPC proto compiler (version 1.30.2)",
     comments = "Source: rpc.proto")
 public final class HelloGrpc {
 

--- a/apm-agent-plugins/apm-scala-concurrent-plugin/pom.xml
+++ b/apm-agent-plugins/apm-scala-concurrent-plugin/pom.xml
@@ -50,6 +50,14 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <includes>
+                        <include>**/*Spec.*</include>
+                    </includes>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -439,11 +439,6 @@
                             <version>${version.junit-jupiter}</version>
                         </dependency>
                     </dependencies>
-                    <configuration>
-                        <includes>
-                            <include>**/*Spec.*</include>
-                        </includes>
-                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>


### PR DESCRIPTION
https://github.com/elastic/apm-agent-java/pull/1048 accidentally disabled all non-Scala tests