### PR TITLE
Avoid segfault when executing tests with JDK < 11.0.4

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -30,7 +30,6 @@ import co.elastic.apm.agent.bci.subpackage.AdviceInSubpackageInstrumentation;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.configuration.SpyConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
-import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.matcher.WildcardMatcher;
@@ -49,6 +48,7 @@ import org.apache.commons.math3.stat.StatUtils;
 import org.apache.commons.pool2.impl.CallStackUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.slf4j.event.SubstituteLoggingEvent;
 import org.stagemonitor.configuration.ConfigurationRegistry;
@@ -92,20 +92,20 @@ class InstrumentationTest {
 
     @Test
     void testIntercept() {
-        init(configurationRegistry, List.of(new TestInstrumentation()));
+        init(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEqualTo("intercepted");
     }
 
     @Test
     void testFieldAccess() {
-        init(configurationRegistry, List.of(new FieldAccessInstrumentation()));
+        init(List.of(new FieldAccessInstrumentation()));
         assignToField("@AssignToField");
         assertThat(privateString).isEqualTo("@AssignToField");
     }
 
     @Test
     void testFieldAccessArray() {
-        init(configurationRegistry, List.of(new FieldAccessArrayInstrumentation()));
+        init(List.of(new FieldAccessArrayInstrumentation()));
         assignToField("@AssignToField");
         assertThat(privateString).isEqualTo("@AssignToField");
     }
@@ -115,7 +115,7 @@ class InstrumentationTest {
 
     @Test
     void testAssignToArgument() {
-        init(configurationRegistry, List.of(new AssignToArgumentInstrumentation()));
+        init(List.of(new AssignToArgumentInstrumentation()));
         assertThat(assignToArgument("foo")).isEqualTo("foo@AssignToArgument");
     }
 
@@ -125,7 +125,7 @@ class InstrumentationTest {
 
     @Test
     void testAssignToArgumentArray() {
-        init(configurationRegistry, List.of(new AssignToArgumentsInstrumentation()));
+        init(List.of(new AssignToArgumentsInstrumentation()));
         assertThat(assignToArguments("foo", "bar")).isEqualTo("barfoo");
     }
 
@@ -135,7 +135,7 @@ class InstrumentationTest {
 
     @Test
     void testAssignToReturnArray() {
-        init(configurationRegistry, List.of(new AssignToReturnArrayInstrumentation()));
+        init(List.of(new AssignToReturnArrayInstrumentation()));
         assertThat(assignToReturn("foo", "bar")).isEqualTo("foobar");
     }
 
@@ -147,13 +147,13 @@ class InstrumentationTest {
     @Test
     void testDisabled() {
         doReturn(Collections.singletonList("test")).when(coreConfig).getDisabledInstrumentations();
-        init(configurationRegistry, List.of(new TestInstrumentation()));
+        init(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEmpty();
     }
 
     @Test
     void testEnsureInstrumented() {
-        init(configurationRegistry, List.of());
+        init(List.of());
         assertThat(interceptMe()).isEmpty();
         ElasticApmAgent.ensureInstrumented(getClass(), List.of(TestInstrumentation.class));
         assertThat(interceptMe()).isEqualTo("intercepted");
@@ -162,21 +162,21 @@ class InstrumentationTest {
     @Test
     void testReInitEnableOneInstrumentation() {
         doReturn(Collections.singletonList("test")).when(coreConfig).getDisabledInstrumentations();
-        init(configurationRegistry, List.of(new TestInstrumentation()));
+        init(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEmpty();
 
         doReturn(List.of()).when(coreConfig).getDisabledInstrumentations();
-        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()), tracer);
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEqualTo("intercepted");
     }
 
     @Test
     void testDefaultDisabledInstrumentation() {
-        init(configurationRegistry, List.of(new TestInstrumentation()));
+        init(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEqualTo("intercepted");
 
         doReturn(Collections.singletonList("experimental")).when(coreConfig).getDisabledInstrumentations();
-        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()), tracer);
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEmpty();
     }
 
@@ -184,8 +184,8 @@ class InstrumentationTest {
     void testExcludedClassesFromInstrumentation() {
         doReturn(List.of(WildcardMatcher.valueOf("co.elastic.apm.agent.bci.InstrumentationTest")))
             .when(coreConfig).getClassesExcludedFromInstrumentation();
-        init(configurationRegistry, List.of(new TestInstrumentation()));
-        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()), tracer);
+        init(List.of(new TestInstrumentation()));
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEmpty();
     }
 
@@ -193,8 +193,8 @@ class InstrumentationTest {
     void testExcludedPackageFromInstrumentation() {
         doReturn(List.of(WildcardMatcher.valueOf("co.elastic.apm.agent.bci.*")))
             .when(coreConfig).getClassesExcludedFromInstrumentation();
-        init(configurationRegistry, List.of(new TestInstrumentation()));
-        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()), tracer);
+        init(List.of(new TestInstrumentation()));
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEmpty();
     }
 
@@ -202,8 +202,8 @@ class InstrumentationTest {
     void testExcludedDefaultClassesFromInstrumentation() {
         doReturn(List.of(WildcardMatcher.valueOf("co.elastic.apm.agent.bci.InstrumentationTest")))
             .when(coreConfig).getDefaultClassesExcludedFromInstrumentation();
-        init(configurationRegistry, List.of(new TestInstrumentation()));
-        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()), tracer);
+        init(List.of(new TestInstrumentation()));
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEmpty();
     }
 
@@ -211,28 +211,28 @@ class InstrumentationTest {
     void testExcludedDefaultPackageFromInstrumentation() {
         doReturn(List.of(WildcardMatcher.valueOf("co.elastic.apm.agent.bci.*")))
             .when(coreConfig).getDefaultClassesExcludedFromInstrumentation();
-        init(configurationRegistry, List.of(new TestInstrumentation()));
-        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()), tracer);
+        init(List.of(new TestInstrumentation()));
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEmpty();
     }
 
     @Test
     void testLegacyDefaultDisabledInstrumentation() {
-        init(configurationRegistry, List.of(new TestInstrumentation()));
+        init(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEqualTo("intercepted");
 
         doReturn(Collections.singletonList("incubating")).when(coreConfig).getDisabledInstrumentations();
-        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()), tracer);
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEmpty();
     }
 
     @Test
     void testReInitDisableAllInstrumentations() {
-        init(configurationRegistry, List.of(new TestInstrumentation()));
+        init(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEqualTo("intercepted");
 
         doReturn(false).when(coreConfig).isInstrument();
-        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()), tracer);
+        ElasticApmAgent.doReInitInstrumentation(List.of(new TestInstrumentation()));
         assertThat(interceptMe()).isEmpty();
     }
 
@@ -455,10 +455,7 @@ class InstrumentationTest {
         return null;
     }
 
-    private void init(ConfigurationRegistry config, List<ElasticApmInstrumentation> instrumentations) {
-        ElasticApmTracer tracer = new ElasticApmTracerBuilder()
-            .configurationRegistry(config)
-            .build();
+    private void init(List<ElasticApmInstrumentation> instrumentations) {
         ElasticApmAgent.initInstrumentation(tracer, ByteBuddyAgent.install(), instrumentations);
     }
 


### PR DESCRIPTION
## What does this PR do?
#1230 required us to update to the latest JDK in order to avoid crashes when executing tests.

I've investigated a little more. While I can't say which parts of the PR triggered the segfault, I can rule out a few options:
- Adding invokedynamic instructions
- Usage of `PostProcessor`/`@AssignTo`

The segfault even triggers when only the `testLegacyDefaultDisabledInstrumentation` test is active in `InstrumentationTest` and when using `@Advice.Return(readOnly = false)` instead of `@AssignTo.Return`.

As described in the JDK tracker https://bugs.openjdk.java.net/browse/JDK-8210457, the issue occurs when there's a retransformation happening concurrently to the `StackWalker` traversing the stack.

The workaround is to only create the logger once.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
    - [ ] ~I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)~
