### PR TITLE
Validate that tests don't leaks tracers, scopes and pooled objects

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -205,7 +205,7 @@ public class ElasticApmAgent {
         if (!tracer.getConfig(CoreConfiguration.class).isEnabled()) {
             return;
         }
-        GlobalTracer.set(tracer);
+        GlobalTracer.init(tracer);
         for (ElasticApmInstrumentation apmInstrumentation : instrumentations) {
             pluginClassLoaderByAdviceClass.put(
                 apmInstrumentation.getAdviceClass().getName(),
@@ -520,6 +520,8 @@ public class ElasticApmAgent {
         if (instrumentation == null) {
             return;
         }
+        GlobalTracer.get().stop();
+        GlobalTracer.setNoop();
         Exception exception = null;
         if (resettableClassFileTransformer != null) {
             try {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Destination.java
@@ -143,7 +143,7 @@ public class Destination implements Recyclable {
     @Override
     public void resetState() {
         address.setLength(0);
-        port = -1;
+        port = 0;
         service.resetState();
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
@@ -42,7 +42,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.JsonSchema;
 import com.networknt.schema.JsonSchemaFactory;
 import com.networknt.schema.ValidationMessage;
-import org.awaitility.core.ConditionFactory;
 import org.awaitility.core.ThrowingRunnable;
 
 import java.io.IOException;
@@ -56,10 +55,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -197,8 +196,7 @@ public class MockReporter implements Reporter {
     }
 
     public Transaction getFirstTransaction(long timeoutMs) {
-        awaitTimeout(timeoutMs)
-            .untilAsserted(() -> assertThat(getTransactions()).isNotEmpty());
+        awaitUntilAsserted(timeoutMs, () -> assertThat(getTransactions()).isNotEmpty());
         return getFirstTransaction();
     }
 
@@ -209,24 +207,11 @@ public class MockReporter implements Reporter {
     }
 
     public void assertNoTransaction(long timeoutMs) {
-        awaitTimeout(timeoutMs)
-            .untilAsserted(this::assertNoTransaction);
-    }
-
-    public void awaitUntilAsserted(long timeoutMs, ThrowingRunnable assertion){
-        awaitTimeout(timeoutMs)
-            .untilAsserted(assertion);
-    }
-
-    private static ConditionFactory awaitTimeout(long timeoutMs) {
-        return await()
-            .pollInterval(1, TimeUnit.MILLISECONDS)
-            .timeout(timeoutMs, TimeUnit.MILLISECONDS);
+        awaitUntilAsserted(timeoutMs, this::assertNoTransaction);
     }
 
     public Span getFirstSpan(long timeoutMs) {
-        awaitTimeout(timeoutMs)
-            .untilAsserted(() -> assertThat(getSpans()).isNotEmpty());
+        awaitUntilAsserted(timeoutMs, () -> assertThat(getSpans()).isNotEmpty());
         return getFirstSpan();
     }
 
@@ -237,15 +222,13 @@ public class MockReporter implements Reporter {
     }
 
     public void assertNoSpan(long timeoutMs) {
-        awaitTimeout(timeoutMs)
-            .untilAsserted(() -> assertThat(getSpans()).isEmpty());
+        awaitUntilAsserted(timeoutMs, () -> assertThat(getSpans()).isEmpty());
 
         assertNoSpan();
     }
 
     public void awaitTransactionCount(int count) {
-        awaitTimeout(1000)
-            .untilAsserted(() -> assertThat(getNumReportedTransactions()).isEqualTo(count));
+        awaitUntilAsserted(() -> assertThat(getNumReportedTransactions()).isEqualTo(count));
     }
 
     public void awaitTransactionReported() {
@@ -254,8 +237,7 @@ public class MockReporter implements Reporter {
     }
 
     public void awaitSpanCount(int count) {
-        awaitTimeout(1000)
-            .untilAsserted(() -> assertThat(getNumReportedSpans()).isEqualTo(count));
+        awaitUntilAsserted(() -> assertThat(getNumReportedSpans()).isEqualTo(count));
     }
 
     public void awaitSpanReported() {
@@ -349,6 +331,11 @@ public class MockReporter implements Reporter {
     }
 
     public synchronized void reset() {
+        assertRecycledAfterDecrementingReferences();
+        resetWithoutRecycling();
+    }
+
+    public synchronized void resetWithoutRecycling() {
         transactions.clear();
         spans.clear();
         errors.clear();
@@ -383,32 +370,61 @@ public class MockReporter implements Reporter {
         transactionsToFlush.forEach(Transaction::decrementReferences);
         spansToFlush.forEach(Span::decrementReferences);
 
-        // transactions might be active after they have already been reported
-        // after a short amount of time, all transactions and spans should have been recycled
-        await()
-            .timeout(1, TimeUnit.SECONDS)
-            .untilAsserted(() -> transactions.forEach(t -> {
-                assertThat(hasEmptyTraceContext(t))
-                    .describedAs("should have empty trace context : %s", t)
-                    .isTrue();
-                assertThat(t.isReferenced())
-                    .describedAs("should not have any reference left, but has %d : %s", t.getReferenceCount(), t)
-                    .isFalse();
-            }));
-        await()
-            .timeout(1, TimeUnit.SECONDS)
-            .untilAsserted(() -> spans.forEach(s -> {
+        awaitUntilAsserted(() -> {
+            spans.forEach(s -> {
                 assertThat(hasEmptyTraceContext(s))
                     .describedAs("should have empty trace context : %s", s)
                     .isTrue();
                 assertThat(s.isReferenced())
                     .describedAs("should not have any reference left, but has %d : %s", s.getReferenceCount(), s)
                     .isFalse();
-            }));
+            });
+            transactions.forEach(t -> {
+                assertThat(hasEmptyTraceContext(t))
+                    .describedAs("should have empty trace context : %s", t)
+                    .isTrue();
+                assertThat(t.isReferenced())
+                    .describedAs("should not have any reference left, but has %d : %s", t.getReferenceCount(), t)
+                    .isFalse();
+            });
+        });
 
         // errors are recycled directly because they have no reference counter
         errors.forEach(ErrorCapture::recycle);
     }
+
+    /**
+     * Uses a timeout of 1s
+     *
+     * @see #awaitUntilAsserted(long, ThrowingRunnable)
+     */
+    public void awaitUntilAsserted(ThrowingRunnable runnable) {
+        awaitUntilAsserted(1000, runnable);
+    }
+
+    /**
+     * This is deliberately not using {@link org.awaitility.Awaitility} as it uses an {@link java.util.concurrent.Executor} for polling.
+     * This is an issue when testing instrumentations that instrument {@link java.util.concurrent.Executor}.
+     *
+     * @param timeoutMs the timeout of the condition
+     * @param runnable  a runnable that trows an exception if the condition is not met
+     */
+    public void awaitUntilAsserted(long timeoutMs, ThrowingRunnable runnable) {
+        Throwable thrown = null;
+        for (int i = 0; i < timeoutMs; i += 5) {
+            try {
+                runnable.run();
+                thrown = null;
+            } catch (Throwable e) {
+                thrown = e;
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(5));
+            }
+        }
+        if (thrown != null) {
+            throw new RuntimeException(String.format("Condition not fulfilled within %d ms", timeoutMs), thrown);
+        }
+    }
+
 
     private static boolean hasEmptyTraceContext(AbstractSpan<?> item) {
         return item.getTraceContext().getId().isEmpty();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
@@ -231,18 +231,8 @@ public class MockReporter implements Reporter {
         awaitUntilAsserted(() -> assertThat(getNumReportedTransactions()).isEqualTo(count));
     }
 
-    public void awaitTransactionReported() {
-        awaitTimeout(1000)
-            .untilAsserted(() -> assertThat(getNumReportedTransactions()).isGreaterThan(0));
-    }
-
     public void awaitSpanCount(int count) {
         awaitUntilAsserted(() -> assertThat(getNumReportedSpans()).isEqualTo(count));
-    }
-
-    public void awaitSpanReported() {
-        awaitTimeout(1000)
-            .untilAsserted(() -> assertThat(getNumReportedSpans()).isGreaterThan(0));
     }
 
     @Override
@@ -372,20 +362,20 @@ public class MockReporter implements Reporter {
 
         awaitUntilAsserted(() -> {
             spans.forEach(s -> {
-                assertThat(hasEmptyTraceContext(s))
-                    .describedAs("should have empty trace context : %s", s)
-                    .isTrue();
                 assertThat(s.isReferenced())
                     .describedAs("should not have any reference left, but has %d : %s", s.getReferenceCount(), s)
                     .isFalse();
+                assertThat(hasEmptyTraceContext(s))
+                    .describedAs("should have empty trace context : %s", s)
+                    .isTrue();
             });
             transactions.forEach(t -> {
-                assertThat(hasEmptyTraceContext(t))
-                    .describedAs("should have empty trace context : %s", t)
-                    .isTrue();
                 assertThat(t.isReferenced())
                     .describedAs("should not have any reference left, but has %d : %s", t.getReferenceCount(), t)
                     .isFalse();
+                assertThat(hasEmptyTraceContext(t))
+                    .describedAs("should have empty trace context : %s", t)
+                    .isTrue();
             });
         });
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
@@ -24,14 +24,10 @@
  */
 package co.elastic.apm.agent;
 
-import co.elastic.apm.agent.bci.ElasticApmAgent;
 import co.elastic.apm.agent.configuration.SpyConfiguration;
 import co.elastic.apm.agent.context.ClosableLifecycleListenerAdapter;
-import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
-import co.elastic.apm.agent.impl.GlobalTracer;
-import co.elastic.apm.agent.impl.Tracer;
-import co.elastic.apm.agent.impl.TracerInternalApiUtils;
+import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
 import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
 import co.elastic.apm.agent.report.Reporter;
 import org.stagemonitor.configuration.ConfigurationRegistry;
@@ -89,56 +85,33 @@ public class MockTracer {
     }
 
     /**
-     * If an instrumentation has already been initialized by some other test, returns the static
-     * {@link GlobalTracer#getTracerImpl()}.
-     * Otherwise, Creates a real tracer with a {@link MockReporter} and a mock configuration which returns default
+     * Creates a real tracer with a {@link MockReporter} and a mock configuration which returns default
      * values that can be customized by mocking the configuration.
      */
-    public static synchronized MockInstrumentationSetup getOrCreateInstrumentationTracer() {
+    public static synchronized MockInstrumentationSetup createMockInstrumentationSetup() {
+        // use an object pool that does bookkeeping to allow for extra usage checks
+        TestObjectPoolFactory objectPoolFactory = new TestObjectPoolFactory();
 
-        ElasticApmTracer tracer = GlobalTracer.getTracerImpl();
-        if (tracer == null || tracer.getState() == Tracer.TracerState.STOPPED ||
-            !(tracer.getReporter() instanceof MockReporter) || !(tracer.getObjectPoolFactory() instanceof TestObjectPoolFactory)) {
+        MockReporter reporter = new MockReporter();
 
-            // use an object pool that does bookkeeping to allow for extra usage checks
-            TestObjectPoolFactory objectPoolFactory = new TestObjectPoolFactory();
-
-            MockReporter reporter = new MockReporter();
-
-            tracer = new ElasticApmTracerBuilder()
-                .configurationRegistry(SpyConfiguration.createSpyConfig())
-                .reporter(reporter)
-                // use testing bookkeeper implementation here so we will check that no forgotten recyclable object
-                // is left behind
-                .withObjectPoolFactory(objectPoolFactory)
-                .withLifecycleListener(ClosableLifecycleListenerAdapter.of(() -> {
-                    reporter.assertRecycledAfterDecrementingReferences();
-                    // checking proper object pool usage using tracer lifecycle events
-                    objectPoolFactory.checkAllPooledObjectsHaveBeenRecycled();
-                }))
-                .buildAndStart();
-        } else {
-            ElasticApmAgent.reset();
-            if (!tracer.isRunning()) {
-                TracerInternalApiUtils.resumeTracer(tracer);
-            }
-            ((MockReporter) tracer.getReporter()).reset();
-            SpyConfiguration.reset(tracer.getConfigurationRegistry());
-        }
+        ElasticApmTracer tracer = new ElasticApmTracerBuilder()
+            .configurationRegistry(SpyConfiguration.createSpyConfig())
+            .reporter(reporter)
+            // use testing bookkeeper implementation here so we will check that no forgotten recyclable object
+            // is left behind
+            .withObjectPoolFactory(objectPoolFactory)
+            .withLifecycleListener(ClosableLifecycleListenerAdapter.of(() -> {
+                reporter.assertRecycledAfterDecrementingReferences();
+                // checking proper object pool usage using tracer lifecycle events
+                objectPoolFactory.checkAllPooledObjectsHaveBeenRecycled();
+            }))
+            .buildAndStart();
         return new MockInstrumentationSetup(
             tracer,
-            (MockReporter) tracer.getReporter(),
+            reporter,
             tracer.getConfigurationRegistry(),
-            (TestObjectPoolFactory) tracer.getObjectPoolFactory()
+            objectPoolFactory
         );
-    }
-
-    public static synchronized void resetTracer() {
-        ElasticApmTracer tracer = GlobalTracer.getTracerImpl();
-        if (tracer != null) {
-            ElasticApmAgent.reset();
-            tracer.stop();
-        }
     }
 
     /**

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -27,7 +27,6 @@ package co.elastic.apm.agent.bci;
 import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.bci.subpackage.AdviceInSubpackageInstrumentation;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
-import co.elastic.apm.agent.configuration.SpyConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Span;
@@ -90,14 +89,14 @@ class InstrumentationTest {
 
     @BeforeEach
     void setup() {
-        configurationRegistry = SpyConfiguration.createSpyConfig();
+        tracer = MockTracer.createRealTracer();
+        configurationRegistry = tracer.getConfigurationRegistry();
         coreConfig = configurationRegistry.getConfig(CoreConfiguration.class);
-        tracer = MockTracer.create(configurationRegistry);
     }
 
     @AfterEach
     void reset() {
-        MockTracer.resetTracer();
+        ElasticApmAgent.reset();
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/methodmatching/TraceMethodInstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/methodmatching/TraceMethodInstrumentationTest.java
@@ -65,7 +65,7 @@ class TraceMethodInstrumentationTest {
 
     @BeforeEach
     void setUp(TestInfo testInfo) {
-        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.getOrCreateInstrumentationTracer();
+        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup();
         reporter = mockInstrumentationSetup.getReporter();
         objectPoolFactory = mockInstrumentationSetup.getObjectPoolFactory();
         ConfigurationRegistry config = mockInstrumentationSetup.getConfig();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/TestObjectPoolFactory.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/TestObjectPoolFactory.java
@@ -69,6 +69,10 @@ public class TestObjectPoolFactory extends ObjectPoolFactory {
         }
     }
 
+    public void reset() {
+        createdPools.forEach(BookkeeperObjectPool::reset);
+    }
+
     @Override
     public ObjectPool<Transaction> createTransactionPool(int maxCapacity, ElasticApmTracer tracer) {
         transactionPool = (BookkeeperObjectPool<Transaction>) super.createTransactionPool(maxCapacity, tracer);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/impl/BookkeeperObjectPool.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/impl/BookkeeperObjectPool.java
@@ -115,4 +115,9 @@ public class BookkeeperObjectPool<T> implements ObjectPool<T> {
     public int getRequestedObjectCount() {
         return objectCounter.get();
     }
+
+    public void reset() {
+        objectCounter.set(0);
+        toReturn.clear();
+    }
 }

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/state/GlobalThreadLocal.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/state/GlobalThreadLocal.java
@@ -74,6 +74,14 @@ public class GlobalThreadLocal<T> extends DetachedThreadLocal<T> {
         return value;
     }
 
+    public T get(T defaultValue) {
+        T value = get();
+        if (value != null) {
+            return value;
+        }
+        return defaultValue;
+    }
+
     @Override
     @Nullable
     protected T initialValue(Thread thread) {

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/plugin/api/SpanInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/plugin/api/SpanInstrumentationTest.java
@@ -26,18 +26,16 @@ package co.elastic.apm.agent.plugin.api;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
-import co.elastic.apm.agent.impl.transaction.TextHeaderGetter;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.api.ElasticApm;
 import co.elastic.apm.api.Scope;
 import co.elastic.apm.api.Span;
 import co.elastic.apm.api.Transaction;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -49,6 +47,11 @@ class SpanInstrumentationTest extends AbstractInstrumentationTest {
     @BeforeEach
     void setUp() {
         transaction = ElasticApm.startTransaction();
+    }
+
+    @AfterEach
+    void tearDown() {
+        transaction.end();
     }
 
     @Test
@@ -118,7 +121,10 @@ class SpanInstrumentationTest extends AbstractInstrumentationTest {
         assertThat(ElasticApm.currentTransaction().isSampled()).isFalse();
         final Transaction transaction = ElasticApm.startTransaction();
         assertThat(transaction.isSampled()).isTrue();
-        assertThat(transaction.startSpan().isSampled()).isTrue();
+        Span span = transaction.startSpan();
+        assertThat(span.isSampled()).isTrue();
+        span.end();
+        transaction.end();
     }
 
     @Test
@@ -132,6 +138,7 @@ class SpanInstrumentationTest extends AbstractInstrumentationTest {
         Span span = transaction.startSpan();
         assertContainsTracingHeaders(span);
         assertContainsTracingHeaders(transaction);
+        span.end();
     }
 
     private void assertContainsNoTracingHeaders(Span span) {

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationApiTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationApiTest.java
@@ -99,7 +99,6 @@ class AnnotationApiTest extends AbstractInstrumentationTest {
 
     @Test
     void testMissingSubtype() {
-        reporter.reset();
         AnnotationTestClass.transactionForMissingSpanSubtype();
         assertThat(reporter.getSpans()).hasSize(1);
         Span internalSpan = reporter.getFirstSpan();

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/BlockingQueueContextPropagationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/BlockingQueueContextPropagationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,7 +25,6 @@
 package co.elastic.apm.api;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
-import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -77,11 +76,6 @@ public class BlockingQueueContextPropagationTest extends AbstractInstrumentation
     public static void tearDown() {
         blockingQueue.clear();
         executorService.shutdownNow();
-    }
-
-    @After
-    public void after() {
-        reporter.reset();
     }
 
     @Test

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/ElasticApmApiInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/ElasticApmApiInstrumentationTest.java
@@ -41,8 +41,10 @@ class ElasticApmApiInstrumentationTest extends AbstractInstrumentationTest {
 
     @Test
     void testCreateTransaction() {
-        assertThat(ElasticApm.startTransaction()).isNotSameAs(NoopTransaction.INSTANCE);
+        Transaction transaction = ElasticApm.startTransaction();
+        assertThat(transaction).isNotSameAs(NoopTransaction.INSTANCE);
         assertThat(ElasticApm.currentTransaction()).isSameAs(NoopTransaction.INSTANCE);
+        transaction.end();
     }
 
     @Test
@@ -52,14 +54,22 @@ class ElasticApmApiInstrumentationTest extends AbstractInstrumentationTest {
 
     @Test
     void testLegacyTransactionCreateSpan() {
-        assertThat(ElasticApm.startTransaction().createSpan()).isNotSameAs(NoopSpan.INSTANCE);
+        Transaction transaction = ElasticApm.startTransaction();
+        Span span = transaction.createSpan();
+        assertThat(span).isNotSameAs(NoopSpan.INSTANCE);
         assertThat(ElasticApm.currentSpan()).isSameAs(NoopSpan.INSTANCE);
+        span.end();
+        transaction.end();
     }
 
     @Test
     void testStartSpan() {
-        assertThat(ElasticApm.startTransaction().startSpan()).isNotSameAs(NoopSpan.INSTANCE);
+        Transaction transaction = ElasticApm.startTransaction();
+        Span span = transaction.startSpan();
+        assertThat(span).isNotSameAs(NoopSpan.INSTANCE);
         assertThat(ElasticApm.currentSpan()).isSameAs(NoopSpan.INSTANCE);
+        span.end();
+        transaction.end();
     }
 
     @Test
@@ -242,6 +252,7 @@ class ElasticApmApiInstrumentationTest extends AbstractInstrumentationTest {
             assertThat(tracer.currentTransaction().getTraceContext().getParentId().toString()).isEqualTo(rumTransactionId);
             assertThat(transaction.ensureParentId()).isEqualTo(rumTransactionId);
         }
+        transaction.end();
     }
 
     @Test
@@ -252,6 +263,7 @@ class ElasticApmApiInstrumentationTest extends AbstractInstrumentationTest {
         parent.propagateTraceContext(headerMap, TextHeaderMapAccessor.INSTANCE);
         ElasticApm.startTransactionWithRemoteParent(headerMap::get).end();
         assertThat(reporter.getFirstTransaction().isChildOf(parent)).isTrue();
+        parent.end();
     }
 
     @Test
@@ -262,6 +274,7 @@ class ElasticApmApiInstrumentationTest extends AbstractInstrumentationTest {
         parent.propagateTraceContext(headerMap, TextHeaderMapAccessor.INSTANCE);
         ElasticApm.startTransactionWithRemoteParent(headerMap::get, key -> Collections.singletonList(headerMap.get(key))).end();
         assertThat(reporter.getFirstTransaction().isChildOf(parent)).isTrue();
+        parent.end();
     }
 
     @Test
@@ -272,6 +285,7 @@ class ElasticApmApiInstrumentationTest extends AbstractInstrumentationTest {
         parent.propagateTraceContext(headerMap, TextHeaderMapAccessor.INSTANCE);
         ElasticApm.startTransactionWithRemoteParent(null, key -> Collections.singletonList(headerMap.get(key))).end();
         assertThat(reporter.getFirstTransaction().isChildOf(parent)).isTrue();
+        parent.end();
     }
 
     @Test

--- a/apm-agent-plugins/apm-dubbo-plugin/src/test/java/co/elastic/apm/agent/dubbo/api/impl/DubboTestApiImpl.java
+++ b/apm-agent-plugins/apm-dubbo-plugin/src/test/java/co/elastic/apm/agent/dubbo/api/impl/DubboTestApiImpl.java
@@ -26,15 +26,14 @@ package co.elastic.apm.agent.dubbo.api.impl;
 
 import co.elastic.apm.agent.dubbo.api.DubboTestApi;
 import co.elastic.apm.agent.dubbo.api.exception.BizException;
+import co.elastic.apm.agent.impl.GlobalTracer;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.MappingBuilder;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import okhttp3.OkHttpClient;
-import okhttp3.Request;
 import org.apache.dubbo.rpc.AsyncContext;
 import org.apache.dubbo.rpc.RpcContext;
 
-import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -135,21 +134,10 @@ public class DubboTestApiImpl implements DubboTestApi {
         return null;
     }
 
-    private void invokeHttp() {
-        Request request = new Request.Builder()
-            .url("http://localhost:" + server.port() + "/")
-            .build();
-        try {
-            client.newCall(request).execute().body().close();
-        } catch (IOException e) {
-
-        }
-    }
-
     private void doSomething() {
         try {
             Thread.sleep(10);
-            invokeHttp();
+            GlobalTracer.get().getActive().createSpan().withName("doSomething").end();
         } catch (InterruptedException e) {
         }
     }

--- a/apm-agent-plugins/apm-error-logging-plugin/src/test/java/co/elastic/apm/agent/error/logging/AbstractErrorLoggingInstrumentationTest.java
+++ b/apm-agent-plugins/apm-error-logging-plugin/src/test/java/co/elastic/apm/agent/error/logging/AbstractErrorLoggingInstrumentationTest.java
@@ -33,19 +33,17 @@ import static org.junit.Assert.assertEquals;
 
 abstract class AbstractErrorLoggingInstrumentationTest extends AbstractInstrumentationTest {
 
+    private Transaction transaction;
+
     @BeforeEach
     void startTransaction() {
-        reporter.reset();
-        tracer.startRootTransaction(null).activate();
+        transaction = tracer.startRootTransaction(null);
+        transaction.activate();
     }
 
     @AfterEach
     void endTransaction() {
-        Transaction currentTransaction = tracer.currentTransaction();
-        if (currentTransaction != null) {
-            currentTransaction.deactivate().end();
-        }
-        reporter.reset();
+        transaction.deactivate().end();
     }
 
     void verifyThatExceptionCaptured(int errorCount, String exceptionMessage, Class exceptionClass) {

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
@@ -25,10 +25,10 @@
 package co.elastic.apm.agent.es.restclient;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
-import co.elastic.apm.agent.impl.context.Destination;
-import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.context.Db;
+import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.context.Http;
+import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import org.junit.After;
@@ -78,13 +78,9 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
 
     @After
     public void endTransaction() {
-        try {
-            Transaction currentTransaction = tracer.currentTransaction();
-            if (currentTransaction != null) {
-                currentTransaction.deactivate().end();
-            }
-        } finally {
-            reporter.reset();
+        Transaction currentTransaction = tracer.currentTransaction();
+        if (currentTransaction != null) {
+            currentTransaction.deactivate().end();
         }
     }
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
@@ -75,19 +75,8 @@ public abstract class AbstractGrpcClientInstrumentationTest extends AbstractInst
                 .end();
         }
 
-        try {
-            // make sure we do not leave anything behind
-            reporter.assertRecycledAfterDecrementingReferences();
-
-            // use a try/finally block here to make sure that if the assertion above fails
-            // we do not have a side effect on other tests execution by leaving app running.
-        } finally {
-            reporter.reset();
-            app.stop();
-        }
-
+        app.stop();
     }
-
 
     @Test
     public void simpleCall() {

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcContextHeadersTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcContextHeadersTest.java
@@ -54,13 +54,7 @@ public abstract class AbstractGrpcContextHeadersTest extends AbstractInstrumenta
 
     @AfterEach
     void afterEach() throws Exception {
-        // make sure we do not leave anything behind
-        try {
-            reporter.assertRecycledAfterDecrementingReferences();
-            reporter.reset();
-        } finally {
-            app.stop();
-        }
+        app.stop();
     }
 
     @Test

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcServerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcServerInstrumentationTest.java
@@ -52,16 +52,7 @@ public abstract class AbstractGrpcServerInstrumentationTest extends AbstractInst
 
     @AfterEach
     void afterEach() throws Exception {
-        try {
-            // make sure we do not leave anything behind
-            reporter.assertRecycledAfterDecrementingReferences();
-
-            // use a try/finally block here to make sure that if the assertion above fails
-            // we do not have a side effect on other tests execution by leaving app running.
-        } finally {
-            app.stop();
-            reporter.reset();
-        }
+        app.stop();
     }
 
     @Test

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/http/client/HttpClientHelperTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/http/client/HttpClientHelperTest.java
@@ -51,7 +51,6 @@ class HttpClientHelperTest extends AbstractInstrumentationTest {
     @AfterEach
     void afterTest() {
         tracer.currentTransaction().deactivate().end();
-        reporter.reset();
     }
 
     @Test

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -73,7 +73,7 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         wireMockRule.stubFor(get(urlEqualTo("/circular-redirect"))
             .willReturn(seeOther("/circular-redirect")));
         final Transaction transaction = tracer.startRootTransaction(getClass().getClassLoader());
-        transaction.withType("request").activate();
+        transaction.withName("parent of http span").withType("request").activate();
     }
 
     @After

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
@@ -74,6 +74,7 @@ public abstract class ExecutorInstrumentation extends TracerAwareInstrumentation
         excludedClasses.add("org.apache.tomcat.util.threads.ThreadPoolExecutor");
     }
 
+
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
         return nameContains("Execut")

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/JavaConcurrent.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/JavaConcurrent.java
@@ -167,9 +167,11 @@ public class JavaConcurrent {
         } else {
             wrapped = null;
         }
+        Boolean context = needsContext.get();
         for (Callable<T> callable : callables) {
+            // restore previous state as withContext always sets to false
+            needsContext.set(context);
             final Callable<T> potentiallyWrappedCallable = withContext(callable, tracer);
-            needsContext.set(Boolean.TRUE);
             if (wrapped != null) {
                 wrapped.add(potentiallyWrappedCallable);
             }

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/AsyncTraceMethodInstrumentationTest.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/AsyncTraceMethodInstrumentationTest.java
@@ -55,7 +55,7 @@ class AsyncTraceMethodInstrumentationTest {
 
     @BeforeEach
     void setUp(TestInfo testInfo) {
-        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.getOrCreateInstrumentationTracer();
+        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup();
         reporter = mockInstrumentationSetup.getReporter();
         ConfigurationRegistry config = mockInstrumentationSetup.getConfig();
         coreConfiguration = config.getConfig(CoreConfiguration.class);

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ScopeManagementTest.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ScopeManagementTest.java
@@ -51,8 +51,8 @@ class ScopeManagementTest extends AbstractInstrumentationTest {
         runTestWithAssertionsDisabled(() -> {
             final Transaction transaction = tracer.startRootTransaction(null).activate();
             final Span span = transaction.createSpan().activate();
-            transaction.deactivate();
-            span.deactivate();
+            transaction.deactivate().end();
+            span.deactivate().end();
 
             assertThat(tracer.getActive()).isNull();
         });
@@ -63,7 +63,8 @@ class ScopeManagementTest extends AbstractInstrumentationTest {
         runTestWithAssertionsDisabled(() -> {
             tracer.startRootTransaction(null)
                 .activate().activate()
-                .deactivate().deactivate();
+                .deactivate().deactivate()
+                .end();
 
             assertThat(tracer.getActive()).isNull();
         });
@@ -71,12 +72,13 @@ class ScopeManagementTest extends AbstractInstrumentationTest {
 
     @Test
     void testRedundantActivation() {
+        disableRecyclingValidation();
         runTestWithAssertionsDisabled(() -> {
             final Transaction transaction = tracer.startRootTransaction(null).activate();
-            transaction.createSpan().activate();
+            transaction.createSpan().activate().end();
             transaction.deactivate();
             assertThat(tracer.getActive()).isEqualTo(transaction);
-            transaction.deactivate();
+            transaction.deactivate().end();
             assertThat(tracer.getActive()).isNull();
         });
     }
@@ -91,7 +93,7 @@ class ScopeManagementTest extends AbstractInstrumentationTest {
             } catch (Exception e) {
                 e.printStackTrace();
             }
-            transaction.deactivate();
+            transaction.deactivate().end();
 
             assertThat(tracer.getActive()).isNull();
         });
@@ -104,7 +106,7 @@ class ScopeManagementTest extends AbstractInstrumentationTest {
             assertThat(tracer.getActive()).isSameAs(transaction);
             assertThat(tracer.currentTransaction()).isSameAs(transaction);
         }).get();
-        transaction.deactivate();
+        transaction.deactivate().end();
 
         assertThat(tracer.getActive()).isNull();
     }
@@ -117,7 +119,7 @@ class ScopeManagementTest extends AbstractInstrumentationTest {
             return tracer.currentTransaction();
         });
         assertThat(transactionFuture.get()).isSameAs(transaction);
-        transaction.deactivate();
+        transaction.deactivate().end();
 
         assertThat(tracer.getActive()).isNull();
     }
@@ -130,7 +132,7 @@ class ScopeManagementTest extends AbstractInstrumentationTest {
             assertThat(tracer.getActive()).isSameAs(transaction);
         };
         Executors.newSingleThreadExecutor().submit(runnable).get();
-        transaction.deactivate();
+        transaction.deactivate().end();
 
         assertThat(tracer.getActive()).isNull();
     }
@@ -142,7 +144,7 @@ class ScopeManagementTest extends AbstractInstrumentationTest {
             assertThat(tracer.currentTransaction()).isSameAs(transaction);
             return tracer.currentTransaction();
         }).get()).isSameAs(transaction);
-        transaction.deactivate();
+        transaction.deactivate().end();
 
         assertThat(tracer.getActive()).isNull();
     }

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/JmsInstrumentationIT.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/JmsInstrumentationIT.java
@@ -118,7 +118,6 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
     public void startTransaction() throws Exception {
         receiveNoWaitFlow.set(false);
         expectNoTraces.set(false);
-        reporter.reset();
         startAndActivateTransaction(null);
         brokerFacade.beforeTest();
         noopQ = brokerFacade.createQueue("NOOP");
@@ -147,7 +146,6 @@ public class JmsInstrumentationIT extends AbstractInstrumentationTest {
             currentTransaction.deactivate().end();
         }
         brokerFacade.afterTest();
-        reporter.reset();
     }
 
     @Test

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/spring/SpringJmsTest.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/spring/SpringJmsTest.java
@@ -75,7 +75,6 @@ public class SpringJmsTest extends AbstractInstrumentationTest {
 
     @Test
     public void testSendListenSpringQueue() throws JMSException, InterruptedException {
-        reporter.reset();
         try (Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
 
             Transaction transaction = tracer.startRootTransaction(null).activate();

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyClientIT.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyClientIT.java
@@ -136,7 +136,6 @@ public class KafkaLegacyClientIT extends AbstractInstrumentationTest {
 
     @Before
     public void startTransaction() {
-        reporter.reset();
         Transaction transaction = tracer.startRootTransaction(null).activate();
         transaction.withName("Kafka-Test Transaction");
         transaction.withType("request");

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaIT.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaIT.java
@@ -144,7 +144,6 @@ public class KafkaIT extends AbstractInstrumentationTest {
 
     @Before
     public void startTransaction() {
-        reporter.reset();
         startAndActivateTransaction(null);
         testScenario = TestScenario.NORMAL;
     }

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyBrokerIT.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyBrokerIT.java
@@ -140,7 +140,6 @@ public class KafkaLegacyBrokerIT extends AbstractInstrumentationTest {
 
     @Before
     public void startTransaction() {
-        reporter.reset();
         Transaction transaction = tracer.startRootTransaction(null).activate();
         transaction.withName("Kafka-Test Transaction");
         transaction.withType("request");

--- a/apm-agent-plugins/apm-log-correlation-plugin/src/test/java/co/elastic/apm/agent/mdc/MdcActivationListenerTest.java
+++ b/apm-agent-plugins/apm-log-correlation-plugin/src/test/java/co/elastic/apm/agent/mdc/MdcActivationListenerTest.java
@@ -85,8 +85,10 @@ class MdcActivationListenerTest extends AbstractInstrumentationTest {
                 try (Scope grandchildScope = grandchild.activateInScope()) {
                     assertMdcIsSet(grandchild);
                 }
+                grandchild.end();
                 assertMdcIsSet(child);
             }
+            child.end();
             assertMdcIsSet(transaction);
         }
         assertMdcIsEmpty();
@@ -114,6 +116,7 @@ class MdcActivationListenerTest extends AbstractInstrumentationTest {
             try (Scope childScope = child.activateInScope()) {
                 assertMdcIsSet(transaction);
             }
+            child.end();
             assertMdcIsSet(transaction);
         }
         assertMdcIsEmpty();
@@ -248,6 +251,7 @@ class MdcActivationListenerTest extends AbstractInstrumentationTest {
                 }).get();
                 assertMdcIsSet(child);
             }
+            child.end();
             assertMdcIsSet(transaction);
         }
         assertMdcIsEmpty();

--- a/apm-agent-plugins/apm-mongoclient-plugin/src/test/java/co/elastic/apm/agent/mongoclient/AbstractMongoClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-mongoclient-plugin/src/test/java/co/elastic/apm/agent/mongoclient/AbstractMongoClientInstrumentationTest.java
@@ -71,17 +71,13 @@ public abstract class AbstractMongoClientInstrumentationTest extends AbstractIns
 
     @After
     public void endTransaction() throws Exception {
-        try {
-            reporter.reset();
-            dropCollection();
-            assertThat(reporter.getSpans()).hasSize(1);
-            assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("testdb.testcollection.drop");
-            Transaction currentTransaction = tracer.currentTransaction();
-            if (currentTransaction != null) {
-                currentTransaction.deactivate().end();
-            }
-        } finally {
-            reporter.reset();
+        reporter.reset();
+        dropCollection();
+        assertThat(reporter.getSpans()).hasSize(1);
+        assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("testdb.testcollection.drop");
+        Transaction currentTransaction = tracer.currentTransaction();
+        if (currentTransaction != null) {
+            currentTransaction.deactivate().end();
         }
     }
 

--- a/apm-agent-plugins/apm-process-plugin/src/test/java/co/elastic/apm/agent/process/ProcessHelperTest.java
+++ b/apm-agent-plugins/apm-process-plugin/src/test/java/co/elastic/apm/agent/process/ProcessHelperTest.java
@@ -97,6 +97,7 @@ class ProcessHelperTest extends AbstractInstrumentationTest {
         assertThat(storageMap.get(process))
             .describedAs("initial span should not be overwritten")
             .isSameAs(span);
+        helper.doEndProcess(process, true);
     }
 
     @Test

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-2-tests/src/test/java/co/elastic/apm/agent/redis/jedis/Jedis2InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-2-tests/src/test/java/co/elastic/apm/agent/redis/jedis/Jedis2InstrumentationTest.java
@@ -24,7 +24,6 @@
  */
 package co.elastic.apm.agent.redis.jedis;
 
-import co.elastic.apm.agent.impl.Scope;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -55,20 +54,16 @@ class Jedis2InstrumentationTest extends Jedis1InstrumentationTest {
 
     @Test
     void testShardedJedis() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            shardedJedis.set("foo", "bar");
-            assertThat(shardedJedis.get("foo".getBytes())).isEqualTo("bar".getBytes());
-        }
+        shardedJedis.set("foo", "bar");
+        assertThat(shardedJedis.get("foo".getBytes())).isEqualTo("bar".getBytes());
 
         assertTransactionWithRedisSpans("SET", "GET");
     }
 
     @Test
     void testBinaryJedis() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            binaryJedis.set("foo".getBytes(), "bar".getBytes());
-            assertThat(binaryJedis.get("foo".getBytes())).isEqualTo("bar".getBytes());
-        }
+        binaryJedis.set("foo".getBytes(), "bar".getBytes());
+        assertThat(binaryJedis.get("foo".getBytes())).isEqualTo("bar".getBytes());
 
         assertTransactionWithRedisSpans("SET", "GET");
     }

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/test/java/co/elastic/apm/agent/redis/jedis/Jedis1InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/test/java/co/elastic/apm/agent/redis/jedis/Jedis1InstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,6 @@
  */
 package co.elastic.apm.agent.redis.jedis;
 
-import co.elastic.apm.agent.impl.Scope;
 import co.elastic.apm.agent.redis.AbstractRedisInstrumentationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -56,10 +55,8 @@ class Jedis1InstrumentationTest extends AbstractRedisInstrumentationTest {
 
     @Test
     void testJedis() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            jedis.set("foo", "bar");
-            assertThat(jedis.get("foo".getBytes())).isEqualTo("bar".getBytes());
-        }
+        jedis.set("foo", "bar");
+        assertThat(jedis.get("foo".getBytes())).isEqualTo("bar".getBytes());
 
         assertTransactionWithRedisSpans("SET", "GET");
     }

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-3-tests/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce3InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-3-tests/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce3InstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,6 @@
  */
 package co.elastic.apm.agent.redis.lettuce;
 
-import co.elastic.apm.agent.impl.Scope;
 import co.elastic.apm.agent.redis.AbstractRedisInstrumentationTest;
 import com.lambdaworks.redis.RedisClient;
 import com.lambdaworks.redis.RedisConnection;
@@ -50,10 +49,8 @@ public class Lettuce3InstrumentationTest extends AbstractRedisInstrumentationTes
 
     @Test
     public void testSyncLettuce() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            connection.set("foo", "bar");
-            assertThat(connection.get("foo")).isEqualTo("bar");
-        }
+        connection.set("foo", "bar");
+        assertThat(connection.get("foo")).isEqualTo("bar");
         assertTransactionWithRedisSpans("SET", "GET");
     }
 

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce4InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce4InstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,12 +24,10 @@
  */
 package co.elastic.apm.agent.redis.lettuce;
 
-import co.elastic.apm.agent.impl.Scope;
 import co.elastic.apm.agent.redis.AbstractRedisInstrumentationTest;
 import com.lambdaworks.redis.RedisClient;
 import com.lambdaworks.redis.api.StatefulRedisConnection;
 import com.lambdaworks.redis.api.async.RedisAsyncCommands;
-import com.lambdaworks.redis.api.rx.RedisReactiveCommands;
 import com.lambdaworks.redis.api.sync.RedisCommands;
 import org.junit.After;
 import org.junit.Before;
@@ -52,29 +50,24 @@ public class Lettuce4InstrumentationTest extends AbstractRedisInstrumentationTes
     @Test
     public void testClusterCommand() {
         RedisCommands<String, String> sync = connection.sync();
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            sync.set("foo", "bar");
-            assertThat(sync.get("foo")).isEqualTo("bar");
-        }
+        sync.set("foo", "bar");
+        assertThat(sync.get("foo")).isEqualTo("bar");
         assertTransactionWithRedisSpans("SET", "GET");
     }
+
     @Test
     public void testSyncLettuce() {
         RedisCommands<String, String> sync = connection.sync();
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            sync.set("foo", "bar");
-            assertThat(sync.get("foo")).isEqualTo("bar");
-        }
+        sync.set("foo", "bar");
+        assertThat(sync.get("foo")).isEqualTo("bar");
         assertTransactionWithRedisSpans("SET", "GET");
     }
 
     @Test
     public void testAsyncLettuce() throws Exception {
         RedisAsyncCommands<String, String> async = connection.async();
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            async.set("foo", "bar").get();
-            assertThat(async.get("foo").get()).isEqualTo("bar");
-        }
+        async.set("foo", "bar").get();
+        assertThat(async.get("foo").get()).isEqualTo("bar");
         assertTransactionWithRedisSpans("SET", "GET");
     }
 

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce5InstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/redis/lettuce/Lettuce5InstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,6 @@
  */
 package co.elastic.apm.agent.redis.lettuce;
 
-import co.elastic.apm.agent.impl.Scope;
 import co.elastic.apm.agent.redis.AbstractRedisInstrumentationTest;
 import io.lettuce.core.LettuceFutures;
 import io.lettuce.core.RedisClient;
@@ -57,52 +56,43 @@ public class Lettuce5InstrumentationTest extends AbstractRedisInstrumentationTes
     @Test
     public void testClusterCommand() {
         RedisCommands<String, String> sync = connection.sync();
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            sync.set("foo", "bar");
-            assertThat(sync.get("foo")).isEqualTo("bar");
-        }
+        sync.set("foo", "bar");
+        assertThat(sync.get("foo")).isEqualTo("bar");
         assertTransactionWithRedisSpans("SET", "GET");
     }
+
     @Test
     public void testSyncLettuce() {
         RedisCommands<String, String> sync = connection.sync();
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            sync.set("foo", "bar");
-            assertThat(sync.get("foo")).isEqualTo("bar");
-        }
+        sync.set("foo", "bar");
+        assertThat(sync.get("foo")).isEqualTo("bar");
         assertTransactionWithRedisSpans("SET", "GET");
     }
 
     @Test
     public void testAsyncLettuce() throws Exception {
         RedisAsyncCommands<String, String> async = connection.async();
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            async.set("foo", "bar").get();
-            assertThat(async.get("foo").get()).isEqualTo("bar");
-        }
+        async.set("foo", "bar").get();
+        assertThat(async.get("foo").get()).isEqualTo("bar");
         assertTransactionWithRedisSpans("SET", "GET");
     }
 
     @Test
     public void testBatchedLettuce() throws Exception {
         RedisAsyncCommands<String, String> async = connection.async();
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            async.set("foo", "bar").get();
-            async.setAutoFlushCommands(false);
-            List<RedisFuture<String>> futures = List.of(async.get("foo"), async.get("foo"));
-            async.flushCommands();
-            LettuceFutures.awaitAll(Duration.ofSeconds(5), futures.toArray(new RedisFuture[0]));
-        }
+        async.set("foo", "bar").get();
+        async.setAutoFlushCommands(false);
+        List<RedisFuture<String>> futures = List.of(async.get("foo"), async.get("foo"));
+        async.flushCommands();
+        LettuceFutures.awaitAll(Duration.ofSeconds(5), futures.toArray(new RedisFuture[0]));
         assertTransactionWithRedisSpans("SET", "GET", "GET");
     }
 
     @Test
     public void testReactiveLettuce() {
         RedisReactiveCommands<String, String> async = connection.reactive();
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            async.set("foo", "bar").block();
-            assertThat(async.get("foo").block()).isEqualTo("bar");
-        }
+        async.set("foo", "bar").block();
+        assertThat(async.get("foo").block()).isEqualTo("bar");
         assertTransactionWithRedisSpans("SET", "GET");
     }
 

--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
@@ -71,11 +71,13 @@ public abstract class AbstractRedisInstrumentationTest extends AbstractInstrumen
             .port(redisPort)
             .build();
         server.start();
+        tracer.startRootTransaction(null).activate();
     }
 
     @After
     @AfterEach
     public final void stopRedis() {
+        tracer.currentTransaction().deactivate().end();
         server.stop();
     }
 

--- a/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/src/test/java/co/elastic/apm/agent/redis/redisson/RedissonInstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/src/test/java/co/elastic/apm/agent/redis/redisson/RedissonInstrumentationTest.java
@@ -24,21 +24,20 @@
  */
 package co.elastic.apm.agent.redis.redisson;
 
-import co.elastic.apm.agent.impl.Scope;
 import co.elastic.apm.agent.redis.AbstractRedisInstrumentationTest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.redisson.Redisson;
+import org.redisson.api.RAtomicLong;
 import org.redisson.api.RBatch;
 import org.redisson.api.RBucket;
 import org.redisson.api.RList;
-import org.redisson.api.RedissonClient;
-import org.redisson.api.RMap;
-import org.redisson.api.RSet;
-import org.redisson.api.RScoredSortedSet;
-import org.redisson.api.RAtomicLong;
 import org.redisson.api.RLock;
+import org.redisson.api.RMap;
+import org.redisson.api.RScoredSortedSet;
+import org.redisson.api.RSet;
+import org.redisson.api.RedissonClient;
 import org.redisson.config.Config;
 
 import java.util.HashMap;
