### PR TITLE
Update Hibernate Search 6 instrumentation to the latest CR

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ endif::[]
 * Add Sampling Profiler support for AArch64 architectures - {pull}1443[1443]
 * Support proper transaction naming when using Spring's `ServletWrappingController` - {pull}1461[#1461]
 * Update async-profiler to 1.8.2 {pull}1471[1471]
+* Update existing Hibernate Search 6 instrumentation to work with the latest CR1 release
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
@@ -12,7 +12,7 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <version.hibernate.search>6.0.0.Alpha6</version.hibernate.search>
+        <version.hibernate.search>6.0.0.CR1</version.hibernate.search>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
 

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch6Instrumentation.java
@@ -61,13 +61,13 @@ public class HibernateSearch6Instrumentation extends TracerAwareInstrumentation 
     @Override
     public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
         return not(isBootstrapClassLoader())
-            .and(classLoaderCanLoadClass("org.hibernate.search.engine.search.query.SearchFetchable"));
+            .and(classLoaderCanLoadClass("org.hibernate.search.engine.search.query.SearchQuery"));
     }
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
         return not(isInterface())
-            .and(hasSuperType(named("org.hibernate.search.engine.search.query.SearchFetchable")));
+            .and(hasSuperType(named("org.hibernate.search.engine.search.query.SearchQuery")));
     }
 
     @Override
