### PR TITLE
[CI] use default m2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-java-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
-    MAVEN_CONFIG = '-Dmaven.repo.local=.m2'
+    MAVEN_CONFIG = "${params.MAVEN_CONFIG}"
     OPBEANS_REPO = 'opbeans-java'
   }
   options {
@@ -46,7 +46,6 @@ pipeline {
         HOME = "${env.WORKSPACE}"
         JAVA_HOME = "${env.HUDSON_HOME}/.java/java11"
         PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
-        MAVEN_CONFIG = "${params.MAVEN_CONFIG} ${env.MAVEN_CONFIG}"
       }
       stages {
         /**
@@ -99,9 +98,6 @@ pipeline {
       when {
         beforeAgent true
         expression { return env.ONLY_DOCS == "false" }
-      }
-      environment {
-        MAVEN_CONFIG = "${params.MAVEN_CONFIG} ${env.MAVEN_CONFIG}"
       }
       failFast true
       parallel {


### PR DESCRIPTION
## What does this PR do?

Avoid override the .m2 location

Relates https://github.com/elastic/apm-agent-java/issues/1375