@@ -68,93 +67,78 @@ class RedissonInstrumentationTest extends AbstractRedisInstrumentationTest {
 
     @Test
     void testString() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            RBucket<String> keyObject = redisson.getBucket("foo");
-            keyObject.set("bar");
+        RBucket<String> keyObject = redisson.getBucket("foo");
+        keyObject.set("bar");
 
-            assertThat(keyObject.get()).isEqualTo("bar");
-        }
-
+        assertThat(keyObject.get()).isEqualTo("bar");
         assertTransactionWithRedisSpans("SET", "GET");
     }
 
     @Test
     void testBatch() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            RBatch batch = redisson.createBatch();
-            batch.getBucket("batch1").setAsync("v1");
-            batch.getBucket("batch2").setAsync("v2");
-            batch.execute();
+        RBatch batch = redisson.createBatch();
+        batch.getBucket("batch1").setAsync("v1");
+        batch.getBucket("batch2").setAsync("v2");
+        batch.execute();
 
-            assertThat(redisson.getBucket("batch1").get()).isEqualTo("v1");
-            assertThat(redisson.getBucket("batch2").get()).isEqualTo("v2");
-        }
+        assertThat(redisson.getBucket("batch1").get()).isEqualTo("v1");
+        assertThat(redisson.getBucket("batch2").get()).isEqualTo("v2");
 
         assertTransactionWithRedisSpans("SET... [bulk]", "GET", "GET");
     }
 
     @Test
     void testList() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            RList<String> strings = redisson.getList("list1");
