### PR TITLE
Update to transaction_ignore_urls config name

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,8 @@ endif::[]
 * Add <<config-enabled,`enabled`>> flag
 * Add experimental support for Scala Futures
 * The agent now collects heap memory pools metrics - {pull}1228[#1228]
+* Deprecating `ignore_urls` config in favour of <<config-transaction-ignore-urls, `transaction_ignore_urls`>> to align
+  with other agents, while still allowing the old config name for backward compatibility - {pull}1315[#1315]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/web/WebConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/web/WebConfiguration.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -58,7 +58,8 @@ public class WebConfiguration extends ConfigurationOptionProvider {
 
     private final ConfigurationOption<List<WildcardMatcher>> ignoreUrls = ConfigurationOption
         .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)
-        .key("ignore_urls")
+        .key("transaction_ignore_urls")
+        .aliasKeys("ignore_urls")
         .configurationCategory(HTTP_CATEGORY)
         .description("Used to restrict requests to certain URLs from being instrumented.\n" +
             "\n" +

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -125,7 +125,7 @@ Click on a key to get more information.
 ** <<config-span-min-duration>>
 * <<config-http>>
 ** <<config-capture-body-content-types>>
-** <<config-ignore-urls>>
+** <<config-transaction-ignore-urls>>
 ** <<config-ignore-user-agents>>
 ** <<config-use-path-as-transaction-name>>
 ** <<config-url-groups>>
@@ -1201,8 +1201,8 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
-[[config-ignore-urls]]
-==== `ignore_urls`
+[[config-transaction-ignore-urls]]
+==== `transaction_ignore_urls`
 
 Used to restrict requests to certain URLs from being instrumented.
 
@@ -1229,7 +1229,7 @@ NOTE: All errors that are captured during a request to an ignored URL are still 
 [options="header"]
 |============
 | Java System Properties      | Property file   | Environment
-| `elastic.apm.ignore_urls` | `ignore_urls` | `ELASTIC_APM_IGNORE_URLS`
+| `elastic.apm.transaction_ignore_urls` | `transaction_ignore_urls` | `ELASTIC_APM_TRANSACTION_IGNORE_URLS`
 |============
 
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
@@ -2825,7 +2825,7 @@ The default unit for this option is `ms`.
 # Type: comma separated list
 # Default value: /VAADIN/*,/heartbeat*,/favicon.ico,*.js,*.css,*.jpg,*.jpeg,*.png,*.gif,*.webp,*.svg,*.woff,*.woff2
 #
-# ignore_urls=/VAADIN/*,/heartbeat*,/favicon.ico,*.js,*.css,*.jpg,*.jpeg,*.png,*.gif,*.webp,*.svg,*.woff,*.woff2
+# transaction_ignore_urls=/VAADIN/*,/heartbeat*,/favicon.ico,*.js,*.css,*.jpg,*.jpeg,*.png,*.gif,*.webp,*.svg,*.woff,*.woff2
 
 # Used to restrict requests from certain User-Agents from being instrumented.
 # 


### PR DESCRIPTION
Closes #1313 

@felixbarny I believe all we are required to do is renaming, while still allowing the old name so it is not a breaking change, right?
cc @gregkalapos 🙂 