### PR TITLE
fetch cloud metada - common logic

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -41,6 +41,7 @@ import org.stagemonitor.configuration.converter.MapValueConverter;
 import org.stagemonitor.configuration.converter.StringValueConverter;
 import org.stagemonitor.configuration.source.ConfigurationSource;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
@@ -577,6 +578,19 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .dynamic(true)
         .buildWithDefault(TimeDuration.of("0ms"));
 
+    private final ConfigurationOption<String> cloudProvider = ConfigurationOption.stringOption()
+        .key("cloud_provider")
+        .tags("added[1.18.2]")
+        .configurationCategory(CORE_CATEGORY)
+        .description("The config value allows you to specify which cloud provider should be assumed\n" +
+            "for metadata collection. By default, the agent will attempt to detect the cloud\n" +
+            "provider or, if that fails, will use trial and error to collect the metadata." +
+            "\n" +
+            "Valid options are `\"aws\"`, `\"gcp\"` and `\"azure\"`. If this config value is set\n" +
+            "to `False`, then no cloud metadata will be collected.")
+        .dynamic(false)
+        .buildWithDefault("None");
+
     public boolean isEnabled() {
         return enabled.get();
     }
@@ -754,6 +768,11 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         } else {
             return configFileLocation;
         }
+    }
+
+    @Nullable
+    public String getCloudProvider() {
+        return cloudProvider.get();
     }
 
     public enum EventType {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
@@ -2,6 +2,8 @@ package co.elastic.apm.agent.impl;
 
 import co.elastic.apm.agent.impl.payload.CloudProviderInfo;
 import com.dslplatform.json.DslJson;
+import com.dslplatform.json.JsonReader;
+import com.dslplatform.json.ObjectConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -12,13 +14,17 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.LinkedHashMap;
 import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Cloud {
     private static final Logger logger = LoggerFactory.getLogger(Cloud.class);
+    private final DslJson<Object> dslJson = new DslJson<>(new DslJson.Settings<>());
 
     @Nullable
-    public static CloudProviderInfo getAwsMetadata() {
+    public CloudProviderInfo getAwsMetadata() {
         try {
             String tokenUrl = "http://169.254.169.254/latest/api/token";
             Map<String, String> headers = Map.of("X-aws-ec2-metadata-token-ttl-seconds", "300");
@@ -27,7 +33,7 @@ public class Cloud {
             Map<String, String> documentHeaders = Map.of("X-aws-ec2-metadata-token", token);
             String metadata = callRequest(metadataUrl, "GET", documentHeaders);
             logger.debug("Got aws metadata = {}", metadata);
-            AwsMetadata awsMetadata = deserialize(metadata, AwsMetadata.class);
+            AwsMetadata awsMetadata = null;
             return awsMetadata.convert();
         } catch (Exception e) {
             logger.debug("Exception during fetching aws metadata", e);
@@ -36,28 +42,72 @@ public class Cloud {
     }
 
     @Nullable
-    public static CloudProviderInfo getGcpMetadata() {
+    public CloudProviderInfo getGcpMetadata() {
         try {
             String gcpUrl = "http://metadata.google.internal/computeMetadata/v1/?recursive=true";
             Map<String, String> headers = Map.of("Metadata-Flavor", "Google");
             String metadata = callRequest(gcpUrl, "GET", headers);
             logger.debug("Got gcp metadata = {}", metadata);
-            GcpMetadata gcpMetadata = deserialize(metadata, GcpMetadata.class);
-            return gcpMetadata.convert();
+            return convertGcpMetadata(metadata);
         } catch (Exception e) {
             logger.debug("Got exception during fetching gcp metadata", e);
             return null;
         }
     }
 
+    /**
+     * {
+     * "instance": {
+     * "id": 4306570268266786072,
+     * "machineType": "projects/513326162531/machineTypes/n1-standard-1",
+     * "name": "basepi-test",
+     * "zone": "projects/513326162531/zones/us-west3-a"
+     * },
+     * "project": {"numericProjectId": 513326162531, "projectId": "elastic-apm"}
+     * }
+     */
     @Nullable
-    public static CloudProviderInfo getAzureMetadata() {
+    protected CloudProviderInfo convertGcpMetadata(@Nullable String data) throws IOException {
+        if (data == null) {
+            return null;
+        }
+        LinkedHashMap<String, Object> map = deserialize(data);
+        CloudProviderInfo cloudProviderInfo = new CloudProviderInfo("gcp");
+        Object instanceData = map.get("instance");
+        if (instanceData instanceof LinkedHashMap) {
+            LinkedHashMap<String, Object> instanceMap = (LinkedHashMap) instanceData;
+            Long instanceId = (instanceMap.get("id") instanceof Long) ? (Long) instanceMap.get("id") : null;
+            String instanceName = (instanceMap.get("name") instanceof String) ? (String) instanceMap.get("name") : null;
+            cloudProviderInfo.setInstance(new CloudProviderInfo.ProviderInstance(instanceId, instanceName));
+            String machineType = instanceMap.get("machineType") instanceof String ? (String) instanceMap.get("machineType") : null;
+            cloudProviderInfo.setMachine(new CloudProviderInfo.ProviderMachine(machineType));
+            String zone = instanceMap.get("zone") instanceof String ? (String) instanceMap.get("zone") : null;
+            if (zone != null) {
+                int indexSlash = zone.lastIndexOf("/");
+                String availabilityZone = indexSlash != -1 ? zone.substring(indexSlash + 1) : zone;
+                cloudProviderInfo.setAvailabilityZone(availabilityZone);
+                int hyphenLastIndex = availabilityZone.lastIndexOf("-");
+                cloudProviderInfo.setRegion(hyphenLastIndex != -1 ? availabilityZone.substring(0, hyphenLastIndex) : null);
+            }
+        }
+        Object projectData = map.get("project");
+        if (projectData instanceof LinkedHashMap) {
+            LinkedHashMap<String, Object> projectMap = (LinkedHashMap) projectData;
+            String projectId = projectMap.get("projectId") instanceof String ? (String) projectMap.get("projectId") : null;
+            Long numericProjectId = projectMap.get("numericProjectId") instanceof Long ? (Long) projectMap.get("numericProjectId") : null;
+            cloudProviderInfo.setProject(new CloudProviderInfo.ProviderProject(projectId, numericProjectId));
+        }
+        return cloudProviderInfo;
+    }
+
+    @Nullable
+    public CloudProviderInfo getAzureMetadata() {
         try {
             String azureUrl = "http://169.254.169.254/metadata/instance/compute?api-version=2019-08-15";
             Map<String, String> headers = Map.of("Metadata", "true");
             String metadata = callRequest(azureUrl, "GET", headers);
             logger.debug("Got azure metadata = {}", metadata);
-            AzureMetadata azureMetadata = deserialize(metadata, AzureMetadata.class);
+            AzureMetadata azureMetadata = null;
             return azureMetadata.convert();
         } catch (Exception e) {
             logger.debug("Got exception during fetching azure metadata", e);
@@ -65,13 +115,13 @@ public class Cloud {
         }
     }
 
-    private static <T> T deserialize(String input, Class<T> clazz) throws IOException {
-        DslJson<Object> json = new DslJson<>();
-        byte[] bytes = input.getBytes("UTF-8");
-        return json.deserialize(clazz, bytes, bytes.length);
+    protected LinkedHashMap deserialize(String input) throws IOException {
+        JsonReader<Object> reader = dslJson.newReader(input.getBytes(UTF_8));
+        reader.startObject();
+        return (LinkedHashMap) ObjectConverter.deserializeObject(reader);
     }
 
-    private static String callRequest(@Nonnull String url, @Nonnull String method, @Nonnull Map<String, String> headers) throws IOException {
+    private String callRequest(@Nonnull String url, @Nonnull String method, @Nonnull Map<String, String> headers) throws IOException {
         URL myURL = new URL(url);
         HttpURLConnection urlConnection = (HttpURLConnection) myURL.openConnection();
         for (String header : headers.keySet()) {
@@ -96,21 +146,21 @@ public class Cloud {
 
     /**
      * {
-     *     "accountId": "946960629917",
-     *     "architecture": "x86_64",
-     *     "availabilityZone": "us-east-2a",
-     *     "billingProducts": null,
-     *     "devpayProductCodes": null,
-     *     "marketplaceProductCodes": null,
-     *     "imageId": "ami-07c1207a9d40bc3bd",
-     *     "instanceId": "i-0ae894a7c1c4f2a75",
-     *     "instanceType": "t2.medium",
-     *     "kernelId": null,
-     *     "pendingTime": "2020-06-12T17:46:09Z",
-     *     "privateIp": "172.31.0.212",
-     *     "ramdiskId": null,
-     *     "region": "us-east-2",
-     *     "version": "2017-09-30"
+     * "accountId": "946960629917",
+     * "architecture": "x86_64",
+     * "availabilityZone": "us-east-2a",
+     * "billingProducts": null,
+     * "devpayProductCodes": null,
+     * "marketplaceProductCodes": null,
+     * "imageId": "ami-07c1207a9d40bc3bd",
+     * "instanceId": "i-0ae894a7c1c4f2a75",
+     * "instanceType": "t2.medium",
+     * "kernelId": null,
+     * "pendingTime": "2020-06-12T17:46:09Z",
+     * "privateIp": "172.31.0.212",
+     * "ramdiskId": null,
+     * "region": "us-east-2",
+     * "version": "2017-09-30"
      * }
      */
     private static class AwsMetadata {
@@ -191,126 +241,14 @@ public class Cloud {
 
     /**
      * {
-     *     "instance": {
-     *         "id": 4306570268266786072,
-     *         "machineType": "projects/513326162531/machineTypes/n1-standard-1",
-     *         "name": "basepi-test",
-     *         "zone": "projects/513326162531/zones/us-west3-a"
-     *     },
-     *     "project": {"numericProjectId": 513326162531, "projectId": "elastic-apm"}
-     * }
-      */
-    private static class GcpMetadata{
-        private GcpInstance instance;
-        private GcpProject project;
-
-        public CloudProviderInfo convert() {
-            CloudProviderInfo cloudProviderInfo = new CloudProviderInfo("gcp");
-            if (instance != null) {
-                cloudProviderInfo.setInstance(new CloudProviderInfo.ProviderInstance(instance.getId(), instance.getName()));
-                cloudProviderInfo.setMachine(new CloudProviderInfo.ProviderMachine(instance.getMachineType()));
-                String zone = instance.getZone();
-                if (zone != null) {
-                    int indexSlash = zone.lastIndexOf("/");
-                    String availabilityZone = indexSlash != -1 ? zone.substring(indexSlash  + 1) : zone;
-                    cloudProviderInfo.setAvailabilityZone(availabilityZone);
-                    int defisLastIndex = availabilityZone.lastIndexOf("-");
-                    cloudProviderInfo.setRegion(defisLastIndex != -1 ? availabilityZone.substring(0, defisLastIndex) : null);
-                }
-            }
-            if (project != null) {
-                cloudProviderInfo.setProject(new CloudProviderInfo.ProviderProject(project.getProjectId(), project.getNumericProjectId()));
-            }
-            return cloudProviderInfo;
-        }
-
-        public GcpInstance getInstance() {
-            return instance;
-        }
-
-        public void setInstance(GcpInstance instance) {
-            this.instance = instance;
-        }
-
-        public GcpProject getProject() {
-            return project;
-        }
-
-        public void setProject(GcpProject project) {
-            this.project = project;
-        }
-    }
-
-    private static class GcpInstance {
-        private Long id;
-        private String name;
-        private String machineType;
-        private String zone;
-
-        public Long getId() {
-            return id;
-        }
-
-        public void setId(Long id) {
-            this.id = id;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public String getMachineType() {
-            return machineType;
-        }
-
-        public void setMachineType(String machineType) {
-            this.machineType = machineType;
-        }
-
-        public String getZone() {
-            return zone;
-        }
-
-        public void setZone(String zone) {
-            this.zone = zone;
-        }
-    }
-
-    private static class GcpProject {
-        private Long numericProjectId;
-        private String projectId;
-
-        public Long getNumericProjectId() {
-            return numericProjectId;
-        }
-
-        public void setNumericProjectId(Long numericProjectId) {
-            this.numericProjectId = numericProjectId;
-        }
-
-        public String getProjectId() {
-            return projectId;
-        }
-
-        public void setProjectId(String projectId) {
-            this.projectId = projectId;
-        }
-    }
-
-    /**
-     * {
-     *     "location": "westus2",
-     *     "name": "basepi-test",
-     *     "resourceGroupName": "basepi-testing",
-     *     "subscriptionId": "7657426d-c4c3-44ac-88a2-3b2cd59e6dba",
-     *     "vmId": "e11ebedc-019d-427f-84dd-56cd4388d3a8",
-     *     "vmScaleSetName": "",
-     *     "vmSize": "Standard_D2s_v3",
-     *     "zone": ""
+     * "location": "westus2",
+     * "name": "basepi-test",
+     * "resourceGroupName": "basepi-testing",
+     * "subscriptionId": "7657426d-c4c3-44ac-88a2-3b2cd59e6dba",
+     * "vmId": "e11ebedc-019d-427f-84dd-56cd4388d3a8",
+     * "vmScaleSetName": "",
+     * "vmSize": "Standard_D2s_v3",
+     * "zone": ""
      * }
      */
     private static class AzureMetadata {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
@@ -1,15 +1,66 @@
 package co.elastic.apm.agent.impl;
 
 import co.elastic.apm.agent.impl.payload.CloudProviderInfo;
+import com.dslplatform.json.DslJson;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
 
 public class Cloud {
+    private static final Logger logger = LoggerFactory.getLogger(Cloud.class);
 
     @Nullable
     public static CloudProviderInfo getAwsMetadata() {
+        try {
+            String tokenUrl = "http://169.254.169.254/latest/api/token";
+            Map<String, String> headers = Map.of("X-aws-ec2-metadata-token-ttl-seconds", "300");
+            String token = callRequest(tokenUrl, "PUT", headers);
+            String metadataUrl = "http://169.254.169.254/latest/dynamic/instance-identity/document";
+            Map<String, String> documentHeaders = Map.of("X-aws-ec2-metadata-token", token);
+            String metadata = callRequest(metadataUrl, "GET", documentHeaders);
+            AwsMetadata awsMetadata = deserialize(metadata, AwsMetadata.class);
+            return awsMetadata.convert();
+        } catch (Exception e) {
+            logger.warn("Exception during fetching aws metadata", e);
+            return null;
+        }
+    }
 
-        return null;
+    private static <T> T deserialize(String input, Class<T> clazz) throws IOException {
+        DslJson<Object> json = new DslJson<>();
+        byte[] bytes = input.getBytes("UTF-8");
+        return json.deserialize(clazz, bytes, bytes.length);
+    }
+
+    private static String callRequest(@Nonnull String url, @Nonnull String method, @Nonnull Map<String, String> headers) throws IOException {
+        URL myURL = new URL(url);
+        HttpURLConnection urlConnection = (HttpURLConnection) myURL.openConnection();
+        for (String header : headers.keySet()) {
+            urlConnection.setRequestProperty(header, headers.get(header));
+        }
+        urlConnection.setRequestMethod(method);
+        urlConnection.setReadTimeout(3000);
+        urlConnection.setConnectTimeout(3000);
+        String response = null;
+        try (BufferedReader in = new BufferedReader(new InputStreamReader(urlConnection.getInputStream()))) {
+            String inputLine;
+            StringBuffer content = new StringBuffer();
+            while ((inputLine = in.readLine()) != null) {
+                content.append(inputLine);
+            }
+            response = content.toString();
+        } finally {
+            urlConnection.disconnect();
+        }
+        return response;
     }
 
     @Nullable
@@ -22,5 +73,82 @@ public class Cloud {
     public static CloudProviderInfo getAzureMetadata() {
 
         return null;
+    }
+
+    private static class AwsMetadata {
+        private String accountId;
+        private String architecture;
+        private String availabilityZone;
+        private String instanceId;
+        private String instanceType;
+        private String region;
+        private String version;
+
+        public CloudProviderInfo convert() {
+            CloudProviderInfo cloudProviderInfo = new CloudProviderInfo();
+            cloudProviderInfo.setAccount(accountId);
+            cloudProviderInfo.setInstance(instanceId);
+            cloudProviderInfo.setMachine(instanceType);
+            cloudProviderInfo.setAvailabilityZone(availabilityZone);
+            cloudProviderInfo.setRegion(region);
+            cloudProviderInfo.setProvider("aws");
+            return cloudProviderInfo;
+        }
+
+        public String getAccountId() {
+            return accountId;
+        }
+
+        public void setAccountId(String accountId) {
+            this.accountId = accountId;
+        }
+
+        public String getArchitecture() {
+            return architecture;
+        }
+
+        public void setArchitecture(String architecture) {
+            this.architecture = architecture;
+        }
+
+        public String getAvailabilityZone() {
+            return availabilityZone;
+        }
+
+        public void setAvailabilityZone(String availabilityZone) {
+            this.availabilityZone = availabilityZone;
+        }
+
+        public String getInstanceId() {
+            return instanceId;
+        }
+
+        public void setInstanceId(String instanceId) {
+            this.instanceId = instanceId;
+        }
+
+        public String getInstanceType() {
+            return instanceType;
+        }
+
+        public void setInstanceType(String instanceType) {
+            this.instanceType = instanceType;
+        }
+
+        public String getRegion() {
+            return region;
+        }
+
+        public void setRegion(String region) {
+            this.region = region;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
@@ -52,11 +52,11 @@ public class Cloud {
     @Nullable
     public CloudProviderInfo getAwsMetadata() {
         try {
-            String awsTokenUrl = "http://localhost:8080/latest/api/token";
+            String awsTokenUrl = "http://169.254.169.254/latest/api/token";
             Map<String, String> headers = new HashMap<>(1);
             headers.put("X-aws-ec2-metadata-token-ttl-seconds", "300");
             String token = callRequest(awsTokenUrl, "PUT", headers);
-            String awsMetadataUrl = "http://localhost:8080/latest/dynamic/instance-identity/document";
+            String awsMetadataUrl = "http://169.254.169.254/latest/dynamic/instance-identity/document";
             Map<String, String> documentHeaders = new HashMap<>(1);
             documentHeaders.put("X-aws-ec2-metadata-token", token);
             String metadata = callRequest(awsMetadataUrl, "GET", documentHeaders);
@@ -152,15 +152,15 @@ public class Cloud {
             LinkedHashMap<String, Object> instanceMap = (LinkedHashMap) instanceData;
             Long instanceId = (instanceMap.get("id") instanceof Long) ? (Long) instanceMap.get("id") : null;
             String instanceName = (instanceMap.get("name") instanceof String) ? (String) instanceMap.get("name") : null;
-            cloudProviderInfo.setInstance(new CloudProviderInfo.ProviderInstance(instanceId, instanceName));
             String machineType = instanceMap.get("machineType") instanceof String ? (String) instanceMap.get("machineType") : null;
-            cloudProviderInfo.setMachine(new CloudProviderInfo.ProviderMachine(machineType));
             String zone = instanceMap.get("zone") instanceof String ? (String) instanceMap.get("zone") : null;
+            cloudProviderInfo.setInstance(new CloudProviderInfo.ProviderInstance(instanceId, instanceName));
+            cloudProviderInfo.setMachine(new CloudProviderInfo.ProviderMachine(machineType));
             if (zone != null) {
                 int indexSlash = zone.lastIndexOf("/");
                 String availabilityZone = indexSlash != -1 ? zone.substring(indexSlash + 1) : zone;
-                cloudProviderInfo.setAvailabilityZone(availabilityZone);
                 int hyphenLastIndex = availabilityZone.lastIndexOf("-");
+                cloudProviderInfo.setAvailabilityZone(availabilityZone);
                 cloudProviderInfo.setRegion(hyphenLastIndex != -1 ? availabilityZone.substring(0, hyphenLastIndex) : null);
             }
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
@@ -1,0 +1,26 @@
+package co.elastic.apm.agent.impl;
+
+import co.elastic.apm.agent.impl.payload.CloudProviderInfo;
+
+import javax.annotation.Nullable;
+
+public class Cloud {
+
+    @Nullable
+    public static CloudProviderInfo getAwsMetadata() {
+
+        return null;
+    }
+
+    @Nullable
+    public static CloudProviderInfo getGcpMetadata() {
+
+        return null;
+    }
+
+    @Nullable
+    public static CloudProviderInfo getAzureMetadata() {
+
+        return null;
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Cloud.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.impl;
 
 import co.elastic.apm.agent.impl.payload.CloudProviderInfo;
@@ -14,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -21,31 +46,80 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Cloud {
     private static final Logger logger = LoggerFactory.getLogger(Cloud.class);
+
     private final DslJson<Object> dslJson = new DslJson<>(new DslJson.Settings<>());
 
     @Nullable
     public CloudProviderInfo getAwsMetadata() {
         try {
-            String tokenUrl = "http://169.254.169.254/latest/api/token";
-            Map<String, String> headers = Map.of("X-aws-ec2-metadata-token-ttl-seconds", "300");
-            String token = callRequest(tokenUrl, "PUT", headers);
-            String metadataUrl = "http://169.254.169.254/latest/dynamic/instance-identity/document";
-            Map<String, String> documentHeaders = Map.of("X-aws-ec2-metadata-token", token);
-            String metadata = callRequest(metadataUrl, "GET", documentHeaders);
+            String awsTokenUrl = "http://localhost:8080/latest/api/token";
+            Map<String, String> headers = new HashMap<>(1);
+            headers.put("X-aws-ec2-metadata-token-ttl-seconds", "300");
+            String token = callRequest(awsTokenUrl, "PUT", headers);
+            String awsMetadataUrl = "http://localhost:8080/latest/dynamic/instance-identity/document";
+            Map<String, String> documentHeaders = new HashMap<>(1);
+            documentHeaders.put("X-aws-ec2-metadata-token", token);
+            String metadata = callRequest(awsMetadataUrl, "GET", documentHeaders);
             logger.debug("Got aws metadata = {}", metadata);
-            AwsMetadata awsMetadata = null;
-            return awsMetadata.convert();
+            return convertAwsMetadata(metadata);
         } catch (Exception e) {
             logger.debug("Exception during fetching aws metadata", e);
             return null;
         }
     }
 
+    /**
+     * {
+     * "accountId": "946960629917",
+     * "architecture": "x86_64",
+     * "availabilityZone": "us-east-2a",
+     * "billingProducts": null,
+     * "devpayProductCodes": null,
+     * "marketplaceProductCodes": null,
+     * "imageId": "ami-07c1207a9d40bc3bd",
+     * "instanceId": "i-0ae894a7c1c4f2a75",
+     * "instanceType": "t2.medium",
+     * "kernelId": null,
+     * "pendingTime": "2020-06-12T17:46:09Z",
+     * "privateIp": "172.31.0.212",
+     * "ramdiskId": null,
+     * "region": "us-east-2",
+     * "version": "2017-09-30"
+     * }
+     */
+    @Nullable
+    protected CloudProviderInfo convertAwsMetadata(@Nullable String data) throws IOException {
+        if (data == null) {
+            return null;
+        }
+        LinkedHashMap<String, Object> map = deserialize(data);
+
+        Object accountIdValue = map.get("accountId");
+        String accountId = accountIdValue instanceof String ? (String) accountIdValue : null;
+        Object instanceIdValue = map.get("instanceId");
+        String instanceId = instanceIdValue instanceof String ? (String) instanceIdValue : null;
+        Object instanceTypeValue = map.get("instanceType");
+        String instanceType = instanceTypeValue instanceof String ? (String) instanceTypeValue : null;
+        Object availabilityZoneValue = map.get("availabilityZone");
+        String availabilityZone = availabilityZoneValue instanceof String ? (String) availabilityZoneValue : null;
+        Object regionValue = map.get("region");
+        String region = regionValue instanceof String ? (String) regionValue : null;
+
+        CloudProviderInfo cloudProviderInfo = new CloudProviderInfo("aws");
+        cloudProviderInfo.setMachine(new CloudProviderInfo.ProviderMachine(instanceType));
+        cloudProviderInfo.setInstance(new CloudProviderInfo.ProviderInstance(instanceId, null));
+        cloudProviderInfo.setAvailabilityZone(availabilityZone);
+        cloudProviderInfo.setAccount(new CloudProviderInfo.ProviderAccount(accountId));
+        cloudProviderInfo.setRegion(region);
+        return cloudProviderInfo;
+    }
+
     @Nullable
     public CloudProviderInfo getGcpMetadata() {
         try {
             String gcpUrl = "http://metadata.google.internal/computeMetadata/v1/?recursive=true";
-            Map<String, String> headers = Map.of("Metadata-Flavor", "Google");
+            Map<String, String> headers = new HashMap<>(1);
+            headers.put("Metadata-Flavor", "Google");
             String metadata = callRequest(gcpUrl, "GET", headers);
             logger.debug("Got gcp metadata = {}", metadata);
             return convertGcpMetadata(metadata);
@@ -104,18 +178,62 @@ public class Cloud {
     public CloudProviderInfo getAzureMetadata() {
         try {
             String azureUrl = "http://169.254.169.254/metadata/instance/compute?api-version=2019-08-15";
-            Map<String, String> headers = Map.of("Metadata", "true");
+            Map<String, String> headers = new HashMap<>(1);
+            headers.put("Metadata", "true");
             String metadata = callRequest(azureUrl, "GET", headers);
             logger.debug("Got azure metadata = {}", metadata);
-            AzureMetadata azureMetadata = null;
-            return azureMetadata.convert();
+            return convertAzureMetadata(metadata);
         } catch (Exception e) {
             logger.debug("Got exception during fetching azure metadata", e);
             return null;
         }
     }
 
-    protected LinkedHashMap deserialize(String input) throws IOException {
+    /**
+     * {
+     * "location": "westus2",
+     * "name": "basepi-test",
+     * "resourceGroupName": "basepi-testing",
+     * "subscriptionId": "7657426d-c4c3-44ac-88a2-3b2cd59e6dba",
+     * "vmId": "e11ebedc-019d-427f-84dd-56cd4388d3a8",
+     * "vmScaleSetName": "",
+     * "vmSize": "Standard_D2s_v3",
+     * "zone": ""
+     * }
+     */
+    @Nullable
+    protected CloudProviderInfo convertAzureMetadata(@Nullable String data) throws IOException {
+        if (data == null) {
+            return null;
+        }
+        LinkedHashMap<String, Object> map = deserialize(data);
+
+        Object subscriptionIdValue = map.get("subscriptionId");
+        String subscriptionId = subscriptionIdValue instanceof String ? (String) subscriptionIdValue : null;
+        Object vmIdValue = map.get("vmId");
+        String vmId = vmIdValue instanceof String ? (String) vmIdValue : null;
+        Object nameValue = map.get("name");
+        String name = nameValue instanceof String ? (String) nameValue : null;
+        Object resourceGroupNameValue = map.get("resourceGroupName");
+        String resourceGroupName = resourceGroupNameValue instanceof String ? (String) resourceGroupNameValue : null;
+        Object zoneValue = map.get("zone");
+        String zone = zoneValue instanceof String ? (String) zoneValue : null;
+        Object vmSizeValue = map.get("vmSize");
+        String vmSize = vmSizeValue instanceof String ? (String) vmSizeValue : null;
+        Object locationValue = map.get("location");
+        String location = locationValue instanceof String ? (String) locationValue : null;
+
+        CloudProviderInfo cloudProviderInfo = new CloudProviderInfo("azure");
+        cloudProviderInfo.setAccount(new CloudProviderInfo.ProviderAccount(subscriptionId));
+        cloudProviderInfo.setInstance(new CloudProviderInfo.ProviderInstance(vmId, name));
+        cloudProviderInfo.setProject(new CloudProviderInfo.ProviderProject(resourceGroupName));
+        cloudProviderInfo.setAvailabilityZone(zone);
+        cloudProviderInfo.setMachine(new CloudProviderInfo.ProviderMachine(vmSize));
+        cloudProviderInfo.setRegion(location);
+        return cloudProviderInfo;
+    }
+
+    private LinkedHashMap deserialize(String input) throws IOException {
         JsonReader<Object> reader = dslJson.newReader(input.getBytes(UTF_8));
         reader.startObject();
         return (LinkedHashMap) ObjectConverter.deserializeObject(reader);
@@ -142,198 +260,5 @@ public class Cloud {
             urlConnection.disconnect();
         }
         return response;
-    }
-
-    /**
-     * {
-     * "accountId": "946960629917",
-     * "architecture": "x86_64",
-     * "availabilityZone": "us-east-2a",
-     * "billingProducts": null,
-     * "devpayProductCodes": null,
-     * "marketplaceProductCodes": null,
-     * "imageId": "ami-07c1207a9d40bc3bd",
-     * "instanceId": "i-0ae894a7c1c4f2a75",
-     * "instanceType": "t2.medium",
-     * "kernelId": null,
-     * "pendingTime": "2020-06-12T17:46:09Z",
-     * "privateIp": "172.31.0.212",
-     * "ramdiskId": null,
-     * "region": "us-east-2",
-     * "version": "2017-09-30"
-     * }
-     */
-    private static class AwsMetadata {
-        private String accountId;
-        private String architecture;
-        private String availabilityZone;
-        private String instanceId;
-        private String instanceType;
-        private String region;
-        private String version;
-
-        public CloudProviderInfo convert() {
-            CloudProviderInfo cloudProviderInfo = new CloudProviderInfo("aws");
-            cloudProviderInfo.setAccount(new CloudProviderInfo.ProviderAccount(accountId));
-            cloudProviderInfo.setInstance(new CloudProviderInfo.ProviderInstance(instanceId, null));
-            cloudProviderInfo.setMachine(new CloudProviderInfo.ProviderMachine(instanceType));
-            cloudProviderInfo.setAvailabilityZone(availabilityZone);
-            cloudProviderInfo.setRegion(region);
-            return cloudProviderInfo;
-        }
-
-        public String getAccountId() {
-            return accountId;
-        }
-
-        public void setAccountId(String accountId) {
-            this.accountId = accountId;
-        }
-
-        public String getArchitecture() {
-            return architecture;
-        }
-
-        public void setArchitecture(String architecture) {
-            this.architecture = architecture;
-        }
-
-        public String getAvailabilityZone() {
-            return availabilityZone;
-        }
-
-        public void setAvailabilityZone(String availabilityZone) {
-            this.availabilityZone = availabilityZone;
-        }
-
-        public String getInstanceId() {
-            return instanceId;
-        }
-
-        public void setInstanceId(String instanceId) {
-            this.instanceId = instanceId;
-        }
-
-        public String getInstanceType() {
-            return instanceType;
-        }
-
-        public void setInstanceType(String instanceType) {
-            this.instanceType = instanceType;
-        }
-
-        public String getRegion() {
-            return region;
-        }
-
-        public void setRegion(String region) {
-            this.region = region;
-        }
-
-        public String getVersion() {
-            return version;
-        }
-
-        public void setVersion(String version) {
-            this.version = version;
-        }
-    }
-
-    /**
-     * {
-     * "location": "westus2",
-     * "name": "basepi-test",
-     * "resourceGroupName": "basepi-testing",
-     * "subscriptionId": "7657426d-c4c3-44ac-88a2-3b2cd59e6dba",
-     * "vmId": "e11ebedc-019d-427f-84dd-56cd4388d3a8",
-     * "vmScaleSetName": "",
-     * "vmSize": "Standard_D2s_v3",
-     * "zone": ""
-     * }
-     */
-    private static class AzureMetadata {
-        private String location;
-        private String name;
-        private String resourceGroupName;
-        private String subscriptionId;
-        private String vmId;
-        private String vmScaleSetName;
-        private String vmSize;
-        private String zone;
-
-        public CloudProviderInfo convert() {
-            CloudProviderInfo cloudProviderInfo = new CloudProviderInfo("azure");
-            cloudProviderInfo.setAccount(new CloudProviderInfo.ProviderAccount(subscriptionId));
-            cloudProviderInfo.setInstance(new CloudProviderInfo.ProviderInstance(vmId, name));
-            cloudProviderInfo.setProject(new CloudProviderInfo.ProviderProject(resourceGroupName));
-            cloudProviderInfo.setAvailabilityZone(zone);
-            cloudProviderInfo.setMachine(new CloudProviderInfo.ProviderMachine(vmSize));
-            cloudProviderInfo.setRegion(location);
-            return cloudProviderInfo;
-        }
-
-        public String getLocation() {
-            return location;
-        }
-
-        public void setLocation(String location) {
-            this.location = location;
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
-        }
-
-        public String getResourceGroupName() {
-            return resourceGroupName;
-        }
-
-        public void setResourceGroupName(String resourceGroupName) {
-            this.resourceGroupName = resourceGroupName;
-        }
-
-        public String getSubscriptionId() {
-            return subscriptionId;
-        }
-
-        public void setSubscriptionId(String subscriptionId) {
-            this.subscriptionId = subscriptionId;
-        }
-
-        public String getVmId() {
-            return vmId;
-        }
-
-        public void setVmId(String vmId) {
-            this.vmId = vmId;
-        }
-
-        public String getVmScaleSetName() {
-            return vmScaleSetName;
-        }
-
-        public void setVmScaleSetName(String vmScaleSetName) {
-            this.vmScaleSetName = vmScaleSetName;
-        }
-
-        public String getVmSize() {
-            return vmSize;
-        }
-
-        public void setVmSize(String vmSize) {
-            this.vmSize = vmSize;
-        }
-
-        public String getZone() {
-            return zone;
-        }
-
-        public void setZone(String zone) {
-            this.zone = zone;
-        }
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/MetaData.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/MetaData.java
@@ -120,4 +120,9 @@ public class MetaData {
     public ArrayList<String> getGlobalLabelValues() {
         return globalLabelValues;
     }
+
+    @Nullable
+    public CloudProviderInfo getCloudProvider() {
+        return cloudProvider;
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/MetaData.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/MetaData.java
@@ -25,6 +25,7 @@
 package co.elastic.apm.agent.impl;
 
 import co.elastic.apm.agent.configuration.CoreConfiguration;
+import co.elastic.apm.agent.impl.payload.CloudProviderInfo;
 import co.elastic.apm.agent.impl.payload.ProcessFactory;
 import co.elastic.apm.agent.impl.payload.ProcessInfo;
 import co.elastic.apm.agent.impl.payload.Service;
@@ -54,13 +55,19 @@ public class MetaData {
      */
     private final SystemInfo system;
 
+    /**
+     * Cloud provider metadata
+     */
+    private final CloudProviderInfo cloudProvider;
+
     private final ArrayList<String> globalLabelKeys;
     private final ArrayList<String> globalLabelValues;
 
-    public MetaData(ProcessInfo process, Service service, SystemInfo system, Map<String, String> globalLabels) {
+    public MetaData(ProcessInfo process, Service service, SystemInfo system, CloudProviderInfo cloudProvider, Map<String, String> globalLabels) {
         this.process = process;
         this.service = service;
         this.system = system;
+        this.cloudProvider = cloudProvider;
         globalLabelKeys = new ArrayList<>(globalLabels.keySet());
         globalLabelValues = new ArrayList<>(globalLabels.values());
     }
@@ -75,7 +82,7 @@ public class MetaData {
         if (!configurationRegistry.getConfig(ReporterConfiguration.class).isIncludeProcessArguments()) {
             processInformation.getArgv().clear();
         }
-        return new MetaData(processInformation, service, SystemInfo.create(coreConfiguration.getHostname()), coreConfiguration.getGlobalLabels());
+        return new MetaData(processInformation, service, SystemInfo.create(coreConfiguration.getHostname()), CloudProviderInfo.create(coreConfiguration.getCloudProvider()), coreConfiguration.getGlobalLabels());
     }
 
     /**

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.impl.payload;
 
 import co.elastic.apm.agent.impl.Cloud;
@@ -162,6 +186,7 @@ public class CloudProviderInfo {
             this.id = id != null ? id.toString() : null;
             this.name = name;
         }
+
         public ProviderInstance(@Nullable String id, @Nullable String name) {
             this.id = id;
             this.name = name;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -50,7 +50,7 @@ public class CloudProviderInfo {
         return region;
     }
 
-    public void setRegion(String region) {
+    public void setRegion(@Nullable String region) {
         this.region = region;
     }
 
@@ -132,7 +132,6 @@ public class CloudProviderInfo {
         return null;
     }
 
-
     public static class ProviderAccount {
         private String id;
 
@@ -152,6 +151,15 @@ public class CloudProviderInfo {
     public static class ProviderInstance {
         private String id;
         private String name;
+
+        public ProviderInstance(@Nullable Long id, @Nullable String name) {
+            this.id = id != null ? id.toString() : null;
+            this.name = name;
+        }
+        public ProviderInstance(@Nullable String id, @Nullable String name) {
+            this.id = id;
+            this.name = name;
+        }
 
         public String getId() {
             return id;
@@ -174,6 +182,15 @@ public class CloudProviderInfo {
     public static class ProviderProject {
         private String id;
         private String name;
+
+        public ProviderProject(@Nullable String name) {
+            this.name = name;
+        }
+
+        public ProviderProject(@Nullable String name, @Nullable Long id) {
+            this.name = name;
+            this.id = id != null ? id.toString() : null;
+        }
 
         public String getId() {
             return id;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -96,36 +96,37 @@ public class CloudProviderInfo {
             return null;
         }
         CloudProviderInfo data = null;
+        Cloud cloud = new Cloud();
         if ("aws".equals(cloudProviderName)) {
-            data = Cloud.getAwsMetadata();
+            data = cloud.getAwsMetadata();
             if (data == null) {
                 logger.warn("Cloud provider {} defined, but no metadata was found.", cloudProviderName);
             }
             return data;
         } else if ("gcp".equals(cloudProviderName)) {
-            data = Cloud.getGcpMetadata();
+            data = cloud.getGcpMetadata();
             if (data == null) {
                 logger.warn("Cloud provider {} defined, but no metadata was found.", cloudProviderName);
             }
             return data;
         } else if ("azure".equals(cloudProviderName)) {
-            data = Cloud.getAzureMetadata();
+            data = cloud.getAzureMetadata();
             if (data == null) {
                 logger.warn("Cloud provider {} defined, but no metadata was found.", cloudProviderName);
             }
             return data;
         } else {
-            data = Cloud.getAwsMetadata();
+            data = cloud.getAwsMetadata();
             if (data != null) {
                 logger.debug("Defined aws cloud provider metadata");
                 return data;
             }
-            data = Cloud.getGcpMetadata();
+            data = cloud.getGcpMetadata();
             if (data != null) {
                 logger.debug("Defined gcp cloud provider metadata");
                 return data;
             }
-            data = Cloud.getAzureMetadata();
+            data = cloud.getAzureMetadata();
             if (data != null) {
                 logger.debug("Defined azure cloud provider metadata");
                 return data;
@@ -189,6 +190,11 @@ public class CloudProviderInfo {
         public ProviderProject(@Nullable String name, @Nullable Long id) {
             this.name = name;
             this.id = id != null ? id.toString() : null;
+        }
+
+        public ProviderProject(@Nullable String name, @Nullable String id) {
+            this.name = name;
+            this.id = id;
         }
 
         @Nullable

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -12,18 +12,23 @@ public class CloudProviderInfo {
 
     private String provider;
 
-    private String instance;
-
     private String availabilityZone;
-
-    private String machine;
 
     private String region;
 
+    private ProviderInstance instance;
+
     // aws - azure
-    private String account;
+    private ProviderAccount account;
+
     // gcp - azure
-    private String project;
+    private ProviderProject project;
+
+    private ProviderMachine machine;
+
+    public CloudProviderInfo(String provider) {
+        this.provider = provider;
+    }
 
     public String getProvider() {
         return provider;
@@ -31,14 +36,6 @@ public class CloudProviderInfo {
 
     public void setProvider(String provider) {
         this.provider = provider;
-    }
-
-    public String getInstance() {
-        return instance;
-    }
-
-    public void setInstance(String instance) {
-        this.instance = instance;
     }
 
     public String getAvailabilityZone() {
@@ -49,14 +46,6 @@ public class CloudProviderInfo {
         this.availabilityZone = availabilityZone;
     }
 
-    public String getMachine() {
-        return machine;
-    }
-
-    public void setMachine(String machine) {
-        this.machine = machine;
-    }
-
     public String getRegion() {
         return region;
     }
@@ -65,20 +54,36 @@ public class CloudProviderInfo {
         this.region = region;
     }
 
-    public String getAccount() {
+    public ProviderInstance getInstance() {
+        return instance;
+    }
+
+    public void setInstance(ProviderInstance instance) {
+        this.instance = instance;
+    }
+
+    public ProviderAccount getAccount() {
         return account;
     }
 
-    public void setAccount(String account) {
+    public void setAccount(ProviderAccount account) {
         this.account = account;
     }
 
-    public String getProject() {
+    public ProviderProject getProject() {
         return project;
     }
 
-    public void setProject(String project) {
+    public void setProject(ProviderProject project) {
         this.project = project;
+    }
+
+    public ProviderMachine getMachine() {
+        return machine;
+    }
+
+    public void setMachine(ProviderMachine machine) {
+        this.machine = machine;
     }
 
     @Nullable
@@ -127,4 +132,79 @@ public class CloudProviderInfo {
         return null;
     }
 
+
+    public static class ProviderAccount {
+        private String id;
+
+        public ProviderAccount(String id) {
+            this.id = id;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+    }
+
+    public static class ProviderInstance {
+        private String id;
+        private String name;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+
+    public static class ProviderProject {
+        private String id;
+        private String name;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class ProviderMachine {
+        private String type;
+
+        public ProviderMachine(String type) {
+            this.type = type;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -161,6 +161,7 @@ public class CloudProviderInfo {
 
     public static class ProviderAccount {
         private String id;
+        private String name;
 
         public ProviderAccount(@Nullable String id) {
             this.id = id;
@@ -208,7 +209,6 @@ public class CloudProviderInfo {
             this.name = name;
         }
     }
-
 
     public static class ProviderProject {
         private String id;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -10,6 +10,77 @@ import javax.annotation.Nullable;
 public class CloudProviderInfo {
     private static final Logger logger = LoggerFactory.getLogger(CloudProviderInfo.class);
 
+    private String provider;
+
+    private String instance;
+
+    private String availabilityZone;
+
+    private String machine;
+
+    private String region;
+
+    // aws - azure
+    private String account;
+    // gcp - azure
+    private String project;
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public String getInstance() {
+        return instance;
+    }
+
+    public void setInstance(String instance) {
+        this.instance = instance;
+    }
+
+    public String getAvailabilityZone() {
+        return availabilityZone;
+    }
+
+    public void setAvailabilityZone(String availabilityZone) {
+        this.availabilityZone = availabilityZone;
+    }
+
+    public String getMachine() {
+        return machine;
+    }
+
+    public void setMachine(String machine) {
+        this.machine = machine;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+
+    public String getAccount() {
+        return account;
+    }
+
+    public void setAccount(String account) {
+        this.account = account;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public void setProject(String project) {
+        this.project = project;
+    }
+
     @Nullable
     public static CloudProviderInfo create(@Nullable String cloudProviderName) {
         cloudProviderName = cloudProviderName != null ? cloudProviderName.toLowerCase() : null;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -161,7 +161,6 @@ public class CloudProviderInfo {
 
     public static class ProviderAccount {
         private String id;
-        private String name;
 
         public ProviderAccount(@Nullable String id) {
             this.id = id;
@@ -172,9 +171,8 @@ public class CloudProviderInfo {
             return id;
         }
 
-        @Nullable
-        public String getName() {
-            return name;
+        public void setId(String id) {
+            this.id = id;
         }
     }
 
@@ -200,6 +198,14 @@ public class CloudProviderInfo {
         @Nullable
         public String getName() {
             return name;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public void setName(String name) {
+            this.name = name;
         }
     }
 
@@ -230,6 +236,14 @@ public class CloudProviderInfo {
         @Nullable
         public String getName() {
             return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public void setId(String id) {
+            this.id = id;
         }
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -116,7 +116,7 @@ public class CloudProviderInfo {
     public static CloudProviderInfo create(@Nullable String cloudProviderName) {
         cloudProviderName = cloudProviderName != null ? cloudProviderName.toLowerCase() : null;
         if (StringUtils.isEmpty(cloudProviderName) || "false".equals(cloudProviderName)) {
-            logger.debug("cloud_provider configuration is null or `FALSE`.");
+            logger.debug("cloud_provider configuration is null or has `false` value.");
             return null;
         }
         CloudProviderInfo data = null;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -1,0 +1,59 @@
+package co.elastic.apm.agent.impl.payload;
+
+import co.elastic.apm.agent.impl.Cloud;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.stagemonitor.util.StringUtils;
+
+import javax.annotation.Nullable;
+
+public class CloudProviderInfo {
+    private static final Logger logger = LoggerFactory.getLogger(CloudProviderInfo.class);
+
+    @Nullable
+    public static CloudProviderInfo create(@Nullable String cloudProviderName) {
+        cloudProviderName = cloudProviderName != null ? cloudProviderName.toLowerCase() : null;
+        if (StringUtils.isEmpty(cloudProviderName) || "false".equals(cloudProviderName)) {
+            logger.debug("cloud_provider configuration is null or `FALSE`.");
+            return null;
+        }
+        CloudProviderInfo data = null;
+        if ("aws".equals(cloudProviderName)) {
+            data = Cloud.getAwsMetadata();
+            if (data == null) {
+                logger.warn("Cloud provider {} defined, but no metadata was found.", cloudProviderName);
+            }
+            return data;
+        } else if ("gcp".equals(cloudProviderName)) {
+            data = Cloud.getGcpMetadata();
+            if (data == null) {
+                logger.warn("Cloud provider {} defined, but no metadata was found.", cloudProviderName);
+            }
+            return data;
+        } else if ("azure".equals(cloudProviderName)) {
+            data = Cloud.getAzureMetadata();
+            if (data == null) {
+                logger.warn("Cloud provider {} defined, but no metadata was found.", cloudProviderName);
+            }
+            return data;
+        } else {
+            data = Cloud.getAwsMetadata();
+            if (data != null) {
+                logger.debug("Defined aws cloud provider metadata");
+                return data;
+            }
+            data = Cloud.getGcpMetadata();
+            if (data != null) {
+                logger.debug("Defined gcp cloud provider metadata");
+                return data;
+            }
+            data = Cloud.getAzureMetadata();
+            if (data != null) {
+                logger.debug("Defined azure cloud provider metadata");
+                return data;
+            }
+        }
+        return null;
+    }
+
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/CloudProviderInfo.java
@@ -5,6 +5,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stagemonitor.util.StringUtils;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 public class CloudProviderInfo {
@@ -18,26 +19,22 @@ public class CloudProviderInfo {
 
     private ProviderInstance instance;
 
-    // aws - azure
     private ProviderAccount account;
 
-    // gcp - azure
     private ProviderProject project;
 
     private ProviderMachine machine;
 
-    public CloudProviderInfo(String provider) {
+    public CloudProviderInfo(@Nonnull String provider) {
         this.provider = provider;
     }
 
+    @Nonnull
     public String getProvider() {
         return provider;
     }
 
-    public void setProvider(String provider) {
-        this.provider = provider;
-    }
-
+    @Nullable
     public String getAvailabilityZone() {
         return availabilityZone;
     }
@@ -46,6 +43,7 @@ public class CloudProviderInfo {
         this.availabilityZone = availabilityZone;
     }
 
+    @Nullable
     public String getRegion() {
         return region;
     }
@@ -54,14 +52,16 @@ public class CloudProviderInfo {
         this.region = region;
     }
 
+    @Nullable
     public ProviderInstance getInstance() {
         return instance;
     }
 
-    public void setInstance(ProviderInstance instance) {
+    public void setInstance(@Nonnull ProviderInstance instance) {
         this.instance = instance;
     }
 
+    @Nullable
     public ProviderAccount getAccount() {
         return account;
     }
@@ -70,6 +70,7 @@ public class CloudProviderInfo {
         this.account = account;
     }
 
+    @Nullable
     public ProviderProject getProject() {
         return project;
     }
@@ -78,11 +79,12 @@ public class CloudProviderInfo {
         this.project = project;
     }
 
+    @Nullable
     public ProviderMachine getMachine() {
         return machine;
     }
 
-    public void setMachine(ProviderMachine machine) {
+    public void setMachine(@Nonnull ProviderMachine machine) {
         this.machine = machine;
     }
 
@@ -134,17 +136,20 @@ public class CloudProviderInfo {
 
     public static class ProviderAccount {
         private String id;
+        private String name;
 
-        public ProviderAccount(String id) {
+        public ProviderAccount(@Nullable String id) {
             this.id = id;
         }
 
+        @Nullable
         public String getId() {
             return id;
         }
 
-        public void setId(String id) {
-            this.id = id;
+        @Nullable
+        public String getName() {
+            return name;
         }
     }
 
@@ -161,20 +166,14 @@ public class CloudProviderInfo {
             this.name = name;
         }
 
+        @Nullable
         public String getId() {
             return id;
         }
 
-        public void setId(String id) {
-            this.id = id;
-        }
-
+        @Nullable
         public String getName() {
             return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
         }
     }
 
@@ -192,36 +191,27 @@ public class CloudProviderInfo {
             this.id = id != null ? id.toString() : null;
         }
 
+        @Nullable
         public String getId() {
             return id;
         }
 
-        public void setId(String id) {
-            this.id = id;
-        }
-
+        @Nullable
         public String getName() {
             return name;
-        }
-
-        public void setName(String name) {
-            this.name = name;
         }
     }
 
     public static class ProviderMachine {
         private String type;
 
-        public ProviderMachine(String type) {
+        public ProviderMachine(@Nullable String type) {
             this.type = type;
         }
 
+        @Nullable
         public String getType() {
             return type;
-        }
-
-        public void setType(String type) {
-            this.type = type;
         }
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -77,7 +77,6 @@ import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -164,8 +163,10 @@ public class DslJsonSerializer implements PayloadSerializer {
         jw.writeByte(COMMA);
         serializeGlobalLabels(metaData.getGlobalLabelKeys(), metaData.getGlobalLabelValues());
         serializeSystem(metaData.getSystem());
-        jw.writeByte(COMMA);
-        serializeCloudProvider(metaData.getCloudProvider());
+        if (metaData.getCloudProvider() != null) {
+            jw.writeByte(COMMA);
+            serializeCloudProvider(metaData.getCloudProvider());
+        }
         jw.writeByte(JsonWriter.OBJECT_END);
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -164,6 +164,7 @@ public class DslJsonSerializer implements PayloadSerializer {
         jw.writeByte(COMMA);
         serializeGlobalLabels(metaData.getGlobalLabelKeys(), metaData.getGlobalLabelValues());
         serializeSystem(metaData.getSystem());
+        jw.writeByte(COMMA);
         serializeCloudProvider(metaData.getCloudProvider());
         jw.writeByte(JsonWriter.OBJECT_END);
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -458,36 +458,39 @@ public class DslJsonSerializer implements PayloadSerializer {
     private void serializeCloudProvider(final @Nonnull CloudProviderInfo cloudProviderInfo) {
         writeFieldName("cloud");
         jw.writeByte(OBJECT_START);
-        writeField("availability_zone", cloudProviderInfo.getAvailabilityZone());
-        if (cloudProviderInfo.getAccount() != null) {
+        if (cloudProviderInfo.getAccount() != null && cloudProviderInfo.getAccount().getId() != null) {
             writeFieldName("account");
             jw.writeByte(JsonWriter.OBJECT_START);
-            writeField("id", cloudProviderInfo.getAccount().getId());
-            writeField("name", cloudProviderInfo.getAccount().getName());
+            writeLastField("id", cloudProviderInfo.getAccount().getId());
             jw.writeByte(JsonWriter.OBJECT_END);
+            jw.writeByte(COMMA);
         }
         if (cloudProviderInfo.getInstance() != null) {
             writeFieldName("instance");
             jw.writeByte(JsonWriter.OBJECT_START);
             writeField("id", cloudProviderInfo.getInstance().getId());
-            writeField("name", cloudProviderInfo.getInstance().getName());
+            writeLastField("name", cloudProviderInfo.getInstance().getName());
             jw.writeByte(JsonWriter.OBJECT_END);
+            jw.writeByte(COMMA);
         }
-        if (cloudProviderInfo.getMachine() != null) {
+        if (cloudProviderInfo.getMachine() != null && cloudProviderInfo.getMachine().getType() != null) {
             writeFieldName("machine");
             jw.writeByte(JsonWriter.OBJECT_START);
-            writeField("type", cloudProviderInfo.getMachine().getType());
+            writeLastField("type", cloudProviderInfo.getMachine().getType());
             jw.writeByte(JsonWriter.OBJECT_END);
+            jw.writeByte(COMMA);
         }
         if (cloudProviderInfo.getProject() != null) {
             writeFieldName("project");
             jw.writeByte(JsonWriter.OBJECT_START);
             writeField("id", cloudProviderInfo.getProject().getId());
-            writeField("name", cloudProviderInfo.getProject().getName());
+            writeLastField("name", cloudProviderInfo.getProject().getName());
             jw.writeByte(JsonWriter.OBJECT_END);
+            jw.writeByte(COMMA);
         }
-        writeField("provider", cloudProviderInfo.getProvider());
+        writeField("availability_zone", cloudProviderInfo.getAvailabilityZone());
         writeField("region", cloudProviderInfo.getRegion());
+        writeLastField("provider", cloudProviderInfo.getProvider());
         jw.writeByte(OBJECT_END);
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -41,6 +41,7 @@ import co.elastic.apm.agent.impl.context.Url;
 import co.elastic.apm.agent.impl.context.User;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.payload.Agent;
+import co.elastic.apm.agent.impl.payload.CloudProviderInfo;
 import co.elastic.apm.agent.impl.payload.Language;
 import co.elastic.apm.agent.impl.payload.Node;
 import co.elastic.apm.agent.impl.payload.ProcessInfo;
@@ -66,6 +67,7 @@ import com.dslplatform.json.StringConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -162,6 +164,7 @@ public class DslJsonSerializer implements PayloadSerializer {
         jw.writeByte(COMMA);
         serializeGlobalLabels(metaData.getGlobalLabelKeys(), metaData.getGlobalLabelValues());
         serializeSystem(metaData.getSystem());
+        serializeCloudProvider(metaData.getCloudProvider());
         jw.writeByte(JsonWriter.OBJECT_END);
     }
 
@@ -449,6 +452,42 @@ public class DslJsonSerializer implements PayloadSerializer {
         writeField("hostname", system.getHostname());
         writeLastField("platform", system.getPlatform());
         jw.writeByte(JsonWriter.OBJECT_END);
+    }
+
+    private void serializeCloudProvider(final @Nonnull CloudProviderInfo cloudProviderInfo) {
+        writeFieldName("cloud");
+        jw.writeByte(OBJECT_START);
+        writeField("availability_zone", cloudProviderInfo.getAvailabilityZone());
+        if (cloudProviderInfo.getAccount() != null) {
+            writeFieldName("account");
+            jw.writeByte(JsonWriter.OBJECT_START);
+            writeField("id", cloudProviderInfo.getAccount().getId());
+            writeField("name", cloudProviderInfo.getAccount().getName());
+            jw.writeByte(JsonWriter.OBJECT_END);
+        }
+        if (cloudProviderInfo.getInstance() != null) {
+            writeFieldName("instance");
+            jw.writeByte(JsonWriter.OBJECT_START);
+            writeField("id", cloudProviderInfo.getInstance().getId());
+            writeField("name", cloudProviderInfo.getInstance().getName());
+            jw.writeByte(JsonWriter.OBJECT_END);
+        }
+        if (cloudProviderInfo.getMachine() != null) {
+            writeFieldName("machine");
+            jw.writeByte(JsonWriter.OBJECT_START);
+            writeField("type", cloudProviderInfo.getMachine().getType());
+            jw.writeByte(JsonWriter.OBJECT_END);
+        }
+        if (cloudProviderInfo.getProject() != null) {
+            writeFieldName("project");
+            jw.writeByte(JsonWriter.OBJECT_START);
+            writeField("id", cloudProviderInfo.getProject().getId());
+            writeField("name", cloudProviderInfo.getProject().getName());
+            jw.writeByte(JsonWriter.OBJECT_END);
+        }
+        writeField("provider", cloudProviderInfo.getProvider());
+        writeField("region", cloudProviderInfo.getRegion());
+        jw.writeByte(OBJECT_END);
     }
 
     private void serializeContainerInfo(@Nullable SystemInfo.Container container) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/JsonUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/JsonUtils.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/CloudTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/CloudTest.java
@@ -1,0 +1,4 @@
+package co.elastic.apm.agent.impl;
+
+public class CloudTest {
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/CloudTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/CloudTest.java
@@ -1,4 +1,46 @@
 package co.elastic.apm.agent.impl;
 
-public class CloudTest {
+import co.elastic.apm.agent.impl.payload.CloudProviderInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CloudTest {
+
+    private Cloud cloud;
+
+    @BeforeEach
+    public void setUp() {
+        cloud = new Cloud();
+    }
+
+    @Test
+    void gcpMetadataDeserializeTest() throws IOException {
+        String input = "{\n" +
+            "         \"instance\": {\n" +
+            "             \"id\": 4306570268266786072,\n" +
+            "             \"machineType\": \"projects/513326162531/machineTypes/n1-standard-1\",\n" +
+            "             \"name\": \"basepi-test\",\n" +
+            "             \"zone\": \"projects/513326162531/zones/us-west3-a\"\n" +
+            "         },\n" +
+            "         \"project\": {\"numericProjectId\": 513326162531, \"projectId\": \"elastic-apm\"}\n" +
+            "     }";
+
+
+        CloudProviderInfo gcpMetadata = cloud.convertGcpMetadata(input);
+
+        assertThat(gcpMetadata).isNotNull();
+        assertThat(gcpMetadata.getProvider()).isEqualTo("gcp");
+        assertThat(gcpMetadata.getAvailabilityZone()).isEqualTo("us-west3-a");
+        assertThat(gcpMetadata.getRegion()).isEqualTo("us-west3");
+        assertThat(gcpMetadata.getInstance().getId()).isEqualTo("4306570268266786072");
+        assertThat(gcpMetadata.getInstance().getName()).isEqualTo("basepi-test");
+        assertThat(gcpMetadata.getAccount()).isNull();
+        assertThat(gcpMetadata.getProject().getId()).isEqualTo("513326162531");
+        assertThat(gcpMetadata.getProject().getName()).isEqualTo("elastic-apm");
+        assertThat(gcpMetadata.getMachine().getType()).isEqualTo("projects/513326162531/machineTypes/n1-standard-1");
+    }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/CloudTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/CloudTest.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.impl;
 
 import co.elastic.apm.agent.impl.payload.CloudProviderInfo;
@@ -42,5 +66,65 @@ class CloudTest {
         assertThat(gcpMetadata.getProject().getId()).isEqualTo("513326162531");
         assertThat(gcpMetadata.getProject().getName()).isEqualTo("elastic-apm");
         assertThat(gcpMetadata.getMachine().getType()).isEqualTo("projects/513326162531/machineTypes/n1-standard-1");
+    }
+
+    @Test
+    void awsMetadataDeserializeTest() throws IOException {
+        String input = "{\n" +
+            "    \"accountId\": \"946960629917\",\n" +
+            "    \"architecture\": \"x86_64\",\n" +
+            "    \"availabilityZone\": \"us-east-2a\",\n" +
+            "    \"billingProducts\": null,\n" +
+            "    \"devpayProductCodes\": null,\n" +
+            "    \"marketplaceProductCodes\": null,\n" +
+            "    \"imageId\": \"ami-07c1207a9d40bc3bd\",\n" +
+            "    \"instanceId\": \"i-0ae894a7c1c4f2a75\",\n" +
+            "    \"instanceType\": \"t2.medium\",\n" +
+            "    \"kernelId\": null,\n" +
+            "    \"pendingTime\": \"2020-06-12T17:46:09Z\",\n" +
+            "    \"privateIp\": \"172.31.0.212\",\n" +
+            "    \"ramdiskId\": null,\n" +
+            "    \"region\": \"us-east-2\",\n" +
+            "    \"version\": \"2017-09-30\"\n" +
+            "}";
+
+        CloudProviderInfo gcpMetadata = cloud.convertAwsMetadata(input);
+
+        assertThat(gcpMetadata).isNotNull();
+        assertThat(gcpMetadata.getProvider()).isEqualTo("aws");
+        assertThat(gcpMetadata.getAvailabilityZone()).isEqualTo("us-east-2a");
+        assertThat(gcpMetadata.getRegion()).isEqualTo("us-east-2");
+        assertThat(gcpMetadata.getInstance().getId()).isEqualTo("i-0ae894a7c1c4f2a75");
+        assertThat(gcpMetadata.getInstance().getName()).isNull();
+        assertThat(gcpMetadata.getAccount().getId()).isEqualTo("946960629917");
+        assertThat(gcpMetadata.getProject()).isNull();
+        assertThat(gcpMetadata.getMachine().getType()).isEqualTo("t2.medium");
+    }
+
+    @Test
+    void azureMetadataDeserializeTest() throws IOException {
+        String input = "{\n" +
+            "    \"location\": \"westus2\",\n" +
+            "    \"name\": \"basepi-test\",\n" +
+            "    \"resourceGroupName\": \"basepi-testing\",\n" +
+            "    \"subscriptionId\": \"7657426d-c4c3-44ac-88a2-3b2cd59e6dba\",\n" +
+            "    \"vmId\": \"e11ebedc-019d-427f-84dd-56cd4388d3a8\",\n" +
+            "    \"vmScaleSetName\": \"\",\n" +
+            "    \"vmSize\": \"Standard_D2s_v3\",\n" +
+            "    \"zone\": \"\"\n" +
+            "}";
+
+        CloudProviderInfo gcpMetadata = cloud.convertAzureMetadata(input);
+
+        assertThat(gcpMetadata).isNotNull();
+        assertThat(gcpMetadata.getProvider()).isEqualTo("azure");
+        assertThat(gcpMetadata.getAvailabilityZone()).isEqualTo("");
+        assertThat(gcpMetadata.getRegion()).isEqualTo("westus2");
+        assertThat(gcpMetadata.getInstance().getId()).isEqualTo("e11ebedc-019d-427f-84dd-56cd4388d3a8");
+        assertThat(gcpMetadata.getInstance().getName()).isEqualTo("basepi-test");
+        assertThat(gcpMetadata.getAccount().getId()).isEqualTo("7657426d-c4c3-44ac-88a2-3b2cd59e6dba");
+        assertThat(gcpMetadata.getProject().getName()).isEqualTo("basepi-testing");
+        assertThat(gcpMetadata.getProject().getId()).isNull();
+        assertThat(gcpMetadata.getMachine().getType()).isEqualTo("Standard_D2s_v3");
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerReporterIntegrationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerReporterIntegrationTest.java
@@ -105,7 +105,8 @@ class ApmServerReporterIntegrationTest {
             reporterConfiguration,
             processorEventHandler,
             new DslJsonSerializer(mock(StacktraceConfiguration.class), apmServerClient),
-            new MetaData(title, service, system, Collections.emptyMap()),
+            // TODO FIX
+            new MetaData(title, service, system, null, Collections.emptyMap()),
             apmServerClient);
         reporter = new ApmServerReporter(false, reporterConfiguration, v2handler);
         reporter.start();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerReporterIntegrationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerReporterIntegrationTest.java
@@ -105,7 +105,6 @@ class ApmServerReporterIntegrationTest {
             reporterConfiguration,
             processorEventHandler,
             new DslJsonSerializer(mock(StacktraceConfiguration.class), apmServerClient),
-            // TODO FIX
             new MetaData(title, service, system, null, Collections.emptyMap()),
             apmServerClient);
         reporter = new ApmServerReporter(false, reporterConfiguration, v2handler);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandlerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandlerTest.java
@@ -113,7 +113,6 @@ class IntakeV2ReportingEventHandlerTest {
             reporterConfiguration,
             mock(ProcessorEventHandler.class),
             new DslJsonSerializer(mock(StacktraceConfiguration.class), apmServerClient),
-            // TODO FIX
             new MetaData(title, service, system, null, Collections.emptyMap()), apmServerClient);
         final ProcessInfo title1 = new ProcessInfo("title");
         final Service service1 = new Service();
@@ -123,7 +122,6 @@ class IntakeV2ReportingEventHandlerTest {
             reporterConfiguration,
             mock(ProcessorEventHandler.class),
             new DslJsonSerializer(mock(StacktraceConfiguration.class), this.apmServerClient),
-            // TODO FIX
             new MetaData(title1, service1, system, null, Collections.emptyMap()),
             apmServerClient);
     }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandlerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/IntakeV2ReportingEventHandlerTest.java
@@ -113,7 +113,8 @@ class IntakeV2ReportingEventHandlerTest {
             reporterConfiguration,
             mock(ProcessorEventHandler.class),
             new DslJsonSerializer(mock(StacktraceConfiguration.class), apmServerClient),
-            new MetaData(title, service, system, Collections.emptyMap()), apmServerClient);
+            // TODO FIX
+            new MetaData(title, service, system, null, Collections.emptyMap()), apmServerClient);
         final ProcessInfo title1 = new ProcessInfo("title");
         final Service service1 = new Service();
         ApmServerClient apmServerClient = new ApmServerClient(reporterConfiguration);
@@ -122,7 +123,8 @@ class IntakeV2ReportingEventHandlerTest {
             reporterConfiguration,
             mock(ProcessorEventHandler.class),
             new DslJsonSerializer(mock(StacktraceConfiguration.class), this.apmServerClient),
-            new MetaData(title1, service1, system, Collections.emptyMap()),
+            // TODO FIX
+            new MetaData(title1, service1, system, null, Collections.emptyMap()),
             apmServerClient);
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -431,7 +431,8 @@ class DslJsonSerializerTest {
         ProcessInfo processInfo = new ProcessInfo("title").withPid(1234);
         processInfo.getArgv().add("test");
 
-        serializer.serializeMetaDataNdJson(new MetaData(processInfo, service, systemInfo, Map.of("foo", "bar", "baz", "qux")));
+        // TODO FIX
+        serializer.serializeMetaDataNdJson(new MetaData(processInfo, service, systemInfo, null, Map.of("foo", "bar", "baz", "qux")));
 
         JsonNode metaDataJson = readJsonString(serializer.toString()).get("metadata");
 
@@ -684,7 +685,8 @@ class DslJsonSerializerTest {
         Service service = new Service().withAgent(new Agent("name", "version")).withName("name");
         final ProcessInfo processInfo = new ProcessInfo("title");
         processInfo.getArgv().add("test");
-        return new MetaData(processInfo, service, system, new HashMap<>(0));
+        // TODO FIX
+        return new MetaData(processInfo, service, system, null, new HashMap<>(0));
     }
 
 

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchRestClientInstrumentationIT_RealReporter.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchRestClientInstrumentationIT_RealReporter.java
@@ -144,7 +144,8 @@ public class ElasticsearchRestClientInstrumentationIT_RealReporter {
             reporterConfiguration,
             processorEventHandler,
             new DslJsonSerializer(mock(StacktraceConfiguration.class), apmServerClient),
-            new MetaData(title, service, system, Collections.emptyMap()),
+            // TODO FIX
+            new MetaData(title, service, system, null, Collections.emptyMap()),
             apmServerClient);
         realReporter = new ApmServerReporter(true, reporterConfiguration, v2handler);
         realReporter.start();

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchRestClientInstrumentationIT_RealReporter.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/test/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchRestClientInstrumentationIT_RealReporter.java
@@ -144,7 +144,6 @@ public class ElasticsearchRestClientInstrumentationIT_RealReporter {
             reporterConfiguration,
             processorEventHandler,
             new DslJsonSerializer(mock(StacktraceConfiguration.class), apmServerClient),
-            // TODO FIX
             new MetaData(title, service, system, null, Collections.emptyMap()),
             apmServerClient);
         realReporter = new ApmServerReporter(true, reporterConfiguration, v2handler);

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -123,6 +123,7 @@ Click on a key to get more information.
 ** <<config-config-file>>
 ** <<config-use-elastic-traceparent-header>>
 ** <<config-span-min-duration>>
+** <<config-cloud-provider>>
 * <<config-http>>
 ** <<config-capture-body-content-types>>
 ** <<config-transaction-ignore-urls>>
@@ -1168,6 +1169,33 @@ The default unit for this option is `ms`.
 |============
 | Java System Properties      | Property file   | Environment
 | `elastic.apm.span_min_duration` | `span_min_duration` | `ELASTIC_APM_SPAN_MIN_DURATION`
+|============
+
+// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
+[float]
+[[config-cloud-provider]]
+==== `cloud_provider` (added[1.18.2])
+
+The config value allows you to specify which cloud provider should be assumed
+for metadata collection. By default, the agent will attempt to detect the cloud
+provider or, if that fails, will use trial and error to collect the metadata.
+Valid options are `"aws"`, `"gcp"` and `"azure"`. If this config value is set
+to `False`, then no cloud metadata will be collected.
+
+
+
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `None` | String | false
+|============
+
+
+[options="header"]
+|============
+| Java System Properties      | Property file   | Environment
+| `elastic.apm.cloud_provider` | `cloud_provider` | `ELASTIC_APM_CLOUD_PROVIDER`
 |============
 
 [[config-http]]
@@ -2829,6 +2857,18 @@ The default unit for this option is `ms`.
 # Default value: 0ms
 #
 # span_min_duration=0ms
+
+# The config value allows you to specify which cloud provider should be assumed
+# for metadata collection. By default, the agent will attempt to detect the cloud
+# provider or, if that fails, will use trial and error to collect the metadata.
+# Valid options are `"aws"`, `"gcp"` and `"azure"`. If this config value is set
+# to `False`, then no cloud metadata will be collected.
+#
+# This setting can not be changed at runtime. Changes require a restart of the application.
+# Type: String
+# Default value: None
+#
+# cloud_provider=None
 
 ############################################
 # HTTP                                     #


### PR DESCRIPTION
refer elastic/apm-agent-java#1264 
Note: we may have problems if a new version is used in the cloud with old versions of apm-server
Note2: I didn't add cloud.account.name field in serialization, because this field value is not available in the selected providers (aws, gcp, azure).