### PR TITLE
Junit5 migrate part1

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/RoundedDoubleConverterTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/RoundedDoubleConverterTest.java
@@ -33,7 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RoundedDoubleConverterTest {
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "input={0}, expected={1}")
     @CsvSource({
         "0.55554,0.5555",
         "0.55555,0.5556",
@@ -55,7 +55,7 @@ class RoundedDoubleConverterTest {
             .isInstanceOf(IllegalArgumentException.class);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "input={0}, precision={1}, expected={2}")
     @CsvSource({
         "0.5555,0,1",
         "0.5555,1,0.6",

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/sampling/ProbabilitySamplerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/sampling/ProbabilitySamplerTest.java
@@ -46,7 +46,7 @@ class ProbabilitySamplerTest {
         assertThat(sampler.getSampleRate()).isEqualTo(SAMPLING_RATE);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "rate = {0}")
     @CsvSource({"0.0","1.0","0.5"})
     void headerCaching(double rate) {
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/ByteUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/ByteUtilsTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.agent.util;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.nio.ByteBuffer;
 

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -31,8 +31,8 @@ import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.impl.nio.client.HttpAsyncClients;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -41,13 +41,13 @@ public class ApacheHttpAsyncClientInstrumentationTest extends AbstractHttpClient
 
     private static CloseableHttpAsyncClient client;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         client = HttpAsyncClients.createDefault();
         client.start();
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() throws IOException {
         client.close();
     }

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/ApacheHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/ApacheHttpClientInstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -28,8 +28,8 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.io.IOException;
 
@@ -37,12 +37,12 @@ public class ApacheHttpClientInstrumentationTest extends AbstractHttpClientInstr
 
     private static CloseableHttpClient client;
 
-    @BeforeClass
+    @BeforeAll
     public static void setUp() {
         client = HttpClients.createDefault();
     }
 
-    @AfterClass
+    @AfterAll
     public static void close() throws IOException {
         client.close();
     }

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientInstrumentationTest.java
@@ -27,21 +27,21 @@ package co.elastic.apm.agent.httpclient;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.DefaultHttpClient;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 public class LegacyApacheHttpClientInstrumentationTest extends AbstractHttpClientInstrumentationTest {
 
     @SuppressWarnings("deprecation")
     private static DefaultHttpClient client;
 
-    @BeforeClass
+    @BeforeAll
     @SuppressWarnings("deprecation")
     public static void setUp() {
         client = new DefaultHttpClient();
     }
 
-    @AfterClass
+    @AfterAll
     public static void close() {
         client.close();
     }

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/BlockingQueueContextPropagationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/BlockingQueueContextPropagationTest.java
@@ -25,9 +25,9 @@
 package co.elastic.apm.api;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
@@ -45,7 +45,7 @@ public class BlockingQueueContextPropagationTest extends AbstractInstrumentation
     private static ExecutorService executorService;
     private static final long nanoTimeOffsetToEpoch = TimeUnit.MILLISECONDS.toNanos(System.currentTimeMillis()) - System.nanoTime();
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         blockingQueue = new ArrayBlockingQueue<>(5);
         executorService = Executors.newSingleThreadExecutor();
@@ -72,7 +72,7 @@ public class BlockingQueueContextPropagationTest extends AbstractInstrumentation
         });
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         blockingQueue.clear();
         executorService.shutdownNow();

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/test/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/test/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentationTest.java
@@ -25,28 +25,64 @@
 package co.elastic.apm.agent.asynchttpclient;
 
 import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
-import org.asynchttpclient.*;
+import org.asynchttpclient.AsyncCompletionHandler;
+import org.asynchttpclient.AsyncCompletionHandlerBase;
+import org.asynchttpclient.AsyncHandler;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.Dsl;
+import org.asynchttpclient.HttpResponseBodyPart;
+import org.asynchttpclient.HttpResponseStatus;
+import org.asynchttpclient.RequestBuilder;
+import org.asynchttpclient.Response;
 import org.asynchttpclient.handler.StreamedAsyncHandler;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.provider.Arguments;
 import org.reactivestreams.Publisher;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
-import static org.asynchttpclient.Dsl.asyncHttpClient;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.asynchttpclient.Dsl.asyncHttpClient;
 
-@RunWith(Parameterized.class)
 public class AsyncHttpClientInstrumentationTest extends AbstractHttpClientInstrumentationTest {
 
-    private final RequestExecutor requestExecutor;
+    public static AsyncHandler<Response> customStreamAsyncHandler = new CustomStreamedAsyncHandler();
+
+    private RequestExecutor requestExecutor;
     private AsyncHttpClient client;
 
-    public AsyncHttpClientInstrumentationTest(RequestExecutor requestExecutor) {
-        this.requestExecutor = requestExecutor;
+    @Override
+    public void setUp(Object arg) {
+        this.requestExecutor = (RequestExecutor) arg;
+    }
+
+    public static Stream<Arguments> args() {
+        List<RequestExecutor> requestExecutors = Arrays.asList(
+            (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build()).get(),
+            (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build(), new AsyncCompletionHandlerBase()).get(),
+            (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build(), customAsyncHandler).get(),
+            (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build(), customStreamAsyncHandler).get(),
+            (client, path) -> client.prepareGet(path).execute(new AsyncCompletionHandlerBase()).get(),
+            (client, path) -> client.prepareGet(path).execute().get()
+        );
+        return requestExecutors.stream().map(k -> Arguments.of(k)).collect(Collectors.toList()).stream();
+    }
+
+    @BeforeEach
+    public void setUp() {
+        client = asyncHttpClient(Dsl.config()
+            .setFollowRedirect(true)
+            .build());
+    }
+
+    @AfterEach
+    public void tearDown() throws IOException {
+        client.close();
     }
 
     public static AsyncHandler<Response> customAsyncHandler = new AsyncCompletionHandler<Response>() {
@@ -87,32 +123,6 @@ public class AsyncHttpClientInstrumentationTest extends AbstractHttpClientInstru
             assertThat(tracer.getActive().isExit()).isTrue();
             return State.ABORT;
         }
-    }
-
-    public static AsyncHandler<Response> customStreamAsyncHandler = new CustomStreamedAsyncHandler();
-
-    @Parameterized.Parameters()
-    public static Iterable<RequestExecutor> data() {
-        return Arrays.asList(
-            (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build()).get(),
-            (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build(), new AsyncCompletionHandlerBase()).get(),
-            (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build(), customAsyncHandler).get(),
-            (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build(), customStreamAsyncHandler).get(),
-            (client, path) -> client.prepareGet(path).execute(new AsyncCompletionHandlerBase()).get(),
-            (client, path) -> client.prepareGet(path).execute().get()
-        );
-    }
-
-    @Before
-    public void setUp() {
-        client = asyncHttpClient(Dsl.config()
-            .setFollowRedirect(true)
-            .build());
-    }
-
-    @After
-    public void tearDown() throws IOException {
-        client.close();
     }
 
     @Override

--- a/apm-agent-plugins/apm-asynchttpclient-plugin/src/test/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-asynchttpclient-plugin/src/test/java/co/elastic/apm/agent/asynchttpclient/AsyncHttpClientInstrumentationTest.java
@@ -41,9 +41,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.reactivestreams.Publisher;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,6 +62,12 @@ public class AsyncHttpClientInstrumentationTest extends AbstractHttpClientInstru
     }
 
     public static Stream<Arguments> args() {
+        List<String> testNames = Arrays.asList("syncRequest",
+            "AsyncCompletionHandlerBase",
+            "customAsyncCompletionHandler",
+            "customStreamAsyncHandler",
+            "boundRequestWithAsyncHandler",
+            "boundRequest");
         List<RequestExecutor> requestExecutors = Arrays.asList(
             (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build()).get(),
             (client, path) -> client.executeRequest(new RequestBuilder().setUrl(path).build(), new AsyncCompletionHandlerBase()).get(),
@@ -70,7 +76,11 @@ public class AsyncHttpClientInstrumentationTest extends AbstractHttpClientInstru
             (client, path) -> client.prepareGet(path).execute(new AsyncCompletionHandlerBase()).get(),
             (client, path) -> client.prepareGet(path).execute().get()
         );
-        return requestExecutors.stream().map(k -> Arguments.of(k)).collect(Collectors.toList()).stream();
+        List<Arguments> arguments = new ArrayList<>(testNames.size());
+        for (int i = 0; i < testNames.size(); i++) {
+            arguments.add(Arguments.of(testNames.get(i), requestExecutors.get(i)));
+        }
+        return arguments.stream();
     }
 
     @BeforeEach

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/AbstractEs6_4ClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/AbstractEs6_4ClientInstrumentationTest.java
@@ -57,7 +57,9 @@ import org.elasticsearch.script.mustache.SearchTemplateRequest;
 import org.elasticsearch.script.mustache.SearchTemplateResponse;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.junit.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -77,8 +79,10 @@ public abstract class AbstractEs6_4ClientInstrumentationTest extends AbstractEsC
     @SuppressWarnings("NullableProblems")
     protected static RestHighLevelClient client;
 
-    @Test
-    public void testCreateAndDeleteIndex() throws IOException, ExecutionException, InterruptedException {
+    @ParameterizedTest(name = "isAsync = {0}")
+    @MethodSource("arguments")
+    public void testCreateAndDeleteIndex(Boolean async) throws IOException, ExecutionException, InterruptedException {
+        super.async = async;
         // Create an Index
         doCreateIndex(new CreateIndexRequest(SECOND_INDEX));
 
@@ -91,8 +95,11 @@ public abstract class AbstractEs6_4ClientInstrumentationTest extends AbstractEsC
         validateSpanContentAfterIndexDeleteRequest();
     }
 
-    @Test
-    public void testTryToDeleteNonExistingIndex() throws IOException, InterruptedException {
+    @ParameterizedTest(name = "isAsync = {0}")
+    @MethodSource("arguments")
+    public void testTryToDeleteNonExistingIndex(Boolean async) throws IOException, InterruptedException {
+        super.async = async;
+
         ElasticsearchStatusException ese = null;
         try {
             doDeleteIndex(new DeleteIndexRequest(SECOND_INDEX));
@@ -109,8 +116,10 @@ public abstract class AbstractEs6_4ClientInstrumentationTest extends AbstractEsC
         assertThatErrorsExistWhenDeleteNonExistingIndex();
     }
 
-    @Test
-    public void testDocumentScenario() throws Exception {
+    @ParameterizedTest(name = "isAsync = {0}")
+    @MethodSource("arguments")
+    public void testDocumentScenario(Boolean async) throws Exception {
+        super.async = async;
         // Index a document
         createDocument();
 
@@ -163,8 +172,11 @@ public abstract class AbstractEs6_4ClientInstrumentationTest extends AbstractEsC
         validateSpanContent(spans.get(0), String.format("Elasticsearch: DELETE /%s/%s/%s", INDEX, DOC_TYPE, DOC_ID), 200, "DELETE");
     }
 
-    @Test
-    public void testCountRequest_validateSpanContentAndDbContext() throws Exception {
+    @ParameterizedTest(name = "isAsync = {0}")
+    @MethodSource("arguments")
+    public void testCountRequest_validateSpanContentAndDbContext(Boolean async) throws Exception {
+        super.async = async;
+
         createDocument();
         reporter.reset();
 
@@ -185,8 +197,11 @@ public abstract class AbstractEs6_4ClientInstrumentationTest extends AbstractEsC
         deleteDocument();
     }
 
-    @Test
-    public void testMultiSearchRequest_validateSpanContentAndDbContext() throws InterruptedException, ExecutionException, IOException {
+    @ParameterizedTest(name = "isAsync = {0}")
+    @MethodSource("arguments")
+    public void testMultiSearchRequest_validateSpanContentAndDbContext(Boolean async) throws InterruptedException, ExecutionException, IOException {
+        super.async = async;
+
         createDocument();
         reporter.reset();
 
@@ -208,8 +223,11 @@ public abstract class AbstractEs6_4ClientInstrumentationTest extends AbstractEsC
         deleteDocument();
     }
 
-    @Test
-    public void testRollupSearch_validateSpanContentAndDbContext() throws InterruptedException, ExecutionException, IOException {
+    @ParameterizedTest(name = "isAsync = {0}")
+    @MethodSource("arguments")
+    public void testRollupSearch_validateSpanContentAndDbContext(Boolean async) throws InterruptedException, ExecutionException, IOException {
+        super.async = async;
+
         createDocument();
         reporter.reset();
 
@@ -232,8 +250,11 @@ public abstract class AbstractEs6_4ClientInstrumentationTest extends AbstractEsC
         deleteDocument();
     }
 
-    @Test
-    public void testSearchTemplateRequest_validateSpanContentAndDbContext() throws InterruptedException, ExecutionException, IOException {
+    @ParameterizedTest(name = "isAsync = {0}")
+    @MethodSource("arguments")
+    public void testSearchTemplateRequest_validateSpanContentAndDbContext(Boolean async) throws InterruptedException, ExecutionException, IOException {
+        super.async = async;
+
         createDocument();
         reporter.reset();
 
@@ -251,8 +272,11 @@ public abstract class AbstractEs6_4ClientInstrumentationTest extends AbstractEsC
         deleteDocument();
     }
 
-    @Test
-    public void testMultisearchTemplateRequest_validateSpanContentAndDbContext() throws InterruptedException, ExecutionException, IOException {
+    @ParameterizedTest(name = "isAsync = {0}")
+    @MethodSource("arguments")
+    public void testMultisearchTemplateRequest_validateSpanContentAndDbContext(Boolean async) throws InterruptedException, ExecutionException, IOException {
+        super.async = async;
+
         createDocument();
         reporter.reset();
 
@@ -317,8 +341,11 @@ public abstract class AbstractEs6_4ClientInstrumentationTest extends AbstractEsC
 
     }
 
-    @Test
-    public void testScenarioAsBulkRequest() throws IOException, ExecutionException, InterruptedException {
+    @ParameterizedTest(name = "isAsync = {0}")
+    @MethodSource("arguments")
+    public void testScenarioAsBulkRequest(Boolean async) throws IOException, ExecutionException, InterruptedException {
+        super.async = async;
+
         doBulk(new BulkRequest()
             .add(new IndexRequest(INDEX, DOC_TYPE, "2").source(
                 jsonBuilder()

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchRestClientInstrumentationIT.java
@@ -37,10 +37,8 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHits;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 import java.io.IOException;
@@ -48,16 +46,11 @@ import java.io.IOException;
 import static org.assertj.core.api.Assertions.assertThat;
 
 
-@RunWith(Parameterized.class)
 public class ElasticsearchRestClientInstrumentationIT extends AbstractEs6_4ClientInstrumentationTest {
 
     private static final String ELASTICSEARCH_CONTAINER_VERSION = "docker.elastic.co/elasticsearch/elasticsearch:6.7.0";
 
-    public ElasticsearchRestClientInstrumentationIT(boolean async) {
-        this.async = async;
-    }
-
-    @BeforeClass
+    @BeforeAll
     public static void startElasticsearchContainerAndClient() throws IOException {
         // Start the container
         container = new ElasticsearchContainer(ELASTICSEARCH_CONTAINER_VERSION);
@@ -75,7 +68,7 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractEs6_4Clien
         reporter.reset();
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopElasticsearchContainerAndClient() throws IOException {
         client.indices().delete(new DeleteIndexRequest(INDEX), RequestOptions.DEFAULT);
         container.stop();

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchRestClientInstrumentationIT_RealReporter.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchRestClientInstrumentationIT_RealReporter.java
@@ -26,8 +26,8 @@ package co.elastic.apm.agent.es.restclient.v6_4;
 
 import co.elastic.apm.agent.bci.ElasticApmAgent;
 import co.elastic.apm.agent.configuration.SpyConfiguration;
-import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
 import co.elastic.apm.agent.impl.MetaData;
 import co.elastic.apm.agent.impl.payload.Agent;
 import co.elastic.apm.agent.impl.payload.ProcessInfo;
@@ -67,12 +67,13 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
@@ -87,7 +88,7 @@ import static org.elasticsearch.common.xcontent.XContentFactory.jsonBuilder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@Ignore
+@Disabled
 public class ElasticsearchRestClientInstrumentationIT_RealReporter {
     private static final String USER_NAME = "elastic-user";
     private static final String PASSWORD = "elastic-pass";
@@ -111,7 +112,7 @@ public class ElasticsearchRestClientInstrumentationIT_RealReporter {
     /**
      * A version of ElasticsearchRestClientInstrumentationIT that can be used to test E2E the ES client instrumentation with the IT stack
      */
-    @BeforeClass
+    @BeforeAll
     public static void startElasticsearchContainerAndClient() throws IOException {
         // Start the container
         container = new ElasticsearchContainer();
@@ -123,7 +124,7 @@ public class ElasticsearchRestClientInstrumentationIT_RealReporter {
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials(USER_NAME, PASSWORD));
 
-        RestClientBuilder builder =  RestClient.builder(new HttpHost("localhost", 9200))
+        RestClientBuilder builder = RestClient.builder(new HttpHost("localhost", 9200))
             .setHttpClientConfigCallback(httpClientBuilder -> httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider));
         client = new RestHighLevelClient(builder);
 
@@ -156,7 +157,7 @@ public class ElasticsearchRestClientInstrumentationIT_RealReporter {
         ElasticApmAgent.initInstrumentation(tracer, ByteBuddyAgent.install());
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopElasticsearchContainerAndClient() throws IOException {
         client.indices().delete(new DeleteIndexRequest(INDEX), RequestOptions.DEFAULT);
         container.stop();
@@ -169,7 +170,7 @@ public class ElasticsearchRestClientInstrumentationIT_RealReporter {
         }
     }
 
-    @Before
+    @BeforeEach
     public void startTransaction() {
         Transaction transaction = tracer.startRootTransaction(null).activate();
         transaction.withName("transaction");
@@ -177,7 +178,7 @@ public class ElasticsearchRestClientInstrumentationIT_RealReporter {
         transaction.withResult("success");
     }
 
-    @After
+    @AfterEach
     public void endTransaction() {
         Transaction currentTransaction = tracer.currentTransaction();
         if (currentTransaction != null) {
@@ -242,18 +243,18 @@ public class ElasticsearchRestClientInstrumentationIT_RealReporter {
     @Test
     public void testScenarioAsBulkRequest() throws IOException {
         client.bulk(new BulkRequest()
-            .add(new IndexRequest(INDEX, DOC_TYPE, "2").source(
-                jsonBuilder()
-                    .startObject()
-                    .field(FOO, BAR)
-                    .endObject()
-            ))
-            .add(new IndexRequest(INDEX, DOC_TYPE, "3").source(
-                jsonBuilder()
-                    .startObject()
-                    .field(FOO, BAR)
-                    .endObject()
-            ))
-        , RequestOptions.DEFAULT);
+                .add(new IndexRequest(INDEX, DOC_TYPE, "2").source(
+                    jsonBuilder()
+                        .startObject()
+                        .field(FOO, BAR)
+                        .endObject()
+                ))
+                .add(new IndexRequest(INDEX, DOC_TYPE, "3").source(
+                    jsonBuilder()
+                        .startObject()
+                        .field(FOO, BAR)
+                        .endObject()
+                ))
+            , RequestOptions.DEFAULT);
     }
 }

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_1/src/test/java/co/elastic/apm/agent/es/restclient/v7_1/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_1/src/test/java/co/elastic/apm/agent/es/restclient/v7_1/ElasticsearchRestClientInstrumentationIT.java
@@ -27,6 +27,9 @@ package co.elastic.apm.agent.es.restclient.v7_1;
 import co.elastic.apm.agent.es.restclient.v6_4.AbstractEs6_4ClientInstrumentationTest;
 import co.elastic.apm.agent.impl.transaction.Span;
 import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
@@ -35,27 +38,19 @@ import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.client.RestHighLevelClient;
 import org.elasticsearch.search.SearchHits;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
-import org.apache.http.client.CredentialsProvider;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(Parameterized.class)
 public class ElasticsearchRestClientInstrumentationIT extends AbstractEs6_4ClientInstrumentationTest {
 
     private static final String ELASTICSEARCH_CONTAINER_VERSION = "docker.elastic.co/elasticsearch/elasticsearch:7.1.0";
 
-    public ElasticsearchRestClientInstrumentationIT(boolean async) { this.async = async; }
-
-    @BeforeClass
+    @BeforeAll
     public static void startElasticsearchContainerAndClient() throws IOException {
         container = new ElasticsearchContainer(ELASTICSEARCH_CONTAINER_VERSION);
         container.start();
@@ -72,7 +67,7 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractEs6_4Clien
         reporter.reset();
     }
 
-    @AfterClass
+    @AfterAll
     public static void stopElasticsearchContainerAndClient() throws IOException {
         client.indices().delete(new DeleteIndexRequest(INDEX), RequestOptions.DEFAULT);
         container.stop();

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/es/restclient/AbstractEsClientInstrumentationTest.java
@@ -31,14 +31,16 @@ import co.elastic.apm.agent.impl.context.Http;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.provider.Arguments;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static co.elastic.apm.agent.es.restclient.ElasticsearchRestClientInstrumentationHelperImpl.ELASTICSEARCH;
 import static co.elastic.apm.agent.es.restclient.ElasticsearchRestClientInstrumentationHelperImpl.SPAN_ACTION;
@@ -63,12 +65,11 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
 
     protected boolean async;
 
-    @Parameterized.Parameters(name = "Async={0}")
-    public static Iterable<Object[]> data() {
-        return Arrays.asList(new Object[][]{{Boolean.FALSE}, {Boolean.TRUE}});
+    public static Stream<Arguments> arguments() {
+        return Arrays.asList(Boolean.FALSE, Boolean.TRUE).stream().map(k -> Arguments.of(k)).collect(Collectors.toList()).stream();
     }
 
-    @Before
+    @BeforeEach
     public void startTransaction() {
         Transaction transaction = tracer.startRootTransaction(null).activate();
         transaction.withName("ES Transaction");
@@ -76,7 +77,7 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
         transaction.withResultIfUnset("success");
     }
 
-    @After
+    @AfterEach
     public void endTransaction() {
         Transaction currentTransaction = tracer.currentTransaction();
         if (currentTransaction != null) {
@@ -142,7 +143,7 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
 
     protected void validateSpanContentAfterIndexDeleteRequest() {
 
-        List<Span>spans = reporter.getSpans();
+        List<Span> spans = reporter.getSpans();
         assertThat(spans).hasSize(1);
         validateSpanContent(spans.get(0), String.format("Elasticsearch: DELETE /%s", SECOND_INDEX), 200, "DELETE");
     }

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -38,6 +38,7 @@ import com.github.tomakehurst.wiremock.http.HttpHeaders;
 import com.github.tomakehurst.wiremock.verification.LoggedRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -94,9 +95,10 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         return true;
     }
 
-    @ParameterizedTest
+    @DisplayName("testHttpCall: GET /")
+    @ParameterizedTest(name = "{0}")
     @MethodSource("args")
-    public void testHttpCall(Object args) {
+    public void testHttpCall(String name, Object args) {
         setUp(args);
 
         String path = "/";
@@ -105,27 +107,30 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         verifyHttpSpan(path);
     }
 
-    @ParameterizedTest
+    @DisplayName("testHttpCallWithUserInfo")
+    @ParameterizedTest(name = "{0}")
     @MethodSource("args")
-    public void testHttpCallWithUserInfo(Object args) throws Exception {
+    public void testHttpCallWithUserInfo(String name, Object args) throws Exception {
         setUp(args);
 
         performGet("http://user:passwd@localhost:" + wireMockServer.port() + "/");
         verifyHttpSpan("/");
     }
 
-    @ParameterizedTest
+    @DisplayName("testHttpCallWithIpv4")
+    @ParameterizedTest(name = "{0}")
     @MethodSource("args")
-    public void testHttpCallWithIpv4(Object args) throws Exception {
+    public void testHttpCallWithIpv4(String name, Object args) throws Exception {
         setUp(args);
 
         performGet("http://127.0.0.1:" + wireMockServer.port() + "/");
         verifyHttpSpan("http", "127.0.0.1", wireMockServer.port(), "/");
     }
 
-    @ParameterizedTest
+    @DisplayName("testHttpCallWithIpv6")
+    @ParameterizedTest(name = "{0}")
     @MethodSource("args")
-    public void testHttpCallWithIpv6(Object args) throws Exception {
+    public void testHttpCallWithIpv6(String name, Object args) throws Exception {
         setUp(args);
 
         if (!isIpv6Supported()) {
@@ -172,9 +177,10 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         });
     }
 
-    @ParameterizedTest
+    @DisplayName("testNonExistingHttpCall")
+    @ParameterizedTest(name = "{0}")
     @MethodSource("args")
-    public void testNonExistingHttpCall(Object args) {
+    public void testNonExistingHttpCall(String name, Object args) {
         setUp(args);
 
         String path = "/non-existing";
@@ -186,9 +192,10 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         assertThat(reporter.getSpans().get(0).getContext().getHttp().getStatusCode()).isEqualTo(404);
     }
 
-    @ParameterizedTest
+    @DisplayName("testErrorHttpCall")
+    @ParameterizedTest(name = "{0}")
     @MethodSource("args")
-    public void testErrorHttpCall(Object args) {
+    public void testErrorHttpCall(String name, Object args) {
         setUp(args);
 
         String path = "/error";
@@ -200,9 +207,10 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         assertThat(reporter.getSpans().get(0).getContext().getHttp().getStatusCode()).isEqualTo(515);
     }
 
-    @ParameterizedTest
+    @DisplayName("testHttpCallRedirect")
+    @ParameterizedTest(name = "{0}")
     @MethodSource("args")
-    public void testHttpCallRedirect(Object args) {
+    public void testHttpCallRedirect(String name, Object args) {
         setUp(args);
 
         String path = "/redirect";
@@ -217,9 +225,10 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         verifyTraceContextHeaders(reporter.getFirstSpan(), "/");
     }
 
-    @ParameterizedTest
+    @DisplayName("testHttpCallCircularRedirect")
+    @ParameterizedTest(name = "{0}")
     @MethodSource("args")
-    public void testHttpCallCircularRedirect(Object args) {
+    public void testHttpCallCircularRedirect(String name, Object args) {
         setUp(args);
 
         if (!isErrorOnCircularRedirectSupported()) {
@@ -281,8 +290,8 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
     }
 
     public static Stream<Arguments> args() {
-        final List<Arguments> configurations = new ArrayList<>(1);
-        configurations.add(Arguments.arguments("test"));
+        final List<Arguments> configurations = new ArrayList<>(2);
+        configurations.add(Arguments.of("test", null));
         return configurations.stream();
     }
 }

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ExcludedExecutorClassTest.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ExcludedExecutorClassTest.java
@@ -26,9 +26,9 @@ package co.elastic.apm.agent.concurrent;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.impl.transaction.Transaction;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -40,14 +40,14 @@ public class ExcludedExecutorClassTest extends AbstractInstrumentationTest {
     private ExecutorService executor;
     private Transaction transaction;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         executor = Executors.newFixedThreadPool(1);
         ExecutorInstrumentation.excludedClasses.add(executor.getClass().getName());
         transaction = tracer.startRootTransaction(null).withName("Transaction").activate();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         transaction.deactivate().end();
         ExecutorInstrumentation.excludedClasses.remove(executor.getClass().getName());

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ExecutorServiceDoubleWrappingTest.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ExecutorServiceDoubleWrappingTest.java
@@ -27,9 +27,9 @@ package co.elastic.apm.agent.concurrent;
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -44,12 +44,12 @@ public class ExecutorServiceDoubleWrappingTest extends AbstractInstrumentationTe
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private Transaction transaction;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         transaction = tracer.startRootTransaction(null).withName("Transaction").activate();
     }
 
-    @After
+    @AfterEach
     public void tearDown() {
         transaction.deactivate().end();
         assertThat(tracer.getActive()).isNull();

--- a/apm-agent-plugins/apm-jaxrs-plugin/src/test/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jaxrs-plugin/src/test/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentationTest.java
@@ -35,9 +35,9 @@ import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.glassfish.jersey.server.ResourceConfig;
 import org.glassfish.jersey.test.JerseyTest;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import javax.ws.rs.GET;
@@ -61,8 +61,10 @@ public class JaxRsTransactionNameInstrumentationTest extends JerseyTest {
     private ConfigurationRegistry config;
     private TestObjectPoolFactory objectPoolFactory;
 
-    @Before
-    public void before() {
+    @BeforeEach
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup();
         reporter = mockInstrumentationSetup.getReporter();
         config = mockInstrumentationSetup.getConfig();
@@ -70,8 +72,9 @@ public class JaxRsTransactionNameInstrumentationTest extends JerseyTest {
         objectPoolFactory = mockInstrumentationSetup.getObjectPoolFactory();
     }
 
-    @After
-    public void after() {
+    @AfterEach
+    @Override
+    public void tearDown() throws Exception {
         try {
             reporter.assertRecycledAfterDecrementingReferences();
             objectPoolFactory.checkAllPooledObjectsHaveBeenRecycled();
@@ -80,6 +83,7 @@ public class JaxRsTransactionNameInstrumentationTest extends JerseyTest {
             objectPoolFactory.reset();
             ElasticApmAgent.reset();
         }
+        super.tearDown();
     }
 
     @Test

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/signature/SignatureParserTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/signature/SignatureParserTest.java
@@ -49,7 +49,7 @@ class SignatureParserTest {
         signatureParser = new SignatureParser();
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "input={0}, output={1}, comment={2}")
     @MethodSource("getTestSignatures_shared")
     void testSignature_shared(String input, String output, String comment) {
         final StringBuilder signature = new StringBuilder();
@@ -63,7 +63,7 @@ class SignatureParserTest {
         return parseTestParameters(TestJsonSpec.getJson("sql_signature_examples.json"));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "input={0}, output={1}, comment={2}")
     @MethodSource("getTestSignatures_java")
     void testSignature_java(String input, String output, String comment) {
         testSignature_shared(input, output, comment);

--- a/apm-agent-plugins/apm-jdk-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/HttpClientAsyncInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jdk-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/HttpClientAsyncInstrumentationTest.java
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.agent.httpclient;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -34,7 +34,7 @@ import java.net.http.HttpResponse;
 public class HttpClientAsyncInstrumentationTest extends AbstractHttpClientInstrumentationTest {
     private HttpClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
     }

--- a/apm-agent-plugins/apm-jdk-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/HttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jdk-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/HttpClientInstrumentationTest.java
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.agent.httpclient;
 
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -34,7 +34,7 @@ import java.net.http.HttpResponse;
 public class HttpClientInstrumentationTest extends AbstractHttpClientInstrumentationTest {
     private HttpClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         client = HttpClient.newBuilder()
             .followRedirects(HttpClient.Redirect.NORMAL)

--- a/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/spring/SpringJmsTest.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/java/co/elastic/apm/agent/jms/spring/SpringJmsTest.java
@@ -30,9 +30,9 @@ import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.activemq.command.ActiveMQMapMessage;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 import javax.jms.Connection;
@@ -59,7 +59,7 @@ public class SpringJmsTest extends AbstractInstrumentationTest {
     private static Connection connection;
     private static ClassPathXmlApplicationContext ctx;
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() throws JMSException {
         ConnectionFactory connectionFactory = new ActiveMQConnectionFactory("vm://localhost?broker.persistent=false");
         connection = connectionFactory.createConnection();
@@ -67,7 +67,7 @@ public class SpringJmsTest extends AbstractInstrumentationTest {
         ctx = new ClassPathXmlApplicationContext("app-context.xml");
     }
 
-    @AfterClass
+    @AfterAll
     public static void teardown() throws JMSException {
         ctx.close();
         connection.stop();

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyClientIT.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyClientIT.java
@@ -43,12 +43,12 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
@@ -74,7 +74,7 @@ import static org.mockito.Mockito.when;
  * b.  the creation of consumer transaction- one per consumed record
  */
 @SuppressWarnings("NotNullFieldNotInitialized")
-@Ignore
+@Disabled
 public class KafkaLegacyClientIT extends AbstractInstrumentationTest {
 
     static final String REQUEST_TOPIC = UUID.randomUUID().toString();
@@ -101,7 +101,7 @@ public class KafkaLegacyClientIT extends AbstractInstrumentationTest {
         this.messagingConfiguration = config.getConfig(MessagingConfiguration.class);
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         // confluent versions 5.3.x correspond Kafka versions 2.3.x -
         // https://docs.confluent.io/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility
@@ -125,7 +125,7 @@ public class KafkaLegacyClientIT extends AbstractInstrumentationTest {
         );
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         producer.close();
         replyConsumer.unsubscribe();
@@ -134,7 +134,7 @@ public class KafkaLegacyClientIT extends AbstractInstrumentationTest {
         kafka.stop();
     }
 
-    @Before
+    @BeforeEach
     public void startTransaction() {
         Transaction transaction = tracer.startRootTransaction(null).activate();
         transaction.withName("Kafka-Test Transaction");
@@ -143,7 +143,7 @@ public class KafkaLegacyClientIT extends AbstractInstrumentationTest {
         testScenario = TestScenario.NORMAL;
     }
 
-    @After
+    @AfterEach
     public void endTransaction() {
         Transaction currentTransaction = tracer.currentTransaction();
         if (currentTransaction != null) {

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyBrokerIT.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/test/java/co/elastic/apm/agent/kafka/KafkaLegacyBrokerIT.java
@@ -45,12 +45,12 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
-import org.junit.After;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
@@ -78,7 +78,7 @@ import static org.mockito.Mockito.when;
  * b.  the creation of consumer transaction- one per consumed record
  */
 @SuppressWarnings("NotNullFieldNotInitialized")
-@Ignore
+@Disabled
 public class KafkaLegacyBrokerIT extends AbstractInstrumentationTest {
 
     static final String REQUEST_TOPIC = UUID.randomUUID().toString();
@@ -104,7 +104,7 @@ public class KafkaLegacyBrokerIT extends AbstractInstrumentationTest {
         this.messagingConfiguration = config.getConfig(MessagingConfiguration.class);
     }
 
-    @BeforeClass
+    @BeforeAll
     public static void setup() {
         reporter.disableDestinationAddressCheck();
 
@@ -129,7 +129,7 @@ public class KafkaLegacyBrokerIT extends AbstractInstrumentationTest {
         );
     }
 
-    @AfterClass
+    @AfterAll
     public static void tearDown() {
         producer.close();
         replyConsumer.unsubscribe();
@@ -138,7 +138,7 @@ public class KafkaLegacyBrokerIT extends AbstractInstrumentationTest {
         kafka.stop();
     }
 
-    @Before
+    @BeforeEach
     public void startTransaction() {
         Transaction transaction = tracer.startRootTransaction(null).activate();
         transaction.withName("Kafka-Test Transaction");
@@ -147,7 +147,7 @@ public class KafkaLegacyBrokerIT extends AbstractInstrumentationTest {
         testScenario = TestScenario.NORMAL;
     }
 
-    @After
+    @AfterEach
     public void endTransaction() {
         Transaction currentTransaction = tracer.currentTransaction();
         if (currentTransaction != null) {

--- a/apm-agent-plugins/apm-micrometer-plugin/pom.xml
+++ b/apm-agent-plugins/apm-micrometer-plugin/pom.xml
@@ -9,6 +9,18 @@
 
     <artifactId>apm-micrometer-plugin</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>

--- a/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentationTest.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentationTest.java
@@ -30,7 +30,7 @@ import okhttp3.Callback;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -39,7 +39,7 @@ public class OkHttp3ClientAsyncInstrumentationTest extends AbstractHttpClientIns
 
     private OkHttpClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         client = new OkHttpClient();
     }

--- a/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentationTest.java
@@ -27,13 +27,13 @@ package co.elastic.apm.agent.okhttp;
 import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class OkHttp3ClientInstrumentationTest extends AbstractHttpClientInstrumentationTest {
 
     private OkHttpClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         client = new OkHttpClient();
     }

--- a/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentationTest.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentationTest.java
@@ -29,7 +29,7 @@ import com.squareup.okhttp.Callback;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
 import com.squareup.okhttp.Response;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
@@ -38,7 +38,7 @@ public class OkHttpClientAsyncInstrumentationTest extends AbstractHttpClientInst
 
     private OkHttpClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         client = new OkHttpClient();
     }

--- a/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/test/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentationTest.java
@@ -27,13 +27,13 @@ package co.elastic.apm.agent.okhttp;
 import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
 import com.squareup.okhttp.OkHttpClient;
 import com.squareup.okhttp.Request;
-import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
 
 public class OkHttpClientInstrumentationTest extends AbstractHttpClientInstrumentationTest {
 
     private OkHttpClient client;
 
-    @Before
+    @BeforeEach
     public void setUp() {
         client = new OkHttpClient();
     }

--- a/apm-agent-plugins/apm-spring-resttemplate-plugin/src/test/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-resttemplate-plugin/src/test/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentationTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -25,8 +25,7 @@
 package co.elastic.apm.agent.resttemplate;
 
 import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+import org.junit.jupiter.params.provider.Arguments;
 import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.http.client.OkHttp3ClientHttpRequestFactory;
@@ -35,22 +34,29 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.Arrays;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
-@RunWith(Parameterized.class)
 public class SpringRestTemplateInstrumentationTest extends AbstractHttpClientInstrumentationTest {
 
     private RestTemplate restTemplate;
 
-    public SpringRestTemplateInstrumentationTest(Supplier<ClientHttpRequestFactory> supplier) {
-        restTemplate = new RestTemplate(supplier.get());
-    }
-
-    @Parameterized.Parameters()
-    public static Iterable<Supplier<ClientHttpRequestFactory>> data() {
-        return Arrays.asList(
+    public static Stream<Arguments> args() {
+        Iterable<Supplier<ClientHttpRequestFactory>> iterable = Arrays.asList(
             SimpleClientHttpRequestFactory::new,
             OkHttp3ClientHttpRequestFactory::new,
             HttpComponentsClientHttpRequestFactory::new);
+        return StreamSupport.stream(iterable.spliterator(), false)
+            .map(k -> Arguments.of(k))
+            .collect(Collectors.toList())
+            .stream();
+    }
+
+    @Override
+    public void setUp(Object arg) {
+        Supplier<ClientHttpRequestFactory> supplier = (Supplier<ClientHttpRequestFactory>) arg;
+        restTemplate = new RestTemplate(supplier.get());
     }
 
     @Override

--- a/apm-agent-plugins/apm-spring-resttemplate-plugin/src/test/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-resttemplate-plugin/src/test/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentationTest.java
@@ -33,6 +33,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,20 +44,15 @@ public class SpringRestTemplateInstrumentationTest extends AbstractHttpClientIns
     private RestTemplate restTemplate;
 
     public static Stream<Arguments> args() {
-        Iterable<Supplier<ClientHttpRequestFactory>> iterable = Arrays.asList(
-            SimpleClientHttpRequestFactory::new,
-            OkHttp3ClientHttpRequestFactory::new,
-            HttpComponentsClientHttpRequestFactory::new);
-        return StreamSupport.stream(iterable.spliterator(), false)
-            .map(k -> Arguments.of(k))
-            .collect(Collectors.toList())
-            .stream();
+        List<Object[]> arguments = Arrays.asList(new Object[][]{{"SimpleClientHttpRequestFactory", new SimpleClientHttpRequestFactory()},
+            {"OkHttp3ClientHttpRequestFactory", new OkHttp3ClientHttpRequestFactory()},
+            {"HttpComponentsClientHttpRequestFactory", new HttpComponentsClientHttpRequestFactory()}});
+        return arguments.stream().map(k -> Arguments.of(k)).collect(Collectors.toList()).stream();
     }
 
     @Override
-    public void setUp(Object arg) {
-        Supplier<ClientHttpRequestFactory> supplier = (Supplier<ClientHttpRequestFactory>) arg;
-        restTemplate = new RestTemplate(supplier.get());
+    public void setUp(Object httpRequestFactory) {
+        restTemplate = new RestTemplate((ClientHttpRequestFactory) httpRequestFactory);
     }
 
     @Override

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/AbstractExceptionHandlerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/AbstractExceptionHandlerInstrumentationTest.java
@@ -32,17 +32,14 @@ import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.servlet.ServletInstrumentation;
 import co.elastic.apm.agent.springwebmvc.ExceptionHandlerInstrumentation;
 import net.bytebuddy.agent.ByteBuddyAgent;
-import org.junit.AfterClass;
-import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -54,7 +51,7 @@ import java.util.Arrays;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(value = SpringJUnit4ClassRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @TestConfiguration
 public abstract class AbstractExceptionHandlerInstrumentationTest {
@@ -67,7 +64,6 @@ public abstract class AbstractExceptionHandlerInstrumentationTest {
     @Autowired
     WebApplicationContext wac;
 
-    @BeforeClass
     @BeforeAll
     public static void setUpAll() {
         MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup();
@@ -78,13 +74,11 @@ public abstract class AbstractExceptionHandlerInstrumentationTest {
             Arrays.asList(new ServletInstrumentation(), new ExceptionHandlerInstrumentation()));
     }
 
-    @AfterClass
     @AfterAll
     public static void afterAll() {
         ElasticApmAgent.reset();
     }
 
-    @Before
     @BeforeEach
     public void setup() {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(wac).build();

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/ExceptionHandlerInstrumentationWithExceptionHandlerTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/ExceptionHandlerInstrumentationWithExceptionHandlerTest.java
@@ -29,7 +29,7 @@ import co.elastic.apm.agent.matcher.WildcardMatcher;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_handler.ExceptionHandlerRuntimeException;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_handler.ExceptionHandlerController;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_handler.ExceptionHandlerRuntimeException200;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MvcResult;

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/ExceptionHandlerInstrumentationWithExceptionResolverTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/ExceptionHandlerInstrumentationWithExceptionResolverTest.java
@@ -27,7 +27,7 @@ package co.elastic.apm.agent.springwebmvc.exception;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_resolver.ExceptionResolverController;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_resolver.ExceptionResolverRuntimeException;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_resolver.RestResponseStatusExceptionResolver;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MvcResult;

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/ExceptionHandlerInstrumentationWithGlobalAdviceTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/ExceptionHandlerInstrumentationWithGlobalAdviceTest.java
@@ -30,7 +30,7 @@ import co.elastic.apm.agent.springwebmvc.exception.testapp.controller_advice.Con
 import co.elastic.apm.agent.springwebmvc.exception.testapp.controller_advice.ControllerAdviceRuntimeException;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.controller_advice.ControllerAdviceRuntimeException200;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.controller_advice.GlobalExceptionHandler;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MvcResult;

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/ExceptionHandlerInstrumentationWithResponseStatusExceptionTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/ExceptionHandlerInstrumentationWithResponseStatusExceptionTest.java
@@ -26,7 +26,7 @@ package co.elastic.apm.agent.springwebmvc.exception;
 
 import co.elastic.apm.agent.springwebmvc.exception.testapp.response_status_exception.ResponseStatusExceptionController;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.response_status_exception.ResponseStatusRuntimeException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MvcResult;

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
@@ -27,8 +27,9 @@ package co.elastic.apm.agent.urlconnection;
 import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
 import co.elastic.apm.agent.impl.Scope;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
-import org.junit.Ignore;
-import org.junit.Test;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
@@ -108,7 +109,7 @@ public class HttpUrlConnectionInstrumentationTest extends AbstractHttpClientInst
     }
 
     @Test
-    @Ignore
+    @Disabled
     public void testFakeReuse() throws Exception {
         final HttpURLConnection urlConnection = (HttpURLConnection) new URL(getBaseUrl() + "/").openConnection();
         urlConnection.getInputStream();

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AgentFileIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AgentFileIT.java
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.servlet;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nullable;
 import java.io.File;


### PR DESCRIPTION
refer elastic/apm-agent-java#310 
There are left some not migrated tests: 
`AbstractServletContainerIntegrationTest` 
`AbstractJdbcInstrumentationTest`
`KafkaIT` 
and tests that used `TestClassWithDependencyRunner`
