### PR TITLE
Avoid serializing the first global label twice

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -172,7 +172,7 @@ public class DslJsonSerializer implements PayloadSerializer {
             writeStringValue(sanitizeLabelKey(globalLabelKeys.get(0), replaceBuilder), replaceBuilder, jw);
             jw.writeByte(JsonWriter.SEMI);
             writeStringValue(globalLabelValues.get(0), replaceBuilder, jw);
-            for (int i = 0; i < globalLabelKeys.size(); i++) {
+            for (int i = 1; i < globalLabelKeys.size(); i++) {
                 jw.writeByte(COMMA);
                 writeStringValue(sanitizeLabelKey(globalLabelKeys.get(i), replaceBuilder), replaceBuilder, jw);
                 jw.writeByte(JsonWriter.SEMI);


### PR DESCRIPTION
A tiny bug, without actual effect besides the size of the serialized metadata