@@ -86,7 +86,7 @@ public class HibernateSearch6Instrumentation extends TracerAwareInstrumentation 
         public static Object onBeforeExecute(@Advice.This SearchQuery<?> query,
                                              @Advice.Origin("#m") String methodName) {
 
-            return HibernateSearchHelper.createAndActivateSpan(tracer, methodName, query.getQueryString());
+            return HibernateSearchHelper.createAndActivateSpan(tracer, methodName, query.queryString());
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernatesearch/Dog.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernatesearch/Dog.java
@@ -24,6 +24,7 @@
  */
 package co.elastic.apm.agent.hibernatesearch;
 
+import org.hibernate.search.engine.backend.types.Sortable;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.GenericField;
 import org.hibernate.search.mapper.pojo.mapping.definition.annotation.Indexed;
 
@@ -40,7 +41,7 @@ public class Dog {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @GenericField
+    @GenericField(sortable = Sortable.YES)
     private String name;
 
     public Dog() {

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernatesearch/EntityManagerFactoryHelper.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernatesearch/EntityManagerFactoryHelper.java
@@ -35,9 +35,9 @@ public class EntityManagerFactoryHelper {
 
     public static EntityManagerFactory buildEntityManagerFactory(final Path tempDirectory) {
         Map<String, Object> configOverrides = new HashMap<>();
-        configOverrides.put("hibernate.search.backends.testBackend.type", "lucene");
-        configOverrides.put("hibernate.search.backends.testBackend.directory_provider", "local_directory");
-        configOverrides.put("hibernate.search.backends.testBackend.root_directory", tempDirectory.toAbsolutePath().toString());
+        configOverrides.put("hibernate.search.backend.testBackend.type", "lucene");
+        configOverrides.put("hibernate.search.backend.testBackend.directory.type", "local-filesystem");
+        configOverrides.put("hibernate.search.backend.directory.root", tempDirectory.toAbsolutePath().toString());
         configOverrides.put("hibernate.search.default_backend", "testBackend");
         return Persistence.createEntityManagerFactory("templatePU", configOverrides);
     }

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch6InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch6InstrumentationTest.java
@@ -59,7 +59,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
     @BeforeAll
     static void setUp() throws IOException {
-        tempDirectory = Files.createTempDirectory("HibernateSearch6nstrumentationTest");
+        tempDirectory = Files.createTempDirectory("HibernateSearch6InstrumentationTest");
         entityManagerFactory = EntityManagerFactoryHelper.buildEntityManagerFactory(tempDirectory);
         entityManager = entityManagerFactory.createEntityManager();
         saveDogsToIndex();

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch6InstrumentationTest.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/test/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch6InstrumentationTest.java
@@ -25,10 +25,12 @@
 package co.elastic.apm.agent.hibernatesearch;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
-import org.hibernate.search.engine.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.engine.search.query.SearchResult;
+import org.hibernate.search.engine.search.query.dsl.SearchQueryOptionsStep;
+import org.hibernate.search.engine.search.query.dsl.SearchQuerySelectStep;
 import org.hibernate.search.mapper.orm.Search;
-import org.hibernate.search.mapper.orm.search.dsl.query.HibernateOrmSearchQueryResultDefinitionContext;
+import org.hibernate.search.mapper.orm.common.EntityReference;
+import org.hibernate.search.mapper.orm.search.loading.dsl.SearchLoadingOptionsStep;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -57,7 +59,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
     @BeforeAll
     static void setUp() throws IOException {
-        tempDirectory = Files.createTempDirectory("HibernateSearch5InstrumentationTest");
+        tempDirectory = Files.createTempDirectory("HibernateSearch6nstrumentationTest");
         entityManagerFactory = EntityManagerFactoryHelper.buildEntityManagerFactory(tempDirectory);
         entityManager = entityManagerFactory.createEntityManager();
         saveDogsToIndex();
@@ -82,22 +84,22 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
     @Test
     void performLuceneIndexSearch() {
-        List<Dog> result = createMatchNameSearch("dog1").fetchHits();
+        List<Dog> result = createMatchNameSearch("dog1").fetchAllHits();
 
         assertAll(() -> {
             assertThat(result.size()).isEqualTo(1);
             assertThat(result.get(0).getName()).isEqualTo("dog1");
-            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetchHits");
+            assertApmSpanInformation(reporter, "+name:dog1", "fetchAllHits");
         });
     }
 
     @Test
     void performMultiResultLuceneIndexSearch() {
-        List<Dog> result = createWildcardNameSearch().fetchHits();
+        List<Dog> result = createWildcardNameSearch().fetchAllHits();
 
         assertAll(() -> {
             assertThat(result.size()).isEqualTo(2);
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetchHits");
+            assertApmSpanInformation(reporter, "+name:dog*", "fetchAllHits");
         });
     }
 
@@ -108,7 +110,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         assertAll(() -> {
             assertThat(result.size()).isEqualTo(1);
             assertThat(result.get(0).getName()).isEqualTo("dog1");
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetchHits");
+            assertApmSpanInformation(reporter, "+name:dog*", "fetchHits");
         });
     }
 
@@ -119,7 +121,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         assertAll(() -> {
             assertThat(result.size()).isEqualTo(1);
             assertThat(result.get(0).getName()).isEqualTo("dog2");
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetchHits");
+            assertApmSpanInformation(reporter, "+name:dog*", "fetchHits");
         });
     }
 
@@ -129,30 +131,30 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
 
         assertAll(() -> {
             assertThat(resultCount).isEqualTo(1);
-            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetchTotalHitCount");
+            assertApmSpanInformation(reporter, "+name:dog1", "fetchTotalHitCount");
         });
     }
 
     @Test
     void performLuceneIndexSearchWithSearchResult() {
-        SearchResult<Dog> result = createMatchNameSearch("dog1").fetch();
+        SearchResult<Dog> result = createMatchNameSearch("dog1").fetchAll();
 
         assertAll(() -> {
-            assertThat(result.getHits().size()).isEqualTo(1);
-            assertThat(result.getTotalHitCount()).isEqualTo(1);
-            assertThat(result.getHits().get(0).getName()).isEqualTo("dog1");
-            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetch");
+            assertThat(result.hits().size()).isEqualTo(1);
+            assertThat(result.total().hitCount()).isEqualTo(1);
+            assertThat(result.hits().get(0).getName()).isEqualTo("dog1");
+            assertApmSpanInformation(reporter, "+name:dog1", "fetchAll");
         });
     }
 
     @Test
     void performMultiResultLuceneIndexSearchWithSearchResult() {
-        SearchResult<Dog> result = createWildcardNameSearch().fetch();
+        SearchResult<Dog> result = createWildcardNameSearch().fetchAll();
 
         assertAll(() -> {
-            assertThat(result.getHits().size()).isEqualTo(2);
-            assertThat(result.getTotalHitCount()).isEqualTo(2);
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetch");
+            assertThat(result.hits().size()).isEqualTo(2);
+            assertThat(result.total().hitCount()).isEqualTo(2);
+            assertApmSpanInformation(reporter, "+name:dog*", "fetchAll");
         });
     }
 
@@ -161,10 +163,10 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         SearchResult<Dog> result = createWildcardNameSearch().fetch(1);
 
         assertAll(() -> {
-            assertThat(result.getHits().size()).isEqualTo(1);
-            assertThat(result.getTotalHitCount()).isEqualTo(2);
-            assertThat(result.getHits().get(0).getName()).isEqualTo("dog1");
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetch");
+            assertThat(result.hits().size()).isEqualTo(1);
+            assertThat(result.total().hitCount()).isEqualTo(2);
+            assertThat(result.hits().get(0).getName()).isEqualTo("dog1");
+            assertApmSpanInformation(reporter, "+name:dog*", "fetch");
         });
     }
 
@@ -173,10 +175,10 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         SearchResult<Dog> result = createWildcardNameSearch().fetch(1, 1);
 
         assertAll(() -> {
-            assertThat(result.getHits().size()).isEqualTo(1);
-            assertThat(result.getTotalHitCount()).isEqualTo(2);
-            assertThat(result.getHits().get(0).getName()).isEqualTo("dog2");
-            assertApmSpanInformation(reporter, "+name:dog* #__HSEARCH_type:main", "fetch");
+            assertThat(result.hits().size()).isEqualTo(1);
+            assertThat(result.total().hitCount()).isEqualTo(2);
+            assertThat(result.hits().get(0).getName()).isEqualTo("dog2");
+            assertApmSpanInformation(reporter, "+name:dog*", "fetch");
         });
     }
 
@@ -187,7 +189,7 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         assertThat(result.isPresent()).isTrue();
         assertAll(() -> {
             assertThat(result.get().getName()).isEqualTo("dog1");
-            assertApmSpanInformation(reporter, "+name:dog1 #__HSEARCH_type:main", "fetchSingleHit");
+            assertApmSpanInformation(reporter, "+name:dog1", "fetchSingleHit");
         });
     }
 
