### PR TITLE
Deprecate non-indy plugins

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -548,7 +548,7 @@ public class ElasticApmAgent {
         }
         dynamicClassFileTransformers.clear();
         instrumentation = null;
-        HelperClassManager.ForIndyPlugin.clear();
+        IndyPluginClassLoaderFactory.clear();
     }
 
     private static AgentBuilder getAgentBuilder(final ByteBuddy byteBuddy, final CoreConfiguration coreConfiguration, final Logger logger,

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyBootstrap.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyBootstrap.java
@@ -67,7 +67,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  *       ↑ └java.lang.IndyBootstrapDispatcher ─ ↑ ─→ └ {@link IndyBootstrap#bootstrap}
  *     Ext/Platform CL               ↑          │                        ╷
  *       ↑                           ╷          │                        ↓
- *     System CL                     ╷          │        {@link HelperClassManager.ForIndyPlugin#getOrCreatePluginClassLoader}
+ *     System CL                     ╷          │        {@link IndyPluginClassLoaderFactory#getOrCreatePluginClassLoader}
  *       ↑                           ╷          │                        ╷
  *     Common               linking of CallSite {@link ExternalPluginClassLoader}
  *     ↑    ↑             (on first invocation) ↑ ├ AdviceClass          ╷
@@ -277,7 +277,7 @@ public class IndyBootstrap {
             } else {
                 pluginClasses = getClassNamesFromBundledPlugin(adviceClassName, adviceClassLoader);
             }
-            ClassLoader pluginClassLoader = HelperClassManager.ForIndyPlugin.getOrCreatePluginClassLoader(
+            ClassLoader pluginClassLoader = IndyPluginClassLoaderFactory.getOrCreatePluginClassLoader(
                 lookup.lookupClass().getClassLoader(),
                 pluginClasses,
                 adviceClassLoader,

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyPluginClassLoaderFactory.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyPluginClassLoaderFactory.java
@@ -1,0 +1,109 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.bci;
+
+import co.elastic.apm.agent.bci.classloading.IndyPluginClassLoader;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.ClassFileLocator;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.pool.TypePool;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.WeakHashMap;
+
+public class IndyPluginClassLoaderFactory {
+
+    private static final Logger logger = LoggerFactory.getLogger(IndyPluginClassLoaderFactory.class);
+
+    private static final Map<ClassLoader, Map<Collection<String>, WeakReference<ClassLoader>>> alreadyInjected = new WeakHashMap<ClassLoader, Map<Collection<String>, WeakReference<ClassLoader>>>();
+
+    /**
+     * Creates an isolated CL that has two parents: the target class loader and the agent CL.
+     * The agent class loader is currently the bootstrap CL but in the future it will be an isolated CL that is a child of the bootstrap CL.
+     */
+    public synchronized static ClassLoader getOrCreatePluginClassLoader(@Nullable ClassLoader targetClassLoader, List<String> classesToInject, ClassLoader parent, ElementMatcher<? super TypeDescription> exclusionMatcher) throws Exception {
+        classesToInject = new ArrayList<>(classesToInject);
+
+        Map<Collection<String>, WeakReference<ClassLoader>> injectedClasses = getOrCreateInjectedClasses(targetClassLoader);
+        if (injectedClasses.containsKey(classesToInject)) {
+            ClassLoader pluginClassLoader = injectedClasses.get(classesToInject).get();
+            if (pluginClassLoader == null) {
+                injectedClasses.remove(classesToInject);
+            } else {
+                return pluginClassLoader;
+            }
+        }
+
+        List<String> classesToInjectCopy = new ArrayList<>(classesToInject.size());
+        TypePool pool = new TypePool.Default.WithLazyResolution(TypePool.CacheProvider.NoOp.INSTANCE, ClassFileLocator.ForClassLoader.of(parent), TypePool.Default.ReaderMode.FAST);
+        for (Iterator<String> iterator = classesToInject.iterator(); iterator.hasNext(); ) {
+            String className = iterator.next();
+            if (!exclusionMatcher.matches(pool.describe(className).resolve())) {
+                classesToInjectCopy.add(className);
+            }
+        }
+        logger.debug("Creating plugin class loader for {} containing {}", targetClassLoader, classesToInjectCopy);
+
+        Map<String, byte[]> typeDefinitions = getTypeDefinitions(classesToInjectCopy, parent);
+        // child first semantics are important here as the plugin CL contains classes that are also present in the agent CL
+        ClassLoader pluginClassLoader = new IndyPluginClassLoader(targetClassLoader, parent, typeDefinitions);
+        injectedClasses.put(classesToInject, new WeakReference<>(pluginClassLoader));
+
+        return pluginClassLoader;
+    }
+
+    private static Map<Collection<String>, WeakReference<ClassLoader>> getOrCreateInjectedClasses(@Nullable ClassLoader targetClassLoader) {
+        Map<Collection<String>, WeakReference<ClassLoader>> injectedClasses = alreadyInjected.get(targetClassLoader);
+        if (injectedClasses == null) {
+            injectedClasses = new HashMap<>();
+            alreadyInjected.put(targetClassLoader, injectedClasses);
+        }
+        return injectedClasses;
+    }
+
+    public synchronized static void clear() {
+        alreadyInjected.clear();
+    }
+
+    private static Map<String, byte[]> getTypeDefinitions(List<String> helperClassNames, ClassLoader classLoader) throws IOException {
+        Map<String, byte[]> typeDefinitions = new HashMap<>();
+        for (final String helperName : helperClassNames) {
+            final byte[] classBytes = ClassFileLocator.ForClassLoader.of(classLoader).locate(helperName).resolve();
+            typeDefinitions.put(helperName, classBytes);
+        }
+        return typeDefinitions;
+    }
+
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/TracerAwareInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/TracerAwareInstrumentation.java
@@ -41,56 +41,18 @@ public abstract class TracerAwareInstrumentation extends ElasticApmInstrumentati
     public static final Tracer tracer = GlobalTracer.get();
 
     /**
-     * When this method returns {@code true} the whole package (starting at the {@linkplain #getAdviceClass() advice's} package)
-     * will be loaded from a plugin class loader that has both the agent class loader and the class loader of the class this instruments as
-     * parents.
-     * <p>
-     * This instructs Byte Buddy to dispatch to the advice methods via an {@code INVOKEDYNAMIC} instruction.
-     * Upon first invocation of an instrumented method,
-     * this will call {@code IndyBootstrap#bootstrap} to determine the target {@link java.lang.invoke.ConstantCallSite}.
-     * </p>
-     * <p>
-     * Things to watch out for when using indy plugins:
-     * </p>
-     * <ul>
-     *     <li>
-     *         Set {@link Advice.OnMethodEnter#inline()} and {@link Advice.OnMethodExit#inline()} to {@code false} on all advices.
-     *         As the {@code readOnly} flag in Byte Buddy annotations such as {@link Advice.Return#readOnly()} cannot be used with non
-     *         {@linkplain Advice.OnMethodEnter#inline() inlined advices},
-     *         use {@link AssignTo} and friends.
-     *     </li>
-     *     <li>
-     *         Both the return type and the arguments of advice methods must not contain types from the agent.
-     *         If you'd like to return a span from an advice, for example, return an {@link Object} instead.
-     *         When using an {@link Advice.Enter} argument on the {@linkplain Advice.OnMethodExit exit advice},
-     *         that argument also has to be of type {@link Object} and you have to cast it within the method body.
-     *         The reason is that the return value will become a local variable in the instrumented method.
-     *         Due to OSGi, those methods may not have access to agent types.
-     *         Another case is when the instrumented class is inside the bootstrap classloader.
-     *     </li>
-     *     <li>
-     *         When an advice instruments classes in multiple class loaders, the plugin classes will be loaded form multiple class loaders.
-     *         In order to still share state across those plugin class loaders,
-     *         use {@link co.elastic.apm.agent.sdk.state.GlobalVariables} or {@link co.elastic.apm.agent.sdk.state.GlobalState}.
-     *         That's necessary as static variables are scoped to the class loader they are defined in.
-     *     </li>
-     *     <li>
-     *         Don't use {@link ThreadLocal}s as it can lead to class loader leaks.
-     *         Use {@link GlobalThreadLocal} instead.
-     *     </li>
-     *     <li>
-     *         Due to the automatic plugin classloader creation that is based on package scanning,
-     *         plugins need be in their own uniquely named package.
-     *         As the package of the {@link #getAdviceClass()} is used as the root,
-     *         all advices have to be at the top level of the plugin.
-     *     </li>
-     * </ul>
+     * Allows to opt-out of indy plugins.
+     * This is just to allow for a migration period where both indy and non-indy plugins are in use.
+     * Once all non-indy plugins are migrated this method will be removed.
      *
+     * @deprecated Overriding this method means not the instrumentation is not an indy plugin.
+     * The usage of non-indy plugins is deprecated.
      * @return whether to load the classes of this plugin in dedicated plugin class loaders (one for each unique class loader)
      * and dispatch to the {@linkplain #getAdviceClass() advice} via an {@code INVOKEDYNAMIC} instruction.
      */
+    @Deprecated
     public boolean indyPlugin() {
-        return false;
+        return true;
     }
 
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/VisibleForAdvice.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/VisibleForAdvice.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,7 +39,10 @@ import java.lang.annotation.Target;
  * the signature of the advice method,
  * as well as the advice class itself need to be public.
  * </p>
+ * @deprecated This annotation is not needed for {@link TracerAwareInstrumentation#indyPlugin()}  indy plugins}.
+ * That's because indy plugins never use {@link Advice.OnMethodEnter#inline() inline}d advices.
  */
+@Deprecated
 @Retention(RetentionPolicy.SOURCE)
 @Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.CONSTRUCTOR})
 public @interface VisibleForAdvice {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/methodmatching/TraceMethodInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/methodmatching/TraceMethodInstrumentation.java
@@ -160,4 +160,9 @@ public class TraceMethodInstrumentation extends TracerAwareInstrumentation {
     public Collection<String> getInstrumentationGroupNames() {
         return Collections.singletonList("method-matching");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -524,6 +524,11 @@ class InstrumentationTest {
         public Collection<String> getInstrumentationGroupNames() {
             return List.of("test", "experimental");
         }
+
+        @Override
+        public boolean indyPlugin() {
+            return false;
+        }
     }
 
     public static class MathInstrumentation extends TracerAwareInstrumentation {
@@ -547,6 +552,11 @@ class InstrumentationTest {
         public Collection<String> getInstrumentationGroupNames() {
             return Collections.emptyList();
         }
+
+        @Override
+        public boolean indyPlugin() {
+            return false;
+        }
     }
 
     public static class ExceptionInstrumentation extends TracerAwareInstrumentation {
@@ -568,6 +578,11 @@ class InstrumentationTest {
         @Override
         public Collection<String> getInstrumentationGroupNames() {
             return Collections.emptyList();
+        }
+
+        @Override
+        public boolean indyPlugin() {
+            return false;
         }
     }
 
@@ -597,6 +612,11 @@ class InstrumentationTest {
         public Collection<String> getInstrumentationGroupNames() {
             return Collections.emptyList();
         }
+
+        @Override
+        public boolean indyPlugin() {
+            return false;
+        }
     }
 
     public static class FieldAccessInstrumentation extends TracerAwareInstrumentation {
@@ -620,6 +640,11 @@ class InstrumentationTest {
         @Override
         public Collection<String> getInstrumentationGroupNames() {
             return List.of("test", "experimental");
+        }
+
+        @Override
+        public boolean indyPlugin() {
+            return false;
         }
     }
 
@@ -645,6 +670,11 @@ class InstrumentationTest {
         public Collection<String> getInstrumentationGroupNames() {
             return List.of("test", "experimental");
         }
+
+        @Override
+        public boolean indyPlugin() {
+            return false;
+        }
     }
 
     public static class AssignToArgumentInstrumentation extends TracerAwareInstrumentation {
@@ -668,6 +698,11 @@ class InstrumentationTest {
         @Override
         public Collection<String> getInstrumentationGroupNames() {
             return List.of("test", "experimental");
+        }
+
+        @Override
+        public boolean indyPlugin() {
+            return false;
         }
     }
 
@@ -696,6 +731,11 @@ class InstrumentationTest {
         public Collection<String> getInstrumentationGroupNames() {
             return List.of("test", "experimental");
         }
+
+        @Override
+        public boolean indyPlugin() {
+            return false;
+        }
     }
 
     public static class AssignToReturnArrayInstrumentation extends TracerAwareInstrumentation {
@@ -719,6 +759,11 @@ class InstrumentationTest {
         @Override
         public Collection<String> getInstrumentationGroupNames() {
             return List.of("test", "experimental");
+        }
+
+        @Override
+        public boolean indyPlugin() {
+            return false;
         }
     }
 
@@ -1010,11 +1055,6 @@ class InstrumentationTest {
         @Override
         public Collection<String> getInstrumentationGroupNames() {
             return Collections.singletonList("test");
-        }
-
-        @Override
-        public boolean indyPlugin() {
-            return true;
         }
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/subpackage/AdviceInSubpackageInstrumentation.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/subpackage/AdviceInSubpackageInstrumentation.java
@@ -55,9 +55,4 @@ public class AdviceInSubpackageInstrumentation extends TracerAwareInstrumentatio
     public Collection<String> getInstrumentationGroupNames() {
         return Collections.singletonList("test");
     }
-
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
 }

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/BaseApacheHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/BaseApacheHttpClientInstrumentation.java
@@ -65,4 +65,9 @@ public abstract class BaseApacheHttpClientInstrumentation extends TracerAwareIns
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("http-client", "apache-httpclient");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/ApiInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/ApiInstrumentation.java
@@ -41,4 +41,9 @@ public abstract class ApiInstrumentation extends TracerAwareInstrumentation {
     public Collection<String> getInstrumentationGroupNames() {
         return Collections.singleton(PUBLIC_API_INSTRUMENTATION_GROUP);
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/CaptureSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/CaptureSpanInstrumentation.java
@@ -119,4 +119,8 @@ public class CaptureSpanInstrumentation extends TracerAwareInstrumentation {
         return Arrays.asList(PUBLIC_API_INSTRUMENTATION_GROUP, "annotations");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/CaptureTransactionInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/CaptureTransactionInstrumentation.java
@@ -120,4 +120,8 @@ public class CaptureTransactionInstrumentation extends TracerAwareInstrumentatio
         return Arrays.asList(PUBLIC_API_INSTRUMENTATION_GROUP, "annotations");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/TracedInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/plugin/api/TracedInstrumentation.java
@@ -132,4 +132,8 @@ public class TracedInstrumentation extends TracerAwareInstrumentation {
         return Arrays.asList(PUBLIC_API_INSTRUMENTATION_GROUP, "annotations");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AbstractAsyncHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/main/java/co/elastic/apm/agent/asynchttpclient/AbstractAsyncHttpClientInstrumentation.java
@@ -98,6 +98,11 @@ public abstract class AbstractAsyncHttpClientInstrumentation extends TracerAware
             .and(classLoaderCanLoadClass("org.asynchttpclient.AsyncHandler"));
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class AsyncHttpClientInstrumentation extends AbstractAsyncHttpClientInstrumentation {
 
         public AsyncHttpClientInstrumentation(ElasticApmTracer tracer) {

--- a/apm-agent-plugins/apm-bootdelegation-plugin/src/main/java/co/elastic/apm/agent/bootdelegation/BootstrapDelegationClassLoaderInstrumentation.java
+++ b/apm-agent-plugins/apm-bootdelegation-plugin/src/main/java/co/elastic/apm/agent/bootdelegation/BootstrapDelegationClassLoaderInstrumentation.java
@@ -109,4 +109,9 @@ public class BootstrapDelegationClassLoaderInstrumentation extends TracerAwareIn
             }
         }
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/AbstractDubboInstrumentation.java
+++ b/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/AbstractDubboInstrumentation.java
@@ -35,4 +35,9 @@ public abstract class AbstractDubboInstrumentation extends TracerAwareInstrument
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("dubbo", "experimental");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-error-logging-plugin/src/main/java/co/elastic/apm/agent/error/logging/AbstractLoggerErrorCapturingInstrumentation.java
+++ b/apm-agent-plugins/apm-error-logging-plugin/src/main/java/co/elastic/apm/agent/error/logging/AbstractLoggerErrorCapturingInstrumentation.java
@@ -56,6 +56,11 @@ public abstract class AbstractLoggerErrorCapturingInstrumentation extends Tracer
         return LoggingAdvice.class;
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class LoggingAdvice {
 
         @Advice.OnMethodEnter(suppress = Throwable.class)

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/es/restclient/ElasticsearchRestClientInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/es/restclient/ElasticsearchRestClientInstrumentation.java
@@ -59,4 +59,9 @@ public abstract class ElasticsearchRestClientInstrumentation extends TracerAware
     public Collection<String> getInstrumentationGroupNames() {
         return Collections.singleton("elasticsearch-restclient");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-grails-plugin/src/main/java/co/elastic/apm/agent/grails/GrailsTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-grails-plugin/src/main/java/co/elastic/apm/agent/grails/GrailsTransactionNameInstrumentation.java
@@ -85,6 +85,11 @@ public class GrailsTransactionNameInstrumentation extends TracerAwareInstrumenta
         return Collections.singletonList("grails");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     @VisibleForAdvice
     public static class HandlerAdapterAdvice {
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/BaseInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/BaseInstrumentation.java
@@ -68,4 +68,8 @@ public abstract class BaseInstrumentation extends TracerAwareInstrumentation {
         return Collections.singleton(GrpcHelper.GRPC);
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernate/search/v5_x/HibernateSearch5Instrumentation.java
@@ -83,6 +83,11 @@ public class HibernateSearch5Instrumentation extends TracerAwareInstrumentation 
         return Collections.singleton(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE);
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class HibernateSearch5ExecuteAdvice {
 
         @Advice.OnMethodEnter(suppress = Throwable.class)

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernate/search/v6_x/HibernateSearch6Instrumentation.java
@@ -82,6 +82,11 @@ public class HibernateSearch6Instrumentation extends TracerAwareInstrumentation 
         return Arrays.asList(HibernateSearchConstants.HIBERNATE_SEARCH_ORM_TYPE, "experimental");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class Hibernate6ExecuteAdvice {
 
         @Advice.OnMethodEnter(suppress = Throwable.class)

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
@@ -103,11 +103,6 @@ public abstract class ExecutorInstrumentation extends TracerAwareInstrumentation
         return Arrays.asList("concurrent", "executor");
     }
 
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
-
     private static boolean isExcluded(@Advice.This Executor executor) {
         return excludedClasses.contains(executor.getClass().getName());
     }

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ForkJoinTaskInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ForkJoinTaskInstrumentation.java
@@ -58,11 +58,6 @@ public class ForkJoinTaskInstrumentation extends TracerAwareInstrumentation {
         return Arrays.asList("concurrent", "fork-join");
     }
 
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
-
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static void onExecute(@Advice.This ForkJoinTask<?> thiz) {
         JavaConcurrent.withContext(thiz, tracer);

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/RunnableCallableForkJoinTaskInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/RunnableCallableForkJoinTaskInstrumentation.java
@@ -72,11 +72,6 @@ public class RunnableCallableForkJoinTaskInstrumentation extends TracerAwareInst
         return Arrays.asList("concurrent", "executor");
     }
 
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
-
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static Object onEnter(@Advice.This Object thiz) {

--- a/apm-agent-plugins/apm-jaxrs-plugin/src/main/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-jaxrs-plugin/src/main/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentation.java
@@ -142,4 +142,9 @@ public class JaxRsTransactionNameInstrumentation extends TracerAwareInstrumentat
     public Advice.OffsetMapping.Factory<?> getOffsetMapping() {
         return new JaxRsOffsetMappingFactory(tracer);
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-jaxws-plugin/src/main/java/co/elastic/apm/agent/jaxws/JaxWsTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-jaxws-plugin/src/main/java/co/elastic/apm/agent/jaxws/JaxWsTransactionNameInstrumentation.java
@@ -101,4 +101,9 @@ public class JaxWsTransactionNameInstrumentation extends TracerAwareInstrumentat
     public Collection<String> getInstrumentationGroupNames() {
         return Collections.singletonList("jax-ws");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/JdbcInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/JdbcInstrumentation.java
@@ -40,9 +40,4 @@ public abstract class JdbcInstrumentation extends TracerAwareInstrumentation {
     public final Collection<String> getInstrumentationGroupNames() {
         return JDBC_GROUPS;
     }
-
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
 }

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/BaseJmsInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/BaseJmsInstrumentation.java
@@ -78,4 +78,9 @@ public abstract class BaseJmsInstrumentation extends TracerAwareInstrumentation 
     public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
         return not(isBootstrapClassLoader()).and(classLoaderCanLoadClass("javax.jms.Message"));
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-jsf-plugin/src/main/java/co/elastic/apm/agent/jsf/JsfLifecycleInstrumentation.java
+++ b/apm-agent-plugins/apm-jsf-plugin/src/main/java/co/elastic/apm/agent/jsf/JsfLifecycleInstrumentation.java
@@ -80,6 +80,11 @@ public abstract class JsfLifecycleInstrumentation extends TracerAwareInstrumenta
         return Arrays.asList("servlet-api", "jsf");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class JsfLifecycleExecuteInstrumentation extends JsfLifecycleInstrumentation {
         @Override
         public ElementMatcher<? super MethodDescription> getMethodMatcher() {

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/main/java/co/elastic/apm/agent/kafka/BaseKafkaInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/main/java/co/elastic/apm/agent/kafka/BaseKafkaInstrumentation.java
@@ -79,4 +79,9 @@ public abstract class BaseKafkaInstrumentation extends TracerAwareInstrumentatio
     public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
         return not(isBootstrapClassLoader()).and(classLoaderCanLoadClass("org.apache.kafka.clients.consumer.ConsumerRecord"));
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/MongoClientInstrumentation.java
+++ b/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/MongoClientInstrumentation.java
@@ -48,4 +48,9 @@ public abstract class MongoClientInstrumentation extends TracerAwareInstrumentat
     public Collection<String> getInstrumentationGroupNames() {
         return Collections.singletonList("mongodb-client");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/AbstractOkHttp3ClientInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/AbstractOkHttp3ClientInstrumentation.java
@@ -56,4 +56,9 @@ public abstract class AbstractOkHttp3ClientInstrumentation extends TracerAwareIn
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("http-client", "okhttp");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/AbstractOkHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/AbstractOkHttpClientInstrumentation.java
@@ -56,4 +56,9 @@ public abstract class AbstractOkHttpClientInstrumentation extends TracerAwareIns
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("http-client", "okhttp");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/OpenTracingBridgeInstrumentation.java
+++ b/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracing/impl/OpenTracingBridgeInstrumentation.java
@@ -39,4 +39,9 @@ public abstract class OpenTracingBridgeInstrumentation extends TracerAwareInstru
     public Collection<String> getInstrumentationGroupNames() {
         return Collections.singleton("opentracing");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/BaseProcessInstrumentation.java
+++ b/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/BaseProcessInstrumentation.java
@@ -44,9 +44,4 @@ public abstract class BaseProcessInstrumentation extends TracerAwareInstrumentat
     public final Collection<String> getInstrumentationGroupNames() {
         return Collections.singletonList("process");
     }
-
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
 }

--- a/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/CommonsExecAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/CommonsExecAsyncInstrumentation.java
@@ -88,11 +88,6 @@ public class CommonsExecAsyncInstrumentation extends TracerAwareInstrumentation 
         return CommonsExecAdvice.class;
     }
 
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
-
     public static final class CommonsExecAdvice {
 
         @Nullable

--- a/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartz/job/JobTransactionNameInstrumentation.java
@@ -77,4 +77,9 @@ public class JobTransactionNameInstrumentation extends TracerAwareInstrumentatio
     public Class<?> getAdviceClass() {
         return JobTransactionNameAdvice.class;
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/main/java/co/elastic/apm/agent/redis/jedis/JedisInstrumentation.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/main/java/co/elastic/apm/agent/redis/jedis/JedisInstrumentation.java
@@ -89,4 +89,9 @@ public class JedisInstrumentation extends TracerAwareInstrumentation {
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("redis", "jedis");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/main/java/co/elastic/apm/agent/redis/jedis/JedisSpanNameInstrumentation.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/main/java/co/elastic/apm/agent/redis/jedis/JedisSpanNameInstrumentation.java
@@ -79,4 +79,9 @@ public class JedisSpanNameInstrumentation extends TracerAwareInstrumentation {
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("redis", "jedis");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce34Instrumentation.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce34Instrumentation.java
@@ -57,4 +57,9 @@ public abstract class Lettuce34Instrumentation extends TracerAwareInstrumentatio
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("redis", "lettuce");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce5StartSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce5StartSpanInstrumentation.java
@@ -92,4 +92,8 @@ public class Lettuce5StartSpanInstrumentation extends TracerAwareInstrumentation
         }
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce5StopSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/main/java/co/elastic/apm/agent/redis/lettuce/Lettuce5StopSpanInstrumentation.java
@@ -74,6 +74,11 @@ public abstract class Lettuce5StopSpanInstrumentation extends TracerAwareInstrum
         return Arrays.asList("redis", "lettuce");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class OnComplete extends Lettuce5StopSpanInstrumentation {
 
         @Advice.OnMethodEnter(suppress = Throwable.class)

--- a/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/src/main/java/co/elastic/apm/agent/redis/redisson/RedisConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/src/main/java/co/elastic/apm/agent/redis/redisson/RedisConnectionInstrumentation.java
@@ -99,4 +99,9 @@ public class RedisConnectionInstrumentation extends TracerAwareInstrumentation {
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("redis", "redisson");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-scala-concurrent-plugin/src/main/java/co/elastic/apm/agent/scala/concurrent/FutureInstrumentation.java
+++ b/apm-agent-plugins/apm-scala-concurrent-plugin/src/main/java/co/elastic/apm/agent/scala/concurrent/FutureInstrumentation.java
@@ -55,6 +55,11 @@ public abstract class FutureInstrumentation extends TracerAwareInstrumentation {
         return Arrays.asList("scala-future", "experimental");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class ConstructorInstrumentation extends FutureInstrumentation {
 
         @Override

--- a/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/spring/scheduled/ScheduledTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/spring/scheduled/ScheduledTransactionNameInstrumentation.java
@@ -106,4 +106,9 @@ public class ScheduledTransactionNameInstrumentation extends TracerAwareInstrume
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("concurrent", "scheduled");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/spring/scheduled/TimerTaskInstrumentation.java
+++ b/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/spring/scheduled/TimerTaskInstrumentation.java
@@ -101,4 +101,9 @@ public class TimerTaskInstrumentation extends TracerAwareInstrumentation {
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("timer-task");
     }
+
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AbstractServletInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AbstractServletInstrumentation.java
@@ -47,9 +47,4 @@ public abstract class AbstractServletInstrumentation extends TracerAwareInstrume
         // for example, 'javax.servlet.annotation.WebServlet' annotation is not working as expected on Payara
         return CustomElementMatchers.classLoaderCanLoadClass("javax.servlet.AsyncContext");
     }
-
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
 }

--- a/apm-agent-plugins/apm-spring-resttemplate-plugin/src/main/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-resttemplate-plugin/src/main/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentation.java
@@ -98,6 +98,11 @@ public class SpringRestTemplateInstrumentation extends TracerAwareInstrumentatio
         return Arrays.asList("http-client", "spring-resttemplate");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class SpringRestTemplateAdvice {
         @Advice.OnMethodEnter(suppress = Throwable.class)
         private static void beforeExecute(@Advice.This ClientHttpRequest request,

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/spring/webmvc/ExceptionHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/spring/webmvc/ExceptionHandlerInstrumentation.java
@@ -45,6 +45,11 @@ public class ExceptionHandlerInstrumentation extends TracerAwareInstrumentation 
         return ExceptionHandlerAdviceService.class;
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class ExceptionHandlerAdviceService {
 
         @Advice.OnMethodEnter(suppress = Throwable.class)

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/spring/webmvc/SpringServiceNameInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/spring/webmvc/SpringServiceNameInstrumentation.java
@@ -67,6 +67,11 @@ public class SpringServiceNameInstrumentation extends TracerAwareInstrumentation
         return SpringServiceNameAdvice.class;
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class SpringServiceNameAdvice {
 
         @Advice.OnMethodExit(suppress = Throwable.class)

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/spring/webmvc/SpringTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/spring/webmvc/SpringTransactionNameInstrumentation.java
@@ -103,6 +103,11 @@ public class SpringTransactionNameInstrumentation extends TracerAwareInstrumenta
         return Collections.singleton("spring-mvc");
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     @VisibleForAdvice
     public static class HandlerAdapterAdvice {
 

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/spring/webmvc/ViewRenderInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/spring/webmvc/ViewRenderInstrumentation.java
@@ -58,6 +58,11 @@ public class ViewRenderInstrumentation extends TracerAwareInstrumentation {
         return ViewRenderAdviceService.class;
     }
 
+    @Override
+    public boolean indyPlugin() {
+        return false;
+    }
+
     public static class ViewRenderAdviceService {
 
         @Advice.OnMethodEnter(suppress = Throwable.class)

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
@@ -69,11 +69,6 @@ public abstract class HttpUrlConnectionInstrumentation extends TracerAwareInstru
         return hasSuperType(is(HttpURLConnection.class));
     }
 
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
-
     public static class CreateSpanInstrumentation extends HttpUrlConnectionInstrumentation {
 
         @Nullable

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/SSLContextInstrumentation.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/SSLContextInstrumentation.java
@@ -77,11 +77,6 @@ public class SSLContextInstrumentation extends TracerAwareInstrumentation {
         return Collections.singleton("ssl-context");
     }
 
-    @Override
-    public boolean indyPlugin() {
-        return true;
-    }
-
     /**
      * This will not allow using the default SSL factory from any agent thread
      */


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

Makes indy plugins the default. Deprecates usage of non-indy plugins and `HelperClassManager`


I have manually verified that the number of indy plugins is the same before and after this change