### PR TITLE
Fix formatting for trace_methods_duration_threshold

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -16,8 +16,6 @@ endif::[]
 
 [float]
 ===== Bug fixes
-* Fix formatting for trace_methods_duration_threshold in documentation
-
 ////
 
 === Unreleased

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -16,6 +16,8 @@ endif::[]
 
 [float]
 ===== Bug fixes
+* Fix formatting for trace_methods_duration_threshold in documentation
+
 ////
 
 === Unreleased

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -477,10 +477,12 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded " +
             "by default.\n" +
             "Such methods will be traced and reported if one of the following applies:\n" +
+            "\n" +
             " - This method's duration crossed the configured threshold.\n" +
             " - This method ended with Exception.\n" +
             " - A method executed as part of the execution of this method crossed the threshold or ended with Exception.\n" +
             " - A \"forcibly-traced method\" (e.g. DB queries, HTTP exits, custom) was executed during the execution of this method.\n" +
+            "\n" +
             "Set to 0 to disable.\n" +
             "\n" +
             "NOTE: Transactions are never discarded, regardless of their duration.\n" +

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -997,12 +997,10 @@ NOTE: Changing this value at runtime can slow down the application temporarily.
 If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on 
 duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded by default.
 Such methods will be traced and reported if one of the following applies:
-
  - This method's duration crossed the configured threshold.
  - This method ended with Exception.
  - A method executed as part of the execution of this method crossed the threshold or ended with Exception.
  - A "forcibly-traced method" (e.g. DB queries, HTTP exits, custom) was executed during the execution of this method.
- 
 Set to 0 to disable.
 
 NOTE: Transactions are never discarded, regardless of their duration.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -997,10 +997,12 @@ NOTE: Changing this value at runtime can slow down the application temporarily.
 If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on 
 duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded by default.
 Such methods will be traced and reported if one of the following applies:
+
  - This method's duration crossed the configured threshold.
  - This method ended with Exception.
  - A method executed as part of the execution of this method crossed the threshold or ended with Exception.
  - A "forcibly-traced method" (e.g. DB queries, HTTP exits, custom) was executed during the execution of this method.
+ 
 Set to 0 to disable.
 
 NOTE: Transactions are never discarded, regardless of their duration.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -997,10 +997,12 @@ NOTE: Changing this value at runtime can slow down the application temporarily.
 If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on 
 duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded by default.
 Such methods will be traced and reported if one of the following applies:
+
  - This method's duration crossed the configured threshold.
  - This method ended with Exception.
  - A method executed as part of the execution of this method crossed the threshold or ended with Exception.
  - A "forcibly-traced method" (e.g. DB queries, HTTP exits, custom) was executed during the execution of this method.
+
 Set to 0 to disable.
 
 NOTE: Transactions are never discarded, regardless of their duration.
@@ -2744,10 +2746,12 @@ The default unit for this option is `ms`.
 # If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on 
 # duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded by default.
 # Such methods will be traced and reported if one of the following applies:
+# 
 #  - This method's duration crossed the configured threshold.
 #  - This method ended with Exception.
 #  - A method executed as part of the execution of this method crossed the threshold or ended with Exception.
 #  - A "forcibly-traced method" (e.g. DB queries, HTTP exits, custom) was executed during the execution of this method.
+# 
 # Set to 0 to disable.
 # 
 # NOTE: Transactions are never discarded, regardless of their duration.


### PR DESCRIPTION
## What does this PR do?
The list of conditions for `trace_methods_duration_threshold` is not formatted properly, resulting in an inline display of list items. This PR fixes the issue and shows the list of conditions in the correct way.

