### PR TITLE
Allow empty server_urls

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,8 @@ endif::[]
 * Add <<config-enabled,`enabled`>> flag
 * Add experimental support for Scala Futures
 * The agent now collects heap memory pools metrics - {pull}1228[#1228]
+* Enabling agent to work without attempting any communication with APM server, by allowing setting `server_urls` with
+  an empty string - {pull}1295[#1295]
 
 [float]
 ===== Bug fixes
@@ -52,6 +54,7 @@ endif::[]
   deadlock issue - {pull}1262[#1262]
 * Fixes missing `jboss.as:*` MBeans on JBoss - {pull}1257[#1257]
 * Fixes a `NoClassDefFoundError` in the JMS instrumentation of `MessageListener` - {pull}1287[#1287]
+* Fix `/ by zero` error message when setting `server_urls` with an empty string - {pull}1295[#1295]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/MetricRegistry.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/MetricRegistry.java
@@ -172,12 +172,14 @@ public class MetricRegistry {
         }
     }
 
+    /**
+     * Replace the active metrics container with a new one in a thread-safe manner.
+     */
     public void resetBuffers() {
         try {
             phaser.readerLock();
-            ConcurrentMap<Labels.Immutable, MetricSet> temp = inactiveMetricSets;
             inactiveMetricSets = activeMetricSets;
-            activeMetricSets = temp;
+            activeMetricSets = new ConcurrentHashMap<>();
             phaser.flipPhase();
         } finally {
             phaser.readerUnlock();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/MetricRegistry.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/MetricRegistry.java
@@ -162,15 +162,15 @@ public class MetricRegistry {
     /**
      * Executes the following steps within a single read-operation critical section:
      * <ul>
-     *     <li>Switch between active and inactive MetricSet buffers</li>
-     *     <li>Report the inactivated buffer (optional)</li>
-     *     <li>Reset the inactivated buffer</li>
+     *     <li>Switch between active and inactive MetricSet containers</li>
+     *     <li>Report the inactivated MetricSets (optional)</li>
+     *     <li>Reset the inactivated MetricSets</li>
      * </ul>
      *
-     * @param metricsReporter a reporter to be used for reporting the inactivated metrics buffer. May be {@code null}
+     * @param metricsReporter a reporter to be used for reporting the inactivated MetricSets. May be {@code null}
      *                        if reporting is not required.
      */
-    public void switchBuffersAndReport(@Nullable MetricsReporter metricsReporter) {
+    public void flipPhaseAndReport(@Nullable MetricsReporter metricsReporter) {
         try {
             phaser.readerLock();
             ConcurrentMap<Labels.Immutable, MetricSet> temp = inactiveMetricSets;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/MetricRegistry.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/MetricRegistry.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -167,6 +167,18 @@ public class MetricRegistry {
             activeMetricSets = temp;
             phaser.flipPhase();
             metricsReporter.report(inactiveMetricSets);
+        } finally {
+            phaser.readerUnlock();
+        }
+    }
+
+    public void resetBuffers() {
+        try {
+            phaser.readerLock();
+            ConcurrentMap<Labels.Immutable, MetricSet> temp = inactiveMetricSets;
+            inactiveMetricSets = activeMetricSets;
+            activeMetricSets = temp;
+            phaser.flipPhase();
         } finally {
             phaser.readerUnlock();
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/MetricSet.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/MetricSet.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,6 +23,8 @@
  * #L%
  */
 package co.elastic.apm.agent.metrics;
+
+import co.elastic.apm.agent.objectpool.Recyclable;
 
 import javax.annotation.Nullable;
 import java.util.Map;
@@ -44,7 +46,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * {"metricset":{"timestamp":1545047730692000,"tags":{"name":"G1 Old Generation"},  "samples":{"jvm.gc.time":{"value":0.0},"jvm.gc.count":{"value":0.0}}}}
  * </pre>
  */
-public class MetricSet {
+public class MetricSet implements Recyclable {
     private final Labels.Immutable labels;
     private final ConcurrentMap<String, DoubleSupplier> gauges;
     // low load factor as hash collisions are quite costly when tracking breakdown metrics
@@ -107,7 +109,16 @@ public class MetricSet {
         return !gauges.isEmpty() || hasNonEmptyTimer || hasNonEmptyCounter;
     }
 
-    public void onAfterReport() {
+    /**
+     * Should be called only when the MetricSet is inactive
+     */
+    public void resetState() {
+        for (Timer timer : timers.values()) {
+            timer.resetState();
+        }
+        for (AtomicLong counter : counters.values()) {
+            counter.set(0);
+        }
         hasNonEmptyTimer = false;
         hasNonEmptyCounter = false;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/AbstractIntakeApiHandler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/AbstractIntakeApiHandler.java
@@ -203,6 +203,10 @@ public class AbstractIntakeApiHandler {
         return dropped;
     }
 
+    public int getErrorCount() {
+        return errorCount;
+    }
+
     public void close() {
         shutDown = true;
         synchronized (WAIT_LOCK) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/AbstractIntakeApiHandler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/AbstractIntakeApiHandler.java
@@ -99,20 +99,23 @@ public class AbstractIntakeApiHandler {
         return endRequest;
     }
 
+    @Nullable
     protected HttpURLConnection startRequest(String endpoint) throws IOException {
         final HttpURLConnection connection = apmServerClient.startRequest(endpoint);
-        if (logger.isDebugEnabled()) {
-            logger.debug("Starting new request to {}", connection.getURL());
+        if (connection != null) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Starting new request to {}", connection.getURL());
+            }
+            connection.setRequestMethod("POST");
+            connection.setDoOutput(true);
+            connection.setChunkedStreamingMode(DslJsonSerializer.BUFFER_SIZE);
+            connection.setRequestProperty("Content-Encoding", "deflate");
+            connection.setRequestProperty("Content-Type", "application/x-ndjson");
+            connection.setUseCaches(false);
+            connection.connect();
+            os = new DeflaterOutputStream(connection.getOutputStream(), deflater);
+            os.write(metaData);
         }
-        connection.setRequestMethod("POST");
-        connection.setDoOutput(true);
-        connection.setChunkedStreamingMode(DslJsonSerializer.BUFFER_SIZE);
-        connection.setRequestProperty("Content-Encoding", "deflate");
-        connection.setRequestProperty("Content-Type", "application/x-ndjson");
-        connection.setUseCaches(false);
-        connection.connect();
-        os = new DeflaterOutputStream(connection.getOutputStream(), deflater);
-        os.write(metaData);
         return connection;
     }
 
@@ -142,6 +145,7 @@ public class AbstractIntakeApiHandler {
             } finally {
                 HttpUtils.consumeAndClose(connection);
                 connection = null;
+                os = null;
                 deflater.reset();
                 currentlyTransmitting = 0;
             }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
@@ -115,8 +115,13 @@ public class ApmServerClient {
         return copy;
     }
 
+    @Nullable
     HttpURLConnection startRequest(String relativePath) throws IOException {
-        return startRequestToUrl(appendPathToCurrentUrl(relativePath));
+        URL url = appendPathToCurrentUrl(relativePath);
+        if (url == null) {
+            return null;
+        }
+        return startRequestToUrl(url);
     }
 
     @Nonnull
@@ -166,9 +171,13 @@ public class ApmServerClient {
         }
     }
 
-    @Nonnull
+    @Nullable
     URL appendPathToCurrentUrl(String apmServerPath) throws MalformedURLException {
-        return appendPath(getCurrentUrl(), apmServerPath);
+        URL currentUrl = getCurrentUrl();
+        if (currentUrl == null) {
+            return null;
+        }
+        return appendPath(currentUrl, apmServerPath);
     }
 
     @Nonnull
@@ -274,8 +283,12 @@ public class ApmServerClient {
         return results;
     }
 
+    @Nullable
     URL getCurrentUrl() {
         List<URL> serverUrls = getServerUrls();
+        if (serverUrls.isEmpty()) {
+            return null;
+        }
         return serverUrls.get(errorCount.get() % serverUrls.size());
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
@@ -46,7 +46,10 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -324,6 +327,14 @@ public class ApmServerClient {
 
     public boolean supportsLogsEndpoint() {
         return isAtLeast(VERSION_7_9);
+    }
+
+    @Nullable
+    Version getApmServerVersion(long timeout, TimeUnit timeUnit) throws InterruptedException, ExecutionException, TimeoutException {
+        if (apmServerVersion != null) {
+            return apmServerVersion.get(timeout, timeUnit);
+        }
+        return null;
     }
 
     public boolean isAtLeast(Version apmServerVersion) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
@@ -119,6 +119,6 @@ public class ApmServerHealthChecker implements Callable<Version> {
         if (!versions.isEmpty()) {
             return Collections.min(versions);
         }
-        return null;
+        return Version.UNKNOWN_VERSION;
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandler.java
@@ -109,7 +109,7 @@ public class IntakeV2ReportingEventHandler extends AbstractIntakeApiHandler impl
             endRequest();
             onConnectionError(null, currentlyTransmitting + 1, 0);
         } finally {
-            event.close();
+            event.end();
         }
 
         if (shouldEndRequest()) {
@@ -149,7 +149,7 @@ public class IntakeV2ReportingEventHandler extends AbstractIntakeApiHandler impl
      */
     private void handleNonWrittenEvent(ReportingEvent event) {
         if (event.getMetricRegistry() != null) {
-            event.getMetricRegistry().resetBuffers();
+            event.getMetricRegistry().switchBuffersAndReport(null);
         }
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandler.java
@@ -149,7 +149,7 @@ public class IntakeV2ReportingEventHandler extends AbstractIntakeApiHandler impl
      */
     private void handleNonWrittenEvent(ReportingEvent event) {
         if (event.getMetricRegistry() != null) {
-            event.getMetricRegistry().switchBuffersAndReport(null);
+            event.getMetricRegistry().flipPhaseAndReport(null);
         }
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandler.java
@@ -98,7 +98,7 @@ public class IntakeV2ReportingEventHandler extends AbstractIntakeApiHandler impl
                 writeEvent(event);
             } else {
                 if (logger.isDebugEnabled()) {
-                    logger.debug("Failed to get APM server connection, dropping event {}", event);
+                    logger.debug("Failed to get APM server connection, dropping event: {}", event);
                 }
                 handleNonWrittenEvent(event);
                 dropped++;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReporterConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReporterConfiguration.java
@@ -67,7 +67,7 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
         .sensitive()
         .build();
 
-    private final ConfigurationOption<List<URL>> serverUrl = ConfigurationOption.urlsOption()
+    private final ConfigurationOption<List<URL>> serverUrls = ConfigurationOption.urlsOption()
         .key("server_urls")
         .aliasKeys("server_url")
         .configurationCategory(REPORTER_CATEGORY)
@@ -77,6 +77,9 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
             "Fails over to the next APM Server URL in the event of connection errors.\n" +
             "Achieves load-balancing by shuffling the list of configured URLs.\n" +
             "When multiple agents are active, they'll tend towards spreading evenly across the set of servers due to randomization.\n" +
+            "\n" +
+            "If set to an empty string, the agent will work as usual, except from any task requiring communication with \n" +
+            "the APM server (since 1.18.0). Events will be dropped as long as no valid server URLs are set. \n" +
             "\n" +
             "If outgoing HTTP traffic has to go through a proxy," +
             "you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.\n" +
@@ -192,7 +195,7 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
     }
 
     public List<URL> getServerUrls() {
-        return serverUrl.get();
+        return serverUrls.get();
     }
 
     public TimeDuration getServerTimeout() {
@@ -232,7 +235,7 @@ public class ReporterConfiguration extends ConfigurationOptionProvider {
     }
 
     public ConfigurationOption<List<URL>> getServerUrlsOption() {
-        return this.serverUrl;
+        return this.serverUrls;
     }
 
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReportingEvent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReportingEvent.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -109,6 +109,16 @@ public class ReportingEvent {
     @Nullable
     public MetricRegistry getMetricRegistry() {
         return metricRegistry;
+    }
+
+    public void close() {
+        if (transaction != null) {
+            transaction.decrementReferences();
+        } else if (span != null) {
+            span.decrementReferences();
+        } else if (error != null) {
+            error.recycle();
+        }
     }
 
     enum ReportingEventType {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReportingEvent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReportingEvent.java
@@ -123,7 +123,7 @@ public class ReportingEvent {
         return metricRegistry;
     }
 
-    public void close() {
+    public void end() {
         if (transaction != null) {
             transaction.decrementReferences();
         } else if (span != null) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReportingEvent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReportingEvent.java
@@ -106,6 +106,18 @@ public class ReportingEvent {
         this.type = SHUTDOWN;
     }
 
+    @Override
+    public String toString() {
+        StringBuilder description = new StringBuilder();
+        description.append("Type: ").append(type);
+        if (transaction != null) {
+            description.append(", ").append(transaction.toString());
+        } else if (span != null) {
+            description.append(", ").append(span.toString());
+        }
+        return description.toString();
+    }
+
     @Nullable
     public MetricRegistry getMetricRegistry() {
         return metricRegistry;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -230,7 +230,7 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
 
     @Override
     public void serializeMetrics(MetricRegistry metricRegistry) {
-        metricRegistry.report(this);
+        metricRegistry.switchBuffersAndReport(this);
     }
 
     @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -230,7 +230,7 @@ public class DslJsonSerializer implements PayloadSerializer, MetricRegistry.Metr
 
     @Override
     public void serializeMetrics(MetricRegistry metricRegistry) {
-        metricRegistry.switchBuffersAndReport(this);
+        metricRegistry.flipPhaseAndReport(this);
     }
 
     @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistrySerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistrySerializer.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -44,7 +44,6 @@ public class MetricRegistrySerializer {
         for (MetricSet metricSet : metricSets.values()) {
             if (metricSet.hasContent()) {
                 serializeMetricSet(metricSet, timestamp, replaceBuilder, jw);
-                metricSet.onAfterReport();
                 jw.writeByte(NEW_LINE);
             }
         }
@@ -167,7 +166,6 @@ public class MetricRegistrySerializer {
         serializeValueStart(key, "", jw);
         NumberConverter.serialize(value.get(), jw);
         jw.writeByte(JsonWriter.OBJECT_END);
-        value.set(0);
     }
 
     private static boolean isValid(double value) {
@@ -178,7 +176,6 @@ public class MetricRegistrySerializer {
         serializeValue(key, ".count", timer.getCount(), jw);
         jw.writeByte(JsonWriter.COMMA);
         serializeValue(key, ".sum.us", timer.getTotalTimeUs(), jw);
-        timer.resetState();
     }
 
     private static void serializeValue(String key, double value, JsonWriter jw) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/Version.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/Version.java
@@ -29,6 +29,9 @@ package co.elastic.apm.agent.util;
  * This code was released into the public domain by Brian Guertin on July 8, 2016 citing, verbatim the unlicense.
  */
 public class Version implements Comparable<Version> {
+
+    public static final Version UNKNOWN_VERSION = of("1.0.0");
+
     private final int[] numbers;
 
     public static Version of(String version) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/SpanTypeBreakdownTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/SpanTypeBreakdownTest.java
@@ -74,7 +74,7 @@ class SpanTypeBreakdownTest {
             .withName("test")
             .withType("request")
             .end(30);
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(30);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -93,7 +93,7 @@ class SpanTypeBreakdownTest {
             .withName("test")
             .withType("request")
             .end(30);
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null)).isNull();
             assertThat(getTimer(metricSets, "span.self_time", "app", null)).isNull();
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -114,7 +114,7 @@ class SpanTypeBreakdownTest {
         transaction.createSpan(10).withType("db").withSubtype("mysql").end(20);
         transaction.end(30);
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(20);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -139,7 +139,7 @@ class SpanTypeBreakdownTest {
         transaction.end(30);
 
         assertThat(transaction.getTimerBySpanTypeAndSubtype()).isEmpty();
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null)).isNull();
             assertThat(getTimer(metricSets, "span.self_time", "db", "mysql")).isNull();
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -159,7 +159,7 @@ class SpanTypeBreakdownTest {
         transaction.createSpan(10).withType("app").end(20);
         transaction.end(30);
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(2);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(30);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -184,7 +184,7 @@ class SpanTypeBreakdownTest {
         span2.end(20);
         transaction.end(30);
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(20);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -211,7 +211,7 @@ class SpanTypeBreakdownTest {
         span2.end(25);
         transaction.end(30);
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(15);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -236,7 +236,7 @@ class SpanTypeBreakdownTest {
         transaction.createSpan(15).withType("db").withSubtype("mysql").end(25);
         transaction.end(30);
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(10);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -261,7 +261,7 @@ class SpanTypeBreakdownTest {
         transaction.createSpan(20).withType("db").withSubtype("redis").end(25);
         transaction.end(30);
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(20);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -290,7 +290,7 @@ class SpanTypeBreakdownTest {
         db.end(25);
         transaction.end(30);
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(2);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(25);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -330,7 +330,7 @@ class SpanTypeBreakdownTest {
         assertThat(app.isReferenced()).isFalse();
         assertThat(db.isReferenced()).isFalse();
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(10);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(20);
@@ -360,7 +360,7 @@ class SpanTypeBreakdownTest {
         reporter.assertRecycledAfterDecrementingReferences();
         assertThat(reporter.getFirstTransaction().getTimerBySpanTypeAndSubtype().get("db")).isNull();
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(10);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(20);
@@ -393,7 +393,7 @@ class SpanTypeBreakdownTest {
 
         reporter.assertRecycledAfterDecrementingReferences();
 
-        tracer.getMetricRegistry().report(metricSets -> {
+        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(10);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(10);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/SpanTypeBreakdownTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/SpanTypeBreakdownTest.java
@@ -74,7 +74,7 @@ class SpanTypeBreakdownTest {
             .withName("test")
             .withType("request")
             .end(30);
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(30);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -93,7 +93,7 @@ class SpanTypeBreakdownTest {
             .withName("test")
             .withType("request")
             .end(30);
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null)).isNull();
             assertThat(getTimer(metricSets, "span.self_time", "app", null)).isNull();
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -114,7 +114,7 @@ class SpanTypeBreakdownTest {
         transaction.createSpan(10).withType("db").withSubtype("mysql").end(20);
         transaction.end(30);
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(20);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -139,7 +139,7 @@ class SpanTypeBreakdownTest {
         transaction.end(30);
 
         assertThat(transaction.getTimerBySpanTypeAndSubtype()).isEmpty();
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null)).isNull();
             assertThat(getTimer(metricSets, "span.self_time", "db", "mysql")).isNull();
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -159,7 +159,7 @@ class SpanTypeBreakdownTest {
         transaction.createSpan(10).withType("app").end(20);
         transaction.end(30);
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(2);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(30);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -184,7 +184,7 @@ class SpanTypeBreakdownTest {
         span2.end(20);
         transaction.end(30);
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(20);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -211,7 +211,7 @@ class SpanTypeBreakdownTest {
         span2.end(25);
         transaction.end(30);
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(15);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -236,7 +236,7 @@ class SpanTypeBreakdownTest {
         transaction.createSpan(15).withType("db").withSubtype("mysql").end(25);
         transaction.end(30);
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(10);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -261,7 +261,7 @@ class SpanTypeBreakdownTest {
         transaction.createSpan(20).withType("db").withSubtype("redis").end(25);
         transaction.end(30);
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(20);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -290,7 +290,7 @@ class SpanTypeBreakdownTest {
         db.end(25);
         transaction.end(30);
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(2);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(25);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(30);
@@ -330,7 +330,7 @@ class SpanTypeBreakdownTest {
         assertThat(app.isReferenced()).isFalse();
         assertThat(db.isReferenced()).isFalse();
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(10);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(20);
@@ -360,7 +360,7 @@ class SpanTypeBreakdownTest {
         reporter.assertRecycledAfterDecrementingReferences();
         assertThat(reporter.getFirstTransaction().getTimerBySpanTypeAndSubtype().get("db")).isNull();
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(10);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(20);
@@ -393,7 +393,7 @@ class SpanTypeBreakdownTest {
 
         reporter.assertRecycledAfterDecrementingReferences();
 
-        tracer.getMetricRegistry().switchBuffersAndReport(metricSets -> {
+        tracer.getMetricRegistry().flipPhaseAndReport(metricSets -> {
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getCount()).isEqualTo(1);
             assertThat(getTimer(metricSets, "span.self_time", "app", null).getTotalTimeUs()).isEqualTo(10);
             assertThat(getTimer(metricSets, "transaction.duration", null, null).getTotalTimeUs()).isEqualTo(10);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/MetricRegistryTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/MetricRegistryTest.java
@@ -59,15 +59,79 @@ class MetricRegistryTest {
         metricRegistry.addUnlessNegative("jvm.gc.count", Labels.EMPTY, problematicMetric);
         metricRegistry.addUnlessNan("jvm.gc.count", Labels.EMPTY, problematicMetric);
         metricRegistry.add("jvm.gc.count", Labels.EMPTY, problematicMetric);
-        metricRegistry.report(metricSets -> assertThat(metricSets).isEmpty());
+        metricRegistry.switchBuffersAndReport(metricSets -> assertThat(metricSets).isEmpty());
     }
 
     @Test
     void testReportGaugeTwice() {
         metricRegistry.add("foo", Labels.EMPTY, () -> 42);
-        metricRegistry.report(metricSets -> assertThat(metricSets.get(Labels.EMPTY).getGauge("foo").get()).isEqualTo(42));
+        metricRegistry.switchBuffersAndReport(metricSets -> assertThat(metricSets.get(Labels.EMPTY).getGauge("foo").get()).isEqualTo(42));
         // the active and inactive metricSets are now switched, verify that the previous inactive metricSets also contain the same gauges
-        metricRegistry.report(metricSets -> assertThat(metricSets.get(Labels.EMPTY).getGauge("foo").get()).isEqualTo(42));
+        metricRegistry.switchBuffersAndReport(metricSets -> assertThat(metricSets.get(Labels.EMPTY).getGauge("foo").get()).isEqualTo(42));
+    }
+
+    @Test
+    void testTimerResetWithReporting() {
+        Labels.Mutable labels = Labels.Mutable.of("foo", "bar");
+        metricRegistry.updateTimer("timer", labels, 20);
+        metricRegistry.updateTimer("timer", labels, 22);
+        metricRegistry.switchBuffersAndReport(metricSets -> verifyTimer(metricSets.get(labels), 2, 42));
+        metricRegistry.switchBuffersAndReport(null);
+        // Now we get the original buffer back
+        metricRegistry.switchBuffersAndReport(metricSets -> verifyTimer(metricSets.get(labels), 0, 0));
+    }
+
+    @Test
+    void testTimerResetWithoutReporting() {
+        Labels.Mutable labels = Labels.Mutable.of("foo", "bar");
+        metricRegistry.updateTimer("timer", labels, 20);
+        metricRegistry.updateTimer("timer", labels, 22);
+        metricRegistry.switchBuffersAndReport(null);
+        metricRegistry.switchBuffersAndReport(null);
+        // Now we get the original buffer back
+        metricRegistry.switchBuffersAndReport(metricSets -> verifyTimer(metricSets.get(labels), 0, 0));
+    }
+
+    private void verifyTimer(MetricSet metricSet, int expectedCount, int expectedTotalDurationUs) {
+        if (expectedCount > 0) {
+            assertThat(metricSet.hasContent()).isTrue();
+        } else {
+            assertThat(metricSet.hasContent()).isFalse();
+        }
+        Timer timer = metricSet.getTimers().get("timer");
+        assertThat(timer.getCount()).isEqualTo(expectedCount);
+        assertThat(timer.getTotalTimeUs()).isEqualTo(expectedTotalDurationUs);
+    }
+
+    @Test
+    void testCounterResetWithReporting() {
+        Labels.Mutable labels = Labels.Mutable.of("foo", "bar");
+        metricRegistry.incrementCounter("counter", labels);
+        metricRegistry.incrementCounter("counter", labels);
+        metricRegistry.switchBuffersAndReport(metricSets -> verifyCounter(metricSets.get(labels), 2));
+        metricRegistry.switchBuffersAndReport(null);
+        // Now we get the original buffer back
+        metricRegistry.switchBuffersAndReport(metricSets -> verifyCounter(metricSets.get(labels), 0));
+    }
+
+    @Test
+    void testCounterResetWithoutReporting() {
+        Labels.Mutable labels = Labels.Mutable.of("foo", "bar");
+        metricRegistry.incrementCounter("counter", labels);
+        metricRegistry.incrementCounter("counter", labels);
+        metricRegistry.switchBuffersAndReport(null);
+        metricRegistry.switchBuffersAndReport(null);
+        // Now we get the original buffer back
+        metricRegistry.switchBuffersAndReport(metricSets -> verifyCounter(metricSets.get(labels), 0));
+    }
+
+    private void verifyCounter(MetricSet metricSet, int expectedCount) {
+        if (expectedCount > 0) {
+            assertThat(metricSet.hasContent()).isTrue();
+        } else {
+            assertThat(metricSet.hasContent()).isFalse();
+        }
+        assertThat(metricSet.getCounters().get("counter").get()).isEqualTo(expectedCount);
     }
 
     @Test
@@ -75,39 +139,35 @@ class MetricRegistryTest {
         IntStream.range(1, 505).forEach(i -> metricRegistry.updateTimer("timer" + i, Labels.Mutable.of("foo", Integer.toString(i)), 1));
         IntStream.range(1, 505).forEach(i -> metricRegistry.updateTimer("timer" + i, Labels.Mutable.of("bar", Integer.toString(i)), 1));
 
-        metricRegistry.report(metricSets -> assertThat(metricSets).hasSize(1000));
+        metricRegistry.switchBuffersAndReport(metricSets -> assertThat(metricSets).hasSize(1000));
         // the active and inactive metricSets are now switched, also check the size of the previously inactive metricSets
-        metricRegistry.report(metricSets -> assertThat(metricSets).hasSize(1000));
+        metricRegistry.switchBuffersAndReport(metricSets -> assertThat(metricSets).hasSize(1000));
     }
 
     @Test
-    void testBuffersRotation() throws ExecutionException, InterruptedException {
+    void testBuffersRotationWithReport() throws ExecutionException, InterruptedException {
         final CompletableFuture<Map<? extends Labels, MetricSet>> originalMetricSets = new CompletableFuture<>();
-        metricRegistry.report(originalMetricSets::complete);
+        metricRegistry.switchBuffersAndReport(originalMetricSets::complete);
 
         final CompletableFuture<Map<? extends Labels, MetricSet>> firstRotationMetricSets = new CompletableFuture<>();
-        metricRegistry.report(firstRotationMetricSets::complete);
+        metricRegistry.switchBuffersAndReport(firstRotationMetricSets::complete);
         assertThat(firstRotationMetricSets.get()).isNotSameAs(originalMetricSets.get());
 
         final CompletableFuture<Map<? extends Labels, MetricSet>> secondRotationMetricSets = new CompletableFuture<>();
-        metricRegistry.report(secondRotationMetricSets::complete);
+        metricRegistry.switchBuffersAndReport(secondRotationMetricSets::complete);
         assertThat(secondRotationMetricSets.get()).isNotSameAs(firstRotationMetricSets.get());
         assertThat(secondRotationMetricSets.get()).isSameAs(originalMetricSets.get());
     }
 
     @Test
-    void testResetBuffers() throws ExecutionException, InterruptedException {
+    void testBuffersRotationWithoutReport() throws ExecutionException, InterruptedException {
         final CompletableFuture<Map<? extends Labels, MetricSet>> originalMetricSets = new CompletableFuture<>();
-        metricRegistry.report(originalMetricSets::complete);
-        metricRegistry.resetBuffers();
+        metricRegistry.switchBuffersAndReport(originalMetricSets::complete);
+
+        metricRegistry.switchBuffersAndReport(null);
 
         final CompletableFuture<Map<? extends Labels, MetricSet>> firstRotationMetricSets = new CompletableFuture<>();
-        metricRegistry.report(firstRotationMetricSets::complete);
-        assertThat(firstRotationMetricSets.get()).isNotSameAs(originalMetricSets.get());
-
-        final CompletableFuture<Map<? extends Labels, MetricSet>> secondRotationMetricSets = new CompletableFuture<>();
-        metricRegistry.report(secondRotationMetricSets::complete);
-        assertThat(secondRotationMetricSets.get()).isNotSameAs(firstRotationMetricSets.get());
-        assertThat(secondRotationMetricSets.get()).isNotSameAs(originalMetricSets.get());
+        metricRegistry.switchBuffersAndReport(firstRotationMetricSets::complete);
+        assertThat(firstRotationMetricSets.get()).isSameAs(originalMetricSets.get());
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/MetricRegistryTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/MetricRegistryTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -30,6 +30,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,5 +78,36 @@ class MetricRegistryTest {
         metricRegistry.report(metricSets -> assertThat(metricSets).hasSize(1000));
         // the active and inactive metricSets are now switched, also check the size of the previously inactive metricSets
         metricRegistry.report(metricSets -> assertThat(metricSets).hasSize(1000));
+    }
+
+    @Test
+    void testBuffersRotation() throws ExecutionException, InterruptedException {
+        final CompletableFuture<Map<? extends Labels, MetricSet>> originalMetricSets = new CompletableFuture<>();
+        metricRegistry.report(originalMetricSets::complete);
+
+        final CompletableFuture<Map<? extends Labels, MetricSet>> firstRotationMetricSets = new CompletableFuture<>();
+        metricRegistry.report(firstRotationMetricSets::complete);
+        assertThat(firstRotationMetricSets.get()).isNotSameAs(originalMetricSets.get());
+
+        final CompletableFuture<Map<? extends Labels, MetricSet>> secondRotationMetricSets = new CompletableFuture<>();
+        metricRegistry.report(secondRotationMetricSets::complete);
+        assertThat(secondRotationMetricSets.get()).isNotSameAs(firstRotationMetricSets.get());
+        assertThat(secondRotationMetricSets.get()).isSameAs(originalMetricSets.get());
+    }
+
+    @Test
+    void testResetBuffers() throws ExecutionException, InterruptedException {
+        final CompletableFuture<Map<? extends Labels, MetricSet>> originalMetricSets = new CompletableFuture<>();
+        metricRegistry.report(originalMetricSets::complete);
+        metricRegistry.resetBuffers();
+
+        final CompletableFuture<Map<? extends Labels, MetricSet>> firstRotationMetricSets = new CompletableFuture<>();
+        metricRegistry.report(firstRotationMetricSets::complete);
+        assertThat(firstRotationMetricSets.get()).isNotSameAs(originalMetricSets.get());
+
+        final CompletableFuture<Map<? extends Labels, MetricSet>> secondRotationMetricSets = new CompletableFuture<>();
+        metricRegistry.report(secondRotationMetricSets::complete);
+        assertThat(secondRotationMetricSets.get()).isNotSameAs(firstRotationMetricSets.get());
+        assertThat(secondRotationMetricSets.get()).isNotSameAs(originalMetricSets.get());
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/TestObjectPoolFactory.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/TestObjectPoolFactory.java
@@ -25,6 +25,7 @@
 package co.elastic.apm.agent.objectpool;
 
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.objectpool.impl.BookkeeperObjectPool;
@@ -43,6 +44,7 @@ public class TestObjectPoolFactory extends ObjectPoolFactory {
     private final List<BookkeeperObjectPool<?>> createdPools = new ArrayList<BookkeeperObjectPool<?>>();
     private BookkeeperObjectPool<Transaction> transactionPool;
     private BookkeeperObjectPool<Span> spanPool;
+    private BookkeeperObjectPool<ErrorCapture> errorPool;
 
     @Override
     protected <T extends Recyclable> ObjectPool<T> createRecyclableObjectPool(int maxCapacity, Allocator<T> allocator) {
@@ -81,11 +83,21 @@ public class TestObjectPoolFactory extends ObjectPoolFactory {
         return spanPool;
     }
 
+    @Override
+    public ObjectPool<ErrorCapture> createErrorPool(int maxCapacity, ElasticApmTracer tracer) {
+        errorPool = (BookkeeperObjectPool<ErrorCapture>) super.createErrorPool(maxCapacity, tracer);
+        return errorPool;
+    }
+
     public BookkeeperObjectPool<Transaction> getTransactionPool() {
         return transactionPool;
     }
 
     public BookkeeperObjectPool<Span> getSpanPool() {
         return spanPool;
+    }
+
+    public BookkeeperObjectPool<ErrorCapture> getErrorPool() {
+        return errorPool;
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientTest.java
@@ -93,10 +93,12 @@ public class ApmServerClientTest {
     }
 
     @Test
-    public void testGetCurrentUrlWithEmptyUrls() {
+    public void testGetCurrentUrlWithEmptyUrls() throws IOException {
         // tests setting server_urls to an empty string in configuration
         apmServerClient.start(Lists.emptyList());
         assertThat(apmServerClient.getCurrentUrl()).isNull();
+        assertThat(apmServerClient.appendPathToCurrentUrl("/path")).isNull();
+        assertThat(apmServerClient.startRequest("/whatever")).isNull();
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandlerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandlerTest.java
@@ -132,9 +132,11 @@ class IntakeV2ReportingEventHandlerTest {
     @Test
     void testUrls() throws MalformedURLException {
         URL server1url = apmServerClient.appendPathToCurrentUrl(INTAKE_V2_URL);
+        assertThat(server1url).isNotNull();
         assertThat(server1url.toString()).isEqualTo(HTTP_LOCALHOST + mockApmServer1.port() + INTAKE_V2_URL);
         apmServerClient.onConnectionError();
         URL server2url = apmServerClient.appendPathToCurrentUrl(INTAKE_V2_URL);
+        assertThat(server2url).isNotNull();
         assertThat(server2url.toString()).isEqualTo(HTTP_LOCALHOST + mockApmServer2.port() + APM_SERVER_PATH + INTAKE_V2_URL);
         // just to restore
         apmServerClient.onConnectionError();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/MetricSetSerializationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/MetricSetSerializationTest.java
@@ -177,7 +177,7 @@ class MetricSetSerializationTest {
 
     @Nonnull
     private JsonNode reportAsJson(Labels labels) throws IOException {
-        registry.switchBuffersAndReport(metricSets -> MetricRegistrySerializer.serializeMetricSet(metricSets.get(labels), System.currentTimeMillis() * 1000, new StringBuilder(), jw));
+        registry.flipPhaseAndReport(metricSets -> MetricRegistrySerializer.serializeMetricSet(metricSets.get(labels), System.currentTimeMillis() * 1000, new StringBuilder(), jw));
         final String jsonString = jw.toString();
         System.out.println(jsonString);
         final JsonNode json = objectMapper.readTree(jsonString);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/MetricSetSerializationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/MetricSetSerializationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -177,7 +177,7 @@ class MetricSetSerializationTest {
 
     @Nonnull
     private JsonNode reportAsJson(Labels labels) throws IOException {
-        registry.report(metricSets -> MetricRegistrySerializer.serializeMetricSet(metricSets.get(labels), System.currentTimeMillis() * 1000, new StringBuilder(), jw));
+        registry.switchBuffersAndReport(metricSets -> MetricRegistrySerializer.serializeMetricSet(metricSets.get(labels), System.currentTimeMillis() * 1000, new StringBuilder(), jw));
         final String jsonString = jw.toString();
         System.out.println(jsonString);
         final JsonNode json = objectMapper.readTree(jsonString);

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/plugin/api/SpanInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/plugin/api/SpanInstrumentationTest.java
@@ -26,7 +26,6 @@ package co.elastic.apm.agent.plugin.api;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
-import co.elastic.apm.agent.impl.transaction.TextHeaderGetter;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.api.ElasticApm;
 import co.elastic.apm.api.Scope;
@@ -35,9 +34,7 @@ import co.elastic.apm.api.Transaction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
@@ -169,7 +169,7 @@ class JmxMetricTrackerTest {
 
     private void printMetricSets() {
         DslJsonSerializer metricsReporter = new DslJsonSerializer(mock(StacktraceConfiguration.class), mock(ApmServerClient.class));
-        metricRegistry.switchBuffersAndReport(metricsReporter);
+        metricRegistry.flipPhaseAndReport(metricsReporter);
         System.out.println(metricsReporter.toString());
     }
 

--- a/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
@@ -169,7 +169,7 @@ class JmxMetricTrackerTest {
 
     private void printMetricSets() {
         DslJsonSerializer metricsReporter = new DslJsonSerializer(mock(StacktraceConfiguration.class), mock(ApmServerClient.class));
-        metricRegistry.report(metricsReporter);
+        metricRegistry.switchBuffersAndReport(metricsReporter);
         System.out.println(metricsReporter.toString());
     }
 

--- a/apm-agent-plugins/apm-log-shipper-plugin/src/main/java/co/elastic/apm/agent/log/shipper/ApmServerLogShipper.java
+++ b/apm-agent-plugins/apm-log-shipper-plugin/src/main/java/co/elastic/apm/agent/log/shipper/ApmServerLogShipper.java
@@ -70,6 +70,9 @@ public class ApmServerLogShipper extends AbstractIntakeApiHandler implements Fil
                 }
                 write(os, line, offset, length, eol);
                 return true;
+            } else {
+                logger.debug("Cannot establish connection to APM server, backing off log shipping.");
+                onConnectionError(null, currentlyTransmitting, 0);
             }
         } catch (Exception e) {
             endRequest();

--- a/apm-agent-plugins/apm-log-shipper-plugin/src/main/java/co/elastic/apm/agent/log/shipper/ApmServerLogShipper.java
+++ b/apm-agent-plugins/apm-log-shipper-plugin/src/main/java/co/elastic/apm/agent/log/shipper/ApmServerLogShipper.java
@@ -62,7 +62,7 @@ public class ApmServerLogShipper extends AbstractIntakeApiHandler implements Fil
             if (connection == null) {
                 connection = startRequest(LOGS_ENDPOINT);
             }
-            if (os != null) {
+            if (connection != null && os != null) {
                 File file = tailableFile.getFile();
                 if (!file.equals(currentFile)) {
                     currentFile = file;
@@ -118,6 +118,7 @@ public class ApmServerLogShipper extends AbstractIntakeApiHandler implements Fil
     }
 
     @Override
+    @Nullable
     protected HttpURLConnection startRequest(String endpoint) throws IOException {
         HttpURLConnection connection = super.startRequest(endpoint);
         httpRequestClosingThreshold = System.currentTimeMillis() + reporterConfiguration.getApiRequestTime().getMillis();

--- a/apm-agent-plugins/apm-log-shipper-plugin/src/test/java/co/elastic/apm/agent/log/shipper/ApmServerLogShipperTest.java
+++ b/apm-agent-plugins/apm-log-shipper-plugin/src/test/java/co/elastic/apm/agent/log/shipper/ApmServerLogShipperTest.java
@@ -34,6 +34,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.assertj.core.util.Lists;
+import org.awaitility.Awaitility;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -44,10 +46,14 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.InputStreamReader;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.nio.file.Files;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.zip.InflaterInputStream;
 
@@ -66,6 +72,7 @@ public class ApmServerLogShipperTest {
     private ApmServerLogShipper logShipper;
     private File logFile;
     private final ByteBuffer buffer = ByteBuffer.allocate(1024);
+    private ApmServerClient apmServerClient;
 
     @Before
     public void setUp() throws Exception {
@@ -73,13 +80,17 @@ public class ApmServerLogShipperTest {
         mockApmServer.stubFor(post("/intake/v2/logs").willReturn(ok()));
         mockApmServer.stubFor(get("/").willReturn(ok()));
 
-        ApmServerClient apmServerClient = new ApmServerClient(config.getConfig(ReporterConfiguration.class));
-        apmServerClient.start(List.of(new URL("http", "localhost", mockApmServer.port(), "/")));
+        apmServerClient = new ApmServerClient(config.getConfig(ReporterConfiguration.class));
+        startClientWithValidUrls();
 
         DslJsonSerializer serializer = new DslJsonSerializer(config.getConfig(StacktraceConfiguration.class), apmServerClient);
         logShipper = new ApmServerLogShipper(apmServerClient, config.getConfig(ReporterConfiguration.class), MetaData.create(config, null), serializer);
         logFile = File.createTempFile("test", ".log");
         tailableFile = new TailableFile(logFile);
+    }
+
+    private void startClientWithValidUrls() throws MalformedURLException {
+        apmServerClient.start(List.of(new URL("http", "localhost", mockApmServer.port(), "/")));
     }
 
     @After
@@ -94,6 +105,33 @@ public class ApmServerLogShipperTest {
         Files.write(logFile.toPath(), List.of("foo"));
         assertThat(tailableFile.tail(buffer, logShipper, 100)).isEqualTo(1);
         logShipper.endRequest();
+        List<String> events = getEvents();
+        mockApmServer.verify(postRequestedFor(urlEqualTo(ApmServerLogShipper.LOGS_ENDPOINT)));
+        assertThat(events).hasSize(3);
+        JsonNode fileMetadata = new ObjectMapper().readTree(events.get(1)).get("metadata").get("log").get("file");
+        assertThat(fileMetadata.get("name").textValue()).isEqualTo(logFile.getName());
+        assertThat(fileMetadata.get("path").textValue()).isEqualTo(logFile.getAbsolutePath());
+        assertThat(events.get(2)).isEqualTo("foo");
+    }
+
+    @Test
+    public void testSendLogsAfterServerUrlsSet() throws Exception {
+        apmServerClient.start(Lists.emptyList());
+        Files.write(logFile.toPath(), List.of("foo"));
+        assertThat(logShipper.getErrorCount()).isEqualTo(0);
+        Future<Integer> readLinesFuture = Executors.newSingleThreadExecutor().submit(() -> tailableFile.tail(buffer, logShipper, 100));
+        // Wait until first failure to send file lines
+        Awaitility.await()
+            .pollInterval(1, TimeUnit.MILLISECONDS)
+            .timeout(100, TimeUnit.MILLISECONDS)
+            .untilAsserted(() -> assertThat(logShipper.getErrorCount()).isGreaterThan(0));
+        // Set valid APM server URLs
+        startClientWithValidUrls();
+        // Verify that after backing off, lines are sent to APM server
+        assertThat(readLinesFuture.get(1500, TimeUnit.MILLISECONDS)).isEqualTo(1);
+        assertThat(logShipper.getErrorCount()).isGreaterThan(0);
+        logShipper.endRequest();
+        assertThat(logShipper.getErrorCount()).isEqualTo(0);
         List<String> events = getEvents();
         mockApmServer.verify(postRequestedFor(urlEqualTo(ApmServerLogShipper.LOGS_ENDPOINT)));
         assertThat(events).hasSize(3);

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1923,13 +1923,15 @@ Fails over to the next APM Server URL in the event of connection errors.
 Achieves load-balancing by shuffling the list of configured URLs.
 When multiple agents are active, they'll tend towards spreading evenly across the set of servers due to randomization.
 
+If set to an empty string, the agent will work as usual, except from any task requiring communication with the APM server (since 1.18.0).
+Events will be dropped as long as no valid server URLs are set.
+
 If outgoing HTTP traffic has to go through a proxy,you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
 See also [Java's proxy documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) for more information.
 
 NOTE: This configuration can only be reloaded dynamically as of 1.8.0
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
-
 
 [options="header"]
 |============
@@ -3220,6 +3222,9 @@ The default unit for this option is `ms`.
 # Fails over to the next APM Server URL in the event of connection errors.
 # Achieves load-balancing by shuffling the list of configured URLs.
 # When multiple agents are active, they'll tend towards spreading evenly across the set of servers due to randomization.
+# 
+# If set to an empty string, the agent will work as usual, except from any task requiring communication with 
+# the APM server (since 1.18.0). Events will be dropped as long as no valid server URLs are set. 
 # 
 # If outgoing HTTP traffic has to go through a proxy,you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
 # See also [Java's proxy documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) for more information.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1923,8 +1923,8 @@ Fails over to the next APM Server URL in the event of connection errors.
 Achieves load-balancing by shuffling the list of configured URLs.
 When multiple agents are active, they'll tend towards spreading evenly across the set of servers due to randomization.
 
-If set to an empty string, the agent will work as usual, except from any task requiring communication with the APM server (since 1.18.0).
-Events will be dropped as long as no valid server URLs are set.
+If set to an empty string, the agent will work as usual, except from any task requiring communication with 
+the APM server (since 1.18.0). Events will be dropped as long as no valid server URLs are set. 
 
 If outgoing HTTP traffic has to go through a proxy,you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
 See also [Java's proxy documentation](https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html) for more information.
@@ -1932,6 +1932,7 @@ See also [Java's proxy documentation](https://docs.oracle.com/javase/8/docs/tech
 NOTE: This configuration can only be reloaded dynamically as of 1.8.0
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
+
 
 [options="header"]
 |============


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Fixes #1281 
- Does not create arithmetic error of dividing by zero when server url list is empty
- Allows setting `server_urls` with an empty string, making the agent trace as usual with any sampling rate, but without attempting to communicate with the APM server and:
    - Metrics are collected as usual with buffers being replaced in the specified interval
    - Events are dropped as long as there is no server URL configured
    - Log shipper can resume working when server urls are set

## Checklist for reviewer
Verify that when `server_urls` are set to an empty string:
- [ ] Events do not leak
- [ ] No communication with the APM server is attempted, including health check and remote config polling
- [ ] File shipper works as expected
- [ ] Threads communicating with APM server are backing off properly

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [x] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
    - [ ] I have updated [CHANGELOG.asciidoc](CHANGELOG.asciidoc)
