### PR TITLE
Minor changes to release process pipeline

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -150,6 +150,7 @@ pipeline {
         stage('Branch creation') {
           steps {
             dir("${BASE_DIR}") {
+              git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba', url: 'git@github.com:elastic/apm-agent-java.git'
               withEnv(["BRANCH_NAME=tags/${env.TAG_BARE}"]){
                 withGitRelease() {
                   script {

--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -87,10 +87,12 @@ pipeline {
             Go over PRs or git log and add bug fixes and features.
             Move release notes from the Unreleased sub-heading to the correct [[release-notes-{major}.x]] sub-heading (Example PR for 1.13.0 release).
 
-            Click 'Proceed' to confirm that this step has been completed or Abort to stop the build in order to complete this step.
+            Click 'Proceed' to confirm that this step has been completed and changes have been pushed or Abort to stop the build.
             """
             )
-            sh(script: "git pull")
+            dir("${BASE_DIR}") {
+              git credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba', url: 'git@github.com:elastic/apm-agent-java.git'
+            }
           }
         }
         stage('Review project version') {

--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
   }
   parameters {
     string(name: 'branch_specifier', defaultValue: 'master')
-    booleanParam(name: 'ignore_branch_ci_status', defaultValue: false, description: "Ignore failing tests in the master branch?")
+    booleanParam(name: 'check_branch_ci_status', defaultValue: true, description: "Check for failing tests in the master branch?")
   }
 
   stages {
@@ -70,7 +70,7 @@ pipeline {
           }
         }
         stage('Check master build status') {
-        when { expression { !params.ignore_branch_ci_status } }
+        when { expression { params.ignore_branch_ci_status } }
          steps {
            script {
              // If this build is not green: https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/master/

--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
   }
   parameters {
     string(name: 'branch_specifier', defaultValue: 'master')
+    booleanParam(name: 'ignore_branch_ci_status', defaultValue: false, description: "Ignore failing tests in the master branch?")
   }
 
   stages {
@@ -68,16 +69,17 @@ pipeline {
             }
           }
         }
-        //stage('Check master build status') {
-        //  steps {
-        //    script {
-        //      // If this build is not green: https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/master/
-        //      if(!buildStatus(host: 'apm-ci.elastic.co', job: ['apm-agent-java', 'apm-agent-java-mbp', 'master'], return_boolean: true)) {
-        //        input(message: "WARNING! The master build is not passing. Do you wish to continue?")
-        //      }
-        //    }
-        //  }
-        //}
+        stage('Check master build status') {
+        when { expression { !params.ignore_branch_ci_status } }
+         steps {
+           script {
+             // If this build is not green: https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/master/
+             if(!buildStatus(host: 'apm-ci.elastic.co', job: ['apm-agent-java', 'apm-agent-java-mbp', 'master'], return_boolean: true)) {
+               input(message: "WARNING! The master build is not passing. Do you wish to continue?")
+             }
+           }
+         }
+        }
         stage('Require confirmation that CHANGELOG.asciidoc has been updated') {
           steps {
             input(message: """

--- a/scripts/jenkins/branch_creation.sh
+++ b/scripts/jenkins/branch_creation.sh
@@ -5,9 +5,6 @@ set -xo pipefail
 # Usage ./branch_creation 1.0.1
 
 # Requires that $TAG_VER already be present in the env
-
-git pull
-
 $(echo ${1}|cut -f2-3 -d '.'|{ read ver; test $ver == '0.0'; })
 VER=$?
 


### PR DESCRIPTION
## What does this PR do?
1. Introduces a new parameter for the release build which allows the check for failures in the branch build to be skipped.
1. Allows the CHANGELOG to be updated during the build process instead of requiring a restart.

Once this PR is merged, it should be safe to re-try to release process. The previous problems with the job failing to start have [been resolved separately](https://github.com/elastic/apm-agent-java/pull/1279).