### PR TITLE
lazy-load jdbc helper

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ endif::[]
 * Eliminate `unsupported class version error` messages related to loading the Java 11 HttpClient plugin in pre-Java-11 JVMs {pull}1397[1397]
 * Fix rejected metric events by APM Server with response code 400 due to data validation error - sanitizing Micrometer
 metricset tag keys - {pull}1413[1413]
+* Fix `NoClassDefFoundError` with JDBC instrumentation plugin {pull}1409[1409]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/ConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/ConnectionInstrumentation.java
@@ -52,7 +52,7 @@ public class ConnectionInstrumentation extends JdbcInstrumentation {
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
     public static void storeSql(@Advice.Return PreparedStatement statement,
                                 @Advice.Argument(0) String sql) {
-        jdbcHelper.mapStatementToSql(statement, sql);
+        getJdbcHelper().mapStatementToSql(statement, sql);
     }
 
     @Override

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/JdbcInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/JdbcInstrumentation.java
@@ -43,7 +43,7 @@ public abstract class JdbcInstrumentation extends TracerAwareInstrumentation {
 
     @Override
     public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
-        return classLoaderCanLoadClass("java.sql.Statement");
+        return classLoaderCanLoadClass("java.sql.Statement"); // in case java.sql module is not there
     }
 
     @Override

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/JdbcInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/JdbcInstrumentation.java
@@ -42,11 +42,6 @@ public abstract class JdbcInstrumentation extends TracerAwareInstrumentation {
     private static JdbcHelper jdbcHelper;
 
     @Override
-    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
-        return classLoaderCanLoadClass("java.sql.Statement"); // in case java.sql module is not there
-    }
-
-    @Override
     public final Collection<String> getInstrumentationGroupNames() {
         return JDBC_GROUPS;
     }

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/JdbcInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/JdbcInstrumentation.java
@@ -26,18 +26,37 @@ package co.elastic.apm.agent.jdbc;
 
 import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import co.elastic.apm.agent.jdbc.helper.JdbcHelper;
+import net.bytebuddy.matcher.ElementMatcher;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
+
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
 
 public abstract class JdbcInstrumentation extends TracerAwareInstrumentation {
 
     private static final Collection<String> JDBC_GROUPS = Collections.singleton("jdbc");
 
-    protected static JdbcHelper jdbcHelper = new JdbcHelper();
+    @Nullable
+    private static JdbcHelper jdbcHelper;
+
+    @Override
+    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
+        return classLoaderCanLoadClass("java.sql.Statement");
+    }
 
     @Override
     public final Collection<String> getInstrumentationGroupNames() {
         return JDBC_GROUPS;
+    }
+
+    protected synchronized static JdbcHelper getJdbcHelper() {
+        // lazily initialize helper to prevent trying to load classes in java.sql package with the bootstrap classloader
+        // this method should only be called from advices
+        if (jdbcHelper == null) {
+            jdbcHelper = new JdbcHelper();
+        }
+        return jdbcHelper;
     }
 }

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/StatementInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/StatementInstrumentation.java
@@ -26,6 +26,7 @@ package co.elastic.apm.agent.jdbc;
 
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.jdbc.helper.JdbcHelper;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
@@ -100,7 +101,7 @@ public abstract class StatementInstrumentation extends JdbcInstrumentation {
         public static Object onBeforeExecute(@Advice.This Statement statement,
                                              @Advice.Argument(0) String sql) {
 
-            return jdbcHelper.createJdbcSpan(sql, statement, tracer.getActive(), false);
+            return getJdbcHelper().createJdbcSpan(sql, statement, tracer.getActive(), false);
         }
 
 
@@ -147,7 +148,7 @@ public abstract class StatementInstrumentation extends JdbcInstrumentation {
         public static Object onBeforeExecute(@Advice.This Statement statement,
                                            @Advice.Argument(0) String sql) {
 
-            return jdbcHelper.createJdbcSpan(sql, statement, tracer.getActive(), false);
+            return getJdbcHelper().createJdbcSpan(sql, statement, tracer.getActive(), false);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
@@ -185,7 +186,7 @@ public abstract class StatementInstrumentation extends JdbcInstrumentation {
 
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static void storeSql(@Advice.This Statement statement, @Advice.Argument(0) String sql) {
-            jdbcHelper.mapStatementToSql(statement, sql);
+            getJdbcHelper().mapStatementToSql(statement, sql);
         }
     }
 
@@ -212,8 +213,9 @@ public abstract class StatementInstrumentation extends JdbcInstrumentation {
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         @SuppressWarnings("DuplicatedCode")
         public static Object onBeforeExecute(@Advice.This Statement statement) {
-            String sql = jdbcHelper.retrieveSqlForStatement(statement);
-            return jdbcHelper.createJdbcSpan(sql, statement, tracer.getActive(), true);
+            JdbcHelper helper = getJdbcHelper();
+            String sql = helper.retrieveSqlForStatement(statement);
+            return helper.createJdbcSpan(sql, statement, tracer.getActive(), true);
 
         }
 
@@ -273,8 +275,9 @@ public abstract class StatementInstrumentation extends JdbcInstrumentation {
         @SuppressWarnings("DuplicatedCode")
         public static Object onBeforeExecute(@Advice.This Statement statement) {
 
-            String sql = jdbcHelper.retrieveSqlForStatement(statement);
-            return jdbcHelper.createJdbcSpan(sql, statement, tracer.getActive(), true);
+            JdbcHelper helper = getJdbcHelper();
+            String sql = helper.retrieveSqlForStatement(statement);
+            return helper.createJdbcSpan(sql, statement, tracer.getActive(), true);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
@@ -317,8 +320,9 @@ public abstract class StatementInstrumentation extends JdbcInstrumentation {
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         @SuppressWarnings("DuplicatedCode")
         public static Object onBeforeExecute(@Advice.This Statement statement) {
-            @Nullable String sql = jdbcHelper.retrieveSqlForStatement(statement);
-            return jdbcHelper.createJdbcSpan(sql, statement, tracer.getActive(), true);
+            JdbcHelper helper = getJdbcHelper();
+            @Nullable String sql = helper.retrieveSqlForStatement(statement);
+            return helper.createJdbcSpan(sql, statement, tracer.getActive(), true);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)


### PR DESCRIPTION
## What does this PR do?

JDBC instrumentation fails on some environments when active.
This appears to be a side-effect of migration to new plugin architecture introduced in version 1.18.0.
We haven't been able to reproduce this directly, but changes have been confirmed to work where it used to happen.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
