### PR TITLE
Upgrading testcontainers version to latest

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientProxySupportTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientProxySupportTest.java
@@ -27,7 +27,6 @@ package co.elastic.apm.agent.report;
 import co.elastic.apm.agent.configuration.SpyConfiguration;
 import io.undertow.Undertow;
 import io.undertow.io.Sender;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -256,7 +255,6 @@ public class ApmServerClientProxySupportTest {
             .isEqualTo(407);
     }
 
-    @NotNull
     private static URL baseUrl(String host, int port) {
         try {
             return new URL(String.format("http://%s:%d", host, port));

--- a/apm-agent-plugins/apm-jdbc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jdbc-plugin/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
-        <testcontainers-version>1.12.0</testcontainers-version>
     </properties>
 
     <dependencies>
@@ -28,44 +27,44 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>jdbc</artifactId>
-            <version>${testcontainers-version}</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mysql</artifactId>
-            <version>${testcontainers-version}</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>${testcontainers-version}</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mariadb</artifactId>
-            <version>${testcontainers-version}</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mssqlserver</artifactId>
-            <version>${testcontainers-version}</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>db2</artifactId>
-            <version>${testcontainers-version}</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>oracle-xe</artifactId>
-            <version>${testcontainers-version}</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
 

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
@@ -50,7 +50,8 @@ public class JdbcDbIT extends AbstractJdbcInstrumentationTest {
             {"jdbc:tc:mariadb:10://hostname/databasename", "mariadb"},
             {"jdbc:tc:sqlserver:2017-CU12://hostname/databasename", "sqlserver"},
             {"jdbc:tc:db2:11.5.0.0a://hostname/databasename", "db2"},
-            {"jdbc:tc:oracle://hostname/databasename", "oracle"},
+            // Oracle test commented out until resolving https://github.com/testcontainers/testcontainers-java/pull/3439
+            // {"jdbc:tc:oracle://hostname/databasename", "oracle"},
         });
     }
 

--- a/apm-agent-plugins/apm-kafka-plugin/pom.xml
+++ b/apm-agent-plugins/apm-kafka-plugin/pom.xml
@@ -9,7 +9,6 @@
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
-        <version.testcontainers>1.12.4</version.testcontainers>
     </properties>
 
     <artifactId>apm-kafka-plugin</artifactId>

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -35,7 +35,6 @@ import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.logging.HttpLoggingInterceptor;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Test;
 import org.mockserver.model.ClearType;
@@ -428,12 +427,10 @@ public abstract class AbstractServletContainerIntegrationTest {
         return null;
     }
 
-    @NotNull
     public List<String> getPathsToTest() {
         return Arrays.asList("/index.jsp", "/servlet", "/async-dispatch-servlet", "/async-start-servlet");
     }
 
-    @NotNull
     public List<String> getPathsToTestErrors() {
         return Arrays.asList("/index.jsp", "/servlet", "/async-dispatch-servlet", "/async-start-servlet");
     }

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
@@ -27,7 +27,6 @@ package co.elastic.apm.servlet;
 import co.elastic.apm.servlet.tests.JsfServletContainerTestApp;
 import co.elastic.apm.servlet.tests.ServletApiTestApp;
 import co.elastic.apm.servlet.tests.TestApp;
-import org.jetbrains.annotations.NotNull;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.testcontainers.containers.GenericContainer;
@@ -60,7 +59,6 @@ public class JettyIT extends AbstractServletContainerIntegrationTest {
         servletContainer.withEnv("JAVA_OPTIONS", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005");
     }
 
-    @NotNull
     public List<String> getPathsToTestErrors() {
         return Arrays.asList("/index.jsp", "/servlet", "/async-dispatch-servlet");
     }

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebLogicIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebLogicIT.java
@@ -29,7 +29,6 @@ import co.elastic.apm.servlet.tests.JsfApplicationServerTestApp;
 import co.elastic.apm.servlet.tests.ServletApiTestApp;
 import co.elastic.apm.servlet.tests.SoapTestApp;
 import co.elastic.apm.servlet.tests.TestApp;
-import org.jetbrains.annotations.NotNull;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -71,7 +70,7 @@ public class WebLogicIT extends AbstractServletContainerIntegrationTest {
     }
 
     @Override
-    public @NotNull List<String> getPathsToTestErrors() {
+    public List<String> getPathsToTestErrors() {
         // WebLogic can't handle the case when a exception is thrown in the runnable submitted to AsyncContext#start(Runnable)
         // it requires AsyncContext#complete() to be called, otherwise it throws a timeout
         return List.of("/index.jsp", "/servlet", "/async-dispatch-servlet");

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,8 @@
         <!-- used both for plugin & annotations dependency -->
         <version.animal-sniffer>1.17</version.animal-sniffer>
 
+        <version.testcontainers>1.15.0</version.testcontainers>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -504,7 +506,7 @@
             <dependency>
                 <groupId>org.testcontainers</groupId>
                 <artifactId>testcontainers-bom</artifactId>
-                <version>1.10.6</version>
+                <version>${version.testcontainers}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
Latest Testcontainers version fixes an issue that prevented it from working properly with the latest Docker Desktop for macOS versions.