### PR TITLE
[automation] Correct difference in newline determination

### DIFF
--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -44,7 +44,7 @@
 
 CATALOG_URL="https://jvm-catalog.elastic.co/jdks"
 
-read -r SDK_URL SDK_FILENAME <<<$(curl -s $CATALOG_URL|jq -Mr '.['\"$1\"'].url, .['\"$1\"'].filename')
+read -d'\n' -r SDK_URL SDK_FILENAME <<<$(curl -s $CATALOG_URL|jq -Mr '.['\"$1\"'].url, .['\"$1\"'].filename')
 
 curl -s -o $SDK_FILENAME $SDK_URL
 


### PR DESCRIPTION
## What does this PR do?
The version of bash running on the Jenkins workers has a slightly different way of calculating the newline than seems to be normal. This forces the script to recognize a carriage return as the delimiter. 

This fixes errors such as the following: https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-java%2Fapm-agent-java-load/detail/apm-agent-java-load/4/pipeline/113/

