### PR TITLE
Fix spring app name startup exception

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -45,7 +45,8 @@ endif::[]
 * Fix `HttpUrlConnection` instrumentation issue (affecting distributed tracing as well) when using HTTPS without using
   `java.net.HttpURLConnection#disconnect` - {pull}1447[1447]
 * Fixes class loading issue that can occur when deploying multiple applications to the same application server - {pull}1458[#1458]
-* Fix ability to disable agent on startup wasn't working for runtime attach {pull}1444[1447]
+* Fix ability to disable agent on startup wasn't working for runtime attach {pull}1444[1444]
+* Avoid `UnsupportedOperationException` on some spring application startup {pull}1464[1464]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -212,7 +212,7 @@ public class ElasticApmTracer implements Tracer {
 
     private void afterTransactionStart(@Nullable ClassLoader initiatingClassLoader, Transaction transaction) {
         if (logger.isDebugEnabled()) {
-            logger.debug("startTransaction {} {", transaction);
+            logger.debug("startTransaction {}", transaction);
             if (logger.isTraceEnabled()) {
                 logger.trace("starting transaction at",
                     new RuntimeException("this exception is just used to record where the transaction has been started from"));

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
@@ -125,7 +125,7 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
             setStartTimestampNow();
         }
         if (logger.isDebugEnabled()) {
-            logger.debug("startSpan {} {", this);
+            logger.debug("startSpan {}", this);
             if (logger.isTraceEnabled()) {
                 logger.trace("starting span at",
                     new RuntimeException("this exception is just used to record where the span has been started from"));

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringServiceNameInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringServiceNameInstrumentation.java
@@ -82,7 +82,10 @@ public class SpringServiceNameInstrumentation extends TracerAwareInstrumentation
             ServletContext servletContext = applicationContext.getServletContext();
             if (servletContext != null) {
                 try {
-                    classLoader = servletContext.getClassLoader();
+                    ClassLoader servletClassloader = servletContext.getClassLoader();
+                    if (servletClassloader != null) {
+                        classLoader = servletClassloader;
+                    }
                 } catch (UnsupportedOperationException e) {
                     // silently ignored
                 }

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringServiceNameInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringServiceNameInstrumentation.java
@@ -71,9 +71,19 @@ public class SpringServiceNameInstrumentation extends TracerAwareInstrumentation
 
         @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
         public static void afterInitPropertySources(@Advice.This WebApplicationContext applicationContext) {
-            if (applicationContext.getServletContext() != null) {
-                tracer.overrideServiceNameForClassLoader(applicationContext.getServletContext().getClassLoader(), applicationContext.getEnvironment().getProperty("spring.application.name"));
+
+            String appName = applicationContext.getEnvironment().getProperty("spring.application.name", "");
+
+            // fallback when application name isn't set through an environment property
+            if (appName.isEmpty()) {
+                appName = applicationContext.getApplicationName();
+                // remove '/' (if any) from application name
+                if (appName.startsWith("/")) {
+                    appName = appName.substring(1);
+                }
             }
+
+            tracer.overrideServiceNameForClassLoader(applicationContext.getClassLoader(), appName);
         }
     }
 }

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringServiceNameInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringServiceNameInstrumentation.java
@@ -72,7 +72,11 @@ public class SpringServiceNameInstrumentation extends TracerAwareInstrumentation
 
         @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
         public static void afterInitPropertySources(@Advice.This WebApplicationContext applicationContext) {
-            // This method will be called whenever the spring application context is refreshed
+            // This method will be called whenever the spring application context is refreshed which may be more than once
+            //
+            // For example, using Tomcat Servlet container, it's called twice with the first not having a ServletContext,
+            // while the second does, and later requests are initiated with the Servlet classloader and not the application
+            // classloader.
             ClassLoader classLoader = applicationContext.getClassLoader();
 
             ServletContext servletContext = applicationContext.getServletContext();


### PR DESCRIPTION
## What does this PR do?

Deploying https://github.com/spring-petclinic/spring-framework-petclinic application on a Tomcat server 9.0.x produces the following exception on startup:

<details><summary>java.lang.UnsupportedOperationException</summary>
<p>

```
java.lang.UnsupportedOperationException: Section 4.4 of the Servlet 3.0 specification does not permit this method to be called from a ServletContextListener that was not defined in web.xml, a web-fragment.xml file
 nor annotated with @WebListener                                                                          
        at org.apache.catalina.core.StandardContext$NoPluggabilityServletContext.getClassLoader(StandardContext.java:6675)
        at co.elastic.apm.agent.springwebmvc.SpringServiceNameInstrumentation$SpringServiceNameAdvice.afterInitPropertySources(SpringServiceNameInstrumentation.java:75)
        at org.springframework.web.context.support.AbstractRefreshableWebApplicationContext.initPropertySources(AbstractRefreshableWebApplicationContext.java:214)
        at org.springframework.context.support.AbstractApplicationContext.prepareRefresh(AbstractApplicationContext.java:600)
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:519)
        at org.springframework.web.context.ContextLoader.configureAndRefreshWebApplicationContext(ContextLoader.java:401)
        at org.springframework.web.context.ContextLoader.initWebApplicationContext(ContextLoader.java:292) 
        at org.springframework.web.context.ContextLoaderListener.contextInitialized(ContextLoaderListener.java:103)
        at org.apache.catalina.core.StandardContext.listenerStart(StandardContext.java:4676)
        at org.apache.catalina.core.StandardContext.startInternal(StandardContext.java:5139)
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
        at org.apache.catalina.core.ContainerBase.addChildInternal(ContainerBase.java:717)
        at org.apache.catalina.core.ContainerBase.addChild(ContainerBase.java:690)
        at org.apache.catalina.core.StandardHost.addChild(StandardHost.java:706)        
        at org.apache.catalina.startup.HostConfig.deployWAR(HostConfig.java:978)                
        at org.apache.catalina.startup.HostConfig$DeployWar.run(HostConfig.java:1848)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)      
        at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)                                                                                                               
        at java.util.concurrent.AbstractExecutorService.submit(AbstractExecutorService.java:112)                                                                                                                             at org.apache.catalina.startup.HostConfig.deployWARs(HostConfig.java:773)
        at org.apache.catalina.startup.HostConfig.deployApps(HostConfig.java:427)                                                                                                                                    
        at org.apache.catalina.startup.HostConfig.start(HostConfig.java:1576)
        at org.apache.catalina.startup.HostConfig.lifecycleEvent(HostConfig.java:309)
        at org.apache.catalina.util.LifecycleBase.fireLifecycleEvent(LifecycleBase.java:123)
        at org.apache.catalina.util.LifecycleBase.setStateInternal(LifecycleBase.java:423)
        at org.apache.catalina.util.LifecycleBase.setState(LifecycleBase.java:366)
        at org.apache.catalina.core.ContainerBase.startInternal(ContainerBase.java:936)                                                                                                                              
        at org.apache.catalina.core.StandardHost.startInternal(StandardHost.java:843)                                                                                                                                
        at org.apache.catalina.util.LifecycleBase.start(LifecycleBase.java:183)
        at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1384)
        at org.apache.catalina.core.ContainerBase$StartChild.call(ContainerBase.java:1374)                                                                                                                           
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at org.apache.tomcat.util.threads.InlineExecutorService.execute(InlineExecutorService.java:75)
```

</p>
</details>

On top of that, we can already initialize the application name with `getApplicationName()` method on the application context.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
