### PR TITLE
[load-test] Account for no domain set in workers

### DIFF
--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -79,7 +79,7 @@ function sendAppReady() {
     "{\"app_token\": \""$APP_TOKEN"\", \
     \"session_token\": \""$SESSION_TOKEN"\", \
     \"service\": \"application\", \
-    \"hostname\": \""$(hostname)"\", \
+    \"hostname\": \""$(hostname -I|cut -f1 -d ' ')"\", \
     \"port\": \"8080\"}" \
     $ORCH_URL/api/ready 
     


### PR DESCRIPTION
## What does this PR do?
It appears that the bare-metal workers do not consistently have their domain name set. 

To work around this, let's use the IP address instead.