### PR TITLE
Avoid inter-thread context propagation for JMS polling transactions

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
@@ -69,6 +69,13 @@ public abstract class AbstractSpan<T extends AbstractSpan<T>> implements Recycla
      * Flag to mark a span as representing an exit event
      */
     private boolean isExit;
+
+    /**
+     * Flag to mark this span as such that should not be activated on a different thread if active when inter-thread
+     * context propagation is attempted.
+     */
+    private boolean asyncPropagationDisabled;
+
     /**
      * <p>
      * This use case for child ids is modifying parent/child relationships for profiler-inferred spans.
@@ -324,6 +331,7 @@ public abstract class AbstractSpan<T extends AbstractSpan<T>> implements Recycla
         namePriority = PRIO_DEFAULT;
         discardRequested = false;
         isExit = false;
+        asyncPropagationDisabled = false;
         childIds = null;
     }
 
@@ -359,6 +367,14 @@ public abstract class AbstractSpan<T extends AbstractSpan<T>> implements Recycla
         return isExit;
     }
 
+    public T disableAsyncPropagation() {
+        asyncPropagationDisabled = true;
+        return (T) this;
+    }
+
+    public boolean isAsyncPropagationDisabled() {
+        return asyncPropagationDisabled;
+    }
 
     public void captureException(long epochMicros, Throwable t) {
         tracer.captureAndReportException(epochMicros, t, this);

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/JavaConcurrent.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/JavaConcurrent.java
@@ -81,7 +81,7 @@ public class JavaConcurrent {
         }
         needsContext.set(Boolean.FALSE);
         AbstractSpan<?> active = tracer.getActive();
-        if (active == null) {
+        if (active == null || active.isAsyncPropagationDisabled()) {
             return runnable;
         }
         if (isLambda(runnable)) {
@@ -109,7 +109,7 @@ public class JavaConcurrent {
         }
         needsContext.set(Boolean.FALSE);
         AbstractSpan<?> active = tracer.getActive();
-        if (active == null) {
+        if (active == null || active.isAsyncPropagationDisabled()) {
             return callable;
         }
         if (isLambda(callable)) {
@@ -126,7 +126,7 @@ public class JavaConcurrent {
         }
         needsContext.set(Boolean.FALSE);
         AbstractSpan<?> active = tracer.getActive();
-        if (active == null) {
+        if (active == null || active.isAsyncPropagationDisabled()) {
             return task;
         }
         captureContext(task, active);

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
@@ -228,6 +228,10 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                     if (messageHandlingTransaction != null) {
                         messageHandlingTransaction.withType(MESSAGE_HANDLING)
                             .withName(RECEIVE_NAME_PREFIX)
+                            // These transactions get a temporary "message-handling" type and left active on the thread
+                            // to be ended when the thread does the next polling for another message. It is a heuristic
+                            // approach that may produce inaccuracies, but in any case, only the activating thread should be able
+                            // to end and deactivate these transactions, otherwise consequences are unpredictable.
                             .disableAsyncPropagation();
 
                         if (destinationName != null) {

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
@@ -227,7 +227,8 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                     Transaction messageHandlingTransaction = helper.startJmsTransaction(message, clazz);
                     if (messageHandlingTransaction != null) {
                         messageHandlingTransaction.withType(MESSAGE_HANDLING)
-                            .withName(RECEIVE_NAME_PREFIX);
+                            .withName(RECEIVE_NAME_PREFIX)
+                            .disableAsyncPropagation();
 
                         if (destinationName != null) {
                             messageHandlingTransaction.appendToName(" from ");

--- a/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
@@ -64,7 +64,6 @@ public class JmsMessageListenerInstrumentation extends BaseJmsInstrumentation {
         return not(isInterface())
             .and(
                 hasSuperType(named("javax.jms.MessageListener"))
-                    .or(hasSuperType(named("org.springframework.jms.listener.SessionAwareMessageListener")))
             );
     }
 

--- a/apm-agent-plugins/apm-jms-plugin/src/test/resources/app-context.xml
+++ b/apm-agent-plugins/apm-jms-plugin/src/test/resources/app-context.xml
@@ -34,6 +34,7 @@
         <property name="connectionFactory" ref="connectionFactory"/>
         <property name="destinationName" value="Spring-Test-Queue"/>
         <property name="messageListener" ref="springMapMessageListener"/>
+        <property name="concurrentConsumers" value="5"/>
     </bean>
 
 </beans>


### PR DESCRIPTION
## What does this PR do?
Fixes an issue reported in [the forum](https://discuss.elastic.co/t/invalid-transactions-grouping-with-activemq/252678).
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
