### PR TITLE
bypass TLS download error for old JDKs

### DIFF
--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -160,6 +160,10 @@ pipeline {
                                 dir("${APP_BASE_DIR}"){
                                     // Launch app in background
                                     withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY'){
+                                        // ensure that wrapper downloads with a recent JVM to avoid TLS issues with old JVMs
+                                        withEnv(["JAVA_HOME=${env.HUDSON_HOME}/.java/java11"]){
+                                            sh(script: "./mvnw clean")
+                                        }
                                         // Start with packaging things up
                                         sh(script: "./mvnw package")
                                         echo "start application with JVM options '${params.jvm_options}'"
@@ -167,10 +171,11 @@ pipeline {
                                             def ver = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
                                             if(ver == '7'){
                                                 echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
-                                                sh(script: "java -jar -javaagent:${WORKSPACE}/${AGENT_BASE_DIR}/apm-agent-java/elastic-apm-agent/target/elastic-apm-agent-${params.apm_version}.jar -Delastic.apm.server_urls=${env.APM_SERVER_URL} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY} ${params.jvm_options} -XX:+FlightRecorder -XX:StartFlightRecording=filename=flight.jfr ./target/petclinic.war &")
+                                                binaryPath = './target/petclinic.war'
                                             } else {
-                                                sh(script: "java -jar -javaagent:${WORKSPACE}/${AGENT_BASE_DIR}/apm-agent-java/elastic-apm-agent/target/elastic-apm-agent-${params.apm_version}.jar -Delastic.apm.server_urls=${env.APM_SERVER_URL} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY} ${params.jvm_options} -XX:+FlightRecorder -XX:StartFlightRecording=filename=flight.jfr ./target/spring-petclinic-*.jar &")
+                                                binaryPath = './target/spring-petclinic-*.jar'
                                             }
+                                            sh(script: "java -jar -javaagent:${WORKSPACE}/${AGENT_BASE_DIR}/apm-agent-java/elastic-apm-agent/target/elastic-apm-agent-${params.apm_version}.jar -Delastic.apm.server_urls=${env.APM_SERVER_URL} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY} ${params.jvm_options} -XX:+FlightRecorder -XX:StartFlightRecording=filename=flight.jfr ${binaryPath} &")
                                         }
                                     }
                                 }


### PR DESCRIPTION
## What does this PR do?

When using older JDKs with the test application, for example `Java 7u111`, we are unable to download maven binary using the wrapper because this JDK does not support the required TLS versions currently used by maven central repository.

```
[2020-11-23T08:35:57.221Z] + ./mvnw package
[2020-11-23T08:35:57.222Z] Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
[2020-11-23T08:35:57.222Z] Downloading https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.3.3/apache-maven-3.3.3-bin.zip
[2020-11-23T08:35:57.222Z] 
[2020-11-23T08:35:57.222Z] Exception in thread "main" javax.net.ssl.SSLException: Received fatal alert: protocol_version
[2020-11-23T08:35:57.222Z] 	at sun.security.ssl.Alerts.getSSLException(Alerts.java:208)
[2020-11-23T08:35:57.222Z] 	at sun.security.ssl.Alerts.getSSLException(Alerts.java:154)
[2020-11-23T08:35:57.222Z] 	at sun.security.ssl.SSLSocketImpl.recvAlert(SSLSocketImpl.java:1991)
[2020-11-23T08:35:57.222Z] 	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:1098)
[2020-11-23T08:35:57.222Z] 	at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1344)
[2020-11-23T08:35:57.222Z] 	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1371)
[2020-11-23T08:35:57.222Z] 	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1355)
[2020-11-23T08:35:57.222Z] 	at sun.net.www.protocol.https.HttpsClient.afterConnect(HttpsClient.java:559)
[2020-11-23T08:35:57.222Z] 	at sun.net.www.protocol.https.AbstractDelegateHttpsURLConnection.connect(AbstractDelegateHttpsURLConnection.java:185)
[2020-11-23T08:35:57.222Z] 	at sun.net.www.protocol.http.HttpURLConnection.getInputStream(HttpURLConnection.java:1302)
[2020-11-23T08:35:57.222Z] 	at sun.net.www.protocol.https.HttpsURLConnectionImpl.getInputStream(HttpsURLConnectionImpl.java:254)
[2020-11-23T08:35:57.222Z] 	at org.apache.maven.wrapper.DefaultDownloader.downloadInternal(DefaultDownloader.java:73)
[2020-11-23T08:35:57.222Z] 	at org.apache.maven.wrapper.DefaultDownloader.download(DefaultDownloader.java:60)
[2020-11-23T08:35:57.222Z] 	at org.apache.maven.wrapper.Installer.createDist(Installer.java:64)
[2020-11-23T08:35:57.222Z] 	at org.apache.maven.wrapper.WrapperExecutor.execute(WrapperExecutor.java:121)
[2020-11-23T08:35:57.222Z] 	at org.apache.maven.wrapper.MavenWrapperMain.main(MavenWrapperMain.java:50)
```

This is an attempt to work-around this issue by executing a simple `clean` goal first with a recent JDK (the same used to build the agent).