### PR TITLE
Remove cgroup inactive_file.bytes metric

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ endif::[]
 [float]
 ===== Features
 * Migrate some plugins to indy dispatcher {pull}1362[1362] {pull}1366[1366] {pull}1363[1363] {pull}1383[1383] {pull}1368[1368] {pull}1364[1364] {pull}1365[1365] {pull}1367[1367] {pull}1371[1371]
+* Remove cgroup inactive_file.bytes metric {pull}1422[1422]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/CGroupMetrics.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/CGroupMetrics.java
@@ -224,31 +224,6 @@ public class CGroupMetrics extends AbstractLifecycleListener {
 
     void bindTo(MetricRegistry metricRegistry) {
         if (cgroupFiles != null) {
-            metricRegistry.addUnlessNan("system.process.cgroup.memory.stats.inactive_file.bytes", Labels.EMPTY, new DoubleSupplier() {
-                @Override
-                public double get() {
-                    try (BufferedReader fileReaderStatFile = new BufferedReader(new FileReader(cgroupFiles.getStatMemoryFile()))) {
-                        String statLine = fileReaderStatFile.readLine();
-                        String inactiveBytes = null;
-                        while (statLine != null) {
-                            final String[] statLineSplit = StringUtils.split(statLine, ' ');
-                            if (statLineSplit.length > 1) {
-                                if ("total_inactive_file".equals(statLineSplit[0])) {
-                                    inactiveBytes = statLineSplit[1];
-                                    break;
-                                } else if ("inactive_file".equals(statLineSplit[0])) {
-                                    inactiveBytes = statLineSplit[1];
-                                }
-                            }
-                            statLine = fileReaderStatFile.readLine();
-                        }
-                        return inactiveBytes != null ? Long.parseLong(inactiveBytes) : Double.NaN;
-                    } catch (Exception e) {
-                        logger.debug("Failed to read " + cgroupFiles.getStatMemoryFile().getAbsolutePath() + " file", e);
-                        return Double.NaN;
-                    }
-                }
-            });
 
             metricRegistry.addUnlessNan("system.process.cgroup.memory.mem.usage.bytes", Labels.EMPTY, new DoubleSupplier() {
                 @Override
@@ -301,6 +276,10 @@ public class CGroupMetrics extends AbstractLifecycleListener {
             return usedMemoryFile;
         }
 
+        /**
+         * Not used at the moment, but contains useful info, so no harm of leaving without opening and reading from
+         * @return the memory.stat file
+         */
         public File getStatMemoryFile() {
             return statMemoryFile;
         }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/CGroupMetricsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/CGroupMetricsTest.java
@@ -84,7 +84,6 @@ class CGroupMetricsTest {
 
         assertThat(metricRegistry.getGaugeValue("system.process.cgroup.memory.mem.usage.bytes", Labels.EMPTY)).isEqualTo(value);
         assertThat(metricRegistry.getGaugeValue("system.process.cgroup.memory.mem.limit.bytes", Labels.EMPTY)).isEqualTo(Double.valueOf(memLimit));
-        assertThat(metricRegistry.getGaugeValue("system.process.cgroup.memory.stats.inactive_file.bytes", Labels.EMPTY)).isEqualTo(10407936L);
     }
     @ParameterizedTest
     @ValueSource(strings ={
@@ -116,7 +115,6 @@ class CGroupMetricsTest {
 
         assertThat(metricRegistry.getGaugeValue("system.process.cgroup.memory.mem.limit.bytes", Labels.EMPTY)).isEqualTo(Double.NaN);
         assertThat(metricRegistry.getGaugeValue("system.process.cgroup.memory.mem.usage.bytes", Labels.EMPTY)).isEqualTo(964778496);
-        assertThat(metricRegistry.getGaugeValue("system.process.cgroup.memory.stats.inactive_file.bytes", Labels.EMPTY)).isEqualTo(10407936L);
     }
 
     @Test
@@ -126,7 +124,6 @@ class CGroupMetricsTest {
 
         assertThat(metricRegistry.getGaugeValue("system.process.cgroup.memory.mem.limit.bytes", Labels.EMPTY)).isEqualTo(Double.NaN);
         assertThat(metricRegistry.getGaugeValue("system.process.cgroup.memory.mem.usage.bytes", Labels.EMPTY)).isEqualTo(964778496);
-        assertThat(metricRegistry.getGaugeValue("system.process.cgroup.memory.stats.inactive_file.bytes", Labels.EMPTY)).isEqualTo(10407936L);
     }
 
 }

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -120,16 +120,6 @@ Memory usage in current cgroup slice.
 --
 
 
-*`system.process.cgroup.memory.stats.inactive_file.bytes`*::
-+
---
-type: long
-
-format: bytes
-
-Inactive memory in current cgroup slice.
---
-
 [float]
 [[metrics-jvm]]
 === JVM Metrics


### PR DESCRIPTION
## What does this PR do?
Closes #1408

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have made corresponding changes to the documentation