### PR TITLE
Relaxing k8s pod discovery pattern some more

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/SystemInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/SystemInfo.java
@@ -46,9 +46,7 @@ public class SystemInfo {
 
     private static final String CONTAINER_UID_REGEX = "^[0-9a-fA-F]{64}$";
     private static final String SHORTENED_UUID_PATTERN = "^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4}\\-[0-9a-fA-F]{4,}";
-    private static final String POD_REGEX =
-        "(?:^/kubepods[\\S]*/pod([^/]+)$)|" +
-            "(?:^/kubepods\\.slice/kubepods-[^/]+\\.slice/kubepods-[^/]+-pod([^/]+)\\.slice$)";
+    private static final String POD_REGEX = "(?:^/kubepods[\\S]*/[\\S]*pod([^/]+)$)";
 
     /**
      * Architecture of the system the agent is running on.
@@ -199,19 +197,18 @@ public class SystemInfo {
                     final Pattern pattern = Pattern.compile(POD_REGEX);
                     final Matcher matcher = pattern.matcher(dir);
                     if (matcher.find()) {
-                        for (int i = 1; i <= matcher.groupCount(); i++) {
-                            String podUid = matcher.group(i);
-                            if (podUid != null && !podUid.isEmpty()) {
-                                if (i == 2) {
-                                    // systemd cgroup driver is being used, so we need to unescape '_' back to '-'.
-                                    podUid = podUid.replace('_', '-');
-                                }
-                                logger.debug("Found Kubernetes pod UID: {}", podUid);
-                                // By default, Kubernetes will set the hostname of the pod containers to the pod name. Users that override
-                                // the name should use the Downward API to override the pod name.
-                                kubernetes = new Kubernetes(hostname, null, null, podUid);
-                                break;
+                        String podUid = matcher.group(1);
+                        if (podUid != null && !podUid.isEmpty()) {
+                            // systemd cgroup driver is being used, so we need to unescape '_' back to '-'.
+                            podUid = podUid.replace('_', '-');
+                            int podPostfixIndex = podUid.indexOf('.');
+                            if (podPostfixIndex > 0) {
+                                podUid = podUid.substring(0, podPostfixIndex);
                             }
+                            logger.debug("Found Kubernetes pod UID: {}", podUid);
+                            // By default, Kubernetes will set the hostname of the pod containers to the pod name. Users that override
+                            // the name should use the Downward API to override the pod name.
+                            kubernetes = new Kubernetes(hostname, null, null, podUid);
                         }
                     }
                 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/ContainerInfoTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/ContainerInfoTest.java
@@ -108,6 +108,14 @@ public class ContainerInfoTest {
     }
 
     @Test
+    void testOpenshiftFormDisney() {
+        String line = "9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice" +
+            "/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope";
+        SystemInfo systemInfo = assertContainerId(line, "b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f");
+        assertKubernetesInfo(systemInfo, "22949dce-fd8b-11ea-8ede-98f2b32c645c", "my-host", null, null);
+    }
+
+    @Test
     void testKubernetesInfo_podUid_with_underscores() {
         // In such cases- underscores should be replaced with hyphens in the pod UID
         String line = "1:name=systemd:/kubepods.slice/kubepods-burstable.slice/" +


### PR DESCRIPTION
## What does this PR do?
Expanding k8s discoverable flavours, eg the formerly non-supported:
```
9:freezer:/kubepods.slice/kubepods-pod22949dce_fd8b_11ea_8ede_98f2b32c645c.slice/docker-b15a5bdedd2e7645c3be271364324321b908314e4c77857bbfd32a041148c07f.scope
```
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
