### PR TITLE
Remove 1.18.0.RC1 from PCF index file

### DIFF
--- a/cloudfoundry/index.yml
+++ b/cloudfoundry/index.yml
@@ -17,5 +17,4 @@
 1.15.0: https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/1.15.0/elastic-apm-agent-1.15.0.jar
 1.16.0: https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/1.16.0/elastic-apm-agent-1.16.0.jar
 1.17.0: https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/1.17.0/elastic-apm-agent-1.17.0.jar
-1.18.0.RC1: https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/1.18.0.RC1/elastic-apm-agent-1.18.0.RC1.jar
 1.18.0: https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/1.18.0/elastic-apm-agent-1.18.0.jar


### PR DESCRIPTION
This version causes an error:
```
WARN  Discarding illegal version 1.18.0.RC1: Invalid micro version '0.RC1'
```