### PR TITLE
Make test regex work for RC versions

### DIFF
--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AgentFileIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AgentFileIT.java
@@ -49,7 +49,7 @@ public class AgentFileIT {
     @Nullable
     private static String getTargetJar(String project, String classifier) {
         File agentBuildDir = new File("../../" + project + "/target/");
-        FileFilter fileFilter = file -> file.getName().matches(project + "-\\d\\.\\d+\\.\\d+(-SNAPSHOT)?" + classifier + ".jar");
+        FileFilter fileFilter = file -> file.getName().matches(project + "-\\d\\.\\d+\\.\\d+(\\.RC\\d+)?(-SNAPSHOT)?" + classifier + ".jar");
         return Arrays.stream(agentBuildDir.listFiles(fileFilter)).findFirst()
             .map(File::getAbsolutePath)
             .orElse(null);


### PR DESCRIPTION
Currently, the `AgentFileIT` fails because it's not recognizing the version `1.18.0.RC1-SNAPSHOT`