### PR TITLE
fix #1402 & make sure we proactively avoid it

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,6 +32,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
+* Fix instrumentation error for HttpClient - {pull}1402[#1402]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -77,6 +77,7 @@ import java.io.FilenameFilter;
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
 import java.security.ProtectionDomain;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -435,6 +436,12 @@ public class ElasticApmAgent {
         if (classLoader == null) {
             classLoader = ClassLoader.getSystemClassLoader();
         }
+
+        int adviceModifiers = adviceClass.getModifiers();
+        if (!Modifier.isPublic(adviceModifiers) || !Modifier.isStatic(adviceModifiers)) {
+            throw new IllegalStateException(String.format("advice class %s should be public static", adviceClassName));
+        }
+
         TypePool pool = new TypePool.Default.WithLazyResolution(TypePool.CacheProvider.NoOp.INSTANCE, ClassFileLocator.ForClassLoader.of(classLoader), TypePool.Default.ReaderMode.FAST);
         TypeDescription typeDescription = pool.describe(adviceClassName).resolve();
         for (MethodDescription.InDefinedShape enterAdvice : typeDescription.getDeclaredMethods().filter(isStatic().and(isAnnotatedWith(Advice.OnMethodEnter.class)))) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -438,8 +438,8 @@ public class ElasticApmAgent {
         }
 
         int adviceModifiers = adviceClass.getModifiers();
-        if (!Modifier.isPublic(adviceModifiers) || !Modifier.isStatic(adviceModifiers)) {
-            throw new IllegalStateException(String.format("advice class %s should be public static", adviceClassName));
+        if (!Modifier.isPublic(adviceModifiers)) {
+            throw new IllegalStateException(String.format("advice class %s should be public", adviceClassName));
         }
 
         TypePool pool = new TypePool.Default.WithLazyResolution(TypePool.CacheProvider.NoOp.INSTANCE, ClassFileLocator.ForClassLoader.of(classLoader), TypePool.Default.ReaderMode.FAST);

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientRedirectInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientRedirectInstrumentation.java
@@ -48,7 +48,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  */
 public class ApacheHttpAsyncClientRedirectInstrumentation extends BaseApacheHttpClientInstrumentation {
 
-    private static class ApacheHttpAsyncClientRedirectAdvice {
+    public static class ApacheHttpAsyncClientRedirectAdvice {
         @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
         public static void onAfterExecute(@Advice.Argument(value = 0) HttpRequest original,
                                           @Advice.Return(typing = Assigner.Typing.DYNAMIC) @Nullable HttpRequest redirect) {


### PR DESCRIPTION
## What does this PR do?

Fixes #1402 

No test update required, we check advice class visibility at runtime, which makes all tests fail if another similar issue happens.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
