### PR TITLE
Setting context class loader of agent threads to null

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ExecutorUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ExecutorUtils.java
@@ -82,6 +82,7 @@ public final class ExecutorUtils {
             Thread thread = new Thread(r);
             thread.setDaemon(true);
             thread.setName(threadName);
+            thread.setContextClassLoader(null);
             return thread;
         }
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ExecutorUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ExecutorUtils.java
@@ -82,6 +82,13 @@ public final class ExecutorUtils {
             Thread thread = new Thread(r);
             thread.setDaemon(true);
             thread.setName(threadName);
+            if (logger.isDebugEnabled()) {
+                logger.debug("A new thread named `{}` was created. The original context class loader of this thread ({}) has been overridden",
+                    threadName, thread.getContextClassLoader());
+            }
+            if (logger.isTraceEnabled()) {
+                logger.trace("Stack trace related to thread creation: ", new Throwable());
+            }
             thread.setContextClassLoader(null);
             return thread;
         }


### PR DESCRIPTION
Setting context class loader of agent threads explicitly to `null` to avoid Tomcat's warnings about possible memory leaks