### PR TITLE
Add ability to specify directory that libasyncProfiler is exported to, to support /tmp partitions that have noexec set

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -50,7 +50,7 @@ endif::[]
   an empty string - {pull}1295[#1295]
 * Add <<metrics-micrometer, micrometer support>> - {pull}1303[#1303]
 * Add `profiling_inferred_spans_lib_directory` option to override the default temp directory used for exporting the async-profiler library.
-  This is useful for server-hardened environments where /tmp is often configured with noexec, leading to java.lang.UnsatisfiedLinkError errors - {pull}1350[#1350]
+  This is useful for server-hardened environments where `/tmp` is often configured with `noexec`, leading to `java.lang.UnsatisfiedLinkError` errors - {pull}1350[#1350]
 
 [float]
 ===== Bug fixes

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,8 @@ endif::[]
 * Enabling agent to work without attempting any communication with APM server, by allowing setting `server_urls` with
   an empty string - {pull}1295[#1295]
 * Add <<metrics-micrometer, micrometer support>> - {pull}1303[#1303]
+* Add `profiling_inferred_spans_lib_directory` option to override the default temp directory used for exporting the async-profiler library.
+  This is useful for server-hardened environments where /tmp is often configured with noexec, leading to java.lang.UnsatisfiedLinkError errors - {pull}1350[#1350]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/IOUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/IOUtils.java
@@ -214,13 +214,14 @@ public class IOUtils {
      * Why it's synchronized : if the same JVM try to lock file, we got an java.nio.channels.OverlappingFileLockException.
      * So we need to block until the file is totally written.
      */
-    public static synchronized File exportResourceToTemp(String resource, String tempFileNamePrefix, String tempFileNameExtension) {
+    public static synchronized File exportResourceToDirectory(String resource, String parentDirectory, String tempFileNamePrefix,
+                                                              String tempFileNameExtension) {
         try (InputStream resourceStream = IOUtils.class.getResourceAsStream("/" + resource)) {
             if (resourceStream == null) {
                 throw new IllegalStateException(resource + " not found");
             }
             String hash = md5Hash(IOUtils.class.getResourceAsStream("/" + resource));
-            File tempFile = new File(System.getProperty("java.io.tmpdir"), tempFileNamePrefix + "-" + hash + tempFileNameExtension);
+            File tempFile = new File(parentDirectory, tempFileNamePrefix + "-" + hash + tempFileNameExtension);
             if (!tempFile.exists()) {
                 try (FileOutputStream out = new FileOutputStream(tempFile)) {
                     FileChannel channel = out.getChannel();

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -170,7 +170,7 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
             "The partition backing this location must be executable, however in some server-hardened environments, " +
             "noexec may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.\n" +
             "Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this.\n" +
-            "If unset, the value of the `java.io.tmpdir` System property will be used.")
+            "If unset, the value of the `java.io.tmpdir` system property will be used.")
         .configurationCategory(PROFILING_CATEGORY)
         .dynamic(false)
         .tags("added[1.18.0]")

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -168,9 +168,9 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
         .description("Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library " +
             "is exported to a temporary location and loaded by the JVM.\n" +
             "The partition backing this location must be executable, however in some server-hardened environments, " +
-            "noexec may be set on the standard /tmp partition, leading to java.lang.UnsatisfiedLinkError errors.\n" +
-            "Set this property to an alternative directory (e.g. '/var/tmp') to resolve this.\n" +
-            "If unset, the value of the \"java.io.tmpdir\" System property will be used.")
+            "noexec may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.\n" +
+            "Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this.\n" +
+            "If unset, the value of the `java.io.tmpdir` System property will be used.")
         .configurationCategory(PROFILING_CATEGORY)
         .dynamic(false)
         .tags("added[1.18.0]")

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -34,7 +34,6 @@ import org.stagemonitor.configuration.ConfigurationOptionProvider;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 
 import static co.elastic.apm.agent.configuration.validation.RangeValidator.isInRange;
 import static co.elastic.apm.agent.configuration.validation.RangeValidator.min;
@@ -164,7 +163,7 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
         .tags("added[1.15.0]", "internal")
         .buildWithDefault(TimeDuration.of("5s"));
 
-    private final ConfigurationOption<Optional<String>> profilerLibDirectory = ConfigurationOption.<String>stringOption()
+    private final ConfigurationOption<String> profilerLibDirectory = ConfigurationOption.<String>stringOption()
         .key("profiling_inferred_spans_lib_directory")
         .description("Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library " +
             "is exported to a temporary location and loaded by the JVM.\n" +
@@ -175,7 +174,7 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
         .configurationCategory(PROFILING_CATEGORY)
         .dynamic(false)
         .tags("added[1.18.0]")
-        .buildOptional();
+        .build();
 
     public boolean isProfilingEnabled() {
         return profilingEnabled.get();
@@ -222,6 +221,6 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
     }
 
     public String getProfilerLibDirectory() {
-        return profilerLibDirectory.get().orElse(System.getProperty("java.io.tmpdir"));
+        return profilerLibDirectory.isDefault() ? System.getProperty("java.io.tmpdir") : profilerLibDirectory.get();
     }
 }

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -168,7 +168,7 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
         .description("Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library " +
             "is exported to a temporary location and loaded by the JVM.\n" +
             "The partition backing this location must be executable, however in some server-hardened environments, " +
-            "noexec may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.\n" +
+            "`noexec` may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.\n" +
             "Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this.\n" +
             "If unset, the value of the `java.io.tmpdir` system property will be used.")
         .configurationCategory(PROFILING_CATEGORY)

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -34,6 +34,7 @@ import org.stagemonitor.configuration.ConfigurationOptionProvider;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 import static co.elastic.apm.agent.configuration.validation.RangeValidator.isInRange;
 import static co.elastic.apm.agent.configuration.validation.RangeValidator.min;
@@ -163,6 +164,19 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
         .tags("added[1.15.0]", "internal")
         .buildWithDefault(TimeDuration.of("5s"));
 
+    private final ConfigurationOption<Optional<String>> profilerLibDirectory = ConfigurationOption.<String>stringOption()
+        .key("profiling_inferred_spans_lib_directory")
+        .description("Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library " +
+            "is exported to a temporary location and loaded by the JVM.\n" +
+            "The partition backing this location must be executable, however in some server-hardened environments, " +
+            "noexec may be set on the standard /tmp partition, leading to java.lang.UnsatisfiedLinkError errors.\n" +
+            "Set this property to an alternative directory (e.g. '/var/tmp') to resolve this.\n" +
+            "If unset, the value of the \"java.io.tmpdir\" System property will be used.")
+        .configurationCategory(PROFILING_CATEGORY)
+        .dynamic(false)
+        .tags("added[1.18.0]")
+        .buildOptional();
+
     public boolean isProfilingEnabled() {
         return profilingEnabled.get();
     }
@@ -205,5 +219,9 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
 
     public boolean isBackupDiagnosticFiles() {
         return backupDiagnosticFiles.get();
+    }
+
+    public String getProfilerLibDirectory() {
+        return profilerLibDirectory.get().orElse(System.getProperty("java.io.tmpdir"));
     }
 }

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
@@ -259,7 +259,7 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     public boolean onActivation(TraceContext activeSpan, @Nullable TraceContext previouslyActive) {
         if (profilingSessionOngoing) {
             if (previouslyActive == null) {
-                AsyncProfiler.getInstance(config).enableProfilingCurrentThread();
+                AsyncProfiler.getInstance(config.getProfilerLibDirectory()).enableProfilingCurrentThread();
             }
             boolean success = eventBuffer.tryPublishEvent(ACTIVATION_EVENT_TRANSLATOR, activeSpan, previouslyActive);
             if (!success && logger.isDebugEnabled()) {
@@ -284,7 +284,7 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     public boolean onDeactivation(TraceContext activeSpan, @Nullable TraceContext previouslyActive) {
         if (profilingSessionOngoing) {
             if (previouslyActive == null) {
-                AsyncProfiler.getInstance(config).disableProfilingCurrentThread();
+                AsyncProfiler.getInstance(config.getProfilerLibDirectory()).disableProfilingCurrentThread();
             }
             boolean success = eventBuffer.tryPublishEvent(DEACTIVATION_EVENT_TRANSLATOR, activeSpan, previouslyActive);
             if (!success && logger.isDebugEnabled()) {
@@ -333,7 +333,7 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     }
 
     private void profile(TimeDuration sampleRate, TimeDuration profilingDuration) throws Exception {
-        AsyncProfiler asyncProfiler = AsyncProfiler.getInstance(config);
+        AsyncProfiler asyncProfiler = AsyncProfiler.getInstance(config.getProfilerLibDirectory());
         try {
             String startCommand = "start,jfr,event=wall,cstack=n,interval=" + sampleRate.getMillis() + "ms,filter,file=" + jfrFile + ",safemode=" + config.getAsyncProfilerSafeMode();
             String startMessage = asyncProfiler.execute(startCommand);

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
@@ -259,7 +259,7 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     public boolean onActivation(TraceContext activeSpan, @Nullable TraceContext previouslyActive) {
         if (profilingSessionOngoing) {
             if (previouslyActive == null) {
-                AsyncProfiler.getInstance().enableProfilingCurrentThread();
+                AsyncProfiler.getInstance(config).enableProfilingCurrentThread();
             }
             boolean success = eventBuffer.tryPublishEvent(ACTIVATION_EVENT_TRANSLATOR, activeSpan, previouslyActive);
             if (!success && logger.isDebugEnabled()) {
@@ -284,7 +284,7 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     public boolean onDeactivation(TraceContext activeSpan, @Nullable TraceContext previouslyActive) {
         if (profilingSessionOngoing) {
             if (previouslyActive == null) {
-                AsyncProfiler.getInstance().disableProfilingCurrentThread();
+                AsyncProfiler.getInstance(config).disableProfilingCurrentThread();
             }
             boolean success = eventBuffer.tryPublishEvent(DEACTIVATION_EVENT_TRANSLATOR, activeSpan, previouslyActive);
             if (!success && logger.isDebugEnabled()) {
@@ -333,7 +333,7 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     }
 
     private void profile(TimeDuration sampleRate, TimeDuration profilingDuration) throws Exception {
-        AsyncProfiler asyncProfiler = AsyncProfiler.getInstance();
+        AsyncProfiler asyncProfiler = AsyncProfiler.getInstance(config);
         try {
             String startCommand = "start,jfr,event=wall,cstack=n,interval=" + sampleRate.getMillis() + "ms,filter,file=" + jfrFile + ",safemode=" + config.getAsyncProfilerSafeMode();
             String startMessage = asyncProfiler.execute(startCommand);

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/asyncprofiler/AsyncProfiler.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/asyncprofiler/AsyncProfiler.java
@@ -75,7 +75,7 @@ public class AsyncProfiler {
                 try {
                     loadNativeLibrary(config.getProfilerLibDirectory());
                 } catch (UnsatisfiedLinkError e) {
-                    throw new IllegalStateException(String.format("Is is likely that %s is not an executable location. Consider setting " +
+                    throw new IllegalStateException(String.format("It is likely that %s is not an executable location. Consider setting " +
                         "the profiling_inferred_spans_lib_directory property to a directory on a partition that allows execution",
                         config.getProfilerLibDirectory()), e);
                 }

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/asyncprofiler/AsyncProfilerTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/asyncprofiler/AsyncProfilerTest.java
@@ -24,55 +24,37 @@
  */
 package co.elastic.apm.agent.profiler.asyncprofiler;
 
-import co.elastic.apm.agent.configuration.SpyConfiguration;
-import co.elastic.apm.agent.profiler.ProfilingConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.stagemonitor.configuration.ConfigurationRegistry;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.FilenameFilter;
-import java.io.IOException;
-import java.lang.reflect.Field;
-import java.nio.file.Files;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 public class AsyncProfilerTest {
 
-    private ProfilingConfiguration profilerConfig;
-
     @BeforeEach
-    void setUp() throws ReflectiveOperationException {
-        ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
-        profilerConfig = config.getConfig(ProfilingConfiguration.class);
-
-        // Ensure that the singleton AsyncProfiler is reset so a new instance is created for each test
-        Field instance = AsyncProfiler.class.getDeclaredField("instance");
-        instance.setAccessible(true);
-        instance.set(null, null);
+    void setUp() {
+        AsyncProfiler.reset();
     }
 
     @Test
     void testShouldCopyLibToTempDirectory() {
-        AsyncProfiler.getInstance(profilerConfig);
+        String defaultTempDirectory = System.getProperty("java.io.tmpdir");
+        AsyncProfiler.getInstance(defaultTempDirectory);
 
-        File libDirectory = new File(profilerConfig.getProfilerLibDirectory());
+        File libDirectory = new File(defaultTempDirectory);
         File[] libasyncProfilers = libDirectory.listFiles(getLibasyncProfilerFilenameFilter());
         assertThat(libasyncProfilers).hasSizeGreaterThanOrEqualTo(1);
     }
 
     @Test
-    void testShouldCopyLibToSpecifiedDirectory() throws IOException {
-        File parentDirectory = Files.createTempDirectory(null).toFile();
-        parentDirectory.deleteOnExit();
-        when(profilerConfig.getProfilerLibDirectory()).thenReturn(parentDirectory.getAbsolutePath());
-        System.out.println(parentDirectory.getAbsolutePath());
+    void testShouldCopyLibToSpecifiedDirectory(@TempDir File nonDefaultTempDirectory) {
+        AsyncProfiler.getInstance(nonDefaultTempDirectory.getAbsolutePath());
 
-        AsyncProfiler.getInstance(profilerConfig);
-
-        File[] libasyncProfilers = parentDirectory.listFiles(getLibasyncProfilerFilenameFilter());
+        File[] libasyncProfilers = nonDefaultTempDirectory.listFiles(getLibasyncProfilerFilenameFilter());
         assertThat(libasyncProfilers).hasSizeGreaterThanOrEqualTo(1);
     }
 

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/asyncprofiler/AsyncProfilerTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/asyncprofiler/AsyncProfilerTest.java
@@ -1,0 +1,82 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.profiler.asyncprofiler;
+
+import co.elastic.apm.agent.configuration.SpyConfiguration;
+import co.elastic.apm.agent.profiler.ProfilingConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.stagemonitor.configuration.ConfigurationRegistry;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Files;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+public class AsyncProfilerTest {
+
+    private ProfilingConfiguration profilerConfig;
+
+    @BeforeEach
+    void setUp() throws ReflectiveOperationException {
+        ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
+        profilerConfig = config.getConfig(ProfilingConfiguration.class);
+
+        // Ensure that the singleton AsyncProfiler is reset so a new instance is created for each test
+        Field instance = AsyncProfiler.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+    }
+
+    @Test
+    void testShouldCopyLibToTempDirectory() {
+        AsyncProfiler.getInstance(profilerConfig);
+
+        File libDirectory = new File(profilerConfig.getProfilerLibDirectory());
+        File[] libasyncProfilers = libDirectory.listFiles(getLibasyncProfilerFilenameFilter());
+        assertThat(libasyncProfilers).hasSizeGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void testShouldCopyLibToSpecifiedDirectory() throws IOException {
+        File parentDirectory = Files.createTempDirectory(null).toFile();
+        parentDirectory.deleteOnExit();
+        when(profilerConfig.getProfilerLibDirectory()).thenReturn(parentDirectory.getAbsolutePath());
+        System.out.println(parentDirectory.getAbsolutePath());
+
+        AsyncProfiler.getInstance(profilerConfig);
+
+        File[] libasyncProfilers = parentDirectory.listFiles(getLibasyncProfilerFilenameFilter());
+        assertThat(libasyncProfilers).hasSizeGreaterThanOrEqualTo(1);
+    }
+
+    private FilenameFilter getLibasyncProfilerFilenameFilter() {
+        return (dir, name) -> name.startsWith("libasyncProfiler") && name.endsWith(".so");
+    }
+}

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1874,7 +1874,7 @@ If unset, the value of the "java.io.tmpdir" System property will be used.
 [options="header"]
 |============
 | Default                          | Type                | Dynamic
-| `<none>` | Optional | false
+| `<none>` | String | false
 |============
 
 
@@ -3222,7 +3222,7 @@ The default unit for this option is `ms`.
 # If unset, the value of the "java.io.tmpdir" System property will be used.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
-# Type: Optional
+# Type: String
 # Default value: 
 #
 # profiling_inferred_spans_lib_directory=

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1864,9 +1864,9 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 ==== `profiling_inferred_spans_lib_directory` (added[1.18.0])
 
 Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library is exported to a temporary location and loaded by the JVM.
-The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard /tmp partition, leading to java.lang.UnsatisfiedLinkError errors.
-Set this property to an alternative directory (e.g. '/var/tmp') to resolve this.
-If unset, the value of the "java.io.tmpdir" System property will be used.
+The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.
+Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this.
+If unset, the value of the `java.io.tmpdir` System property will be used.
 
 
 
@@ -3217,9 +3217,9 @@ The default unit for this option is `ms`.
 # profiling_inferred_spans_excluded_classes=(?-i)java.*,(?-i)javax.*,(?-i)sun.*,(?-i)com.sun.*,(?-i)jdk.*,(?-i)org.apache.tomcat.*,(?-i)org.apache.catalina.*,(?-i)org.apache.coyote.*,(?-i)org.jboss.as.*,(?-i)org.glassfish.*,(?-i)org.eclipse.jetty.*,(?-i)com.ibm.websphere.*,(?-i)io.undertow.*
 
 # Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library is exported to a temporary location and loaded by the JVM.
-# The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard /tmp partition, leading to java.lang.UnsatisfiedLinkError errors.
-# Set this property to an alternative directory (e.g. '/var/tmp') to resolve this.
-# If unset, the value of the "java.io.tmpdir" System property will be used.
+# The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.
+# Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this.
+# If unset, the value of the `java.io.tmpdir` System property will be used.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -149,6 +149,7 @@ Click on a key to get more information.
 ** <<config-profiling-inferred-spans-min-duration>>
 ** <<config-profiling-inferred-spans-included-classes>>
 ** <<config-profiling-inferred-spans-excluded-classes>>
+** <<config-profiling-inferred-spans-lib-directory>>
 * <<config-reporter>>
 ** <<config-secret-token>>
 ** <<config-api-key>>
@@ -1857,6 +1858,32 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 | `elastic.apm.profiling_inferred_spans_excluded_classes` | `profiling_inferred_spans_excluded_classes` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_EXCLUDED_CLASSES`
 |============
 
+// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
+[float]
+[[config-profiling-inferred-spans-lib-directory]]
+==== `profiling_inferred_spans_lib_directory` (added[1.18.0])
+
+Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library is exported to a temporary location and loaded by the JVM.
+The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard /tmp partition, leading to java.lang.UnsatisfiedLinkError errors.
+Set this property to an alternative directory (e.g. '/var/tmp') to resolve this.
+If unset, the value of the "java.io.tmpdir" System property will be used.
+
+
+
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `<none>` | Optional | false
+|============
+
+
+[options="header"]
+|============
+| Java System Properties      | Property file   | Environment
+| `elastic.apm.profiling_inferred_spans_lib_directory` | `profiling_inferred_spans_lib_directory` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_LIB_DIRECTORY`
+|============
+
 [[config-reporter]]
 === Reporter configuration options
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
@@ -3188,6 +3215,17 @@ The default unit for this option is `ms`.
 # Default value: (?-i)java.*,(?-i)javax.*,(?-i)sun.*,(?-i)com.sun.*,(?-i)jdk.*,(?-i)org.apache.tomcat.*,(?-i)org.apache.catalina.*,(?-i)org.apache.coyote.*,(?-i)org.jboss.as.*,(?-i)org.glassfish.*,(?-i)org.eclipse.jetty.*,(?-i)com.ibm.websphere.*,(?-i)io.undertow.*
 #
 # profiling_inferred_spans_excluded_classes=(?-i)java.*,(?-i)javax.*,(?-i)sun.*,(?-i)com.sun.*,(?-i)jdk.*,(?-i)org.apache.tomcat.*,(?-i)org.apache.catalina.*,(?-i)org.apache.coyote.*,(?-i)org.jboss.as.*,(?-i)org.glassfish.*,(?-i)org.eclipse.jetty.*,(?-i)com.ibm.websphere.*,(?-i)io.undertow.*
+
+# Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library is exported to a temporary location and loaded by the JVM.
+# The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard /tmp partition, leading to java.lang.UnsatisfiedLinkError errors.
+# Set this property to an alternative directory (e.g. '/var/tmp') to resolve this.
+# If unset, the value of the "java.io.tmpdir" System property will be used.
+#
+# This setting can not be changed at runtime. Changes require a restart of the application.
+# Type: Optional
+# Default value: 
+#
+# profiling_inferred_spans_lib_directory=
 
 ############################################
 # Reporter                                 #

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1866,7 +1866,7 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library is exported to a temporary location and loaded by the JVM.
 The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.
 Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this.
-If unset, the value of the `java.io.tmpdir` System property will be used.
+If unset, the value of the `java.io.tmpdir` system property will be used.
 
 
 
@@ -3219,7 +3219,7 @@ The default unit for this option is `ms`.
 # Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library is exported to a temporary location and loaded by the JVM.
 # The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.
 # Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this.
-# If unset, the value of the `java.io.tmpdir` System property will be used.
+# If unset, the value of the `java.io.tmpdir` system property will be used.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1864,7 +1864,7 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 ==== `profiling_inferred_spans_lib_directory` (added[1.18.0])
 
 Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library is exported to a temporary location and loaded by the JVM.
-The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.
+The partition backing this location must be executable, however in some server-hardened environments, `noexec` may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.
 Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this.
 If unset, the value of the `java.io.tmpdir` system property will be used.
 
@@ -3217,7 +3217,7 @@ The default unit for this option is `ms`.
 # profiling_inferred_spans_excluded_classes=(?-i)java.*,(?-i)javax.*,(?-i)sun.*,(?-i)com.sun.*,(?-i)jdk.*,(?-i)org.apache.tomcat.*,(?-i)org.apache.catalina.*,(?-i)org.apache.coyote.*,(?-i)org.jboss.as.*,(?-i)org.glassfish.*,(?-i)org.eclipse.jetty.*,(?-i)com.ibm.websphere.*,(?-i)io.undertow.*
 
 # Profiling requires that the https://github.com/jvm-profiling-tools/async-profiler[async-profiler] shared library is exported to a temporary location and loaded by the JVM.
-# The partition backing this location must be executable, however in some server-hardened environments, noexec may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.
+# The partition backing this location must be executable, however in some server-hardened environments, `noexec` may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors.
 # Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this.
 # If unset, the value of the `java.io.tmpdir` system property will be used.
 #


### PR DESCRIPTION
## What does this PR do?
- Adds `elastic.apm.profiling_inferred_spans_lib_directory` property that can be set to specify a directory which should be used to place the libasyncProfiler.so shared library, so that it can take a value such as `/var/tmp` when running in a server-hardened environment, without needing to change the `java.io.tmpdir` system property which would apply to the system being profiled as well. If not set, the `java.io.tmpdir` system property is used as before.
- When loading the library, catch any UnsatisfiedLinkError errors, which would usually indicate a /tmp partition that has noexec set, and and re-throw the exception with a message to suggest setting the property
- Add unit tests which cover this configurable behaviour
- Update changelog and configuration docs

Fixes #1226

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [x] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
