### PR TITLE
[cache][ci] use cached m2 repository

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
     REPO = 'apm-agent-java'
     BASE_DIR = "src/github.com/elastic/${env.REPO}"
     NOTIFY_TO = credentials('notify-to')
-    JOB_GCS_BUCKET = credentials('gcs-bucket')
+    JOB_GCS_BUCKET = 'apm-ci-temp'
     DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
     ELASTIC_DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-java-codecov'
@@ -16,6 +16,7 @@ pipeline {
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     MAVEN_CONFIG = '-Dmaven.repo.local=.m2'
     OPBEANS_REPO = 'opbeans-java'
+    JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
   }
   options {
     timeout(time: 1, unit: 'HOURS')
@@ -87,7 +88,7 @@ pipeline {
                 sh label: 'mvn install', script: "./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true"
                 sh label: 'mvn license', script: "./mvnw license:aggregate-third-party-report -Dlicense.excludedGroups=^co\\.elastic\\."
               }
-              stash allowEmpty: true, name: 'build', useDefaultExcludes: false
+              stashV2(name: 'build', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
               archiveArtifacts allowEmptyArchive: true,
                 artifacts: "${BASE_DIR}/elastic-apm-agent/target/elastic-apm-agent-*.jar,${BASE_DIR}/apm-agent-attach/target/apm-agent-attach-*.jar,\
                       ${BASE_DIR}/target/site/aggregate-third-party-report.html",
@@ -124,7 +125,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Unit Tests', tab: 'tests') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
               dir("${BASE_DIR}"){
                 sh """#!/bin/bash
                 set -euxo pipefail
@@ -157,7 +158,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Smoke Tests 01', tab: 'tests') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
               dir("${BASE_DIR}"){
                 sh './scripts/jenkins/smoketests-01.sh'
               }
@@ -187,7 +188,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Smoke Tests 02', tab: 'tests') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
               dir("${BASE_DIR}"){
                 sh './scripts/jenkins/smoketests-02.sh'
               }
@@ -229,7 +230,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Benchmarks', tab: 'artifacts') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
               dir("${BASE_DIR}"){
                 script {
                   env.COMMIT_ISO_8601 = sh(script: 'git log -1 -s --format=%cI', returnStdout: true).trim()
@@ -268,7 +269,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Javadoc') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET}", credentialsId: "${JOB_GCS_CREDENTIALS}")
               dir("${BASE_DIR}"){
                 sh """#!/bin/bash
                 set -euxo pipefail

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-java-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
-    MAVEN_CONFIG = '-Dmaven.repo.local=/var/lib/jenkins/.m2/repository'
+    MAVEN_CONFIG = '-Dmaven.repo.local=.m2'
     OPBEANS_REPO = 'opbeans-java'
   }
   options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-java-codecov'
     GITHUB_CHECK_ITS_NAME = 'Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
-    MAVEN_CONFIG = '-Dmaven.repo.local=.m2'
+    MAVEN_CONFIG = '-Dmaven.repo.local=/var/lib/jenkins/.m2/repository'
     OPBEANS_REPO = 'opbeans-java'
   }
   options {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,10 @@ pipeline {
             withGithubNotify(context: 'Build', tab: 'artifacts') {
               deleteDir()
               unstash 'source'
+              // prepare m2 repository with the existing dependencies
+              if (fileExists('/var/lib/jenkins/.m2/repository')) {
+                sh label: 'Prepare .m2 cached folder', returnStatus: true, script: 'cp -rf /var/lib/jenkins/.m2/repository .m2'
+              }
               dir("${BASE_DIR}"){
                 sh label: 'mvn install', script: "./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true"
                 sh label: 'mvn license', script: "./mvnw license:aggregate-third-party-report -Dlicense.excludedGroups=^co\\.elastic\\."

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,6 +82,7 @@ pipeline {
               // prepare m2 repository with the existing dependencies
               whenTrue(fileExists('/var/lib/jenkins/.m2/repository')) {
                 sh label: 'Prepare .m2 cached folder', returnStatus: true, script: 'cp -rf /var/lib/jenkins/.m2/repository .m2'
+                sh label: 'Size .m2', returnStatus: true, script: 'du -hs .m2'
               }
               dir("${BASE_DIR}"){
                 sh label: 'mvn install', script: "./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
               deleteDir()
               unstash 'source'
               // prepare m2 repository with the existing dependencies
-              if (fileExists('/var/lib/jenkins/.m2/repository')) {
+              whenTrue(fileExists('/var/lib/jenkins/.m2/repository')) {
                 sh label: 'Prepare .m2 cached folder', returnStatus: true, script: 'cp -rf /var/lib/jenkins/.m2/repository .m2'
               }
               dir("${BASE_DIR}"){


### PR DESCRIPTION
## What does this PR do?

The build stage is the one preparing the build artifacts that are later on used in the following stages, so, in order to honour the .m2 cache, the build stage does the following:

- If the `.m2` cached folder in the CI worker exists then copy the content to the `$WORKSPACE/.m2`.  <--- **This is the hack**
- maven build
- the whole workspace is archived to be consumed later on in the UTs, Javadoc, Smoke Tests and so on stages.

~~Speed up the stash/unstash with our v2 that uses Google Storage. Ideally from 2 minutes to just a ?? seconds:~~


## Tests
- [x] UTs
- [x] ITs
- [x] Smoke tests
- [x] Benchmarks
- [x] Javadoc

## Screenshots

- Prepare the .m2 during the build stage

![image](https://user-images.githubusercontent.com/2871786/100095732-db842a80-2e52-11eb-8f15-b63ad91e9939.png)


## Iterations

- Use absolute path where the .m2 repository is hosted in the CI workers.

It did not work since the built cached artifacts were hosted in another CI workers.
 
- Stash/Unstash

Reverted 156a41efc04f0ad1636ceb9bbf28e58dbc54d3e3 since there was no much improvement, so let's keep it simple

|currently|proposal|
|---------|--------|
|![image](https://user-images.githubusercontent.com/2871786/100107926-1c377000-2e62-11eb-9cf9-f84eb0554518.png)|![image](https://user-images.githubusercontent.com/2871786/100114854-c5ce2f80-2e69-11eb-9e41-eee36c144809.png)|
|![image](https://user-images.githubusercontent.com/2871786/100107854-04f88280-2e62-11eb-99e8-12b5c176980e.png)|![image](https://user-images.githubusercontent.com/2871786/100114732-a20ae980-2e69-11eb-97cf-6c0289022760.png)|
