### PR TITLE
[load test] Improve handling of non-2xx responses in load generation

### DIFF
--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         DEBUG_MODE = '0' // set to '0' for production
         LOCUST_RUN_TIME = "${params.duration}"
         LOCUST_USERS = "${params.concurrent_requests}"
-
+        LOCUST_IGNORE_ERRORS = "${params.ignore_application_errors}"
     }
     options {
         timeout(time: 72, unit: 'HOURS')
@@ -34,6 +34,7 @@ pipeline {
         text(name: "agent_config", "defaultValue": "", description: "Custom APM Agent configuration. (WARNING: May echo to console. Do not supply sensitive data.)")
         text(name: "locustfile", "defaultValue": "", description: "Locust load-generator plan")
         booleanParam(name: "local_metrics", description: "Enable local metrics collection?", defaultValue: false)
+        booleanParam(name: "ignore_application_errors", description: "Instruct the load generator to ignore non-2xx errors on exit", defaultValue: true)
         // End script auto-generation
     }
 
@@ -51,14 +52,16 @@ pipeline {
                 stage('Load generation') {
                     agent { label 'metal' }
                     steps {
-                            withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
-                                echo 'Preparing load generation..'
-                                whenTrue(Boolean.valueOf(params.locustfile)) {
-                                    echo 'Using user-supplied plan for load-generation with Locust'
-                                    sh script: "echo \"${params.locustfile}\">.ci/load/scripts/locustfile.py"
-                                }
+                        withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
+                            echo 'Preparing load generation..'
+                            whenTrue(Boolean.valueOf(params.locustfile)) {
+                                echo 'Using user-supplied plan for load-generation with Locust'
+                                sh script: "echo \"${params.locustfile}\">.ci/load/scripts/locustfile.py"
+                            }
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
                                 sh(script: ".ci/load/scripts/load_agent.sh")
                             }
+                        }
                     }
                 }
                 stage('Test application') {

--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -161,7 +161,7 @@ function tearDown() {
 }
 
 if [ ! $DEBUG_MODE ]; then
-trap "tearDown" EXIT
+    trap "tearDown" ERR EXIT
     setUp
 fi
 waitForApp

--- a/.ci/load/scripts/param_gen/gen_params.py
+++ b/.ci/load/scripts/param_gen/gen_params.py
@@ -126,6 +126,7 @@ print(
     'text(name: "agent_config", "defaultValue": "", description: "Custom APM Agent configuration. (WARNING: May echo to console. Do not supply sensitive data.)")',  # noqa E501
     'text(name: "locustfile", "defaultValue": "", description: "Locust load-generator plan")',  # noqa E5011
     'booleanParam(name: "local_metrics", description: "Enable local metrics collection?", defaultValue: false)',  # noqa E501
+    'booleanParam(name: "ignore_application_errors", description: "Instruct the load generator to ignore non-2xx errors on exit", defaultValue: true)',  # noqa E501
     '// End script auto-generation',
     sep="\n"
 )


### PR DESCRIPTION
## What does this PR do?
Fixes an issue where the load generation step would fail if the application returned a non 2xx HTTP error code.

This improves the handling of that condition so that Locust will no longer fail the build if this situation is encountered. Instead, it will continue normally if this happens and the stage will pass. 

Additionally, a new option was introduced which allows the user to de-select an option to ignore errors. If this flag is turned off, any non 2xx errors will cause the stage to fail, but the build itself will still succeed and artifacts will still be available.
