### PR TITLE
[CI] disable shallow clone

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -42,7 +42,7 @@
           after: true
           before: true
         prune: true
-        shallow-clone: true
+        shallow-clone: false
         depth: 3
         do-not-fetch-tags: true
         submodule:

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,8 @@ pipeline {
           steps {
             pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             deleteDir()
-            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, reference: '/var/lib/jenkins/.git-references/apm-agent-java.git')
+            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, shallow: false,
+                        reference: '/var/lib/jenkins/.git-references/apm-agent-java.git')
             stash allowEmpty: true, name: 'source', useDefaultExcludes: false
             script {
               dir("${BASE_DIR}"){


### PR DESCRIPTION
## What does this PR do?

Shallow clone is already [disabled for PRs](https://github.com/elastic/apm-pipeline-library/blob/3f9bdb848aa48559d59042638932fc68cd60c57c/vars/gitCheckout.groovy#L65-L72), let's do the same for branches.

The benchmark requires to access the git log to fetch some commit metadata to be consumed later on but when using a shallow clone some commits won't be in the workspace.

```
[2020-10-30T09:07:16.487Z] + git log -1 -s --format=%cI
[2020-10-30T09:07:16.487Z] error: Could not read 98707982806d720666c57e60f87c54de46220e93
[2020-10-30T09:07:16.487Z] fatal: Failed to traverse parents of commit 09510916c6506f8aee9ac70ed42168cd7ecb4cc1
script returned exit code 128
```

Since we already use a git reference repo and there is no issues with the space this particular fix should be harmless