### PR TITLE
Silencing log4j StatusLogger during initialization

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,7 +60,7 @@ endif::[]
 * Fixes missing `jboss.as:*` MBeans on JBoss - {pull}1257[#1257]
 * Fixes a `NoClassDefFoundError` in the JMS instrumentation of `MessageListener` - {pull}1287[#1287]
 * Fix `/ by zero` error message when setting `server_urls` with an empty string - {pull}1295[#1295]
-* Fix `ClassNotFoundException` in some cases where special log4j configurations are used - {pull}1322[#1322]
+* Fix `ClassNotFoundException` or `ClassCastException` in some cases where special log4j configurations are used - {pull}1322[#1322]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ endif::[]
 * Fixes missing `jboss.as:*` MBeans on JBoss - {pull}1257[#1257]
 * Fixes a `NoClassDefFoundError` in the JMS instrumentation of `MessageListener` - {pull}1287[#1287]
 * Fix `/ by zero` error message when setting `server_urls` with an empty string - {pull}1295[#1295]
+* Fix `ClassNotFoundException` in some cases where special log4j configurations are used - {pull}1322[#1322]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
@@ -66,7 +66,7 @@ public class LoggingConfiguration extends ConfigurationOptionProvider {
     static final String DEFAULT_MAX_SIZE = "50mb";
     static final String SHIP_AGENT_LOGS = "ship_agent_logs";
     static final String LOG_FORMAT_SOUT_KEY = "log_format_sout";
-    static final String LOG_FORMAT_FILE_KEY = "log_format_file";
+    public static final String LOG_FORMAT_FILE_KEY = "log_format_file";
     static final String INITIAL_LISTENERS_LEVEL = "log4j2.StatusLogger.level";
     static final String INITIAL_STATUS_LOGGER_LEVEL = "org.apache.logging.log4j.simplelog.StatusLogger.level";
     static final String DEFAULT_LISTENER_LEVEL = "Log4jDefaultStatusLevel";


### PR DESCRIPTION
## What does this PR do?
Fixes #1316 

The result of the described error (and other similar errors) is falling back to the log4j default, which we expect anyway.
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] ~~I have added tests that would fail without this fix~~
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
