### PR TITLE
docs: add disable instructions

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -223,4 +223,4 @@ you can disable the recording of events by setting <<config-recording,`recording
 
 If that doesn't work, you can completely disable the agent by setting
 <<config-enabled,`enabled`>> to `false`.
-You'll need to restart your application for the changes to take effect.
+You'll need to restart your application for this change to take effect.

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -204,9 +204,23 @@ Updating them to a more recent version should resolve the problem.
 [[trouble-shooting-incorrect-manual-jar-file]]
 ==== Failed to find Premain-Class manifest attribute ====
 
-If you are using a manual setup with a `-javaagent` flag against an application server and are seeing the 
+If you are using a manual setup with a `-javaagent` flag against an application server and are seeing the
 `Failed to find Premain-Class manifest attribute` error and a failure to start, then you might be pointing
 at the incorrect jar file.
 
-The correct jar file to be pointing at should be in the form of `elastic-apm-agent-<version>.jar` and 
+The correct jar file to be pointing at should be in the form of `elastic-apm-agent-<version>.jar` and
 further information about how to download this file can be found <<setup-javaagent, in the manual setup instructions.>>
+
+[float]
+[[disable-agent]]
+=== Disable the Agent
+
+In the unlikely event the agent causes disruptions to a production application,
+you can disable the agent while you troubleshoot.
+
+Using <<configuration-dynamic,dynamic configuration>>,
+you can disable the recording of events by setting <<config-recording,`recording`>> to `false`.
+
+If that doesn't work, you can completely disable the agent by setting
+<<config-enabled,`enabled`>> to `false`.
+You'll need to restart your application for the changes to take effect.


### PR DESCRIPTION
## What does this pull request do?

To assist support, we're adding disable instructions to each Agent's troubleshooting docs.

<img width="710" alt="Screen Shot 2020-07-29 at 1 43 13 PM" src="https://user-images.githubusercontent.com/5618806/88851428-99e3bb80-d1a1-11ea-8a8c-8fda34aeb38b.png">


## Related issues

For https://github.com/elastic/observability-docs/issues/35.
