### PR TITLE
Add scala future test case using multiple threads

### DIFF
--- a/apm-agent-plugins/apm-scala-concurrent-plugin/src/test/scala/co/elastic/apm/agent/scala/concurrent/FutureInstrumentation2Spec.scala
+++ b/apm-agent-plugins/apm-scala-concurrent-plugin/src/test/scala/co/elastic/apm/agent/scala/concurrent/FutureInstrumentation2Spec.scala
@@ -1,0 +1,66 @@
+package co.elastic.apm.agent.scala.concurrent
+
+import java.util.concurrent.Executors
+
+import co.elastic.apm.agent.MockReporter
+import co.elastic.apm.agent.bci.ElasticApmAgent
+import co.elastic.apm.agent.configuration.{CoreConfiguration, SpyConfiguration}
+import co.elastic.apm.agent.impl.transaction.Transaction
+import co.elastic.apm.agent.impl.{ElasticApmTracer, ElasticApmTracerBuilder}
+import munit.FunSuite
+import net.bytebuddy.agent.ByteBuddyAgent
+import org.stagemonitor.configuration.ConfigurationRegistry
+
+import scala.concurrent.duration._
+import scala.concurrent.{Await, ExecutionContext, ExecutionContextExecutor, Future}
+
+class FutureInstrumentation2Spec extends FunSuite {
+
+  private var reporter: MockReporter = _
+  private var tracer: ElasticApmTracer = _
+  private var coreConfiguration: CoreConfiguration = _
+
+  override def beforeEach(context: BeforeEach): Unit = {
+    reporter = new MockReporter
+    val config: ConfigurationRegistry = SpyConfiguration.createSpyConfig
+    coreConfiguration = config.getConfig(classOf[CoreConfiguration])
+    tracer = new ElasticApmTracerBuilder().configurationRegistry(config).reporter(reporter).build
+    ElasticApmAgent.initInstrumentation(tracer, ByteBuddyAgent.install)
+    tracer.start()
+  }
+
+  override def afterEach(context: AfterEach): Unit = ElasticApmAgent.reset()
+
+  test("Scala Future should not propagate the tracing-context to unrelated threads") {
+    implicit val executionContext: ExecutionContextExecutor =
+      ExecutionContext.fromExecutor(Executors.newFixedThreadPool(10))
+
+    def startFuture(num: Int): Future[(Transaction, Int)] = {
+      Future {
+        println(s"thread=${Thread.currentThread().getId}, trace=${tracer.currentTransaction()} before num=$num")
+        val transaction = tracer.startRootTransaction(getClass.getClassLoader).withName("Transaction" + num).activate()
+        println(s"thread=${Thread.currentThread().getId}, trace=${tracer.currentTransaction()} start transaction num=$num")
+        Thread.sleep(10)
+        (transaction, num)
+      }
+    }
+
+    val futures = (1 to 10).map(x =>
+      startFuture(x)
+        .map { case (transaction: Transaction, num: Int) =>
+          Thread.sleep(10)
+          println(s"thread=${Thread.currentThread().getId}, trace=${tracer.currentTransaction()} map1 $num")
+          val x = transaction == tracer.currentTransaction()
+          assertEquals(transaction, tracer.currentTransaction())
+          (transaction, x)
+        })
+
+    val future = Future.sequence(futures)
+
+    val result = Await.result(future, 10.seconds).toList
+    assertEquals(result.forall(x => x._2), true)
+    //    result.foreach(x => x._1.deactivate().end())
+    result.foreach(x => x._1.end())
+  }
+
+}


### PR DESCRIPTION
## What does this PR do?
I wanted to give the [scala futures implementation](https://github.com/elastic/apm-agent-java/pull/1048) a spin but, hit a snag when using it with multiple threads.
It seems like the transaction is not activated/deactivated at the right time in some cases.
The existing test cases only use a single transaction so it wouldn't catch it.


Sometimes it fails because current tracer != the tracer passed as parameter. 
Also sometimes `num` is different some the transaction name.
Example output:
`thread=35, trace='Transaction7' 00-852e1e7ca03813413465fc7c21b4ab5e-42a231f21779d2aa-01 (4cd1e659) start transaction num=20`
`num` should be the same as the number in the transaction name. It looks like the transaction from one future is still active when starting a different unrelated future.

The test sometimes passes. The Thread.sleep is not necessary for it to fail but makes it happen more often.

Not intended to be merged as-is, just to show the issue.




## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
    - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
