### PR TITLE
fix micrometer invalid double values

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ endif::[]
 * Eliminate `unsupported class version error` messages related to loading the Java 11 HttpClient plugin in pre-Java-11 JVMs {pull}1397[1397]
 * Fix rejected metric events by APM Server with response code 400 due to data validation error - sanitizing Micrometer
 metricset tag keys - {pull}1413[1413]
+* Fix invalid micrometer metrics with non-numeric values {pull}1419[1419]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
@@ -27,7 +27,6 @@ package co.elastic.apm.agent.micrometer;
 import co.elastic.apm.agent.report.serialize.DslJsonSerializer;
 import com.dslplatform.json.DslJson;
 import com.dslplatform.json.JsonWriter;
-import com.dslplatform.json.Nullable;
 import com.dslplatform.json.NumberConverter;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.DistributionSummary;
@@ -116,10 +115,15 @@ public class MicrometerMeterRegistrySerializer {
                         serializeDistributionSummary(jw, timer.getId(), timer.count(), timer.totalAmount());
                         hasValue = true;
                     } else if (meter instanceof Gauge) {
-                        if (hasValue) jw.writeByte(JsonWriter.COMMA);
                         Gauge gauge = (Gauge) meter;
-                        serializeValue(gauge.getId(), gauge.value(), jw);
-                        hasValue = true;
+
+                        // gauge values can be Double.NaN or +/-Infinite
+                        if (isValidValue(gauge.value())) {
+                            if (hasValue) jw.writeByte(JsonWriter.COMMA);
+                            serializeValue(gauge.getId(), gauge.value(), jw);
+                            hasValue = true;
+                        }
+
                     } else if (meter instanceof Counter) {
                         if (hasValue) jw.writeByte(JsonWriter.COMMA);
                         Counter counter = (Counter) meter;
@@ -195,5 +199,9 @@ public class MicrometerMeterRegistrySerializer {
         jw.writeAscii("value");
         jw.writeByte(JsonWriter.QUOTE);
         jw.writeByte(JsonWriter.SEMI);
+    }
+
+    private static boolean isValidValue(double value) {
+        return !Double.isNaN(value) && !Double.isInfinite(value);
     }
 }

--- a/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMetricsReporterTest.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMetricsReporterTest.java
@@ -209,6 +209,23 @@ class MicrometerMetricsReporterTest {
         assertThat(metricSet.get("metricset").get("samples").get("timer.sum").get("value").longValue()).isEqualTo(3);
     }
 
+    @Test
+    void tryToSerializeInvalidGaugeValues() {
+        for (Double invalidValue : Arrays.asList(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY, Double.NaN)) {
+            List<Tag> tags = List.of(Tag.of("foo", "bar"));
+            meterRegistry.gauge("gauge1", tags, 42, v -> invalidValue);
+            meterRegistry.gauge("gauge2", tags, 42, v -> 42D);
+            JsonNode metricSet = getSingleMetricSet();
+            assertThat(metricSet.get("metricset").get("samples").get("gauge1"))
+                .describedAs("value of %s is not expected to be written to json", invalidValue)
+                .isNull();
+
+            // serialization should handle ignoring the 1st value
+            assertThat(metricSet.get("metricset").get("samples").get("gauge2").get("value").doubleValue())
+                .isEqualTo(42D);
+        }
+    }
+
     private JsonNode getSingleMetricSet() {
         List<JsonNode> metricSets = getMetricSets();
         assertThat(metricSets).hasSize(1);


### PR DESCRIPTION
## What does this PR do?

Micrometer plugin reports metrics through a dedicated JSON serialization code, and does not properly handle corner cases with gauges that can have values of `Double.NaN` or `Double.NEGATIVE_INFINITY`, as a result there are cases where metric sets are sent with strings as values instead of numbers, for example `-Infinity`.

Ideally in the future if we start to have multiple plugins that report metrics, we should probably provide an internal API for this so there is no duplication of code and potential issues.

## Checklist

- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
