### PR TITLE
implement fix for hp-ux version parsing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ endif::[]
 * Fix ignored runtime attach `config_file` {pull}1469[1469]
 * Fix `IllegalAccessError: Module 'java.base' no access to: package 'java.lang'...` in J9 VMs of Java version >= 9 -
   {pull}1468[#1468]
+* Fix JVM version parsing on HP-UX {pull}1477[#1477]
 
 ===== Refactors
 * Migrate some plugins to indy dispatcher {pull}1404[1404] {pull}1411[1411]

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
@@ -92,7 +92,7 @@ public class AgentMain {
                 msgTemplate = "WARNING : JVM version unknown or not supported, safety check disabled - %s %s %s";
             } else {
                 doDisable = true;
-                msgTemplate = "Failed to start agent - JVM version not supported: %s %s %s";
+                msgTemplate = "Failed to start agent - JVM version not supported: %s %s %s. To override Java version verification, set the "elastic.apm.disable_bootstrap_checks" System property to "true".";
             }
 
             System.err.println(String.format(msgTemplate,

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
@@ -92,7 +92,7 @@ public class AgentMain {
                 msgTemplate = "WARNING : JVM version unknown or not supported, safety check disabled - %s %s %s";
             } else {
                 doDisable = true;
-                msgTemplate = "Failed to start agent - JVM version not supported: %s %s %s. To override Java version verification, set the "elastic.apm.disable_bootstrap_checks" System property to "true".";
+                msgTemplate = "Failed to start agent - JVM version not supported: %s %s %s.\nTo override Java version verification, set the 'elastic.apm.disable_bootstrap_checks' System property to 'true'.";
             }
 
             System.err.println(String.format(msgTemplate,

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/AgentMain.java
@@ -82,9 +82,26 @@ public class AgentMain {
             // version is not supported. Agent might trigger known JVM bugs causing JVM crashes, notably on early Java 8
             // versions (but fixed in later versions), given those versions are obsolete and agent can't have workarounds
             // for JVM internals, there is no other option but to use an up-to-date JVM instead.
-            System.err.println(String.format("Failed to start agent - JVM version not supported: %s %s %s",
+
+            String msgTemplate;
+
+            boolean doDisable;
+            if (Boolean.parseBoolean(System.getProperty("elastic.apm.disable_bootstrap_checks"))) {
+                // safety check disabled, warn end user that it might
+                doDisable = false;
+                msgTemplate = "WARNING : JVM version unknown or not supported, safety check disabled - %s %s %s";
+            } else {
+                doDisable = true;
+                msgTemplate = "Failed to start agent - JVM version not supported: %s %s %s";
+            }
+
+            System.err.println(String.format(msgTemplate,
                 JvmRuntimeInfo.getJavaVersion(), JvmRuntimeInfo.getJavaVmName(), JvmRuntimeInfo.getJavaVmVersion()));
-            return;
+
+            if (doDisable) {
+                return;
+            }
+
         }
 
         try {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/JvmRuntimeInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/JvmRuntimeInfo.java
@@ -38,6 +38,7 @@ public class JvmRuntimeInfo {
     private static boolean isHotSpot;
     private static boolean isIbmJ9;
     private static boolean isJ9;
+    private static boolean isHpUx;
 
     static {
         parseVmInfo(System.getProperty("java.version"), System.getProperty("java.vm.name"), System.getProperty("java.vm.version"));
@@ -57,6 +58,16 @@ public class JvmRuntimeInfo {
         javaVmName = vmName;
         javaVmVersion = vmVersion;
 
+        isHotSpot = vmName.contains("HotSpot(TM)") || vmName.contains("OpenJDK");
+        isIbmJ9 = vmName.contains("IBM J9");
+        isJ9 = vmName.contains("J9");
+        isHpUx = version.endsWith("-hp-ux");
+
+        if (isHpUx) {
+            // remove extra hp-ux suffix for parsing
+            version = version.substring(0, version.length() - 6);
+        }
+
         // new scheme introduced in java 9, thus we can use it as a shortcut
         if (version.startsWith("1.")) {
             majorVersion = Character.digit(version.charAt(2), 10);
@@ -71,8 +82,18 @@ public class JvmRuntimeInfo {
 
         int updateIndex = version.lastIndexOf("_");
         if (updateIndex <= 0) {
-            // GA release like '1.8.0'
-            updateVersion = 0;
+
+            if (isHpUx) {
+                try {
+                    updateVersion = Integer.parseInt(version.substring(version.lastIndexOf('.') + 1));
+                } catch (NumberFormatException e) {
+                    updateVersion = -1;
+                }
+            } else {
+                // GA release like '1.8.0'
+                updateVersion = 0;
+            }
+
         } else {
             String updateVersionString;
             int versionSuffixIndex = version.indexOf('-', updateIndex + 1);
@@ -85,14 +106,15 @@ public class JvmRuntimeInfo {
                 updateVersion = Integer.parseInt(updateVersionString);
             } catch (NumberFormatException e) {
                 // in case of unknown format, we just support by default
-                System.err.println("Unsupported format of the java.version system property - " + version);
+
                 updateVersion = -1;
             }
         }
 
-        isHotSpot = vmName.contains("HotSpot(TM)") || vmName.contains("OpenJDK");
-        isIbmJ9 = vmName.contains("IBM J9");
-        isJ9 = vmName.contains("J9");
+        if (updateVersion < 0) {
+            System.err.println("Unsupported format of the java.version system property - " + version);
+        }
+
     }
 
     public static String getJavaVersion() {
@@ -114,6 +136,10 @@ public class JvmRuntimeInfo {
 
     public static boolean isJ9VM() {
         return isJ9;
+    }
+
+    public static boolean isIsHpUx(){
+        return isHpUx;
     }
 
     /**
@@ -144,12 +170,19 @@ public class JvmRuntimeInfo {
             return true;
         }
 
+        // versions prior to that have unreliable invoke dynamic support according to https://groovy-lang.org/indy.html
+        int java7min = 60;
+        int java8min = 40;
+        if (isIsHpUx()) {
+            java7min = 10; // hotspot 7u65
+            java8min = 2; // hotspot 8u45
+        }
+
         switch (majorVersion) {
             case 7:
-                // versions prior to that have unreliable invoke dynamic support according to https://groovy-lang.org/indy.html
-                return updateVersion >= 60;
+                return updateVersion >= java7min;
             case 8:
-                return updateVersion >= 40;
+                return updateVersion >= java8min;
             default:
                 return true;
         }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JvmRuntimeInfoTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JvmRuntimeInfoTest.java
@@ -26,7 +26,6 @@ package co.elastic.apm.agent.util;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.List;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -146,8 +145,26 @@ class JvmRuntimeInfoTest {
     void testIbmJava8SupportedAfterBuild2_8() {
         JvmRuntimeInfo.parseVmInfo("1.8.0", "IBM J9 VM", "2.8");
         assertThat(JvmRuntimeInfo.isJavaVersionSupported()).isFalse();
+        assertThat(JvmRuntimeInfo.isJ9VM()).isTrue();
         JvmRuntimeInfo.parseVmInfo("1.8.0", "IBM J9 VM", "2.9");
         assertThat(JvmRuntimeInfo.isJavaVersionSupported()).isTrue();
+        assertThat(JvmRuntimeInfo.isJ9VM()).isTrue();
+    }
+
+    @Test
+    void testHpUxSupport() {
+        checkHpUx("1.8.0.1-hp-ux", "1.8.0.2-hp-ux");
+        checkHpUx("1.7.0.9-hp-ux", "1.7.0.10-hp-ux");
+    }
+
+    private static void checkHpUx(String unsupportedVersion, String supportedVersion){
+        JvmRuntimeInfo.parseVmInfo(unsupportedVersion, HOTSPOT_VM_NAME, null);
+        assertThat(JvmRuntimeInfo.isJavaVersionSupported()).isFalse();
+        assertThat(JvmRuntimeInfo.isIsHpUx()).isTrue();
+
+        JvmRuntimeInfo.parseVmInfo(supportedVersion, HOTSPOT_VM_NAME, null);
+        assertThat(JvmRuntimeInfo.isJavaVersionSupported()).isTrue();
+        assertThat(JvmRuntimeInfo.isIsHpUx()).isTrue();
     }
 
     private static void checkSupported(String vmName, Stream<String> versions) {

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -63,8 +63,12 @@ Similarly, Java 7 versions before update 60 are not supported as they are buggy 
 
 Here is an example of the message displayed when this happens.
 ```
-Failed ot start agent - JVM version not supported: 1.8.0_31
+Failed to start agent - JVM version not supported: 1.8.0_31 Java HotSpot(TM) 64-Bit Server VM 25.31-b07.
+To override Java version verification, set the 'elastic.apm.disable_bootstrap_checks' System property to 'true'.
 ```
+
+As this message states, you can disable this check if required by adding `-Delastic.apm.disable_bootstrap_checks` to
+the JVM arguments.
 
 
 [float]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -52,7 +52,11 @@ the agent does not capture transactions.
 |`--module-path` has not been tested yet
 
 |IBM J9 VM
-|8 service refresh 5+
+|8 service refresh 5+ (build 2.8)
+|
+
+|HP-UX JVM
+| 7.0.10+, 8.0.02+
 |
 |===
 


### PR DESCRIPTION
## What does this PR do?

Fixes #1474 

Add an extra runtime property `elastic.apm.disable_bootstrap_checks` that allows to bypass JVM version check when it's value is set to `true`.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
  - [x] I have updated [supported JVM version docs](https://www.elastic.co/guide/en/apm/agent/java/current/supported-technologies-details.html#supported-java-versions)
  - [x] I have documented the `elastic.apm.disable_bootstrap_checks` flag