### PR TITLE
Fix JSF error in Jetty 9.4 and upgrading Byte Buddy to 1.10.18

### DIFF
--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-tree</artifactId>
-            <version>8.0.1</version>
+            <version>9.0</version>
         </dependency>
         <dependency>
             <groupId>org.hdrhistogram</groupId>

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm-tree</artifactId>
-            <version>9.0</version>
+            <version>${version.asm}</version>
         </dependency>
         <dependency>
             <groupId>org.hdrhistogram</groupId>

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JettyIT.java
@@ -56,7 +56,7 @@ public class JettyIT extends AbstractServletContainerIntegrationTest {
 
     @Override
     protected void enableDebugging(GenericContainer<?> servletContainer) {
-        servletContainer.withEnv("JAVA_OPTIONS", "-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=5005");
+        servletContainer.withEnv("JAVA_OPTIONS", "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:5005");
     }
 
     public List<String> getPathsToTestErrors() {

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/TomcatIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/TomcatIT.java
@@ -33,7 +33,9 @@ import org.junit.runners.Parameterized;
 import org.testcontainers.containers.GenericContainer;
 
 import javax.annotation.Nullable;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 
 @RunWith(Parameterized.class)
 public class TomcatIT extends AbstractServletContainerIntegrationTest {
@@ -71,7 +73,14 @@ public class TomcatIT extends AbstractServletContainerIntegrationTest {
 
     @Override
     protected Iterable<Class<? extends TestApp>> getTestClasses() {
-        return Arrays.asList(ServletApiTestApp.class, JsfServletContainerTestApp.class, CdiServletContainerTestApp.class);
+        List<Class<? extends TestApp>> testClasses = new ArrayList<>();
+        testClasses.add(ServletApiTestApp.class);
+        testClasses.add(CdiServletContainerTestApp.class);
+        if (!getImageName().contains("jre7")) {
+            // The JSF test app depends on myfaces 2.3.2 which requires Java 8 or higher
+            testClasses.add(JsfServletContainerTestApp.class);
+        }
+        return testClasses;
     }
 
     @Override

--- a/integration-tests/jsf-app/jsf-app-standalone/pom.xml
+++ b/integration-tests/jsf-app/jsf-app-standalone/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>org.apache.myfaces.core</groupId>
             <artifactId>myfaces-impl</artifactId>
-            <version>2.2.12</version>
+            <version>2.3.2</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,9 @@
         <version.spring>5.0.15.RELEASE</version.spring>
         <version.jetty-server>9.4.11.v20180605</version.jetty-server>
         <version.json-schema-validator>0.1.19</version.json-schema-validator>
+        <!-- Byte Buddy and ASM must be kept in sync -->
         <version.byte-buddy>1.10.18</version.byte-buddy>
+        <version.asm>9.0</version.asm>
 
         <!-- used both for plugin & annotations dependency -->
         <version.animal-sniffer>1.17</version.animal-sniffer>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
         <version.spring>5.0.15.RELEASE</version.spring>
         <version.jetty-server>9.4.11.v20180605</version.jetty-server>
         <version.json-schema-validator>0.1.19</version.json-schema-validator>
-        <version.byte-buddy>1.10.12</version.byte-buddy>
+        <version.byte-buddy>1.10.18</version.byte-buddy>
 
         <!-- used both for plugin & annotations dependency -->
         <version.animal-sniffer>1.17</version.animal-sniffer>


### PR DESCRIPTION
Fixing recent failures in Jetty 9.4 tests ([example](https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/master/653/)).

It seems that with the [latest Jetty 9.4 release](https://mvnrepository.com/artifact/org.eclipse.jetty/jetty-server/9.4.34.v20201102) there is a bytecode transformation error when instrumenting `javax.faces.webapp.FacesServlet`, which fails instrumentation for an entire batch of classes, causing a seemingly non-related symptom.

Upgrading the `myfaces` dependency of the JSF app to `2.3.2` works around the problem.
A separate issue related to the BCI was opened in BB repo - https://github.com/raphw/byte-buddy/issues/979.