### PR TITLE
Lazily create profiler temporary files

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ endif::[]
   This is useful for server-hardened environments where `/tmp` is often configured with `noexec`, leading to `java.lang.UnsatisfiedLinkError` errors - {pull}1350[#1350]
 * Create spans for Servlet dispatches to FORWARD, INCLUDE and ERROR - {pull}1212[#1212]
 * Support sync, async calls made by JDK 11 HTTPClient - {pull}1307[#1307]
+* Lazily create profiler temporary files {pull}1360[#1360]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/agent/benchmark/ProfilerBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/agent/benchmark/ProfilerBenchmark.java
@@ -26,7 +26,6 @@ package co.elastic.apm.agent.benchmark;
 
 import co.elastic.apm.agent.profiler.SamplingProfiler;
 import co.elastic.apm.agent.profiler.SystemNanoClock;
-import co.elastic.apm.agent.util.ExecutorUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -58,7 +57,6 @@ public class ProfilerBenchmark extends AbstractMockApmServerBenchmark {
     @Setup
     public void setUp() throws Exception {
         samplingProfiler = new SamplingProfiler(tracer,
-            ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler"),
             new SystemNanoClock(),
             new File(getClass().getClassLoader().getResource("apm-activation-events.bin").toURI()),
             new File(getClass().getClassLoader().getResource("apm-traces.jfr").toURI()));

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/agent/benchmark/ProfilerBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/agent/benchmark/ProfilerBenchmark.java
@@ -26,6 +26,7 @@ package co.elastic.apm.agent.benchmark;
 
 import co.elastic.apm.agent.profiler.SamplingProfiler;
 import co.elastic.apm.agent.profiler.SystemNanoClock;
+import co.elastic.apm.agent.util.ExecutorUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -37,6 +38,7 @@ import org.openjdk.jmh.annotations.TearDown;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SampleTime)
@@ -58,6 +60,7 @@ public class ProfilerBenchmark extends AbstractMockApmServerBenchmark {
     public void setUp() throws Exception {
         samplingProfiler = new SamplingProfiler(tracer,
             new SystemNanoClock(),
+            ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler"),
             new File(getClass().getClassLoader().getResource("apm-activation-events.bin").toURI()),
             new File(getClass().getClassLoader().getResource("apm-traces.jfr").toURI()));
     }

--- a/apm-agent-benchmarks/src/main/java/co/elastic/apm/agent/benchmark/ProfilerBenchmark.java
+++ b/apm-agent-benchmarks/src/main/java/co/elastic/apm/agent/benchmark/ProfilerBenchmark.java
@@ -26,7 +26,6 @@ package co.elastic.apm.agent.benchmark;
 
 import co.elastic.apm.agent.profiler.SamplingProfiler;
 import co.elastic.apm.agent.profiler.SystemNanoClock;
-import co.elastic.apm.agent.util.ExecutorUtils;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -38,7 +37,6 @@ import org.openjdk.jmh.annotations.TearDown;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 @BenchmarkMode(Mode.SampleTime)
@@ -60,7 +58,6 @@ public class ProfilerBenchmark extends AbstractMockApmServerBenchmark {
     public void setUp() throws Exception {
         samplingProfiler = new SamplingProfiler(tracer,
             new SystemNanoClock(),
-            ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler"),
             new File(getClass().getClassLoader().getResource("apm-activation-events.bin").toURI()),
             new File(getClass().getClassLoader().getResource("apm-traces.jfr").toURI()));
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ExecutorUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ExecutorUtils.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import javax.annotation.Nullable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -127,6 +128,16 @@ public final class ExecutorUtils {
         }
         if (t != null) {
             logger.error(t.getMessage(), t);
+        }
+    }
+
+    public static void shutdown(ExecutorService executor) {
+        executor.shutdown();
+        try {
+            executor.awaitTermination(1, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            logger.warn("executor service shutdown has been interrupted", e);
+            executor.shutdownNow();
         }
     }
 }

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -184,10 +184,6 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
         return asyncProfilerSafeMode.get();
     }
 
-    public boolean isProfilingDisabled() {
-        return !isProfilingEnabled();
-    }
-
     public TimeDuration getSamplingInterval() {
         return samplingInterval.get();
     }

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingFactory.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingFactory.java
@@ -26,8 +26,10 @@ package co.elastic.apm.agent.profiler;
 
 import co.elastic.apm.agent.context.AbstractLifecycleListener;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.util.ExecutorUtils;
 
 import java.io.IOException;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public class ProfilingFactory extends AbstractLifecycleListener {
 
@@ -39,7 +41,8 @@ public class ProfilingFactory extends AbstractLifecycleListener {
         // in unit tests, where assertions are enabled, this envTest is true
         assert envTest = true;
         nanoClock = envTest ? new FixedNanoClock() : new SystemNanoClock();
-        profiler = new SamplingProfiler(tracer, nanoClock);
+        ScheduledThreadPoolExecutor scheduler = ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler");
+        profiler = new SamplingProfiler(tracer, nanoClock, scheduler);
     }
 
     @Override

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingFactory.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingFactory.java
@@ -26,23 +26,18 @@ package co.elastic.apm.agent.profiler;
 
 import co.elastic.apm.agent.context.AbstractLifecycleListener;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
-import co.elastic.apm.agent.util.ExecutorUtils;
-
-import java.io.IOException;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 public class ProfilingFactory extends AbstractLifecycleListener {
 
     private final SamplingProfiler profiler;
     private final NanoClock nanoClock;
 
-    public ProfilingFactory(ElasticApmTracer tracer) throws IOException {
+    public ProfilingFactory(ElasticApmTracer tracer) {
         boolean envTest = false;
         // in unit tests, where assertions are enabled, this envTest is true
         assert envTest = true;
         nanoClock = envTest ? new FixedNanoClock() : new SystemNanoClock();
-        ScheduledThreadPoolExecutor scheduler = ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler");
-        profiler = new SamplingProfiler(tracer, nanoClock, scheduler);
+        profiler = new SamplingProfiler(tracer, nanoClock);
     }
 
     @Override

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingFactory.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingFactory.java
@@ -26,30 +26,20 @@ package co.elastic.apm.agent.profiler;
 
 import co.elastic.apm.agent.context.AbstractLifecycleListener;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
-import co.elastic.apm.agent.util.ExecutorUtils;
 
-import java.io.File;
 import java.io.IOException;
 
 public class ProfilingFactory extends AbstractLifecycleListener {
 
     private final SamplingProfiler profiler;
     private final NanoClock nanoClock;
-    private final File activationEventsFile;
-    private final File jfrFile;
 
     public ProfilingFactory(ElasticApmTracer tracer) throws IOException {
         boolean envTest = false;
         // in unit tests, where assertions are enabled, this envTest is true
         assert envTest = true;
         nanoClock = envTest ? new FixedNanoClock() : new SystemNanoClock();
-        activationEventsFile = File.createTempFile("apm-activation-events-", ".bin");
-        jfrFile = File.createTempFile("apm-traces-", ".jfr");
-        profiler = new SamplingProfiler(tracer,
-            ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler"),
-            nanoClock,
-            activationEventsFile,
-            jfrFile);
+        profiler = new SamplingProfiler(tracer, nanoClock);
     }
 
     @Override
@@ -61,13 +51,6 @@ public class ProfilingFactory extends AbstractLifecycleListener {
     @Override
     public void stop() throws Exception {
         profiler.stop();
-        if (!jfrFile.delete()) {
-            jfrFile.deleteOnExit();
-        }
-
-        if (!activationEventsFile.delete()) {
-            activationEventsFile.deleteOnExit();
-        }
     }
 
     public SamplingProfiler getProfiler() {

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
@@ -150,7 +150,8 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
 
     private final ProfilingConfiguration config;
     private final CoreConfiguration coreConfig;
-    private final ScheduledExecutorService scheduler;
+    @Nullable
+    private ScheduledExecutorService scheduler;
     private final Long2ObjectHashMap<CallTree.Root> profiledThreads = new Long2ObjectHashMap<>();
     private final RingBuffer<ActivationEvent> eventBuffer;
     private volatile boolean profilingSessionOngoing = false;
@@ -160,7 +161,9 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     private final ObjectPool<CallTree.Root> rootPool;
     private final ThreadMatcher threadMatcher = new ThreadMatcher();
     private final EventPoller<ActivationEvent> poller;
-    private final File jfrFile;
+    @Nullable
+    private File jfrFile;
+    private boolean canDeleteJfrFile;
     private final WriteActivationEventToFileHandler writeActivationEventToFileHandler = new WriteActivationEventToFileHandler();
     @Nullable
     private JfrParser jfrParser;
@@ -170,23 +173,23 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     /**
      * Used to efficiently write {@link #activationEventsBuffer} via {@link FileChannel#write(ByteBuffer)}
      */
-    private final FileChannel activationEventsFileChannel;
+    @Nullable
+    private File activationEventsFile;
+    private boolean canDeleteActivationEventsFile;
+
+    @Nullable
+    private FileChannel activationEventsFileChannel;
     private final ObjectPool<CallTree> callTreePool;
     private final TraceContext contextForLogging;
 
-    public SamplingProfiler(ElasticApmTracer tracer, NanoClock nanoClock) throws IOException {
-        this(tracer,
-            ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler"),
-            nanoClock,
-            File.createTempFile("apm-activation-events-", ".bin"),
-            File.createTempFile("apm-traces-", ".jfr"));
+    public SamplingProfiler(final ElasticApmTracer tracer, NanoClock nanoClock) {
+        this(tracer, nanoClock, null, null);
     }
 
-    public SamplingProfiler(final ElasticApmTracer tracer, ScheduledExecutorService scheduler, NanoClock nanoClock, File activationEventsFile, File jfrFile) throws IOException {
+    public SamplingProfiler(final ElasticApmTracer tracer, NanoClock nanoClock, @Nullable File activationEventsFile, @Nullable File jfrFile) {
         this.tracer = tracer;
         this.config = tracer.getConfig(ProfilingConfiguration.class);
         this.coreConfig = tracer.getConfig(CoreConfiguration.class);
-        this.scheduler = scheduler;
         this.nanoClock = nanoClock;
         this.eventBuffer = createRingBuffer();
         this.sequence = new Sequence();
@@ -209,6 +212,20 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
         });
         this.jfrFile = jfrFile;
         activationEventsBuffer = ByteBuffer.allocateDirect(ACTIVATION_EVENTS_BUFFER_SIZE);
+        this.activationEventsFile = activationEventsFile;
+    }
+
+    private synchronized void createFilesIfRequired() throws IOException {
+        if (jfrFile == null || !jfrFile.exists()) {
+            jfrFile = File.createTempFile("apm-traces-", ".jfr");
+            jfrFile.deleteOnExit();
+            canDeleteJfrFile = true;
+        }
+        if (activationEventsFile == null || !activationEventsFile.exists()) {
+            activationEventsFile = File.createTempFile("apm-activation-events-", ".bin");
+            activationEventsFile.deleteOnExit();
+            canDeleteActivationEventsFile = true;
+        }
         activationEventsFileChannel = FileChannel.open(activationEventsFile.toPath(), StandardOpenOption.READ, StandardOpenOption.WRITE);
         if (activationEventsFileChannel.size() == 0) {
             preAllocate(activationEventsFileChannel, PRE_ALLOCATE_ACTIVATION_EVENTS_FILE_MB);
@@ -304,6 +321,14 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
                 callTreePool.clear();
             }
             scheduler.schedule(this, config.getProfilingInterval().getMillis(), TimeUnit.MILLISECONDS);
+            return;
+        }
+
+        // lazily create temporary files
+        try {
+            createFilesIfRequired();
+        } catch (IOException e) {
+            logger.error("unable to initialize profiling files", e);
             return;
         }
 
@@ -495,7 +520,7 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
      * The events in the JFR file are not in order.
      * Even for the same thread, a more recent event might come before an older event.
      * In order to be able to correlate stack trace events and activation events, both need to be in order.
-     *
+     * <p>
      * Returns only events for threads where at least one activation happened (because only those are profiled by async-profiler)
      */
     private List<StackTraceEvent> getSortedStackTraceEvents(JfrParser jfrParser) throws IOException {
@@ -598,17 +623,32 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     }
 
     @Override
-    public void start(ElasticApmTracer tracer) {
+    public synchronized void start(ElasticApmTracer tracer) {
+        if (scheduler == null) {
+            scheduler = ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler");
+        }
         scheduler.submit(this);
     }
 
     @Override
-    public void stop() throws Exception {
+    public synchronized void stop() throws Exception {
         // cancels/interrupts the profiling thread
         // implicitly clears profiled threads
-        scheduler.shutdownNow();
-        scheduler.awaitTermination(1, TimeUnit.SECONDS);
-        activationEventsFileChannel.close();
+        if (scheduler != null) {
+            ExecutorUtils.shutdown(scheduler);
+        }
+        scheduler = null;
+
+        if (activationEventsFileChannel != null) {
+            activationEventsFileChannel.close();
+        }
+
+        if (jfrFile != null && canDeleteJfrFile) {
+            jfrFile.delete();
+        }
+        if (activationEventsFile != null && canDeleteActivationEventsFile) {
+            activationEventsFile.delete();
+        }
     }
 
     void setProfilingSessionOngoing(boolean profilingSessionOngoing) {

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
@@ -187,14 +187,13 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
      * @param tracer    tracer
      * @param nanoClock clock
      */
-    public SamplingProfiler(ElasticApmTracer tracer, NanoClock nanoClock, ScheduledExecutorService scheduler) {
-        this(tracer, nanoClock, scheduler, null, null);
+    public SamplingProfiler(ElasticApmTracer tracer, NanoClock nanoClock) {
+        this(tracer, nanoClock, null, null);
     }
 
     /**
      * Creates a sampling profiler, optionally relying on existing files.
      * <p>
-     * <br/>
      * This constructor is most likely used for tests that rely on a known set of files
      *
      * @param tracer               tracer
@@ -202,11 +201,11 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
      * @param activationEventsFile activation events file, if {@literal null} a temp file will be used
      * @param jfrFile              java flight recorder file, if {@literal null} a temp file will be used instead
      */
-    public SamplingProfiler(final ElasticApmTracer tracer, NanoClock nanoClock, ScheduledExecutorService scheduler, @Nullable File activationEventsFile, @Nullable File jfrFile) {
+    public SamplingProfiler(final ElasticApmTracer tracer, NanoClock nanoClock, @Nullable File activationEventsFile, @Nullable File jfrFile) {
         this.tracer = tracer;
         this.config = tracer.getConfig(ProfilingConfiguration.class);
         this.coreConfig = tracer.getConfig(CoreConfiguration.class);
-        this.scheduler = scheduler;
+        this.scheduler = ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler");
         this.nanoClock = nanoClock;
         this.eventBuffer = createRingBuffer();
         this.sequence = new Sequence();
@@ -337,7 +336,7 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
                 rootPool.clear();
                 callTreePool.clear();
             }
-            if (scheduler.isShutdown()) {
+            if (!scheduler.isShutdown()) {
                 scheduler.schedule(this, config.getProfilingInterval().getMillis(), TimeUnit.MILLISECONDS);
             }
             return;

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
@@ -182,10 +182,27 @@ public class SamplingProfiler extends AbstractLifecycleListener implements Runna
     private final ObjectPool<CallTree> callTreePool;
     private final TraceContext contextForLogging;
 
-    public SamplingProfiler(final ElasticApmTracer tracer, NanoClock nanoClock) {
+    /**
+     * Creates a sampling profiler using temporary files
+     *
+     * @param tracer    tracer
+     * @param nanoClock clock
+     */
+    public SamplingProfiler(ElasticApmTracer tracer, NanoClock nanoClock) {
         this(tracer, nanoClock, null, null);
     }
 
+    /**
+     * Creates a sampling profiler, optionally relying on existing files.
+     * <p>
+     * <br/>
+     * This constructor is most likely used for tests that rely on a known set of files
+     *
+     * @param tracer               tracer
+     * @param nanoClock            clock
+     * @param activationEventsFile activation events file, if {@literal null} a temp file will be used
+     * @param jfrFile              java flight recorder file, if {@literal null} a temp file will be used instead
+     */
     public SamplingProfiler(final ElasticApmTracer tracer, NanoClock nanoClock, @Nullable File activationEventsFile, @Nullable File jfrFile) {
         this.tracer = tracer;
         this.config = tracer.getConfig(ProfilingConfiguration.class);

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerQueueTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerQueueTest.java
@@ -38,6 +38,7 @@ public class SamplingProfilerQueueTest {
         ElasticApmTracer tracer = MockTracer.create();
 
         SamplingProfiler profiler = new SamplingProfiler(tracer, new SystemNanoClock());
+
         profiler.setProfilingSessionOngoing(true);
         TraceContext traceContext = TraceContext.with64BitId(tracer);
 
@@ -45,7 +46,7 @@ public class SamplingProfilerQueueTest {
         long timeAfterFirstEvent = System.nanoTime();
         Thread.sleep(1);
 
-        for (int i = 0; i < SamplingProfiler.RING_BUFFER_SIZE -1; i++) {
+        for (int i = 0; i < SamplingProfiler.RING_BUFFER_SIZE - 1; i++) {
             assertThat(profiler.onActivation(traceContext, null)).isTrue();
         }
 

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerQueueTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerQueueTest.java
@@ -27,7 +27,10 @@ package co.elastic.apm.agent.profiler;
 import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
+import co.elastic.apm.agent.util.ExecutorUtils;
 import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -37,7 +40,9 @@ public class SamplingProfilerQueueTest {
     void testFillQueue() throws Exception {
         ElasticApmTracer tracer = MockTracer.create();
 
-        SamplingProfiler profiler = new SamplingProfiler(tracer, new SystemNanoClock());
+        ScheduledThreadPoolExecutor scheduler = ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler");
+
+        SamplingProfiler profiler = new SamplingProfiler(tracer, new SystemNanoClock(), scheduler);
 
         profiler.setProfilingSessionOngoing(true);
         TraceContext traceContext = TraceContext.with64BitId(tracer);

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerQueueTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerQueueTest.java
@@ -42,7 +42,7 @@ public class SamplingProfilerQueueTest {
 
         ScheduledThreadPoolExecutor scheduler = ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler");
 
-        SamplingProfiler profiler = new SamplingProfiler(tracer, new SystemNanoClock(), scheduler);
+        SamplingProfiler profiler = new SamplingProfiler(tracer, new SystemNanoClock());
 
         profiler.setProfilingSessionOngoing(true);
         TraceContext traceContext = TraceContext.with64BitId(tracer);

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerReplay.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerReplay.java
@@ -26,7 +26,6 @@ package co.elastic.apm.agent.profiler;
 
 import co.elastic.apm.agent.MockReporter;
 import co.elastic.apm.agent.MockTracer;
-import co.elastic.apm.agent.util.ExecutorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +53,6 @@ public class SamplingProfilerReplay {
         jfrFile.deleteOnExit();
         MockReporter reporter = new MockReporter();
         SamplingProfiler samplingProfiler = new SamplingProfiler(MockTracer.createRealTracer(reporter),
-            ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler"),
             new SystemNanoClock(),
             activationEventsFile,
             jfrFile);

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerReplay.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerReplay.java
@@ -26,6 +26,7 @@ package co.elastic.apm.agent.profiler;
 
 import co.elastic.apm.agent.MockReporter;
 import co.elastic.apm.agent.MockTracer;
+import co.elastic.apm.agent.util.ExecutorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,7 @@ public class SamplingProfilerReplay {
         MockReporter reporter = new MockReporter();
         SamplingProfiler samplingProfiler = new SamplingProfiler(MockTracer.createRealTracer(reporter),
             new SystemNanoClock(),
+            ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler"),
             activationEventsFile,
             jfrFile);
         Path baseDir = Paths.get(System.getProperty("java.io.tmpdir"), "profiler");

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerReplay.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerReplay.java
@@ -26,7 +26,6 @@ package co.elastic.apm.agent.profiler;
 
 import co.elastic.apm.agent.MockReporter;
 import co.elastic.apm.agent.MockTracer;
-import co.elastic.apm.agent.util.ExecutorUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +54,6 @@ public class SamplingProfilerReplay {
         MockReporter reporter = new MockReporter();
         SamplingProfiler samplingProfiler = new SamplingProfiler(MockTracer.createRealTracer(reporter),
             new SystemNanoClock(),
-            ExecutorUtils.createSingleThreadSchedulingDaemonPool("sampling-profiler"),
             activationEventsFile,
             jfrFile);
         Path baseDir = Paths.get(System.getProperty("java.io.tmpdir"), "profiler");

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerTest.java
@@ -76,7 +76,7 @@ class SamplingProfilerTest {
     }
 
     @AfterEach
-    void tearDown() throws Exception {
+    void tearDown() {
         tracer.stop();
     }
 

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/SamplingProfilerTest.java
@@ -40,9 +40,15 @@ import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
@@ -53,35 +59,100 @@ import static org.mockito.Mockito.when;
 class SamplingProfilerTest {
 
     private MockReporter reporter;
+
+    @Nullable
     private ElasticApmTracer tracer;
     private SamplingProfiler profiler;
+    private ProfilingConfiguration profilingConfig;
 
     @BeforeEach
-    void setUp() {
-        reporter = new MockReporter();
-        ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
-        ProfilingConfiguration profilingConfig = config.getConfig(ProfilingConfiguration.class);
-        when(profilingConfig.getIncludedClasses()).thenReturn(List.of(WildcardMatcher.valueOf(getClass().getName())));
-        when(profilingConfig.isProfilingEnabled()).thenReturn(true);
-        when(profilingConfig.getProfilingDuration()).thenReturn(TimeDuration.of("500ms"));
-        when(profilingConfig.getProfilingInterval()).thenReturn(TimeDuration.of("500ms"));
-        when(profilingConfig.getSamplingInterval()).thenReturn(TimeDuration.of("5ms"));
-        tracer = MockTracer.createRealTracer(reporter, config);
-        profiler = tracer.getLifecycleListener(ProfilingFactory.class).getProfiler();
-        // ensure profiler is initialized
-        await()
-            .pollDelay(10, TimeUnit.MILLISECONDS)
-            .timeout(6000, TimeUnit.MILLISECONDS)
-            .until(() -> profiler.getProfilingSessions() > 1);
+    void setup() {
+        // avoids any test failure to make other tests to fail
+        getProfilerTempFiles().forEach(SamplingProfilerTest::silentDeleteFile);
     }
 
     @AfterEach
     void tearDown() {
-        tracer.stop();
+        if (tracer != null) {
+            tracer.stop();
+        }
+
+        getProfilerTempFiles().forEach(SamplingProfilerTest::silentDeleteFile);
+    }
+
+    @Test
+    void shouldLazilyCreateTempFilesAndCleanThem() throws Exception {
+
+        List<Path> tempFiles = getProfilerTempFiles();
+        assertThat(tempFiles).isEmpty();
+
+        // temporary files should be created on-demand, and properly deleted afterwards
+        setupProfiler(false);
+
+        assertThat(profiler.getProfilingSessions())
+            .describedAs("profiler should not have any session when disabled")
+            .isEqualTo(0);
+
+        assertThat(getProfilerTempFiles())
+            .describedAs("should not create a temp file when disabled")
+            .isEmpty();
+
+        when(profilingConfig.isProfilingEnabled())
+            .thenReturn(true);
+
+        awaitProfilerStarted(profiler);
+
+        assertThat(getProfilerTempFiles())
+            .describedAs("should have created two temp files")
+            .hasSize(2);
+
+        profiler.stop();
+
+        assertThat(getProfilerTempFiles())
+            .describedAs("should delete temp files when profiler is stopped")
+            .isEmpty();
+
+
+    }
+
+    private static List<Path> getProfilerTempFiles() {
+        Path tempFolder = Paths.get(System.getProperty("java.io.tmpdir"));
+        try {
+            return Files.list(tempFolder)
+                .filter(f -> f.getFileName().toString().startsWith("apm-"))
+                .sorted()
+                .collect(Collectors.toList());
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    void shouldNotDeleteProvidedFiles() throws Exception {
+        // when an existing file is provided to the profiler, we should not delete it
+        // unlike the temporary files that are created by profiler itself
+
+        setupProfiler(true);
+        profiler.stop();
+
+        Path tempFile1 = Files.createTempFile("apm-provided", "test.bin");
+        Path tempFile2 = Files.createTempFile("apm-provided", "test.jfr");
+
+        SamplingProfiler otherProfiler = new SamplingProfiler(tracer, new FixedNanoClock(), tempFile1.toFile(), tempFile2.toFile());
+
+        otherProfiler.start(tracer);
+        awaitProfilerStarted(otherProfiler);
+        otherProfiler.stop();
+
+        assertThat(tempFile1).exists();
+        assertThat(tempFile2).exists();
     }
 
     @Test
     void testProfileTransaction() throws Exception {
+        setupProfiler(true);
+        awaitProfilerStarted(profiler);
+
         Transaction transaction = tracer.startRootTransaction(null).withName("transaction");
         try (Scope scope = transaction.activateInScope()) {
             // makes sure that the rest will be captured by another profiling session
@@ -136,5 +207,37 @@ class SamplingProfilerTest {
 
     private void dInferred() throws Exception {
         Thread.sleep(50);
+    }
+
+
+    private void setupProfiler(boolean enabled) {
+        reporter = new MockReporter();
+        ConfigurationRegistry config1 = SpyConfiguration.createSpyConfig();
+        profilingConfig = config1.getConfig(ProfilingConfiguration.class);
+        when(profilingConfig.getIncludedClasses()).thenReturn(List.of(WildcardMatcher.valueOf(getClass().getName())));
+        when(profilingConfig.isProfilingEnabled()).thenReturn(enabled);
+        when(profilingConfig.getProfilingDuration()).thenReturn(TimeDuration.of("500ms"));
+        when(profilingConfig.getProfilingInterval()).thenReturn(TimeDuration.of("500ms"));
+        when(profilingConfig.getSamplingInterval()).thenReturn(TimeDuration.of("5ms"));
+        ConfigurationRegistry config = config1;
+        tracer = MockTracer.createRealTracer(reporter, config);
+        profiler = tracer.getLifecycleListener(ProfilingFactory.class).getProfiler();
+    }
+
+
+    private static void awaitProfilerStarted(SamplingProfiler profiler) {
+        // ensure profiler is initialized
+        await()
+            .pollDelay(10, TimeUnit.MILLISECONDS)
+            .timeout(6000, TimeUnit.MILLISECONDS)
+            .until(() -> profiler.getProfilingSessions() > 1);
+    }
+
+    private static void silentDeleteFile(Path f) {
+        try {
+            Files.delete(f);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Originally reported in [our forum](https://discuss.elastic.co/t/disable-profiling-apm-agent-java/246593)

When agent is started, the sampling profiler creates temporary files (usually in `/tmp`) even when it's disabled.

Ideally, those files should only be created when and if the profiler is used.
If those are created without any need, then it's a bug.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix

