### PR TITLE
Sanitize metricset tag keys

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,8 @@ endif::[]
 ===== Bug fixes
 * Fix instrumentation error for HttpClient - {pull}1402[#1402]
 * Eliminate `unsupported class version error` messages related to loading the Java 11 HttpClient plugin in pre-Java-11 JVMs {pull}1397[1397]
+* Fix rejected metric events by APM Server with response code 400 due to data validation error - sanitizing Micrometer
+metricset tag keys - {pull}1413[1413]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -987,7 +987,7 @@ public class DslJsonSerializer implements PayloadSerializer {
         }
     }
 
-    private static CharSequence sanitizeLabelKey(String key, StringBuilder replaceBuilder) {
+    public static CharSequence sanitizeLabelKey(String key, StringBuilder replaceBuilder) {
         for (int i = 0; i < DISALLOWED_IN_LABEL_KEY.length; i++) {
             if (key.contains(DISALLOWED_IN_LABEL_KEY[i])) {
                 return replaceAll(key, DISALLOWED_IN_LABEL_KEY, "_", replaceBuilder);
@@ -1171,7 +1171,7 @@ public class DslJsonSerializer implements PayloadSerializer {
         writeStringValue(value, replaceBuilder, jw);
     }
 
-    private static void writeStringValue(CharSequence value, StringBuilder replaceBuilder, JsonWriter jw) {
+    public static void writeStringValue(CharSequence value, StringBuilder replaceBuilder, JsonWriter jw) {
         if (value.length() > MAX_VALUE_LENGTH) {
             replaceBuilder.setLength(0);
             replaceBuilder.append(value, 0, Math.min(value.length(), MAX_VALUE_LENGTH + 1));

--- a/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
@@ -150,7 +150,9 @@ public class MicrometerMeterRegistrySerializer {
             if (i > 0) {
                 jw.writeByte(COMMA);
             }
-            DslJsonSerializer.writeLastField(tag.getKey(), tag.getValue(), replaceBuilder, jw);
+            DslJsonSerializer.writeStringValue(DslJsonSerializer.sanitizeLabelKey(tag.getKey(), replaceBuilder), replaceBuilder, jw);
+            jw.writeByte(JsonWriter.SEMI);
+            DslJsonSerializer.writeStringValue(tag.getValue(), replaceBuilder, jw);
         }
         jw.writeByte(OBJECT_END);
         jw.writeByte(COMMA);


### PR DESCRIPTION
## What does this PR do?
APM Server would reject metricset tag keys if they contain disallowed characters.
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