-            strings.add("a");
+        RList<String> strings = redisson.getList("list1");
+        strings.add("a");
 
-            assertThat(strings.size()).isEqualTo(1);
-            assertThat(strings.get(0)).isEqualTo("a");
-        }
+        assertThat(strings.size()).isEqualTo(1);
+        assertThat(strings.get(0)).isEqualTo("a");
 
         assertTransactionWithRedisSpans("RPUSH", "LLEN", "LINDEX");
     }
 
     @Test
     void testHash() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            RMap<String, String> rMap = redisson.getMap("map1");
-            rMap.put("key1", "value1");
+        RMap<String, String> rMap = redisson.getMap("map1");
+        rMap.put("key1", "value1");
 
-            assertThat(rMap.get("key1")).isEqualTo("value1");
-        }
+        assertThat(rMap.get("key1")).isEqualTo("value1");
 
         assertTransactionWithRedisSpans("EVAL", "HGET");
     }
 
     @Test
     void testSet() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            RSet<String> rSet = redisson.getSet("set1");
-            rSet.add("s1");
+        RSet<String> rSet = redisson.getSet("set1");
+        rSet.add("s1");
 
-            assertThat(rSet.contains("s1")).isTrue();
-        }
+        assertThat(rSet.contains("s1")).isTrue();
 
         assertTransactionWithRedisSpans("SADD", "SISMEMBER");
     }
 
     @Test
     void testSortedSet() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            Map<String, Double> scores = new HashMap<>();
