### PR TITLE
Add test that reproduces LinkageError on MethodHandle lookup

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/LookupExposer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/LookupExposer.java
@@ -32,6 +32,7 @@ import java.lang.invoke.MethodHandles;
  * instead of calling {@link MethodHandles#lookup()} which uses the caller class as the lookup class.
  * <p>
  * This circumvents a nasty JVM bug that's described <a href="https://github.com/elastic/apm-agent-java/issues/1450">here</a>.
+ * The error is reproduced in {@code MethodHandleLookupTest}
  * </p>
  */
 public class LookupExposer {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/Bar.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/Bar.java
@@ -1,0 +1,29 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.lookup;
+
+public class Bar {
+
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/Foo.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/Foo.java
@@ -1,0 +1,37 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.lookup;
+
+import java.lang.invoke.MethodHandles;
+
+public class Foo {
+    public static String foo(Bar bar) {
+        return "foo";
+    }
+
+    public static MethodHandles.Lookup getLookup() {
+        return MethodHandles.lookup();
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/MethodHandleLookupTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/MethodHandleLookupTest.java
@@ -43,7 +43,10 @@ class MethodHandleLookupTest {
             Bar.class.getName(), Bar.class.getResourceAsStream("Bar.class").readAllBytes()
         );
 
+        // MethodHandles.publicLookup() always succeeds on the first invocation
         lookupAndInvoke(new ByteArrayClassLoader(null, typeDefinitions, ByteArrayClassLoader.PersistenceHandler.MANIFEST));
+        // MethodHandles.publicLookup() fails on the second invocation,
+        // even though the classes are loaded from an isolated class loader hierarchy
         lookupAndInvoke(new ByteArrayClassLoader(null, typeDefinitions, ByteArrayClassLoader.PersistenceHandler.MANIFEST));
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/MethodHandleLookupTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/MethodHandleLookupTest.java
@@ -1,0 +1,61 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2020 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.agent.lookup;
+
+import net.bytebuddy.dynamic.loading.ByteArrayClassLoader;
+import org.junit.jupiter.api.Test;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class MethodHandleLookupTest {
+
+    @Test
+    void name() throws Throwable {
+        Map<String, byte[]> typeDefinitions = Map.of(
+            Foo.class.getName(), Foo.class.getResourceAsStream("Foo.class").readAllBytes(),
+            Bar.class.getName(), Bar.class.getResourceAsStream("Bar.class").readAllBytes()
+        );
+
+        lookupAndInvoke(new ByteArrayClassLoader(null, typeDefinitions, ByteArrayClassLoader.PersistenceHandler.MANIFEST));
+        lookupAndInvoke(new ByteArrayClassLoader(null, typeDefinitions, ByteArrayClassLoader.PersistenceHandler.MANIFEST));
+    }
+
+    private void lookupAndInvoke(ClassLoader classLoader) throws Throwable {
+        Class<?> fooClass = classLoader.loadClass(Foo.class.getName());
+        MethodHandles.Lookup lookup;
+        // using public lookup fails with LinkageError - is this a (known) JVM bug?
+        // lookup = MethodHandles.publicLookup();
+        lookup = (MethodHandles.Lookup) fooClass.getMethod("getLookup").invoke(null);
+        MethodHandle methodHandle = lookup
+            .findStatic(fooClass, "foo", MethodType.methodType(String.class, classLoader.loadClass(Bar.class.getName())));
+        assertThat(methodHandle.invoke((Bar) null)).isEqualTo("foo");
+    }
+
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/MethodHandleLookupTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/lookup/MethodHandleLookupTest.java
@@ -53,7 +53,7 @@ class MethodHandleLookupTest {
     private void lookupAndInvoke(ClassLoader classLoader) throws Throwable {
         Class<?> fooClass = classLoader.loadClass(Foo.class.getName());
         MethodHandles.Lookup lookup;
-        // using public lookup fails with LinkageError - is this a (known) JVM bug?
+        // using public lookup fails with LinkageError on second invocation - is this a (known) JVM bug?
         // lookup = MethodHandles.publicLookup();
         lookup = (MethodHandles.Lookup) fooClass.getMethod("getLookup").invoke(null);
         MethodHandle methodHandle = lookup


### PR DESCRIPTION
This adds a test to reproduce the issue fixed in #1458

This is the exception message:
`java.lang.LinkageError: loader constraint violation: when resolving method 'java.lang.String co.elastic.apm.agent.lookup.Foo.foo(co.elastic.apm.agent.lookup.Bar)' the class loader 'bootstrap' of the current class, java/lang/Object, and the class loader net.bytebuddy.dynamic.loading.ByteArrayClassLoader @50b5ac82 for the method's defining class, co/elastic/apm/agent/lookup/Foo, have different Class objects for the type co/elastic/apm/agent/lookup/Bar used in the signature (java.lang.Object is in module java.base of loader 'bootstrap'; co.elastic.apm.agent.lookup.Foo is in unnamed module of loader net.bytebuddy.dynamic.loading.ByteArrayClassLoader @50b5ac82, parent loader 'bootstrap')`