### PR TITLE
Release pipeline fixes

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -118,7 +118,7 @@ pipeline {
                       ]
                     ]
                   )
-                  sh(name: "mavenVersionUpdate", script: "./mvnw --batch-mode release:update-versions -DdevelopmentVersion=${new_version}")
+                  sh(label: "mavenVersionUpdate", script: "./mvnw --batch-mode release:update-versions -DdevelopmentVersion=${new_version}")
                   withEnv(["BRANCH_NAME=tags/${env.TAG_BARE}"]){
                     withGitRelease() {
                       sh(script: "git commit -a -m 'Version bump'")

--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -140,7 +140,7 @@ pipeline {
         stage('Nexus release') {
           steps {
             script {
-              def spid = getVault('nexus')["staging-profile-id"]
+              def spid = getVaultSecret('nexus')["staging-profile-id"]
               dir("${BASE_DIR}"){
                 withEnvMask(vars: [[var: "SPID", password: spid]]){
                   def foundStagingId = nexusFindStagingId(stagingProfileId: "${SPID}", groupId: "co.elastic.apm")

--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -119,9 +119,11 @@ pipeline {
                     ]
                   )
                   sh(name: "mavenVersionUpdate", script: "./mvnw --batch-mode release:update-versions -DdevelopmentVersion=${new_version}")
-                  withGitRelease() {
-                    sh(script: "git commit -a -m 'Version bump'")
-                    gitPush()
+                  withEnv(["BRANCH_NAME=tags/${env.TAG_BARE}"]){
+                    withGitRelease() {
+                      sh(script: "git commit -a -m 'Version bump'")
+                      gitPush()
+                    }
                   }
                 } else {
                   echo "Skipping version update"
@@ -210,9 +212,11 @@ pipeline {
             deleteDir()
             unstash 'source'
             dir("${BASE_DIR}"){
-              withGitRelease() {
-                sh(script: "./scripts/jenkins/update_cloudfoundry.sh")
-                gitPush()
+              withEnv(["BRANCH_NAME=tags/${env.TAG_BARE}"]){
+                withGitRelease() {
+                  sh(script: "./scripts/jenkins/update_cloudfoundry.sh")
+                  gitPush()
+                }
               }
             }
           }


### PR DESCRIPTION
## What does this PR do?
 * Corrects typo in call to `getVaultSecret`
 * Wraps git calls in an environment which sets `BRANCH_NAME`
 * Fixes a call to the `sh` step which threw a non-fatal warning by replacing the incorrect parameter name of `name` with `label`.