### PR TITLE
fix broken path to 'jps' thanks to symlinks to a JRE

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -68,6 +68,7 @@ endif::[]
 * Fix `NumberFormatException` when using early access Java version - {pull}1325[#1325]
 * Fix `service_name` config being ignored when set to the same auto-discovered default value - {pull}1324[#1324]
 * Fix service name error when updating a web app on a Servlet container - {pull}1326[#1326]
+* Fix remote attach 'jps' executable not found when 'java' binary is symlinked ot a JRE - {pull}1352[#1352]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -60,7 +60,7 @@ public class RemoteAttacher {
             arguments = Arguments.parse(args);
             if (!arguments.getIncludes().isEmpty() || !arguments.getExcludes().isEmpty()) {
                 if (!JvmDiscoverer.Jps.INSTANCE.isAvailable()) {
-                    String jpsPath = JvmDiscoverer.JpsFinder.getJpsPath(System.getProperties()).toString();
+                    String jpsPath = JvmDiscoverer.JpsFinder.getJpsPaths(System.getProperties(), System.getenv()).toString();
                     throw new IllegalStateException("Matching JVMs with --include or --exclude requires jps, unable to execute " + jpsPath);
                 }
             }

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -60,7 +60,8 @@ public class RemoteAttacher {
             arguments = Arguments.parse(args);
             if (!arguments.getIncludes().isEmpty() || !arguments.getExcludes().isEmpty()) {
                 if (!JvmDiscoverer.Jps.INSTANCE.isAvailable()) {
-                    throw new IllegalStateException("Matching JVMs with --include or --exclude requires jps to be installed");
+                    String jpsPath = JvmDiscoverer.getJpsPath(System.getProperties()).toString();
+                    throw new IllegalStateException("Matching JVMs with --include or --exclude requires jps, unable to execute " + jpsPath);
                 }
             }
         } catch (IllegalArgumentException e) {

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -60,8 +60,8 @@ public class RemoteAttacher {
             arguments = Arguments.parse(args);
             if (!arguments.getIncludes().isEmpty() || !arguments.getExcludes().isEmpty()) {
                 if (!JvmDiscoverer.Jps.INSTANCE.isAvailable()) {
-                    String jpsPath = JvmDiscoverer.JpsFinder.getJpsPaths(System.getProperties(), System.getenv()).toString();
-                    throw new IllegalStateException("Matching JVMs with --include or --exclude requires jps, unable to execute " + jpsPath);
+                    String locations = JvmDiscoverer.JpsFinder.getJpsPaths(System.getProperties(), System.getenv()).toString();
+                    throw new IllegalStateException("Matching JVMs with --include or --exclude requires jps, unable to find it in searched locations: " + locations);
                 }
             }
         } catch (IllegalArgumentException e) {

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/RemoteAttacher.java
@@ -60,7 +60,7 @@ public class RemoteAttacher {
             arguments = Arguments.parse(args);
             if (!arguments.getIncludes().isEmpty() || !arguments.getExcludes().isEmpty()) {
                 if (!JvmDiscoverer.Jps.INSTANCE.isAvailable()) {
-                    String jpsPath = JvmDiscoverer.getJpsPath(System.getProperties()).toString();
+                    String jpsPath = JvmDiscoverer.JpsFinder.getJpsPath(System.getProperties()).toString();
                     throw new IllegalStateException("Matching JVMs with --include or --exclude requires jps, unable to execute " + jpsPath);
                 }
             }

--- a/apm-agent-attach/src/test/java/co/elastic/apm/attach/JvmDiscovererTest.java
+++ b/apm-agent-attach/src/test/java/co/elastic/apm/attach/JvmDiscovererTest.java
@@ -61,7 +61,7 @@ class JvmDiscovererTest {
     @Test
     void getJpsPathNoJavaHome() {
         Properties sysProperties = new Properties();
-        Path path = JvmDiscoverer.getJpsPath(sysProperties);
+        Path path = JvmDiscoverer.JpsFinder.getJpsPath(sysProperties);
         assertThat(path).asString()
             .describedAs("should use binary in path as fallback")
             .isEqualTo("jps");
@@ -71,14 +71,14 @@ class JvmDiscovererTest {
     void getJpsPathWindows() {
         Properties sysProperties = new Properties();
         sysProperties.put("os.name", "Windows ME"); // the best one ever !
-        Path path = JvmDiscoverer.getJpsPath(sysProperties);
+        Path path = JvmDiscoverer.JpsFinder.getJpsPath(sysProperties);
         assertThat(path).asString().isEqualTo("jps.exe");
         // note: we can't really test both windows+java.home set as it relies on absolute path resolution
     }
 
     @Test
     void getJpsPathCurrentJvm() {
-        Path path = JvmDiscoverer.getJpsPath(System.getProperties());
+        Path path = JvmDiscoverer.JpsFinder.getJpsPath(System.getProperties());
         assertThat(Files.isExecutable(path)).isTrue();
     }
 

--- a/apm-agent-attach/src/test/java/co/elastic/apm/attach/JvmDiscovererTest.java
+++ b/apm-agent-attach/src/test/java/co/elastic/apm/attach/JvmDiscovererTest.java
@@ -61,7 +61,7 @@ class JvmDiscovererTest {
     @Test
     void getJpsPathNoJavaHome() {
         Properties sysProperties = new Properties();
-        Path path = JvmDiscoverer.Jps.getJpsPath(sysProperties);
+        Path path = JvmDiscoverer.getJpsPath(sysProperties);
         assertThat(path).asString()
             .describedAs("should use binary in path as fallback")
             .isEqualTo("jps");
@@ -71,14 +71,14 @@ class JvmDiscovererTest {
     void getJpsPathWindows() {
         Properties sysProperties = new Properties();
         sysProperties.put("os.name", "Windows ME"); // the best one ever !
-        Path path = JvmDiscoverer.Jps.getJpsPath(sysProperties);
+        Path path = JvmDiscoverer.getJpsPath(sysProperties);
         assertThat(path).asString().isEqualTo("jps.exe");
         // note: we can't really test both windows+java.home set as it relies on absolute path resolution
     }
 
     @Test
     void getJpsPathCurrentJvm() {
-        Path path = JvmDiscoverer.Jps.getJpsPath(System.getProperties());
+        Path path = JvmDiscoverer.getJpsPath(System.getProperties());
         assertThat(Files.isExecutable(path)).isTrue();
     }
 


### PR DESCRIPTION
## What does this PR do?

This PR fixes the issue reported in this [forum discussion](https://discuss.elastic.co/t/apm-agent-telling-jps-is-not-installed-though-it-is/245891/2)

The issue is the following
- when using remote attach feature, agent relies on the `jps` binary that is part of JDK (and not included in the JRE).
- in order to locate this `jps` binary, we rely on the value returned by `System.getProperty("java.home")`.
- some linux distribution packages (for example ubuntu 16.04) use symlinks which creates the unexpected situation:

```bash
# both jps and java are available in the shell

readlink -f $(which java)
# >> /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java

readlink -f $(which jps) 
# >> /usr/lib/jvm/java-8-openjdk-amd64/bin/jps
```

But `${JAVA_HOME}/bin/java` is symlinked to the jre in `${JAVA_HOME}/jre/bin/java`
```
ls -ld /usr/lib/jvm/java-8-openjdk-amd64/bin/java
# >> lrwxrwxrwx 1 root root 15 Aug  3 02:56 /usr/lib/jvm/java-8-openjdk-amd64/bin/java -> ../jre/bin/java
```

## Fix description

When the JAVA_HOME environment variable is set, we use its value instead to resolve the path to `jps`. 

As this JAVA_HOME property might not be set or point to a JRE, we should detect `jps` by testing the following locations:
- `System.getEnv("JAVA_HOME")+"/bin/jps"` (if JAVA_HOME is set)
- `System.getEnv("JAVA_HOME")+"/../bin/jps"` (if JAVA_HOME is set)
- `System.getProperty("java.home")+"/bin/jps"`
- `System.getProperty("java.home")+"/../bin/jps"`

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix