### PR TITLE
Limit public API accessibility to APIs only

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,12 @@ endif::[]
 ==== 1.19.1 - YYYY/MM/DD
 
 [float]
+===== Breaking changes
+* The following public API types were `public` so far and became package-private: `NoopScope`, `ScopeImpl` and `AbstractSpanImpl`.
+  If your code is using them, you will need to change that when upgrading to this version.
+  Related PR: {pull}1532[#1532]
+
+[float]
 ===== Features
 
 [float]

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/AbstractSpanImpl.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/AbstractSpanImpl.java
@@ -28,7 +28,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.lang.invoke.MethodHandle;
 
-public abstract class AbstractSpanImpl implements Span {
+abstract class AbstractSpanImpl implements Span {
     @Nonnull
     // co.elastic.apm.agent.impl.transaction.Span
     protected final Object span;

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/NoopScope.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/NoopScope.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.api;
 
-public enum NoopScope implements Scope {
+enum NoopScope implements Scope {
     INSTANCE;
 
     @Override

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/ScopeImpl.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/ScopeImpl.java
@@ -26,7 +26,7 @@ package co.elastic.apm.api;
 
 import javax.annotation.Nonnull;
 
-public class ScopeImpl implements Scope {
+class ScopeImpl implements Scope {
 
     @Nonnull
     @SuppressWarnings({"FieldCanBeLocal", "unused"})


### PR DESCRIPTION
## What does this PR do?
As pointed out by @manoelstilpen in #1529, we have a couple of bridge-implementations in the public API package that are publicly accessible. Ideally, only the actual APIs should be publicly accessible.

<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->
- [x] All implementations are package-private and all APIs are `public` 
- [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc) to reflect the potential breaking change
