### PR TITLE
[dependabot] enable for maven multimodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,21 @@ updates:
     open-pull-requests-limit: 3
     reviewers:
       - "@elastic/apm-agent-java"
+    allow:
+      - dependency-name: "react*"
+      - dependency-name: "com.lmax:disruptor"
+      - dependency-name: "org.jctools:jctools-core"
+      - dependency-name: "co.elastic.logging:log4j2-ecs-layout"
+      - dependency-name: "org.testcontainers:testcontainers"
+      - dependency-name: "org.junit.jupiter:*"
+      - dependency-name: "junit:junit"
+      - dependency-name: "org.junit.vintage:*"
+      - dependency-name: "org.assertj:assertj-core"
+      - dependency-name: "org.mockito:mockito-core"
+      - dependency-name: "com.networknt:json-schema-validator"
+      - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
+      - dependency-name: "org.eclipse.jetty:jetty-servlet"
+      - dependency-name: "com.github.tomakehurst:wiremock-standalone"
+      - dependency-name: "org.awaitility:awaitility"
+      - dependency-name: "org.apache.ivy:ivy"
+      - dependency-name: "org.testcontainers:testcontainers"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "@elastic/apm-agent-java"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
     reviewers:
       - "@elastic/apm-agent-java"
     allow:
-      - dependency-name: "react*"
       - dependency-name: "com.lmax:disruptor"
       - dependency-name: "org.jctools:jctools-core"
       - dependency-name: "co.elastic.logging:log4j2-ecs-layout"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,3 +25,5 @@ updates:
       - dependency-name: "org.awaitility:awaitility"
       - dependency-name: "org.apache.ivy:ivy"
       - dependency-name: "org.testcontainers:testcontainers"
+      - dependency-name: "net.bytebuddy:*"
+      - dependency-name: "org.ow2.asm:asm-tree"


### PR DESCRIPTION
## What does this PR do?

Enable `dependabot` that runs on a weekly basis and create up to 3 different PRs at once.

Further details -> https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/configuration-options-for-dependency-updates#about-the-dependabotyml-file

What are your thoughts?

## Checklist

For internal use