### PR TITLE
ci: fix missing env variable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     MAVEN_CONFIG = '-Dmaven.repo.local=.m2'
+    OPBEANS_REPO = 'opbeans-java'
   }
   options {
     timeout(time: 1, unit: 'HOURS')


### PR DESCRIPTION
## What does this PR do?

`OPBEANS_REPO` env variable was removed so let's put it back to allow the opbeans bump automation.