### PR TITLE
Catch HttpUrlConnection Already Connected error

### DIFF
--- a/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
@@ -28,7 +28,6 @@ import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import co.elastic.apm.agent.http.client.HttpClientHelper;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
-import co.elastic.apm.agent.sdk.state.CallDepth;
 import co.elastic.apm.agent.sdk.weakmap.WeakMapSupplier;
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
 import net.bytebuddy.asm.Advice;
@@ -53,9 +52,6 @@ public abstract class HttpUrlConnectionInstrumentation extends TracerAwareInstru
 
     private static final WeakConcurrentMap<HttpURLConnection, Span> inFlightSpans = WeakMapSupplier.createMap();
 
-    // Used instead of inspecting sun.net.www.protocol.http.HttpURLConnection.connecting which was added in Java 8
-    private static final CallDepth connecting = CallDepth.get(HttpUrlConnectionInstrumentation.class);
-
     @Override
     public Collection<String> getInstrumentationGroupNames() {
         return Arrays.asList("http-client", "urlconnection");
@@ -78,9 +74,6 @@ public abstract class HttpUrlConnectionInstrumentation extends TracerAwareInstru
         public static Object enter(@Advice.This HttpURLConnection thiz,
                                  @Advice.FieldValue("connected") boolean connected,
                                  @Advice.Origin String signature) {
-            if (connecting.isNestedCallAndIncrement()) {
-                return null;
-            }
 
             if (tracer.getActive() == null) {
                 return null;
@@ -107,12 +100,6 @@ public abstract class HttpUrlConnectionInstrumentation extends TracerAwareInstru
                                 @Advice.FieldValue("responseCode") int responseCode,
                                 @Nullable @Advice.Enter Object spanObject,
                                 @Advice.Origin String signature) {
-
-            // This is not behaving exactly like the sun.net.www.protocol.http.HttpURLConnection.connecting flag,
-            // which is a state of the connection that can only be changed from false to true. However, it should
-            // be good enough to maintain as a state only during the execution of the current stack, as at this time
-            // of method exit, the java.net.URLConnection.connected flag should already indicate the connection state
-            connecting.decrement();
 
             Span span = (Span) spanObject;
             if (span == null) {

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/UrlConnectionPropertyAccessor.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/UrlConnectionPropertyAccessor.java
@@ -49,7 +49,11 @@ public class UrlConnectionPropertyAccessor implements TextHeaderSetter<HttpURLCo
             urlConnection.addRequestProperty(headerName, headerValue);
         } catch (IllegalStateException e) {
             // Indicating that it is too late now to add request properties, see sun.net.www.protocol.http.HttpURLConnection#connecting
-            logger.debug("Failed to add header {} to connection: {}", headerName, e.getMessage());
+            if (logger.isTraceEnabled()) {
+                logger.trace("Failed to add header to the request", e);
+            } else if (logger.isDebugEnabled()) {
+                logger.debug("Failed to add header {} to the request through HttpUrlConnection: {}", headerName, e.getMessage());
+            }
         }
     }
 


### PR DESCRIPTION
This reverts the change introduced in #1391 - the nesting check approach is only valid if the nested calls are not related to the same method. For example, consider this stack trace:
```
   sun.net.www.protocol.http.HttpURLConnection.connect()
   com.example.HttpUrlConnectionWrapper.connect()
```
where `com.example.HttpUrlConnectionWrapper` does not delegate `addRequestProperty` to the actual implementation, which means it must be invoked through `sun.net.www.protocol.http.HttpURLConnection` in order to add headers. The current call-depth restriction does not allow that.

Instead, this PR always tries to add headers to requests that do not contain them already, and we catch the related `IllegalStateException` indicating it is `Already connected`.