### PR TITLE
[load test] build test app with recent JDK

### DIFF
--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -14,6 +14,10 @@ pipeline {
         LOCUST_RUN_TIME = "${params.duration}"
         LOCUST_USERS = "${params.concurrent_requests}"
         LOCUST_IGNORE_ERRORS = "${params.ignore_application_errors}"
+        //
+        JAVA_HOME_BUILD_AGENT = "${env.HUDSON_HOME}/.java/java11" // agent should always be built with Java 11
+        JAVA_HOME_BUILD_APP = '' // set at a later state depending on JDK
+        JDK_MAJOR_VERSION = '' // set at a later state depending on JDK
     }
     options {
         timeout(time: 72, unit: 'HOURS')
@@ -46,7 +50,7 @@ pipeline {
                 withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
                     setEnvVar('SESSION_TOKEN', sh(script: ".ci/load/scripts/start.sh", returnStdout: true).trim())
                 }
-            }    
+            }
         }
         stage('Load test') {
             parallel {
@@ -75,6 +79,15 @@ pipeline {
                                 setEnvVar('JAVA_HOME', sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim())
                                 setEnvVar('JAVACMD', "${env.JAVA_HOME}/bin/java")
                                 setEnvVar('PATH', "${env.JAVA_HOME}/bin:$PATH")
+
+                                def jdk_major = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim())
+                                def app_build_jdk = "${env.JAVA_HOME}"
+                                if(jdk_major == '7'){
+                                    // build application with a more recent JDK that don't have TLS issues
+                                    app_build_jdk = sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
+                                }
+                                setEnvVar('JAVA_HOME_BUILD_APP', app_build_jdk)
+                                setEnvVar('JDK_MAJOR_VERSION', jdk_major)
                             }
                         }
                         stage ('Provision agent') {
@@ -92,13 +105,13 @@ pipeline {
                                         echo 'Switching to requested version'
                                         sh(script: "git checkout v${params.apm_version}")
                                         echo 'Building agent'
-                                        withEnv(["JAVA_HOME=${env.HUDSON_HOME}/.java/java11"]){
+                                        withEnv(["JAVA_HOME=${env.JAVA_HOME_BUILD_AGENT}"]){
                                             withEnv(["JAVACMD=${env.JAVA_HOME}/bin/java", "PATH=${env.JAVA_HOME}/bin:$ORIG_PATH"]){
                                                 echo("Building the Agent with Java 11\nJAVA_HOME set to ${env.JAVA_HOME}\nJAVACMD set to ${env.JAVACMD}\nPATH set to ${env.PATH}")
                                                 sh(script: './mvnw  clean install -DskipTests=true -Dmaven.javadoc.skip=true')
                                             }
                                         }
-                                            echo("Post-build env:\nJAVA_HOME set to ${env.JAVA_HOME}\nJAVACMD set to ${env.JAVACMD}\nPATH set to ${env.PATH}")
+                                        echo("Post-build env:\nJAVA_HOME set to ${env.JAVA_HOME}\nJAVACMD set to ${env.JAVACMD}\nPATH set to ${env.PATH}")
 
                                     }
                                 }
@@ -114,10 +127,9 @@ pipeline {
                             steps {
                                 echo 'Determining version to checkout'
                                 script {
-                                    def ver = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
                                     def app_branch = "main"
-                                    if(ver == '7'){
-                                        echo "Java 7.x detected. Installing compliant version of test application"
+                                    if(env.JDK_MAJOR_VERSION == '7'){
+                                        echo "Java 7.x detected. Installing compliant version of test application and JDK"
                                         app_branch = "3450c3d99ecaaf46231feb2c404b72d1727517e1"
                                     }
                                     echo "Installing test application from: ${app_branch}"
@@ -128,6 +140,11 @@ pipeline {
                                         credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                                         shallow: false
                                     )
+
+                                    echo "Building test application using JDK = ${env.JAVA_HOME_BUILD_APP}"
+                                    withEnv(["JAVA_HOME=${JAVA_HOME_BUILD_APP}"]){
+                                        sh(script: "./mvnw package")
+                                    }
                                 }
                             }
                         }
@@ -160,16 +177,9 @@ pipeline {
                                 dir("${APP_BASE_DIR}"){
                                     // Launch app in background
                                     withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY'){
-                                        // ensure that wrapper downloads with a recent JVM to avoid TLS issues with old JVMs
-                                        withEnv(["JAVA_HOME=${env.HUDSON_HOME}/.java/java11"]){
-                                            sh(script: "./mvnw clean")
-                                        }
-                                        // Start with packaging things up
-                                        sh(script: "./mvnw package")
                                         echo "start application with JVM options '${params.jvm_options}'"
                                         script {
-                                            def ver = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
-                                            if(ver == '7'){
+                                            if(env.JDK_MAJOR_VERSION == '7'){
                                                 echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
                                                 binaryPath = './target/petclinic.war'
                                             } else {

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -80,8 +80,8 @@ pipeline {
                                 setEnvVar('JAVACMD', "${env.JAVA_HOME}/bin/java")
                                 setEnvVar('PATH', "${env.JAVA_HOME}/bin:$PATH")
 
-                                def jdk_major = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
-                                def app_build_jdk = "${env.JAVA_HOME}"
+                                jdk_major = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
+                                app_build_jdk = "${env.JAVA_HOME}"
                                 if(jdk_major == '7'){
                                     // build application with a more recent JDK that don't have TLS issues
                                     app_build_jdk = sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -83,7 +83,7 @@ pipeline {
                                 setEnvVar('JDK_MAJOR_VERSION', sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim())
                                 script {
                                     def app_build_jdk = "${env.JAVA_HOME}"
-                                    if("${env.JDK_MAJOR_VERSION" == '7'){
+                                    if("${env.JDK_MAJOR_VERSION}" == '7') {
                                         // build application with a more recent JDK that don't have TLS issues
                                         app_build_jdk = sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
                                     }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
                                 setEnvVar('JAVACMD', "${env.JAVA_HOME}/bin/java")
                                 setEnvVar('PATH', "${env.JAVA_HOME}/bin:$PATH")
 
-                                def jdk_major = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim())
+                                def jdk_major = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
                                 def app_build_jdk = "${env.JAVA_HOME}"
                                 if(jdk_major == '7'){
                                     // build application with a more recent JDK that don't have TLS issues

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -80,14 +80,15 @@ pipeline {
                                 setEnvVar('JAVACMD', "${env.JAVA_HOME}/bin/java")
                                 setEnvVar('PATH', "${env.JAVA_HOME}/bin:$PATH")
 
-                                jdk_major = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
-                                app_build_jdk = "${env.JAVA_HOME}"
-                                if(jdk_major == '7'){
-                                    // build application with a more recent JDK that don't have TLS issues
-                                    app_build_jdk = sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
+                                setEnvVar('JDK_MAJOR_VERSION', sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim())
+                                script {
+                                    def app_build_jdk = "${env.JAVA_HOME}"
+                                    if("${env.JDK_MAJOR_VERSION" == '7'){
+                                        // build application with a more recent JDK that don't have TLS issues
+                                        app_build_jdk = sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
+                                    }
+                                    setEnvVar('JAVA_HOME_BUILD_APP', app_build_jdk)
                                 }
-                                setEnvVar('JAVA_HOME_BUILD_APP', app_build_jdk)
-                                setEnvVar('JDK_MAJOR_VERSION', jdk_major)
                             }
                         }
                         stage ('Provision agent') {

--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -46,13 +46,11 @@ CATALOG_URL="https://jvm-catalog.elastic.co/jdks"
 
 read -d'\n' -r SDK_URL SDK_FILENAME <<<$(curl -s $CATALOG_URL|jq -Mr '.['\"$1\"'].url, .['\"$1\"'].filename')
 
-curl -s -o $SDK_FILENAME $SDK_URL
+curl -s -o /tmp/${SDK_FILENAME} ${SDK_URL}
 
-if [ ! -e tmp_java ]; then
-    mkdir tmp_java/
-fi
+JDK_FOLDER=$(mktemp -d)
 
-tar xfz $SDK_FILENAME -C tmp_java/
+tar xfz /tmp/${SDK_FILENAME} -C ${JDK_FOLDER}
 
-UNPACKED_JDK_DIR=$(ls tmp_java)
-echo $PWD/tmp_java/$UNPACKED_JDK_DIR
+SUB_FOLDER=$(ls ${JDK_FOLDER})
+echo $(readlink -f ${JDK_FOLDER}/${SUB_FOLDER})


### PR DESCRIPTION
We currently have 2 JDKs involved in load tests:
- one (Java11) that is used to build the agent
- one for the test application, which version is provided through a parameter that is used to build & run the test application.

When trying to run test on old Java7 versions, like 7u111, we have maven that is unable to download dependencies due to TLS/certificate issues.

Thus, in this case we need to:
- use Java 8 JDK to run maven, test application will still target and be compatible with Java 7.
- for more recent versions, we will build and run the test application with the selected JDK.