### PR TITLE
Delay agent start for Tomcat running on Java 7

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -511,7 +511,7 @@ public class ElasticApmTracer implements Tracer {
     private boolean shouldDelayOnPremain() {
         String javaVersion = System.getProperty("java.version");
         return javaVersion != null &&
-            javaVersion.startsWith("1.8") &&
+            (javaVersion.startsWith("1.7") || javaVersion.startsWith("1.8")) &&
             ClassLoader.getSystemClassLoader().getResource("org/apache/catalina/startup/Bootstrap.class") != null;
     }
 


### PR DESCRIPTION
Based on https://discuss.elastic.co/t/elastic-apm-latest-java-agent-doest-not-work-on-tomcat-7/245112 - we should delay on Tomcat when running on Java 7 as well.