### PR TITLE
Move SPID check to dir block in release job

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -147,9 +147,9 @@ pipeline {
         stage('Nexus release') {
           steps {
             script {
-              def spid = sh(script: "./scripts/jenkins/fetch_nexus_id.sh", returnStdout: true).trim()
               dir("${BASE_DIR}"){
                 withEnvMask(vars: [[var: "SPID", password: spid]]){
+                  def spid = sh(script: "./scripts/jenkins/fetch_nexus_id.sh", returnStdout: true).trim()
                   def foundStagingId = nexusFindStagingId(stagingProfileId: "${SPID}", groupId: "co.elastic.apm")
                   nexusCloseStagingRepository(stagingProfileId: "${SPID}", stagingId: foundStagingId)
                   nexusReleaseStagingRepository(stagingProfileId: "${SPID}", stagingId: foundStagingId)


### PR DESCRIPTION
## What does this PR do?
Should fix an error encountered in the release attempt.

`./scripts/jenkins/fetch_nexus_id.sh: not found`

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
