### PR TITLE
Restore inlining for JMS Listener wrapping advice

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,6 +51,7 @@ endif::[]
 * Adding a delay by default what attaching the agent to Tomcat using the premain route to work around the JUL
   deadlock issue - {pull}1262[#1262]
 * Fixes missing `jboss.as:*` MBeans on JBoss - {pull}1257[#1257]
+* Fixes a `NoClassDefFoundError` in the JMS instrumentation of `MessageListener` - {pull}1287[#1287]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,7 +51,7 @@ endif::[]
 * Adding a delay by default what attaching the agent to Tomcat using the premain route to work around the JUL
   deadlock issue - {pull}1262[#1262]
 * Fixes missing `jboss.as:*` MBeans on JBoss - {pull}1257[#1257]
-* Fixes a `NoClassDefFoundError` in the JMS instrumentation of `javax.jms.MessageListener` - {pull}1287[#1287]
+* Fixes a `NoClassDefFoundError` in the JMS instrumentation of `MessageListener` - {pull}1287[#1287]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -51,7 +51,7 @@ endif::[]
 * Adding a delay by default what attaching the agent to Tomcat using the premain route to work around the JUL
   deadlock issue - {pull}1262[#1262]
 * Fixes missing `jboss.as:*` MBeans on JBoss - {pull}1257[#1257]
-* Fixes a `NoClassDefFoundError` in the JMS instrumentation of `MessageListener` - {pull}1287[#1287]
+* Fixes a `NoClassDefFoundError` in the JMS instrumentation of `javax.jms.MessageListener` - {pull}1287[#1287]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
@@ -262,7 +262,7 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
 
             @Nullable
             @AssignTo.Argument(0)
-            @Advice.OnMethodEnter(inline = false)
+            @Advice.OnMethodEnter()
             public static MessageListener beforeSetListener(@Advice.Argument(0) @Nullable MessageListener original) {
                 //noinspection ConstantConditions - the Advice must be invoked only if the BaseJmsInstrumentation constructor was invoked
                 JmsInstrumentationHelper<Destination, Message, MessageListener> helper =


### PR DESCRIPTION
## What does this PR do?

Fixes #1286 
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] ~I have added tests that would fail without this fix~
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
    - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
