### PR TITLE
proxy support with authentication

### DIFF
--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -158,6 +158,11 @@
             <version>2.6.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/proxysupport/AuthenticatorInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/proxysupport/AuthenticatorInstrumentation.java
@@ -1,0 +1,174 @@
+package co.elastic.apm.agent.proxysupport;
+
+import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
+import co.elastic.apm.agent.sdk.advice.AssignTo;
+import co.elastic.apm.agent.sdk.state.CallDepth;
+import co.elastic.apm.agent.sdk.state.GlobalThreadLocal;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import javax.annotation.Nullable;
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public class AuthenticatorInstrumentation extends ElasticApmInstrumentation {
+
+    private static final CallDepth callDepth = CallDepth.get(AuthenticatorInstrumentation.class);
+    private static final GlobalThreadLocal<Boolean> useFallback = GlobalThreadLocal.get(AuthenticatorInstrumentation.class, "fallback");
+    private static final AgentAuthenticator agentAuthenticator = new AgentAuthenticator();
+
+    public static void toggleFallback(boolean enable) {
+        useFallback.set(enable);
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named("java.net.Authenticator");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named("requestPasswordAuthentication");
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        // TODO is it required ? apart from bug workaround on the feature there is no good reason to disable it
+        return Collections.singleton("jdk-proxy-auth");
+    }
+
+    @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+    public static void onEnter() {
+        callDepth.increment();
+    }
+
+    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+    @AssignTo.Return
+    @Nullable
+    public static PasswordAuthentication onExit(@Advice.Thrown @Nullable Throwable thrown,
+                                                @Advice.Return @Nullable PasswordAuthentication rv,
+                                                @Advice.AllArguments Object[] arguments) {
+
+        if (thrown != null || rv != null || callDepth.isNestedCallAndDecrement()) {
+            return rv;
+        }
+
+        if (!Boolean.TRUE.equals(useFallback.get())) {
+            return null;
+        }
+
+        switch (arguments.length) {
+            case 5:
+                // requestPasswordAuthentication( InetAddress addr, int port, String protocol, String prompt, String scheme)
+                return passwordAuthenticationFallback((String) arguments[2], null);
+            case 6:
+                // requestPasswordAuthentication( String host, InetAddress addr, int port, String protocol, String prompt, String scheme) {
+                return passwordAuthenticationFallback((String) arguments[3], null);
+            case 8:
+                // requestPasswordAuthentication( String host, InetAddress addr, int port, String protocol, String prompt, String scheme, URL url, RequestorType reqType) {
+                return passwordAuthenticationFallback((String) arguments[3], (Authenticator.RequestorType) arguments[7]);
+            case 9:
+                // requestPasswordAuthentication( Authenticator authenticator, String host, InetAddress addr, int port, String protocol, String prompt, String scheme, URL url, RequestorType reqType) {
+                return passwordAuthenticationFallback((String) arguments[4], (Authenticator.RequestorType) arguments[8]);
+            default:
+                return null;
+        }
+    }
+
+    @Nullable
+    public static PasswordAuthentication passwordAuthenticationFallback(String protocol,
+                                                                        @Nullable Authenticator.RequestorType reqType) {
+
+        if (reqType != null && reqType != Authenticator.RequestorType.PROXY) {
+            // not a proxy request
+            return null;
+        }
+
+        String user = System.getProperty(protocol + ".proxyUser");
+        String password = System.getProperty(protocol + ".proxyPassword");
+
+        if (user == null || password == null) {
+            return null;
+        }
+
+        return new PasswordAuthentication(user, password.toCharArray());
+    }
+
+
+    /*
+    // -> they don't delegate to each other, thus we have to instrument them all
+
+public static PasswordAuthentication requestPasswordAuthentication( InetAddress addr, int port, String protocol, String prompt, String scheme)
+public static PasswordAuthentication requestPasswordAuthentication( String host, InetAddress addr, int port, String protocol, String prompt, String scheme) {
+public static PasswordAuthentication requestPasswordAuthentication( String host, InetAddress addr, int port, String protocol, String prompt, String scheme, URL url, RequestorType reqType) {
+public static PasswordAuthentication requestPasswordAuthentication( Authenticator authenticator, String host, InetAddress addr, int port, String protocol, String prompt, String scheme, URL url, RequestorType reqType) {
+
+// -> when there is already an instance set, this one is called
+public PasswordAuthentication requestPasswordAuthenticationInstance(String host, InetAddress addr, int port, String protocol, String prompt, String scheme, URL url, RequestorType reqType) {
+     */
+
+    static {
+        Authenticator.setDefault(new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                String protocol = getRequestingProtocol();
+                final String user = System.getProperty(protocol + ".proxyUser");
+                final String password = System.getProperty(protocol + ".proxyPassword");
+
+                if (getRequestorType() != RequestorType.PROXY) {
+                    return null;
+                }
+                if (user == null || password == null) {
+                    return null;
+                }
+
+                // extra safety optinal checks: limit credentials usage to known services
+
+                URL requestingURL = getRequestingURL();
+                if (requestingURL != null) {
+                    // TODO : optional check against request URL, if provided
+                }
+
+                return new PasswordAuthentication(user, password.toCharArray());
+            }
+        });
+    }
+
+    public static class AgentAuthenticator extends Authenticator {
+
+
+        @Nullable
+        @Override
+        protected PasswordAuthentication getPasswordAuthentication() {
+            String protocol = getRequestingProtocol();
+            final String user = System.getProperty(protocol + ".proxyUser");
+            final String password = System.getProperty(protocol + ".proxyPassword");
+
+            if (getRequestorType() != RequestorType.PROXY) {
+                return null;
+            }
+            if (user == null || password == null) {
+                return null;
+            }
+
+            // extra safety checks: limit credentials usage to known services
+
+            URL requestingURL = getRequestingURL();
+            if (requestingURL != null) {
+                // TODO : optional check against request URL, if provided
+            }
+
+
+
+
+            return new PasswordAuthentication(user, password.toCharArray());
+        }
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/proxysupport/package-info.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/proxysupport/package-info.java
@@ -1,0 +1,28 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+@NonnullApi
+package co.elastic.apm.agent.proxysupport;
+
+import co.elastic.apm.agent.sdk.NonnullApi;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/AbstractIntakeApiHandler.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/AbstractIntakeApiHandler.java
@@ -25,6 +25,7 @@
 package co.elastic.apm.agent.report;
 
 import co.elastic.apm.agent.impl.MetaData;
+import co.elastic.apm.agent.proxysupport.AuthenticatorInstrumentation;
 import co.elastic.apm.agent.report.serialize.DslJsonSerializer;
 import co.elastic.apm.agent.report.serialize.PayloadSerializer;
 import org.slf4j.Logger;
@@ -112,7 +113,12 @@ public class AbstractIntakeApiHandler {
             connection.setRequestProperty("Content-Encoding", "deflate");
             connection.setRequestProperty("Content-Type", "application/x-ndjson");
             connection.setUseCaches(false);
-            connection.connect();
+            try {
+                AuthenticatorInstrumentation.toggleFallback(true);
+                connection.connect();
+            } finally {
+                AuthenticatorInstrumentation.toggleFallback(false);
+            }
             os = new DeflaterOutputStream(connection.getOutputStream(), deflater);
             os.write(metaData);
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistryReporter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistryReporter.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.report.serialize;
 
 import co.elastic.apm.agent.context.AbstractLifecycleListener;

--- a/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -1,0 +1,1 @@
+co.elastic.apm.agent.proxysupport.AuthenticatorInstrumentation

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientProxySupportTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientProxySupportTest.java
@@ -1,0 +1,292 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.report;
+
+import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.configuration.SpyConfiguration;
+import co.elastic.apm.agent.proxysupport.AuthenticatorInstrumentation;
+import io.undertow.Undertow;
+import io.undertow.io.Sender;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.Testcontainers;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.MalformedURLException;
+import java.net.PasswordAuthentication;
+import java.net.URL;
+import java.net.URLConnection;
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+// Using a separate test class for proxy support
+//
+// We have to inherit from instrumentation tests because proxy support relies on instrumentation thanks to Authenticator
+public class ApmServerClientProxySupportTest extends AbstractInstrumentationTest {
+
+    private static final Logger logger = LoggerFactory.getLogger(ApmServerClientProxySupportTest.class);
+
+    private static final String PROXY_HEADER = "proxy-header";
+    private static final String PROXY_HEADER_VALUE = "1234";
+
+    private static final String DOCKER_IMAGE_NAME = "sameersbn/squid:3.5.27-2";
+    private static final String PROXY_LOGIN = "elastic";
+    private static final String PROXY_PASSWORD = "elasticpwd";
+
+    private static URL directUrl;
+    private static URL proxyUrl;
+
+    @Nullable
+    private GenericContainer<?> proxy = null;
+
+    @BeforeAll
+    static void initAll() {
+        String host = "127.0.0.1";
+        Undertow server = Undertow.builder()
+            .addHttpListener(0, "0.0.0.0") // listen to all interfaces
+            .setHandler(exchange -> {
+                exchange.setStatusCode(200);
+                String path = exchange.getRequestPath();
+                Sender response = exchange.getResponseSender();
+                if (path.equals("/")) {
+                    response.send("{\"version\":\"7.9.0\"}");
+                } else if (path.equals("/proxy")) {
+                    String proxyHeader = exchange.getRequestHeaders().getFirst(PROXY_HEADER);
+                    response.send(PROXY_HEADER_VALUE.equals(proxyHeader) ? "proxy" : "no-proxy");
+                }
+                exchange.endExchange();
+            }).build();
+        server.start();
+        int port = ((InetSocketAddress) server.getListenerInfo().get(0).getAddress()).getPort();
+
+        directUrl = baseUrl(host, port);
+        // we have to use another host name so the proxy host can call the docker host where
+        // the http server is running
+        proxyUrl = baseUrl("host.testcontainers.internal", port);
+
+        logger.info("server direct url = {}", directUrl);
+        logger.info("server proxy url = {}", proxyUrl);
+
+        // allow proxy to connect to host port
+        Testcontainers.exposeHostPorts(port);
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        // ensure that there is no global authenticator set
+        Authenticator.setDefault(null);
+    }
+
+    @AfterEach
+    void afterEach() {
+        if (proxy != null) {
+            proxy.stop();
+        }
+
+        System.setProperty("http.proxyHost", "");
+        System.setProperty("http.proxyPort", "");
+        System.setProperty("http.proxyUser", "");
+        System.setProperty("http.proxyPassword", "");
+    }
+
+    private void startProxy(boolean useAuth) {
+        String squidConfig = String.format("squid/squid_%s.conf", useAuth ? "basic-auth" : "no-auth");
+
+        proxy = new GenericContainer<>(DOCKER_IMAGE_NAME)
+            .withClasspathResourceMapping(squidConfig, "/etc/squid/squid.conf", BindMode.READ_ONLY)
+            .withClasspathResourceMapping("squid/squid_passwd", "/etc/squid/passwd", BindMode.READ_ONLY);
+
+        proxy.addExposedPorts(3128);
+        proxy.start();
+    }
+
+
+    @Test
+    void noProxy() throws IOException {
+        simpleTestScenario(false);
+    }
+
+    @Test
+    void noAuthProxy() throws IOException {
+        startProxy(false);
+
+        setSystemProxyProperties();
+
+        simpleTestScenario(true);
+    }
+
+    @Test
+    void basicAuthProxy_noAuthenticator() throws IOException {
+        startProxy(true);
+
+        setSystemProxyProperties();
+        setSystemProxyCredentialProperties();
+
+        ApmServerClient client = createAndStartClient(true);
+        URL requestUrl = requestUrl(true);
+
+        AuthenticatorInstrumentation.toggleFallback(true);
+        checkUsingProxy(client.startRequest(requestUrl.getPath()), true); // TODO : use client.execute instead to enable proper wrapping
+        AuthenticatorInstrumentation.toggleFallback(false);
+
+        // in this case, no global authenticator is set
+        // thus we should get a 407 error from the proxy because credentials aren't taken in account by default
+        checkProxyAuthenticationError(requestUrl.openConnection());
+
+        assertThat(Authenticator.getDefault())
+            .describedAs("global authenticator should remain unset")
+            .isNull();
+    }
+
+    @Test
+    void basicAuthProxy_globalAuthenticator() throws IOException {
+        startProxy(true);
+
+        setSystemProxyProperties();
+        setSystemProxyCredentialProperties();
+
+        final AtomicBoolean allow = new AtomicBoolean(false);
+
+        // hostile authenticator that does not allow agent to connect
+        Authenticator authenticator = new Authenticator() {
+            @Nullable
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                return !allow.get() ? null : new PasswordAuthentication(PROXY_LOGIN, PROXY_PASSWORD.toCharArray());
+            }
+        };
+        Authenticator.setDefault(authenticator);
+
+        ApmServerClient client = createAndStartClient(true);
+        URL requestUrl = requestUrl(true);
+        checkUsingProxy(client.startRequest(requestUrl.getPath()), true);
+
+        allow.set(true);
+        checkUsingProxy(requestUrl.openConnection(), true);
+
+        assertThat(Authenticator.getDefault())
+            .describedAs("authenticator instance should remain unchanged")
+            .isSameAs(authenticator);
+    }
+
+    private void simpleTestScenario(boolean useProxy) throws IOException {
+        ApmServerClient client = createAndStartClient(useProxy);
+        URL requestUrl = requestUrl(useProxy);
+        checkUsingProxy(client.startRequest(requestUrl.getPath()), useProxy);
+        checkUsingProxy(requestUrl.openConnection(), useProxy);
+    }
+
+    private void setSystemProxyProperties() {
+        System.setProperty("http.proxyHost", proxy.getContainerIpAddress());
+        System.setProperty("http.proxyPort", Integer.toString(proxy.getMappedPort(3128)));
+    }
+
+    private void setSystemProxyCredentialProperties() {
+        System.setProperty("http.proxyUser", PROXY_LOGIN);
+        System.setProperty("http.proxyPassword", PROXY_PASSWORD);
+    }
+
+    private static ApmServerClient createAndStartClient(boolean useProxy) {
+        ReporterConfiguration config = SpyConfiguration.createSpyConfig().getConfig(ReporterConfiguration.class);
+
+        doReturn(Collections.singletonList(useProxy ? proxyUrl : directUrl)).when(config).getServerUrls();
+        ApmServerClient client = new ApmServerClient(config);
+        client.start();
+        return client;
+    }
+
+    private static URL requestUrl(boolean useProxy) {
+        try {
+            return new URL((useProxy ? proxyUrl : directUrl).toString() + "/proxy");
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void checkUsingProxy(@Nullable URLConnection connection, boolean expectProxy) throws IOException {
+        assertThat(connection)
+            .isNotNull()
+            .isInstanceOf(HttpURLConnection.class);
+
+        assertThat(HttpUtils.readToString(connection.getInputStream()))
+            .isEqualTo(expectProxy ? "proxy" : "no-proxy");
+
+        assertThat(((HttpURLConnection) connection).getResponseCode())
+            .isEqualTo(200);
+    }
+
+    private void checkProxyAuthenticationError(@Nullable URLConnection connection) throws IOException {
+        assertThat(connection)
+            .isNotNull()
+            .isInstanceOf(HttpURLConnection.class);
+
+        assertThat(((HttpURLConnection) connection).getResponseCode())
+            .isEqualTo(407);
+    }
+
+    @NotNull
+    private static URL baseUrl(String host, int port) {
+        try {
+            return new URL(String.format("http://%s:%d", host, port));
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    // test cases to cover
+    //
+    // no proxy
+    // proxy without authentication
+    // proxy with authentication (basic)
+    //
+    // authenticator
+    // - no global authenticator set
+    // - one global authenticator is set, we have to override it's returned value
+
+    // how to test
+    // using a squid proxy docker image
+    //
+    //
+    // -> how to make squid provide basic/digest authentication ?
+    //   - might be doable, but that does not really help here
+    //
+    // -> how to make sure that requests go through the proxy ?
+    //   - one more line in the proxy logs
+    //   - adding an extra header in proxy
+}

--- a/apm-agent-core/src/test/resources/squid/squid_basic-auth.conf
+++ b/apm-agent-core/src/test/resources/squid/squid_basic-auth.conf
@@ -1,0 +1,41 @@
+# local network ACL definition
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+auth_param basic program /usr/lib/squid3/basic_ncsa_auth /etc/squid/passwd
+acl ncsa_users proxy_auth REQUIRED
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+
+http_access deny CONNECT !SSL_ports
+
+http_access allow localhost manager
+http_access deny manager
+
+http_access allow localnet ncsa_users
+
+http_access deny all
+
+http_port 3128
+
+# adding a header to allow checking that request goes through proxy
+request_header_add proxy-header 1234

--- a/apm-agent-core/src/test/resources/squid/squid_no-auth.conf
+++ b/apm-agent-core/src/test/resources/squid/squid_no-auth.conf
@@ -1,0 +1,38 @@
+# local network ACL definition
+acl localnet src 0.0.0.1-0.255.255.255	# RFC 1122 "this" network (LAN)
+acl localnet src 10.0.0.0/8		# RFC 1918 local private network (LAN)
+acl localnet src 100.64.0.0/10		# RFC 6598 shared address space (CGN)
+acl localnet src 169.254.0.0/16 	# RFC 3927 link-local (directly plugged) machines
+acl localnet src 172.16.0.0/12		# RFC 1918 local private network (LAN)
+acl localnet src 192.168.0.0/16		# RFC 1918 local private network (LAN)
+acl localnet src fc00::/7       	# RFC 4193 local private network range
+acl localnet src fe80::/10      	# RFC 4291 link-local (directly plugged) machines
+
+acl SSL_ports port 443
+acl Safe_ports port 80		# http
+acl Safe_ports port 21		# ftp
+acl Safe_ports port 443		# https
+acl Safe_ports port 70		# gopher
+acl Safe_ports port 210		# wais
+acl Safe_ports port 1025-65535	# unregistered ports
+acl Safe_ports port 280		# http-mgmt
+acl Safe_ports port 488		# gss-http
+acl Safe_ports port 591		# filemaker
+acl Safe_ports port 777		# multiling http
+acl CONNECT method CONNECT
+
+http_access deny !Safe_ports
+
+http_access deny CONNECT !SSL_ports
+
+http_access allow localhost manager
+http_access deny manager
+
+http_access allow localnet
+
+http_access deny all
+
+http_port 3128
+
+# adding a header to allow checking that request goes through proxy
+request_header_add proxy-header 1234

--- a/apm-agent-core/src/test/resources/squid/squid_passwd
+++ b/apm-agent-core/src/test/resources/squid/squid_passwd
@@ -1,0 +1,2 @@
+# login: 'elastic', password: 'elasticpwd'
+elastic:$apr1$d64P1Leg$KDM8rdmfV5mEZOwBVFopc0


### PR DESCRIPTION
## What does this PR do?

- provides a way to test proxy usage with & without authentication using a squid proxy container
- currently instruments `Authenticator.register*` static methods to provide an automatic fallback (still WIP)

In a regular application, using proxy with authentication requires to setup a global `Authenticator` [as described here](https://blogs.oracle.com/wssfc/handling-proxy-server-authentication-requests-in-java).

The goal here is not to merge this as-is, but rather to discuss how to properly implement support for proxies using authentication.

## Constraints

- agent uses `java.net.HttpUrlConnection` to communicate with backend server
- `http.proxyHost` and `http.proxyPort` JVM system properties allow to set a global proxy for the whole JVM
- while `http.proxyUser` and `http.proxyPassword` are also defined, they can't be used without registering an `Authenticator` instance explicitly
- unless using Java 9 and later, there is no way to avoid the global authenticator that is set through `Authenticator.setDefault(...)`, also, `Authenticator.getDefault()` is only available on Java 9.
- once the JVM has authenticated against a proxy server, credentials are cached and reused to avoid round-trips with the proxy

## Proposal

- get rid of the jdk `Authenticator` instrumentation as it introduces extra complexity for a very minor benefit
- add a new opt-in configuration option : `proxy_authenticator` which can have values `auto` (default), `false`, `true`
- when set to `false`, feature is disabled
- when set to `true`, a global authenticator will be registered if `http.proxyUser` and `http.proxyPassword` are set
- when set to `auto`, behavior depends on Java version:
  * Java < 9: equivalent to `false`, users have to explicitly set `true` to enable proxy authentication
  * Java >= 9: a global `Authenticator` will be registered _only if application did not already set one_ (we have a getter on the global instance).


This allows to:
- avoid any extra complexity in agent code (proxies with/without authentication aren't used by most users)
- do not have any impact on applications that already register a global `Authenticator` instance
- provide a fallback option for users that do not have any `Authenticator` instance in their application (the app isn't using the proxy) without having to modify their application.
- bonus of this PR: provide tests for proxy support.

## Alternatives
- Still provide an option to register a global `Authenticator` (true|false) to make it work with java 7 and 8. With java >= 9, use reflection to set `Authenticator` on the connection.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