@@ -196,21 +198,22 @@ class HibernateSearch6InstrumentationTest extends AbstractInstrumentationTest {
         Optional<Dog> result = createMatchNameSearch("dog1234").fetchSingleHit();
 
         assertThat(result.isPresent()).isFalse();
-        assertAll(() -> assertApmSpanInformation(reporter, "+name:dog1234 #__HSEARCH_type:main", "fetchSingleHit"));
+        assertAll(() -> assertApmSpanInformation(reporter, "+name:dog1234", "fetchSingleHit"));
     }
 
-    private SearchQueryContext<?, Dog, ?> createMatchNameSearch(final String dogName) {
+    private SearchQueryOptionsStep<?, Dog, SearchLoadingOptionsStep, ?, ?> createMatchNameSearch(final String dogName) {
         return createDogSearch()
-            .predicate(f -> f.match().onField("name").matching(dogName));
+            .where(f -> f.match().field("name").matching(dogName));
     }
 
-    private SearchQueryContext<?, Dog, ?> createWildcardNameSearch() {
+    private SearchQueryOptionsStep<?, Dog, SearchLoadingOptionsStep, ?, ?> createWildcardNameSearch() {
         return createDogSearch()
-            .predicate(f -> f.wildcard().onField("name").matching("dog*"));
+            .where(f -> f.wildcard().field("name").matching("dog*"))
+            .sort(searchSortFactory -> searchSortFactory.field("name").asc());
     }
 
-    private HibernateOrmSearchQueryResultDefinitionContext<Dog> createDogSearch() {
-        return Search.getSearchSession(entityManager)
+    private SearchQuerySelectStep<?, EntityReference, Dog, SearchLoadingOptionsStep, ?, ?> createDogSearch() {
+        return Search.session(entityManager)
             .search(Dog.class);
     }
 


### PR DESCRIPTION
## What does this PR do?

Since the first CR is released for the upcoming Hibernate Search 6 version I thought it would be a good time to revisit the existing instrumentation and update it to work with the latest version. According to the release blog post [here](https://in.relation.to/2020/11/04/hibernate-search-6-0-0-CR1/) there aren't any changes planned for the final release so this might also work when the final version is released.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
