### PR TITLE
document runtime attach as beta

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,7 @@ endif::[]
   AsyncHttpClient, Apache HttpClient
 * The agent now collects cgroup memory metrics (see details in <<metrics-cgroup,Metrics page>>)
 * Update async-profiler to 1.8.1 {pull}1382[#1382]
+* Runtime attach install option is promoted to 'beta' status (was experimental).
 
 [float]
 ===== Bug fixes

--- a/docs/setup-attach-api.asciidoc
+++ b/docs/setup-attach-api.asciidoc
@@ -1,7 +1,7 @@
 [[setup-attach-api]]
 === Programmatic API setup to self-attach
 
-NOTE: This installation method is experimental.
+NOTE: This installation method is in beta.
 
 [float]
 [[setup-attach-api-supported-environments]]

--- a/docs/setup-attach-cli.asciidoc
+++ b/docs/setup-attach-cli.asciidoc
@@ -1,7 +1,7 @@
 [[setup-attach-cli]]
 === Automatic setup with `apm-agent-attach-standalone.jar`
 
-NOTE: This installation method is experimental.
+NOTE: This installation method is in beta.
 
 You can use the attacher as a standalone application on the command line or include it in your application to programmatically attach to the current JVM.
 


### PR DESCRIPTION
## What does this PR do?

Document that runtime attach is not a 'beta' feature, was previously experimental.

## Checklist

- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
