### PR TITLE
Fix typo in label name for load-gen pipeline

### DIFF
--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -62,7 +62,7 @@ pipeline {
                     }
                 }
                 stage('Test application') {
-                    agent { label 'benchmark' }
+                    agent { label 'benchmarks' }
                     stages{
                         stage('Provision Java') {
                             steps {


### PR DESCRIPTION
## What does this PR do?

I thought originally that this was labeled as `benchmark` but it is actually `benchmarks`: https://apm-ci.elastic.co/computer/worker-1213919/