### PR TITLE
Properly disable agent on startup

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ endif::[]
 ===== Bug fixes
 * Fix `HttpUrlConnection` instrumentation issue (affecting distributed tracing as well) when using HTTPS without using
   `java.net.HttpURLConnection#disconnect` - {pull}1447[1447]
+* Fix ability to disable agent on startup wasn't working for runtime attach {pull}1444[1447]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -69,6 +69,7 @@ import net.bytebuddy.utility.JavaModule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.stagemonitor.configuration.ConfigurationOption;
+import org.stagemonitor.configuration.source.ConfigurationSource;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -132,9 +133,19 @@ public class ElasticApmAgent {
      * @param agentJarFile    a reference to the agent jar on the file system
      */
     @SuppressWarnings("unused") // called through reflection
-    public static void initialize(String agentArguments, Instrumentation instrumentation, File agentJarFile, boolean premain) {
+    public static void initialize(@Nullable String agentArguments, Instrumentation instrumentation, File agentJarFile, boolean premain) {
         ElasticApmAgent.agentJarFile = agentJarFile;
-        ElasticApmTracer tracer = new ElasticApmTracerBuilder(agentArguments).build();
+
+        // silently early abort when agent is disabled to minimize the number of loaded classes
+        List<ConfigurationSource> configSources = ElasticApmTracerBuilder.getConfigSources(agentArguments);
+        for (ConfigurationSource configSource : configSources) {
+            String enabled = configSource.getValue(CoreConfiguration.ENABLED_KEY);
+            if (enabled != null && !Boolean.parseBoolean(enabled))
+                return;
+
+        }
+
+        ElasticApmTracer tracer = new ElasticApmTracerBuilder(configSources).build();
         initInstrumentation(tracer, instrumentation, premain);
         tracer.start(premain);
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -140,8 +140,9 @@ public class ElasticApmAgent {
         List<ConfigurationSource> configSources = ElasticApmTracerBuilder.getConfigSources(agentArguments);
         for (ConfigurationSource configSource : configSources) {
             String enabled = configSource.getValue(CoreConfiguration.ENABLED_KEY);
-            if (enabled != null && !Boolean.parseBoolean(enabled))
+            if (enabled != null && !Boolean.parseBoolean(enabled)) {
                 return;
+            }
 
         }
 
@@ -229,7 +230,7 @@ public class ElasticApmAgent {
                 try {
                     File bytecodeDumpDir = Paths.get(bytecodeDumpPath).toFile();
                     if (!bytecodeDumpDir.exists()) {
-                        bytecodeDumpDir.mkdir();
+                        bytecodeDumpDir.mkdirs();
                     }
                     System.setProperty("co.elastic.apm.agent.shaded.bytebuddy.dump", bytecodeDumpDir.getPath());
                 } catch (Exception e) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -61,9 +61,10 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
     public static final String CORE_CATEGORY = "Core";
     private static final String DEFAULT_CONFIG_FILE = AGENT_HOME_PLACEHOLDER + "/elasticapm.properties";
     public static final String CONFIG_FILE = "config_file";
+    public static final String ENABLED_KEY = "enabled";
 
     private final ConfigurationOption<Boolean> enabled = ConfigurationOption.booleanOption()
-        .key("enabled")
+        .key(ENABLED_KEY)
         .configurationCategory(CORE_CATEGORY)
         .description("Setting to false will completely disable the agent, including instrumentation and remote config polling.\n" +
             "If you want to dynamically change the status of the agent, use <<config-recording,`recording`>> instead.")

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilder.java
@@ -60,10 +60,10 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class ElasticApmTracerBuilder {
-
     /**
      * See {@link co.elastic.apm.attach.ElasticApmAttacher#TEMP_PROPERTIES_FILE_KEY}
      */
+    @SuppressWarnings("JavadocReference")
     private static final String TEMP_PROPERTIES_FILE_KEY = "c";
 
     private final Logger logger;
@@ -75,21 +75,20 @@ public class ElasticApmTracerBuilder {
     @Nullable
     private Reporter reporter;
 
-    @Nullable
-    private final String agentArguments;
-
     private ObjectPoolFactory objectPoolFactory;
 
     private final List<LifecycleListener> extraLifecycleListeners;
 
+    private final List<ConfigurationSource> configSources;
+
     public ElasticApmTracerBuilder() {
-        this(null);
+        this(getConfigSources(null));
     }
 
-    public ElasticApmTracerBuilder(@Nullable String agentArguments) {
-        this.agentArguments = agentArguments;
+    public ElasticApmTracerBuilder(List<ConfigurationSource> configSources){
+        this.configSources = configSources;
         this.ephemeralId = UUID.randomUUID().toString();
-        LoggingConfiguration.init(getConfigSources(agentArguments), ephemeralId);
+        LoggingConfiguration.init(configSources, ephemeralId);
         logger = LoggerFactory.getLogger(getClass());
         objectPoolFactory = new ObjectPoolFactory();
         extraLifecycleListeners = new ArrayList<>();
@@ -136,7 +135,6 @@ public class ElasticApmTracerBuilder {
         if (configurationRegistry == null) {
             // setup default config registry, should be already set when testing
             addApmServerConfigSource = true;
-            List<ConfigurationSource> configSources = getConfigSources(agentArguments);
             configurationRegistry = getDefaultConfigurationRegistry(configSources);
             lifecycleListeners.add(scheduleReloadAtRate(configurationRegistry, 30, TimeUnit.SECONDS));
         }
@@ -217,7 +215,7 @@ public class ElasticApmTracerBuilder {
      * @return ordered list of configuration sources
      */
     // Must not initialize any loggers with this as the logger is configured based on configuration.
-    private List<ConfigurationSource> getConfigSources(@Nullable String agentArguments) {
+    public static List<ConfigurationSource> getConfigSources(@Nullable String agentArguments) {
         List<ConfigurationSource> result = new ArrayList<>();
 
         // highest priority : JVM system properties (before adding remote configuration)
@@ -261,7 +259,7 @@ public class ElasticApmTracerBuilder {
      * Loads the configuration from the temporary properties file created by ElasticApmAttacher
      */
     @Nullable
-    private ConfigurationSource getAttachmentConfigSource(@Nullable String configFileLocation) {
+    private static ConfigurationSource getAttachmentConfigSource(@Nullable String configFileLocation) {
         if (configFileLocation != null) {
             Properties fromFileSystem = PropertyFileConfigurationSource.getFromFileSystem(configFileLocation);
             if (fromFileSystem != null) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilder.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilder.java
@@ -81,11 +81,19 @@ public class ElasticApmTracerBuilder {
 
     private final List<ConfigurationSource> configSources;
 
+    /**
+     * Constructs a new builder instance with default configuration sources
+     */
     public ElasticApmTracerBuilder() {
         this(getConfigSources(null));
     }
 
-    public ElasticApmTracerBuilder(List<ConfigurationSource> configSources){
+    /**
+     * Constructs a new builder instance
+     *
+     * @param configSources configuration sources, obtained from calling {@link #getConfigSources(String)}
+     */
+    public ElasticApmTracerBuilder(List<ConfigurationSource> configSources) {
         this.configSources = configSources;
         this.ephemeralId = UUID.randomUUID().toString();
         LoggingConfiguration.init(configSources, ephemeralId);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilderTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerBuilderTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.stagemonitor.configuration.ConfigurationRegistry;
+import org.stagemonitor.configuration.source.ConfigurationSource;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -64,7 +65,9 @@ class ElasticApmTracerBuilderTest {
         Path file = Files.createFile(tempDir.resolve("elstcapm.tmp"));
         Files.write(file, List.of("instrument=false"));
 
-        ConfigurationRegistry configurationRegistry = new ElasticApmTracerBuilder("c=" + file.toAbsolutePath()).build().getConfigurationRegistry();
+        List<ConfigurationSource> configSources = ElasticApmTracerBuilder.getConfigSources("c=" + file.toAbsolutePath());
+
+        ConfigurationRegistry configurationRegistry = new ElasticApmTracerBuilder(configSources).build().getConfigurationRegistry();
         CoreConfiguration config = configurationRegistry.getConfig(CoreConfiguration.class);
         assertThat(config.isInstrument()).isFalse();
     }


### PR DESCRIPTION
## What does this PR do?

Allow to completely disable the agent on startup, even when using remote and runtime attach.

Fixes #1444 

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix

Tested locally with runtime attach.
