### PR TITLE
Fix HttpUrlConnection instrumentation

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
@@ -42,12 +42,4 @@ public class IndyPluginClassLoader extends ByteArrayClassLoader.ChildFirst {
     public IndyPluginClassLoader(@Nullable ClassLoader targetClassLoader, ClassLoader agentClassLoader, Map<String, byte[]> typeDefinitions) {
         super(new MultipleParentClassLoader(agentClassLoader, Arrays.asList(agentClassLoader, targetClassLoader)), true, typeDefinitions, PersistenceHandler.MANIFEST);
     }
-
-    @Override
-    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
-        if (name.equals("java.lang.ThreadLocal")) {
-            throw new ClassNotFoundException("The usage of ThreadLocals is not allowed in instrumentation plugins. Use GlobalThreadLocal instead.");
-        }
-        return super.loadClass(name, resolve);
-    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
@@ -42,4 +42,12 @@ public class IndyPluginClassLoader extends ByteArrayClassLoader.ChildFirst {
     public IndyPluginClassLoader(@Nullable ClassLoader targetClassLoader, ClassLoader agentClassLoader, Map<String, byte[]> typeDefinitions) {
         super(new MultipleParentClassLoader(agentClassLoader, Arrays.asList(agentClassLoader, targetClassLoader)), true, typeDefinitions, PersistenceHandler.MANIFEST);
     }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        if (name.equals("java.lang.ThreadLocal")) {
+            throw new ClassNotFoundException("The usage of ThreadLocals is not allowed in instrumentation plugins. Use GlobalThreadLocal instead.");
+        }
+        return super.loadClass(name, resolve);
+    }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -1019,37 +1019,6 @@ class InstrumentationTest {
 
     }
 
-    public static class UsingThreadLocal extends TracerAwareInstrumentation {
-
-        private static final ThreadLocal<AbstractSpan<?>> localSpan = new ThreadLocal<>() {
-            @Override
-            @Nullable
-            protected AbstractSpan<?> initialValue() {
-                return tracer.startRootTransaction(null);
-            }
-        };
-
-        @Advice.OnMethodEnter(inline = false)
-        public static void onEnter() {
-            localSpan.get();
-        }
-
-        @Override
-        public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-            return named(InstrumentationTest.class.getName());
-        }
-
-        @Override
-        public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-            return named("getSpanFromThreadLocal");
-        }
-
-        @Override
-        public Collection<String> getInstrumentationGroupNames() {
-            return Collections.singletonList("test");
-        }
-    }
-
     public static class GetClassLoaderInstrumentation extends ElasticApmInstrumentation {
 
         @AssignTo.Return

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -477,14 +477,6 @@ class InstrumentationTest {
             .isInstanceOf(IllegalStateException.class);
     }
 
-    @Test
-    void testAdviceUsingThreadLocal() {
-        ElasticApmAgent.initInstrumentation(tracer,
-            ByteBuddyAgent.install(),
-            Collections.singletonList(new UsingThreadLocal()));
-        assertThat(getSpanFromThreadLocal()).isNull();
-    }
-
     @Nullable
     public AbstractSpan<?> getSpanFromThreadLocal() {
         return null;


### PR DESCRIPTION
Currently our instrumentation only looks at the `java.net.URLConnection#connected` field and not the `sun.net.www.protocol.http.HttpURLConnection#connecting` when trying to add the header.
Since the `connecting` field was only introduced in Java 8, we are doing something instead.

In addition - removing the restriction for using `ThreadLocal` within advice classes.