### PR TITLE
[load-generation] Remove hard-coded test run time

### DIFF
--- a/.ci/load/scripts/load_agent.sh
+++ b/.ci/load/scripts/load_agent.sh
@@ -104,7 +104,6 @@ function buildArgs() {
         $ORCH_URL/api/poll | \
         jq '.services.application.port')"
     export LOCUST_HOST=http://$(echo $LOCUST_HOSTNAME|sed 's/"//g'):$(echo $LOCUST_PORT|sed 's/"//g')
-    export LOCUST_RUN_TIME=30s
 }
 
 function startLoad() {


### PR DESCRIPTION
## What does this PR do?
Removes a hard-coded 30s timeout for the tests to use what's passed in from the params.
