### PR TITLE
docs: fix more asciidoc `rendering issue`s

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -68,7 +68,7 @@ endif::[]
 * New mitigation of OSGi bootdelegation errors (`NoClassDefFoundError`).
   You can remove any `org.osgi.framework.bootdelegation` related configuration.
   This release also removes the configuration option `boot_delegation_packages`.
-* Overhaul of the `ExecutorService` instrumentation that avoids issues like ``ClassCastException``s - {pull}1206[#1206]
+* Overhaul of the `ExecutorService` instrumentation that avoids `ClassCastException` issues - {pull}1206[#1206]
 * Support for `ForkJoinPool` and `ScheduledExecutorService` (see <<supported-async-frameworks>>)
 * Support for `ExecutorService#invokeAny` and `ExecutorService#invokeAll`
 * Added support for `java.util.TimerTask` - {pull}1235[#1235]

--- a/docs/setup-attach-api.asciidoc
+++ b/docs/setup-attach-api.asciidoc
@@ -17,7 +17,7 @@ which is part of the JDK distribution and does not typically come with the JRE d
 [[setup-attach-api-caveats]]
 ==== Caveats
 
-The approach to mitigate ``NoClassDefFoundError``s when used in OSGi containers (which includes most application servers) is experimental.
+The approach to mitigate `NoClassDefFoundError` s when used in OSGi containers (which includes most application servers) is experimental.
 Versions prior to 1.18.0 don't support OSGi containers.
 
 There can only be one agent instance with one configuration per JVM.

--- a/docs/setup-attach-cli.asciidoc
+++ b/docs/setup-attach-cli.asciidoc
@@ -27,7 +27,7 @@ The OS user executing `apm-agent-attach-standalone.jar` and the OS user of the a
 
 When attaching to a J9 VM, you have to explicitly set the `--pid <pid>` argument, or have `jps` installed.
 
-The approach to mitigate ``NoClassDefFoundError``s when used in OSGi containers (which includes most application servers) is experimental.
+The approach to mitigate `NoClassDefFoundError` s when used in OSGi containers (which includes most application servers) is experimental.
 Versions prior to 1.18.0 don't support OSGi containers.
 
 [float]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -289,7 +289,7 @@ This section lists all supported asynchronous frameworks.
 
 |`ExecutorService`
 |
-|The agent propagates the context for ``ExecutorService``s.
+|The agent propagates the context for `ExecutorService` s.
 |1.4.0
 
 |`ScheduledExecutorService`
@@ -299,7 +299,7 @@ This section lists all supported asynchronous frameworks.
 
 |`ForkJoinPool`
 |
-|The agent propagates the context for ``ForkJoinPool``s.
+|The agent propagates the context for `ForkJoinPool` s.
 |1.17.0
 
 |Scala Future


### PR DESCRIPTION
## What does this PR do?
While some asciidoc dialects support
```
``Exception``s
```

to be rendered like `Exception`s, this doesn't seem like it's the case for asciidoctor.

This changes it to be rendered like `Exception` s. Note the additional space before the `s`. There doesn't seem to be a way around it.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
    - [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
