### PR TITLE
Disable the agent when -XX:+UseG1GC is used on Java 7

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,8 @@ endif::[]
 
 [float]
 ===== Breaking changes
+* Agent will abort when used on HotSpot JVM of version 7 where the `-XX:+UseG1GC` command line argument is used, as it
+  may cause JVM crash - {pull}1435[#1435]
 
 [float]
 ===== Features

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
@@ -24,7 +24,8 @@
  */
 package co.elastic.apm.agent.bci;
 
-import javax.annotation.Nullable;
+import co.elastic.apm.agent.util.JvmRuntimeInfo;
+
 import java.io.File;
 import java.lang.instrument.Instrumentation;
 import java.net.URISyntaxException;
@@ -76,15 +77,13 @@ public class AgentMain {
             return;
         }
 
-        String javaVersion = System.getProperty("java.version");
-        String javaVmName = System.getProperty("java.vm.name");
-        String javaVmVersion = System.getProperty("java.vm.version");
-        if (!isJavaVersionSupported(javaVersion, javaVmName, javaVmVersion)) {
+        if (!JvmRuntimeInfo.isJavaVersionSupported()) {
             // Gracefully abort agent startup is better than unexpected failure down the road when we known a given JVM
             // version is not supported. Agent might trigger known JVM bugs causing JVM crashes, notably on early Java 8
             // versions (but fixed in later versions), given those versions are obsolete and agent can't have workarounds
             // for JVM internals, there is no other option but to use an up-to-date JVM instead.
-            System.err.println(String.format("Failed to start agent - JVM version not supported: %s %s %s", javaVersion, javaVmName, javaVmVersion));
+            System.err.println(String.format("Failed to start agent - JVM version not supported: %s %s %s",
+                JvmRuntimeInfo.getJavaVersion(), JvmRuntimeInfo.getJavaVmName(), JvmRuntimeInfo.getJavaVmVersion()));
             return;
         }
 
@@ -105,96 +104,6 @@ public class AgentMain {
         } catch (Exception | LinkageError e) {
             System.err.println("Failed to start agent");
             e.printStackTrace();
-        }
-    }
-
-    /**
-     * Checks if a given version of the JVM is likely supported by this agent.
-     * <br>
-     * Supports values provided before and after https://openjdk.java.net/jeps/223, in case parsing fails due to an
-     * unknown version format, we assume it's supported, thus this method might return false positives, but never false
-     * negatives.
-     *
-     * @param version   jvm version, from {@code System.getProperty("java.version")}
-     * @param vmName    jvm name, from {@code System.getProperty("java.vm.name")}
-     * @param vmVersion jvm version, from {@code System.getProperty("java.vm.version")}
-     * @return true if the version is supported, false otherwise
-     */
-    // package-protected for testing
-    static boolean isJavaVersionSupported(String version, String vmName, @Nullable String vmVersion) {
-        // new scheme introduced in java 9, thus we can use it as a shortcut
-        int major;
-        if (version.startsWith("1.")) {
-            major = Character.digit(version.charAt(2), 10);
-        } else {
-            String majorAsString = version.split("\\.")[0];
-            int indexOfDash = majorAsString.indexOf('-');
-            if (indexOfDash > 0) {
-                majorAsString = majorAsString.substring(0, indexOfDash);
-            }
-            major = Integer.parseInt(majorAsString);
-        }
-
-        boolean isHotSpot = vmName.contains("HotSpot(TM)") || vmName.contains("OpenJDK");
-        boolean isIbmJ9 = vmName.contains("IBM J9");
-        if (major < 7) {
-            // given code is compiled with java 7, this one is unlikely in practice
-            return false;
-        }
-        if (isHotSpot) {
-            return isHotSpotVersionSupported(version, major);
-        } else if (isIbmJ9) {
-            return isIbmJ9VersionSupported(vmVersion, major);
-        }
-        // innocent until proven guilty
-        return true;
-    }
-
-    private static boolean isHotSpotVersionSupported(String version, int major) {
-        switch (major) {
-            case 7:
-                // versions prior to that have unreliable invoke dynamic support according to https://groovy-lang.org/indy.html
-                return isUpdateVersionAtLeast(version, 60);
-            case 8:
-                return isUpdateVersionAtLeast(version, 40);
-            default:
-                return true;
-        }
-    }
-
-    private static boolean isIbmJ9VersionSupported(@Nullable String vmVersion, int major) {
-        switch (major) {
-            case 7:
-                return false;
-            case 8:
-                // early versions crash during invokedynamic bootstrap
-                // the exact version that fixes that error is currently not known
-                // presumably, service refresh 5 (build 2.8) fixes the issue
-                return !"2.8".equals(vmVersion);
-            default:
-                return true;
-        }
-    }
-
-    private static boolean isUpdateVersionAtLeast(String version, int minimumUpdateVersion) {
-        int updateIndex = version.lastIndexOf("_");
-        if (updateIndex <= 0) {
-            // GA release '1.8.0'
-            return false;
-        } else {
-            int versionSuffixIndex = version.indexOf('-', updateIndex + 1);
-            String updateVersion;
-            if (versionSuffixIndex <= 0) {
-                updateVersion = version.substring(updateIndex + 1);
-            } else {
-                updateVersion = version.substring(updateIndex + 1, versionSuffixIndex);
-            }
-            try {
-                return Integer.parseInt(updateVersion) >= minimumUpdateVersion;
-            } catch (NumberFormatException e) {
-                // in case of unknown format, we just support by default
-                return true;
-            }
         }
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
@@ -87,6 +87,11 @@ public class AgentMain {
             return;
         }
 
+        if (!JvmRuntimeInfo.isJvmConfigurationSupported()) {
+            System.err.println("JVM configuration is not supported. Aborting agent initialization.");
+            return;
+        }
+
         try {
             // workaround for classloader deadlock https://bugs.openjdk.java.net/browse/JDK-8194653
             FileSystems.getDefault();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -526,8 +526,7 @@ public class ElasticApmAgent {
     /**
      * Reverts instrumentation of classes and re-transforms them to their state without the agent.
      * <p>
-     * NOTE: THIS IS ONLY TO BE USED FOR UNIT TESTS
-     * NOTE2: THIS METHOD MUST BE CALLED AFTER AGENT WAS INITIALIZED
+     * NOTE: THIS METHOD MUST BE CALLED AFTER AGENT WAS INITIALIZED
      * </p>
      */
     public static synchronized void reset() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -47,7 +47,6 @@ import co.elastic.apm.agent.util.DependencyInjectingServiceLoader;
 import co.elastic.apm.agent.util.ExecutorUtils;
 import co.elastic.apm.agent.util.ObjectUtils;
 import co.elastic.apm.agent.util.ThreadUtils;
-import co.elastic.apm.agent.util.VersionUtils;
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.agent.builder.AgentBuilder;
@@ -74,7 +73,6 @@ import org.stagemonitor.configuration.ConfigurationOption;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FilenameFilter;
 import java.io.IOException;
 import java.lang.instrument.Instrumentation;
@@ -93,7 +91,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.jar.JarInputStream;
 
 import static co.elastic.apm.agent.bci.bytebuddy.ClassLoaderNameMatcher.classLoaderWithName;
 import static co.elastic.apm.agent.bci.bytebuddy.ClassLoaderNameMatcher.isReflectionClassLoader;
@@ -526,7 +523,8 @@ public class ElasticApmAgent {
     /**
      * Reverts instrumentation of classes and re-transforms them to their state without the agent.
      * <p>
-     * NOTE: THIS METHOD MUST BE CALLED AFTER AGENT WAS INITIALIZED
+     * NOTE: THIS IS ONLY TO BE USED FOR UNIT TESTS
+     * NOTE2: THIS METHOD MUST BE CALLED AFTER AGENT WAS INITIALIZED
      * </p>
      */
     public static synchronized void reset() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyBootstrap.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyBootstrap.java
@@ -27,6 +27,7 @@ package co.elastic.apm.agent.bci;
 import co.elastic.apm.agent.bci.classloading.ExternalPluginClassLoader;
 import co.elastic.apm.agent.bci.classloading.IndyPluginClassLoader;
 import co.elastic.apm.agent.sdk.state.GlobalState;
+import co.elastic.apm.agent.util.JvmRuntimeInfo;
 import co.elastic.apm.agent.util.PackageScanner;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.dynamic.loading.ClassInjector;
@@ -148,7 +149,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  *     <li>
  *         The {@code INVOKEDYNAMIC} support of early Java 7 versions is not reliable.
  *         That's why we disable the agent on them.
- *         See also {@link AgentMain#isJavaVersionSupported}
+ *         See also {@link JvmRuntimeInfo#isJavaVersionSupported}
  *     </li>
  *     <li>
  *         There are some things to watch out for when writing plugins,

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
@@ -75,9 +75,7 @@ public class StartupInfo extends AbstractLifecycleListener {
     void logConfiguration(ConfigurationRegistry configurationRegistry, Logger logger) {
         final String serviceName = configurationRegistry.getConfig(CoreConfiguration.class).getServiceName();
         logger.info("Starting Elastic APM {} as {} on {}", elasticApmVersion, serviceName, getJvmAndOsVersionString());
-        if (logger.isDebugEnabled()) {
-            logger.debug("VM Arguments: {}", ManagementFactory.getRuntimeMXBean().getInputArguments());
-        }
+        logger.info("VM Arguments: {}", ManagementFactory.getRuntimeMXBean().getInputArguments());
         for (List<ConfigurationOption<?>> options : configurationRegistry.getConfigurationOptionsByCategory().values()) {
             for (ConfigurationOption<?> option : options) {
                 if (!option.isDefault()) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -48,6 +48,7 @@ import co.elastic.apm.agent.report.ReporterConfiguration;
 import co.elastic.apm.agent.sdk.weakmap.WeakMapSupplier;
 import co.elastic.apm.agent.util.DependencyInjectingServiceLoader;
 import co.elastic.apm.agent.util.ExecutorUtils;
+import co.elastic.apm.agent.util.JvmRuntimeInfo;
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -496,6 +497,13 @@ public class ElasticApmTracer implements Tracer {
         }
     }
 
+    /**
+     * Starts the tracer. Depending on several environment and setup parameters, the tracer may be started synchronously
+     * on this thread, or its start may be delayed and invoked on a dedicated thread.
+     *
+     * @param premain true if this tracer is attached through the {@code premain()} method (i.e. using the `javaagent`
+     *                jvm parameter); false otherwise
+     */
     public synchronized void start(boolean premain) {
         long delayInitMs = getConfig(CoreConfiguration.class).getDelayInitMs();
         if (premain && shouldDelayOnPremain()) {
@@ -509,9 +517,7 @@ public class ElasticApmTracer implements Tracer {
     }
 
     private boolean shouldDelayOnPremain() {
-        String javaVersion = System.getProperty("java.version");
-        return javaVersion != null &&
-            (javaVersion.startsWith("1.7") || javaVersion.startsWith("1.8")) &&
+        return JvmRuntimeInfo.getMajorVersion() <= 8 &&
             ClassLoader.getSystemClassLoader().getResource("org/apache/catalina/startup/Bootstrap.class") != null;
     }
 
@@ -537,6 +543,10 @@ public class ElasticApmTracer implements Tracer {
     private synchronized void startSync() {
         if (tracerState != TracerState.UNINITIALIZED) {
             logger.warn("Trying to start an already initialized agent");
+            return;
+        }
+        if (!JvmRuntimeInfo.isJvmConfigurationSupported()) {
+            logger.error("JVM configuration is not supported. The agent will not be started.");
             return;
         }
         apmServerClient.start();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -24,6 +24,7 @@
  */
 package co.elastic.apm.agent.impl;
 
+import co.elastic.apm.agent.bci.ElasticApmAgent;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.configuration.ServiceNameUtil;
 import co.elastic.apm.agent.context.ExecutorServiceShutdownLifecycleListener;
@@ -546,7 +547,8 @@ public class ElasticApmTracer implements Tracer {
             return;
         }
         if (!JvmRuntimeInfo.isJvmConfigurationSupported()) {
-            logger.error("JVM configuration is not supported. The agent will not be started.");
+            logger.error("JVM configuration is not supported. The agent will not be started and classes are un-instrumented.");
+            ElasticApmAgent.reset();
             return;
         }
         apmServerClient.start();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -24,7 +24,6 @@
  */
 package co.elastic.apm.agent.impl;
 
-import co.elastic.apm.agent.bci.ElasticApmAgent;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.configuration.ServiceNameUtil;
 import co.elastic.apm.agent.context.ExecutorServiceShutdownLifecycleListener;
@@ -544,11 +543,6 @@ public class ElasticApmTracer implements Tracer {
     private synchronized void startSync() {
         if (tracerState != TracerState.UNINITIALIZED) {
             logger.warn("Trying to start an already initialized agent");
-            return;
-        }
-        if (!JvmRuntimeInfo.isJvmConfigurationSupported()) {
-            logger.error("JVM configuration is not supported. The agent will not be started and classes are un-instrumented.");
-            ElasticApmAgent.reset();
             return;
         }
         apmServerClient.start();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/JvmRuntimeInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/JvmRuntimeInfo.java
@@ -47,13 +47,14 @@ public class JvmRuntimeInfo {
     }
 
     /**
-     * Parses Java major version, update version and JVM vendor
+     * Parses Java major version, update version and JVM vendor.
+     *
+     * NOTE: THIS METHOD IS ONLY FOR UNIT TESTING. THE JVM INFO SHOULD COME FROM SYSTEM PROPERTIES
      *
      * @param version   jvm version, from {@code System.getProperty("java.version")}
      * @param vmName    jvm name, from {@code System.getProperty("java.vm.name")}
      * @param vmVersion jvm version, from {@code System.getProperty("java.vm.version")}
      */
-    // package-protected for testing
     static void parseVmInfo(String version, String vmName, @Nullable String vmVersion) {
         javaVersion = version;
         javaVmName = vmName;
@@ -166,12 +167,6 @@ public class JvmRuntimeInfo {
         }
     }
 
-    /**
-     * NOTE: THIS METHOD REQUIRES JMX OPERATION, THEREFORE IS SHOULD ONLY BE USED WITHIN OR AFTER THE TRACER HAVE
-     * BEEN STARTED (see {@link ElasticApmTracer#start(boolean)} for details).
-     *
-     * @return true if the setup of this JVM is supported
-     */
     public static boolean isJvmConfigurationSupported() {
         List<String> jvmArgs = null;
         try {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JvmRuntimeInfoTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JvmRuntimeInfoTest.java
@@ -22,17 +22,18 @@
  * under the License.
  * #L%
  */
-package co.elastic.apm.agent.bci;
+package co.elastic.apm.agent.util;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class AgentMainTest {
+class JvmRuntimeInfoTest {
 
-    private static String HOTSPOT_VM_NAME = "Java HotSpot(TM) 64-Bit Server VM";
+    private static final String HOTSPOT_VM_NAME = "Java HotSpot(TM) 64-Bit Server VM";
 
     @Test
     void java6AndEarlierNotSupported() {
@@ -143,13 +144,16 @@ class AgentMainTest {
 
     @Test
     void testIbmJava8SupportedAfterBuild2_8() {
-        assertThat(AgentMain.isJavaVersionSupported("1.8.0", "IBM J9 VM", "2.8")).isFalse();
-        assertThat(AgentMain.isJavaVersionSupported("1.8.0", "IBM J9 VM", "2.9")).isTrue();
+        JvmRuntimeInfo.parseVmInfo("1.8.0", "IBM J9 VM", "2.8");
+        assertThat(JvmRuntimeInfo.isJavaVersionSupported()).isFalse();
+        JvmRuntimeInfo.parseVmInfo("1.8.0", "IBM J9 VM", "2.9");
+        assertThat(JvmRuntimeInfo.isJavaVersionSupported()).isTrue();
     }
 
     private static void checkSupported(String vmName, Stream<String> versions) {
         versions.forEach((v) -> {
-            boolean supported = AgentMain.isJavaVersionSupported(v, vmName, null);
+            JvmRuntimeInfo.parseVmInfo(v, vmName, null);
+            boolean supported = JvmRuntimeInfo.isJavaVersionSupported();
             assertThat(supported)
                 .describedAs("java.version = '%s' java.vm.name = '%s' should be supported", v, vmName)
                 .isTrue();
@@ -158,11 +162,20 @@ class AgentMainTest {
 
     private static void checkNotSupported(String vmName, Stream<String> versions) {
         versions.forEach((v) -> {
-            boolean supported = AgentMain.isJavaVersionSupported(v, vmName, null);
+            JvmRuntimeInfo.parseVmInfo(v, vmName, null);
+            boolean supported = JvmRuntimeInfo.isJavaVersionSupported();
             assertThat(supported)
                 .describedAs("java.version = '%s' java.vm.name = '%s' should not be supported", v, vmName)
                 .isFalse();
         });
     }
 
+    @Test
+    void testG1GConJava7NotSupported() {
+        JvmRuntimeInfo.parseVmInfo("1.7.0_241", HOTSPOT_VM_NAME, null);
+        assertThat(JvmRuntimeInfo.isJvmConfigurationSupported(List.of("-Xmx256m", "-Xms256"))).isTrue();
+        assertThat(JvmRuntimeInfo.isJvmConfigurationSupported(List.of("-Xmx256m", "-XX:+UseG1GC", "-Xms256"))).isFalse();
+        JvmRuntimeInfo.parseVmInfo("1.8.0_241", HOTSPOT_VM_NAME, null);
+        assertThat(JvmRuntimeInfo.isJvmConfigurationSupported(List.of("-Xmx256m", "-XX:+UseG1GC", "-Xms256"))).isTrue();
+    }
 }

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -61,6 +61,9 @@ several bugs that might result in JVM crashes when a java agent is active,
 thus agent *will not start* on those versions.
 Similarly, Java 7 versions before update 60 are not supported as they are buggy in regard to invokedynamic.
 
+NOTE: Installing the Java agent on HotSpot JVM of version 7 in combination with the `-XX:+UseG1GC` JVM argumnent
+may cause JVM crash. If such a setup is identified, the agent will abort.
+
 Here is an example of the message displayed when this happens.
 ```
 Failed ot start agent - JVM version not supported: 1.8.0_31

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -227,6 +227,41 @@ troubleshooting section].
 You can add `-Djavax.net.debug=all` to the JVM cmd line to get more details about your problem.
 
 [float]
+[[trouble-shooting-uncommon-issues]]
+=== Uncommon problems
+
+[float]
+[[trouble-shooting-jvm-crashes]]
+==== JVM Crashes ====
+
+More often than not, JVM crashes indicate a JVM bug being surfaced by the installation of the Java agent within the
+specific configuration of the traced application and it's dependencies. Therefore, the first thing to try is upgrade
+the JVM to the latest minor version.
+
+Known issues:
+
+- Early Java 8 versions before update 40 are *not supported* because they have
+several bugs that might result in JVM crashes when a java agent is active,
+thus agent *will not start* on those versions.
+- Similarly, Java 7 versions before update 60 are not supported as they are buggy in regard to `invokedynamic`.
+- Using the `-XX:+UseG1GC` JVM argument with Java 7 is not supported, as it may cause crashes as well.
+- When <<config-profiling-inferred-spans-enabled>> is set to `true`, it uses a native library that collects low-level
+information from the JVM. All known issues so far had been fixed. Try to disable it if you think the crash may be relaed.
+
+Whenever you encounter a JVM crash, please report through https://discuss.elastic.co/c/observability/apm/58[our forum]
+or by opening an issue on our https://github.com/elastic/apm-agent-java[GitHub repository]. Look for the crash log
+(e.g. an `hs_err_pid<PID>.log`) and provide it when reporting, as well as all factors describing you setup and scenario.
+
+
+[float]
+[[trouble-shooting-jvm-hangs]]
+==== JVM Hangs ====
+
+If your JVM gets hang when attaching the Java agent, please create a thread dump (e.g. through `jstack`) and report
+through https://discuss.elastic.co/c/observability/apm/58[our forum] or by opening an issue on our
+https://github.com/elastic/apm-agent-java[GitHub repository].
+
+[float]
 [[disable-agent]]
 === Disable the Agent
 

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
@@ -76,7 +76,7 @@ public class JettyIT extends AbstractServletContainerIntegrationTest {
     }
 
     @Override
-    protected boolean runtimeAttach() {
+    protected boolean runtimeAttachSupported() {
         return true;
     }
 }

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/TomcatIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/TomcatIT.java
@@ -75,7 +75,12 @@ public class TomcatIT extends AbstractServletContainerIntegrationTest {
     }
 
     @Override
-    protected boolean runtimeAttach() {
+    protected boolean runtimeAttachSupported() {
         return true;
+    }
+
+    @Override
+    protected String getJavaagentEnvVariable() {
+        return "CATALINA_OPTS";
     }
 }

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebLogicIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebLogicIT.java
@@ -85,7 +85,7 @@ public class WebLogicIT extends AbstractServletContainerIntegrationTest {
     }
 
     @Override
-    protected boolean runtimeAttach() {
+    protected boolean runtimeAttachSupported() {
         return true;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
 
         <maven.compiler.target>7</maven.compiler.target>
         <maven.compiler.testTarget>11</maven.compiler.testTarget>
-        
+
         <maven.compiler.source>${maven.compiler.target}</maven.compiler.source>
         <maven.compiler.testSource>${maven.compiler.testTarget}</maven.compiler.testSource>
 


### PR DESCRIPTION
## What does this PR do?
Closes #1435 

No need to take special measures with the JMX operation - we already have it in
https://github.com/elastic/apm-agent-java/blob/842185664456651f1d6a99602d21a7c052ddf111/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/ProcessFactory.java#L91
which is executed during initialization.
Therefore, I modified the print of JVM arguments to be done at `INFO` level.

I also restored the ability to test servlet containers with `-javaagent` even if they are tested through runtime attachment by default (only applied to Tomcat for now) in order to test manually.
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] Updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc) - under breaking changes
- [x] Add a unit test for the discovery of the JVM argument
- [x] Test manually that agent is not started when this configuration is detected, both as runtime attach and as `javaagent`
- [x] Test manually that other JVM info dependent issues are not affected 
- [x] Test manually that using this JMX operations works on J9 (and capture related errors anyway)
- [x] Document in the troubleshooting area
- [x] Document as a caveat related to Java 7 support (in supported technologies) 