### PR TITLE
Remove special handling for MariaDB

### DIFF
--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
@@ -360,8 +360,8 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
         }
 
         long expectedAffected = 2;
-        if (isKnownDatabase("MySQL", "10.") || isKnownDatabase("Oracle", "")) {
-            // for an unknown reason mariadb 10 and Oracle express have unexpected but somehow consistent behavior here
+        if (isKnownDatabase("Oracle", "")) {
+            // for an unknown reason Oracle express have unexpected but somehow consistent behavior here
             assertThat(updates).containsExactly(-2, -2);
             expectedAffected = -4;
         } else {


### PR DESCRIPTION
Fixing a newly introduced flakiness, for example - master build [642](https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/master/642/execution/node/180/log/): 

```
JdbcDbIT>AbstractJdbcInstrumentationTest.test:134->
  AbstractJdbcInstrumentationTest.executeTest:150->
    AbstractJdbcInstrumentationTest.lambda$test$8:134->
      AbstractJdbcInstrumentationTest.testBatchPreparedStatement:365

...

12:08:52 [ERROR] Failures: 
12:08:52 [ERROR]   JdbcDbIT>AbstractJdbcInstrumentationTest.test:134->AbstractJdbcInstrumentationTest.executeTest:150->AbstractJdbcInstrumentationTest.lambda$test$8:134->AbstractJdbcInstrumentationTest.testBatchPreparedStatement:365 
12:08:52 Expecting:
12:08:52   <[1L, 1L]>
12:08:52 to contain exactly (and in same order):
12:08:52   <[-2L, -2L]>
12:08:52 but some elements were not found:
12:08:52   <[-2L, -2L]>
12:08:52 and others were not expected:
12:08:52   <[1L, 1L]>
```


Apparently, the formerly erroneous behaviour we witnessed from MariaDB was fixed in newer images and either #1481 surfaced that or that `testcontainers` fetch the `latest` and it had changed.
The reason it was not immediately reproduced on public CI and locally is probably due to Docker image caching. Removing the `mariadb` image from my local Docker cache reproduced the issue.