### PR TITLE
[load-testing] Use standard port on orchestrator

### DIFF
--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -7,7 +7,7 @@ pipeline {
         APP_BASE_DIR = "src/${APP}"
         METRICS_BASE_DIR="metrics/"
         AGENT_BASE_DIR = "agent/"
-        ORCH_URL = 'obs-load-orch.app.elastic.co:8000'
+        ORCH_URL = 'https://obs-load-orch.app.elastic.co'
         // Set below for local development
         // ORCH_URL='10.0.2.2:8000'
         DEBUG_MODE = '0' // set to '0' for production


### PR DESCRIPTION
## What does this PR do?
Just swing over to the standard URL/port for the orchestrator now that is it in production.