-            scores.put("u1", 1.0d);
-            scores.put("u2", 3.0d);
-            scores.put("u3", 0.0d);
-            RScoredSortedSet<String> sortSet = redisson.getScoredSortedSet("sort_set1");
-            sortSet.addAll(scores);
+        Map<String, Double> scores = new HashMap<>();
+        scores.put("u1", 1.0d);
+        scores.put("u2", 3.0d);
+        scores.put("u3", 0.0d);
+        RScoredSortedSet<String> sortSet = redisson.getScoredSortedSet("sort_set1");
+        sortSet.addAll(scores);
 
-            assertThat(sortSet.rank("u1")).isEqualTo(1);
-            assertThat(sortSet.rank("u3")).isEqualTo(0);
-        }
+        assertThat(sortSet.rank("u1")).isEqualTo(1);
+        assertThat(sortSet.rank("u3")).isEqualTo(0);
 
         assertTransactionWithRedisSpans("ZADD", "ZRANK", "ZRANK");
     }
 
     @Test
     void testAtomicLong() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            RAtomicLong atomicLong = redisson.getAtomicLong("AtomicLong");
-            atomicLong.incrementAndGet();
+        RAtomicLong atomicLong = redisson.getAtomicLong("AtomicLong");
+        atomicLong.incrementAndGet();
 
