### PR TITLE
Fixes for git error in release pipeline

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -46,9 +46,9 @@ pipeline {
             stash(allowEmpty: true, name: 'source', useDefaultExcludes: false)
             dir("${BASE_DIR}") {
               script {
-                env.TAG_BARE = sh(script: "git tag | tail -1", returnStdout: true)
-                env.TAG_VER = sh(script: "git tag | tail -1 | sed s/v//", returnStdout: true)
-                env.TAG_DOT_X = sh(script: 'git tag|tail -1|sed s/v//|cut -f1 -d "."|awk \'{print $1".x"}\'', returnStdout: true)
+                env.TAG_BARE = sh(script: "./scripts/jenkins/tags.sh bare", returnStdout: true)
+                env.TAG_VER = sh(script: "./scripts/jenkins/tags.sh ver", returnStdout: true)
+                env.TAG_DOT_X = sh(script: "./scripts/jenkins/tags.sh dot_x", returnStdout: true)
               }
             }
           }

--- a/scripts/jenkins/tags.sh
+++ b/scripts/jenkins/tags.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 case  $1  in
     bare)
-        git tag | sort -V|tail -1|tr -d '\n'
+        git tag | sort -V | tail -1 | tr -d '\n'
         ;;
     ver)
-        git tag | sort -V |tail -1| sed s/v// | tr -d '\n'
+        git tag | sort -V | tail -1 | sed s/v// | tr -d '\n'
         ;;
     dot_x)
-        git tag|sort -V|tail -1 |cut -f1 -d "."|awk '{print $1".x"}' | tr -d '\n'
+        git tag | sort -V | tail -1 | cut -f1 -d "." | awk '{print $1".x"}' | tr -d '\n'
         ;;
 esac

--- a/scripts/jenkins/tags.sh
+++ b/scripts/jenkins/tags.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 case  $1  in
     bare)
-        git tag | sort -V|tail -1|sed s/\n//
+        git tag | sort -V|tail -1|tr -d '\n'
         ;;
     ver)
         git tag | sort -V |tail -1| sed s/v//

--- a/scripts/jenkins/tags.sh
+++ b/scripts/jenkins/tags.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 case  $1  in
     bare)
-        git tag | sort -V | tail -1 | tr -d '\n'
+        git tag | sort --version-sort | tail -1 | tr -d '\n'
         ;;
     ver)
         git tag | sort -V | tail -1 | sed s/v// | tr -d '\n'

--- a/scripts/jenkins/tags.sh
+++ b/scripts/jenkins/tags.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+case  $1  in
+    bare)
+        git tag | sort -V|tail -1
+        ;;
+    ver)
+        git tag | sort -V |tail -1| sed s/v//
+        ;;
+    dot_x)
+        git tag|sort -V|tail -1 |cut -f1 -d "."|awk '{print $1".x"}'
+        ;;
+esac

--- a/scripts/jenkins/tags.sh
+++ b/scripts/jenkins/tags.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 case  $1  in
     bare)
-        git tag | sort -V|tail -1
+        git tag | sort -V|tail -1|sed s/\n//
         ;;
     ver)
         git tag | sort -V |tail -1| sed s/v//

--- a/scripts/jenkins/tags.sh
+++ b/scripts/jenkins/tags.sh
@@ -4,9 +4,9 @@ case  $1  in
         git tag | sort -V|tail -1|tr -d '\n'
         ;;
     ver)
-        git tag | sort -V |tail -1| sed s/v//
+        git tag | sort -V |tail -1| sed s/v// | tr -d '\n'
         ;;
     dot_x)
-        git tag|sort -V|tail -1 |cut -f1 -d "."|awk '{print $1".x"}'
+        git tag|sort -V|tail -1 |cut -f1 -d "."|awk '{print $1".x"}' | tr -d '\n'
         ;;
 esac


### PR DESCRIPTION
## What does this PR do?
Fixes the following error in the release pipeline:

```
17:32:48  [Pipeline] withEnv
17:32:48  [Pipeline] {
17:32:48  [Pipeline] isUnix
17:32:48  [Pipeline] withCredentials
17:32:48  Masking supported pattern matches of $GITHUB_USER or $GITHUB_TOKEN
17:32:48  [Pipeline] {
17:32:48  [Pipeline] libraryResource
17:32:48  [Pipeline] sh (Setup git release)
17:32:48  + BRANCH_NAME='tags/v1.9.0
17:32:48  '
17:32:48  + GIT_BASE_COMMIT=5de8899283b5ec1a4d9f6cb6a0fdf1ca86b32073
17:32:48  + GITHUB_TOKEN=****
17:32:48  + GITHUB_USER=****
17:32:48  + ORG_NAME=elastic
17:32:48  + REPO_NAME=apm-agent-java
17:32:48  + git config remote.origin.url https://****:****@github.com/elastic/apm-agent-java.git
17:32:48  + git config remote.origin.fetch '+refs/heads/*:refs/remotes/origin/*'
17:32:48  ++ git log -1 --pretty=format:%ae
17:32:48  + USER_MAIL=felix.barnsteiner@elastic.co
17:32:48  ++ git log -1 --pretty=format:%an
17:32:48  + USER_NAME='Felix Barnsteiner'
17:32:48  + git config user.email felix.barnsteiner@elastic.co
17:32:48  + git config user.name 'Felix Barnsteiner'
17:32:48  + git config checkout.defaultRemote origin
17:32:48  + git fetch --all
17:32:48  Fetching origin
17:32:49  + git checkout 'tags/v1.9.0
17:32:49  '
17:32:49  error: pathspec 'tags/v1.9.0
17:32:49  ' did not match any file(s) known to git.
17:32:49  [Pipeline] error
17:32:49  [Pipeline] sh (Rollback git context)
17:32:49  + git config remote.origin.url https://github.com/elastic/apm-agent-java.git
17:32:49  + git config remote.upstream.url https://github.com/elastic/apm-agent-java.git
17:32:49  [Pipeline] }
17:32:49  [Pipeline] // withCredentials
```

