### PR TITLE
Move main load test pipeline to linux worker

### DIFF
--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -1,6 +1,6 @@
 // For documentation on this pipeline, please see the README.md in this directory
 pipeline {
-    agent any
+    agent { label 'linux && immutable' }
     environment {
         REPO = 'apm-agent-java'
         APP = 'spring-petclinic'


### PR DESCRIPTION
## What does this PR do?

Runs the orchestration layer, which manages the load-generation and the application, on a regular linux worker instead of the jenkins master itself. This should get us around needing to install things like `jq` on the Jenkins masters, as shown here: https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-load/2/console