-            assertThat(atomicLong.get()).isEqualTo(1);
-        }
+        assertThat(atomicLong.get()).isEqualTo(1);
 
         assertTransactionWithRedisSpans("INCR", "GET");
     }
@@ -164,11 +148,9 @@ class RedissonInstrumentationTest extends AbstractRedisInstrumentationTest {
      */
     @Test
     void testLock() {
-        try (Scope scope = tracer.startRootTransaction(getClass().getClassLoader()).withName("transaction").activateInScope()) {
-            RLock lock = redisson.getLock("lock");
-            lock.lock();
-            lock.unlock();
-        }
+        RLock lock = redisson.getLock("lock");
+        lock.lock();
+        lock.unlock();
 
         assertTransactionWithRedisSpans("EVAL", "EVAL");
     }

--- a/apm-agent-plugins/apm-scheduled-annotation-plugin/src/test/java/co/elastic/apm/agent/spring/scheduled/ScheduledTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-scheduled-annotation-plugin/src/test/java/co/elastic/apm/agent/spring/scheduled/ScheduledTransactionNameInstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,14 +24,13 @@
  */
 package co.elastic.apm.agent.spring.scheduled;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import javax.ejb.Schedule;
-
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import org.junit.jupiter.api.Test;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.scheduling.annotation.Schedules;
+
+import javax.ejb.Schedule;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -40,7 +39,6 @@ class ScheduledTransactionNameInstrumentationTest extends AbstractInstrumentatio
 
     @Test
     void testSpringScheduledAnnotatedMethodsAreTraced() {
-        reporter.reset();
         SpringCounter springCounter = new SpringCounter();
         springCounter.scheduled();
         springCounter.scheduled();
@@ -50,7 +48,6 @@ class ScheduledTransactionNameInstrumentationTest extends AbstractInstrumentatio
 
     @Test
     void testSpringJ8RepeatableScheduledAnnotatedMethodsAreTraced() {
-        reporter.reset();
         SpringCounter springCounter = new SpringCounter();
         springCounter.scheduledJava8Repeatable();
         springCounter.scheduledJava8Repeatable();
@@ -60,7 +57,6 @@ class ScheduledTransactionNameInstrumentationTest extends AbstractInstrumentatio
 
     @Test
     void testSpringJ7RepeatableScheduledAnnotatedMethodsAreTraced() {
-        reporter.reset();
         SpringCounter springCounter = new SpringCounter();
         springCounter.scheduledJava7Repeatable();
         springCounter.scheduledJava7Repeatable();
@@ -70,7 +66,6 @@ class ScheduledTransactionNameInstrumentationTest extends AbstractInstrumentatio
 
     @Test
     void testJeeScheduledAnnotatedMethodsAreTraced() {
-        reporter.reset();
         JeeCounter jeeCounter = new JeeCounter();
         jeeCounter.scheduled();
         jeeCounter.scheduled();
@@ -80,7 +75,6 @@ class ScheduledTransactionNameInstrumentationTest extends AbstractInstrumentatio
 
     @Test
     void testJeeJ7RepeatableScheduledAnnotatedMethodsAreTraced() {
-        reporter.reset();
         JeeCounter jeeCounter = new JeeCounter();
         jeeCounter.scheduledJava7Repeatable();
         jeeCounter.scheduledJava7Repeatable();

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/TestRequestBodyCapturing.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/TestRequestBodyCapturing.java
@@ -32,7 +32,6 @@ import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.report.serialize.DslJsonSerializer;
 import co.elastic.apm.agent.util.PotentiallyMultiValuedMap;
 import org.apache.commons.lang3.RandomStringUtils;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -110,15 +109,6 @@ class TestRequestBodyCapturing extends AbstractInstrumentationTest {
         streamConsumer = is -> is.readLine(BUFFER, 0, BUFFER.length);
         streamCloser = InputStream::close;
 
-    }
-
-    @AfterEach
-    void tearDown() {
-        Transaction transaction = reporter.getFirstTransaction();
-        reporter.assertRecycledAfterDecrementingReferences();
-        assertThat(transaction.getContext().getRequest().getRawBody()).isNull();
-        assertThat(transaction.getContext().getRequest().getBody()).isNull();
-        assertThat((CharSequence) transaction.getContext().getRequest().getBodyBufferForSerialization()).isNull();
     }
 
     @ParameterizedTest

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/spring/webmvc/exception/AbstractExceptionHandlerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/spring/webmvc/exception/AbstractExceptionHandlerInstrumentationTest.java
@@ -70,7 +70,7 @@ public abstract class AbstractExceptionHandlerInstrumentationTest {
     @BeforeClass
     @BeforeAll
     public static void setUpAll() {
-        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.getOrCreateInstrumentationTracer();
+        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup();
         reporter = mockInstrumentationSetup.getReporter();
         tracer = mockInstrumentationSetup.getTracer();
         config = mockInstrumentationSetup.getConfig();

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/spring/webmvc/template/AbstractViewRenderingInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/spring/webmvc/template/AbstractViewRenderingInstrumentationTest.java
@@ -69,7 +69,7 @@ abstract class AbstractViewRenderingInstrumentationTest {
 
     @BeforeAll
     static void beforeAll() {
-        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.getOrCreateInstrumentationTracer();
+        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup();
         reporter = mockInstrumentationSetup.getReporter();
         config = mockInstrumentationSetup.getConfig();
         tracer = mockInstrumentationSetup.getTracer();

--- a/apm-opentracing/src/test/java/co/elastic/apm/opentracing/OpenTracingBridgeCloseTest.java
+++ b/apm-opentracing/src/test/java/co/elastic/apm/opentracing/OpenTracingBridgeCloseTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -36,7 +36,9 @@ public class OpenTracingBridgeCloseTest extends AbstractInstrumentationTest {
 
     @BeforeEach
     void setUp() {
-        reporter.reset();
+        // OT always leaks the spans
+        // see co.elastic.apm.agent.opentracing.impl.ApmSpanBuilderInstrumentation.CreateSpanInstrumentation.doCreateTransactionOrSpan
+        disableRecyclingValidation();
     }
 
     @Test

--- a/apm-opentracing/src/test/java/co/elastic/apm/opentracing/OpenTracingBridgeTest.java
+++ b/apm-opentracing/src/test/java/co/elastic/apm/opentracing/OpenTracingBridgeTest.java
@@ -60,7 +60,9 @@ class OpenTracingBridgeTest extends AbstractInstrumentationTest {
     @BeforeEach
     void setUp() {
         apmTracer = new ElasticApmTracer();
-        reporter.reset();
+        // OT always leaks the spans
+        // see co.elastic.apm.agent.opentracing.impl.ApmSpanBuilderInstrumentation.CreateSpanInstrumentation.doCreateTransactionOrSpan
+        disableRecyclingValidation();
     }
 
     @AfterEach
@@ -560,7 +562,7 @@ class OpenTracingBridgeTest extends AbstractInstrumentationTest {
         spanBuilder.start().finish();
         assertThat(reporter.getTransactions()).hasSize(1);
         final Transaction transaction = reporter.getFirstTransaction();
-        reporter.reset();
+        reporter.resetWithoutRecycling();
         return transaction;
     }
 
@@ -575,7 +577,7 @@ class OpenTracingBridgeTest extends AbstractInstrumentationTest {
         assertThat(reporter.getTransactions()).hasSize(1);
         assertThat(reporter.getSpans()).hasSize(1);
         final co.elastic.apm.agent.impl.transaction.Span span = reporter.getFirstSpan();
-        reporter.reset();
+        reporter.resetWithoutRecycling();
         return span;
     }
 }

--- a/integration-tests/spring-boot-1-5/src/test/java/co/elastic/apm/spring/boot/SpringBoot1_5IT.java
+++ b/integration-tests/spring-boot-1-5/src/test/java/co/elastic/apm/spring/boot/SpringBoot1_5IT.java
@@ -64,7 +64,7 @@ public class SpringBoot1_5IT {
 
     @Before
     public void setUp() {
-        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.getOrCreateInstrumentationTracer();
+        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup();
         config = mockInstrumentationSetup.getConfig();
         reporter = mockInstrumentationSetup.getReporter();
         ElasticApmAgent.initInstrumentation(mockInstrumentationSetup.getTracer(), ByteBuddyAgent.install());

--- a/integration-tests/spring-boot-2/spring-boot-2-base/src/test/java/co/elastic/apm/spring/boot/AbstractSpringBootTest.java
+++ b/integration-tests/spring-boot-2/spring-boot-2-base/src/test/java/co/elastic/apm/spring/boot/AbstractSpringBootTest.java
@@ -27,12 +27,11 @@ package co.elastic.apm.spring.boot;
 import co.elastic.apm.agent.MockReporter;
 import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.bci.ElasticApmAgent;
+import co.elastic.apm.agent.impl.context.web.WebConfiguration;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.report.ReporterConfiguration;
-import co.elastic.apm.agent.impl.context.web.WebConfiguration;
 import co.elastic.apm.api.ElasticApm;
 import net.bytebuddy.agent.ByteBuddyAgent;
-import org.assertj.core.api.Assertions;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -75,7 +74,7 @@ public abstract class AbstractSpringBootTest {
 
     @BeforeClass
     public static void beforeClass() {
-        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.getOrCreateInstrumentationTracer();
+        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup();
         config = mockInstrumentationSetup.getConfig();
         reporter = mockInstrumentationSetup.getReporter();
         ElasticApmAgent.initInstrumentation(mockInstrumentationSetup.getTracer(), ByteBuddyAgent.install());


### PR DESCRIPTION
## What does this PR do?

Depends on #1271 

With #1270 we have a good foundation to make sure tracers don't leak to other tests classes. This makes `GlobalTracer` more restrictive so that a tracer can only be set via `init` that throws if the current tracer is not a noop.

I have also added the recycling tests on the `@AfterEach` method of `AbstractInstrumentationTest` which required some adjustments to tests to make sure all transactions and spans are ended and thus recycled after being reported. It also checks the bookkeeper object pool to make sure all objects have returned. This also implicitly tests for scope leaks as those would prevent objects from being recycled.

As a bonus, I've found and fixed a scope leak in the currently unreleased instrumentation of `Executor#executeAll`.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else: Test improvements
    - [ ] ~I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)~
