### PR TITLE
Fix NoSuchMethodError in external-plugin-test

### DIFF
--- a/integration-tests/external-plugin-test/pom.xml
+++ b/integration-tests/external-plugin-test/pom.xml
@@ -45,7 +45,11 @@
         -->
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <!--
+            TODO use this artifact when we don't shade anymore
             <artifactId>elastic-apm-agent</artifactId>
+            -->
+            <artifactId>apm-api-plugin</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
https://internal-ci.elastic.co/job/elastic+apm-agent-java+deploy-snapshot/470/console

```
12:35:45 [INFO] Running co.elastic.apm.plugin.PluginInstrumentationTest
12:35:47 2020-07-26 10:35:47,164 [main] WARN  com.networknt.schema.JsonMetaSchema - Unknown keyword regexProperties - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
12:35:47 2020-07-26 10:35:47,231 [main] WARN  com.networknt.schema.JsonMetaSchema - Unknown keyword deprecated - you should define your own Meta Schema. If the keyword is irrelevant for validation, just use a NonValidationKeyword
12:35:48 WARNING: sun.reflect.Reflection.getCallerClass is not supported. This will impact performance.
12:35:49 [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 4.471 s <<< FAILURE! - in co.elastic.apm.plugin.PluginInstrumentationTest
12:35:49 [ERROR] co.elastic.apm.plugin.PluginInstrumentationTest  Time elapsed: 4.471 s  <<< ERROR!
12:35:49 java.lang.NoSuchMethodError: co.elastic.apm.agent.sdk.weakmap.WeakMapSupplier.createMap()Lco/elastic/apm/agent/shaded/weaklockfree/WeakConcurrentMap;
12:35:49 	at co.elastic.apm.agent.bci.ElasticApmAgent.<clinit>(ElasticApmAgent.java:120)
12:35:49 	at co.elastic.apm.agent.configuration.CoreConfiguration.getConfigFileLocation(CoreConfiguration.java:716)
12:35:49 	at co.elastic.apm.agent.impl.ElasticApmTracerBuilder.getConfigSources(ElasticApmTracerBuilder.java:233)
12:35:49 	at co.elastic.apm.agent.impl.ElasticApmTracerBuilder.<init>(ElasticApmTracerBuilder.java:92)
12:35:49 	at co.elastic.apm.agent.impl.ElasticApmTracerBuilder.<init>(ElasticApmTracerBuilder.java:86)
12:35:49 	at co.elastic.apm.agent.MockTracer.createMockInstrumentationSetup(MockTracer.java:97)
12:35:49 	at co.elastic.apm.agent.AbstractInstrumentationTest.beforeAll(AbstractInstrumentationTest.java:54)
12:35:49 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
12:35:49 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
12:35:49 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
12:35:49 	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
12:35:49 	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
12:35:49 	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
12:35:49 	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
12:35:49 	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
12:35:49 	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptLifecycleMethod(TimeoutExtension.java:126)
12:35:49 	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptBeforeAllMethod(TimeoutExtension.java:68)
12:35:49 	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
12:35:49 	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
12:35:49 	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
12:35:49 	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
12:35:49 	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
12:35:49 	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
12:35:49 	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
12:35:49 	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
12:35:49 	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeBeforeAllMethods$8(ClassBasedTestDescriptor.java:375)
12:35:49 	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
12:35:49 	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeBeforeAllMethods(ClassBasedTestDescriptor.java:373)
12:35:49 	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.before(ClassBasedTestDescriptor.java:193)
12:35:49 	at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.before(ClassBasedTestDescriptor.java:78)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:132)
12:35:49 	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
12:35:49 	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
12:35:49 	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
12:35:49 	at java.base/java.util.ArrayList.forEach(ArrayList.java:1540)
12:35:49 	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:38)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$5(NodeTestTask.java:139)
12:35:49 	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:125)
12:35:49 	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:135)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:123)
12:35:49 	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:122)
12:35:49 	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:80)
12:35:49 	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:32)
12:35:49 	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
12:35:49 	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:51)
12:35:49 	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:220)
12:35:49 	at org.junit.platform.launcher.core.DefaultLauncher.lambda$execute$6(DefaultLauncher.java:188)
12:35:49 	at org.junit.platform.launcher.core.DefaultLauncher.withInterceptedStreams(DefaultLauncher.java:202)
12:35:49 	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:181)
12:35:49 	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:128)
12:35:49 	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invokeAllTests(JUnitPlatformProvider.java:150)
12:35:49 	at org.apache.maven.surefire.junitplatform.JUnitPlatformProvider.invoke(JUnitPlatformProvider.java:124)
12:35:49 	at org.apache.maven.surefire.booter.ForkedBooter.invokeProviderInSameClassLoader(ForkedBooter.java:384)
12:35:49 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:345)
12:35:49 	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:126)
12:35:49 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:418)
12:35:49 	Suppressed: java.lang.NoClassDefFoundError: Could not initialize class co.elastic.apm.agent.bci.ElasticApmAgent
12:35:49 		at co.elastic.apm.agent.AbstractInstrumentationTest.afterAll(AbstractInstrumentationTest.java:66)
12:35:49 		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
12:35:49 		at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
12:35:49 		at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
12:35:49 		at java.base/java.lang.reflect.Method.invoke(Method.java:566)
12:35:49 		at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:686)
12:35:49 		at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
12:35:49 		at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
12:35:49 		at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
12:35:49 		at org.junit.jupiter.engine.extension.TimeoutExtension.interceptLifecycleMethod(TimeoutExtension.java:126)
12:35:49 		at org.junit.jupiter.engine.extension.TimeoutExtension.interceptAfterAllMethod(TimeoutExtension.java:116)
12:35:49 		at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
12:35:49 		at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
12:35:49 		at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
12:35:49 		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
12:35:49 		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
12:35:49 		at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
12:35:49 		at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
12:35:49 		at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
12:35:49 		at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeAfterAllMethods$10(ClassBasedTestDescriptor.java:403)
12:35:49 		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
12:35:49 		at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.lambda$invokeAfterAllMethods$11(ClassBasedTestDescriptor.java:401)
12:35:49 		at java.base/java.util.ArrayList.forEach(ArrayList.java:1540)
12:35:49 		at java.base/java.util.Collections$UnmodifiableCollection.forEach(Collections.java:1085)
12:35:49 		at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.invokeAfterAllMethods(ClassBasedTestDescriptor.java:401)
12:35:49 		at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.after(ClassBasedTestDescriptor.java:209)
12:35:49 		at org.junit.jupiter.engine.descriptor.ClassBasedTestDescriptor.after(ClassBasedTestDescriptor.java:78)
12:35:49 		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:145)
12:35:49 		at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
12:35:49 		at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$7(NodeTestTask.java:145)
12:35:49 		... 29 more
12:35:49 
12:35:50 [INFO] 
12:35:50 [INFO] Results:
12:35:50 [INFO] 
12:35:50 [ERROR] Errors: 
12:35:50 [ERROR]   PluginInstrumentationTest>AbstractInstrumentationTest.beforeAll:54 » NoSuchMethod
12:35:50 [INFO] 
12:35:50 [ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
```

I think the problem is that after `install`ing the `elastic-apm-agent` module, the shaded version will be used in `external-plugin-test`