### PR TITLE
Fix service name caching based on context path

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -63,6 +63,7 @@ endif::[]
 * Fix `ClassNotFoundException` or `ClassCastException` in some cases where special log4j configurations are used - {pull}1322[#1322]
 * Fix `NumberFormatException` when using early access Java version - {pull}1325[#1325]
 * Fix `service_name` config being ignored when set to the same auto-discovered default value - {pull}1324[#1324]
+* Fix service name error when updating a web app on a Servlet container - {pull}1326[#1326]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletGlobalState.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletGlobalState.java
@@ -25,6 +25,8 @@
 package co.elastic.apm.agent.servlet;
 
 import co.elastic.apm.agent.sdk.state.GlobalState;
+import co.elastic.apm.agent.sdk.weakmap.WeakMapSupplier;
+import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
 
 import java.util.Collections;
 import java.util.Set;
@@ -33,7 +35,7 @@ import java.util.concurrent.ConcurrentHashMap;
 @GlobalState
 public class ServletGlobalState {
 
-    public static final Set<String> nameInitialized = Collections.newSetFromMap(new ConcurrentHashMap<String, Boolean>());
+    public static final WeakConcurrentMap<ClassLoader, Boolean> nameInitialized = WeakMapSupplier.createMap();
 
     // visible for testing as clearing cache is required between tests execution
     static void clearServiceNameCache() {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -69,8 +69,8 @@ public class ServletTransactionHelper {
         this.webConfiguration = tracer.getConfig(WebConfiguration.class);
     }
 
-    public static void determineServiceName(@Nullable String servletContextName, ClassLoader servletContextClassLoader, @Nullable String contextPath) {
-        if (!nameInitialized.add(contextPath == null ? "null" : contextPath)) {
+    public static void determineServiceName(@Nullable String servletContextName, @Nullable ClassLoader servletContextClassLoader, @Nullable String contextPath) {
+        if (servletContextClassLoader == null || nameInitialized.putIfAbsent(servletContextClassLoader, Boolean.TRUE) != null) {
             return;
         }
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
@@ -100,6 +100,9 @@ class ServletTransactionHelperTest extends AbstractInstrumentationTest {
         assertThat(transaction.getNameAsString()).isEqualTo("GET /foo/bar/*");
     }
 
+    /**
+     * Tests a scenario of un-deploying a webapp and then re-deploying it on a Servlet container
+     */
     @Test
     void testServiceNameConsistencyAcrossDifferentClassLoaders() {
         final String testContext = "test-context";


### PR DESCRIPTION
## What does this PR do?
Fixes service name caching. 

### Context 
A bug reported in https://discuss.elastic.co/t/apm-agent-not-working-after-updating-war-in-tomcat/239750 - after un-deploying and re-deploying a web app on a Servlet container, the web-app-specific service name (based on auto-discovery) is not used anymore. Instead, events are reported with the generic process service name.
The problem is with two inconsistent caches of the service name - it is cached in `ServletTransactionHelper` based on the context path and then in `ElasticApmTracer` based on the instrumented class's initiating class loader. When redeploying an app, the same context app is used with a different class loader and this causes the problem.

NOTE: I am not sure the first caching even worth it, only a few String comparisons. Maybe it's enough to leave only the second (class-loader-based) caching in `ElasticApmTracer`).

<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
