### PR TITLE
Send error.transaction_id and error.parent_id only if there is trace_id

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ endif::[]
 ===== Bug fixes
 * Fix small memory allocation regression introduced with tracestate header {pull}1508[#1508]
 * Fix `NullPointerException` from `WeakConcurrentMap.put` through the Elasticsearch client instrumentation - {pull}1531[1531]
+* Sending `transaction_id` and `parent_id` only for events that contain a valid `trace_id` as well - {pull}1537[1537]
 
 [float]
 ===== Refactors

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorCapture.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorCapture.java
@@ -134,6 +134,12 @@ public class ErrorCapture implements Recyclable {
      */
     public ErrorCapture asChildOf(AbstractSpan<?> parent) {
         this.traceContext.asChildOf(parent.getTraceContext());
+        if (traceContext.getTraceId().isEmpty()) {
+            logger.debug("Creating an Error as child of {} with a null trace_id", parent.getNameAsString());
+            if (logger.isTraceEnabled()) {
+                logger.trace("Stack trace related to Error capture: ", new Throwable());
+            }
+        }
         if (parent instanceof Transaction) {
             Transaction transaction = (Transaction) parent;
             // The error might have occurred in a different thread than the one the transaction was recorded

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -522,12 +522,13 @@ public class DslJsonSerializer implements PayloadSerializer {
         writeHexField("id", traceContext.getId());
         if (!traceContext.getTraceId().isEmpty()) {
             writeHexField("trace_id", traceContext.getTraceId());
-        }
-        if (serializeTransactionId && !traceContext.getTransactionId().isEmpty()) {
-            writeHexField("transaction_id", traceContext.getTransactionId());
-        }
-        if (!traceContext.getParentId().isEmpty()) {
-            writeHexField("parent_id", traceContext.getParentId());
+            // transaction_id and parent_id may only be sent alongside a valid trace_id
+            if (serializeTransactionId && !traceContext.getTransactionId().isEmpty()) {
+                writeHexField("transaction_id", traceContext.getTransactionId());
+            }
+            if (!traceContext.getParentId().isEmpty()) {
+                writeHexField("parent_id", traceContext.getParentId());
+            }
         }
     }
 


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Context - reported in [the forum](https://discuss.elastic.co/t/apm-java-agnet-return-400-sending-report-to-elastic-and-create-holes-co-elastic-apm-agent-report-intakev2reportingeventhandler/256536).
APM Server will reject Error events that contain `parent_id` and/or `transaction_id` but do not contain `trace_id`. This PR ensures that this restriction is enforced.
In addition, it provides logs to analyze the reason for getting error captures that are not adhering this.
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
