### PR TITLE
Fix load testing build with multiple JDKs

### DIFF
--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
         LOCUST_USERS = "${params.concurrent_requests}"
         LOCUST_IGNORE_ERRORS = "${params.ignore_application_errors}"
         //
+        JAVA_HOME_RUN = '' // set at a later state depending on JDK
         JAVA_HOME_BUILD_AGENT = "${env.HUDSON_HOME}/.java/java11" // agent should always be built with Java 11
         JAVA_HOME_BUILD_APP = '' // set at a later state depending on JDK
         JDK_MAJOR_VERSION = '' // set at a later state depending on JDK
@@ -52,24 +53,20 @@ pipeline {
                             steps {
                                 echo "Provisioning Java version: ${params.jvm_version}"
                                 script {
+                                    echo "--- 1"
+                                    env.JAVA_HOME_RUN=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
+
+                                    echo "--- 2"
                                     echo "${env.JDK_MAJOR_VERSION}"
-                                    echo "${env.JAVA_HOME}"
-
-                                    env.JAVA_HOME=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
-                                    env.JDK_MAJOR_VERSION = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
-
+                                    env.JDK_MAJOR_VERSION=sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
                                     echo "${env.JDK_MAJOR_VERSION}"
-                                    echo "${env.JAVA_HOME}"
-                                }
 
-
-                                script {
-                                    def app_build_jdk = "${env.JAVA_HOME}"
-                                    if("${env.JDK_MAJOR_VERSION}" == '7') {
+                                    echo "--- 3"
+                                    env.JAVA_HOME_BUILD_APP=env.JAVA_HOME_RUN
+                                    if(env.JDK_MAJOR_VERSION == '7') {
                                         // build application with a more recent JDK that don't have TLS issues
-                                        app_build_jdk = sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
+                                        env.JAVA_HOME_BUILD_APP=sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
                                     }
-                                    setEnvVar('JAVA_HOME_BUILD_APP', app_build_jdk)
                                     echo " build application with ${env.JAVA_HOME_BUILD_APP}"
                                 }
                             }
@@ -89,7 +86,7 @@ pipeline {
                                         echo 'Switching to requested version'
                                         sh(script: "git checkout v${params.apm_version}")
                                         echo 'Building agent'
-                                        withEnv(["JAVA_HOME=${env.HUDSON_HOME}/.java/java11"]){
+                                        withEnv(["JAVA_HOME=${env.JAVA_HOME_BUILD_AGENT}"]){
                                             echo("Building the Agent with Java 11\nJAVA_HOME set to ${env.JAVA_HOME}")
                                             sh(script: './mvnw  clean install -DskipTests=true -Dmaven.javadoc.skip=true')
                                         }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -40,9 +40,33 @@ pipeline {
     }
 
     stages {
+        stage('Pre-flight'){
+            steps {
+                echo 'Getting authentication information from Vault'
+                withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
+                    setEnvVar('SESSION_TOKEN', sh(script: ".ci/load/scripts/start.sh", returnStdout: true).trim())
+                }
+            }
+        }
         stage('Load test') {
             parallel {
+                stage('Load generation') {
+                    agent { label 'metal' }
+                    steps {
+                        withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
+                            echo 'Preparing load generation..'
+                            whenTrue(Boolean.valueOf(params.locustfile)) {
+                                echo 'Using user-supplied plan for load-generation with Locust'
+                                sh script: "echo \"${params.locustfile}\">.ci/load/scripts/locustfile.py"
+                            }
+                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
+                                sh(script: ".ci/load/scripts/load_agent.sh")
+                            }
+                        }
+                    }
+                }
                 stage('Test application') {
+                    agent { label 'benchmarks' }
                     stages{
                         stage('Provision Java') {
                             steps {
@@ -66,14 +90,11 @@ pipeline {
                                         shallow: false
                                     )
                                     dir("apm-agent-java"){
-                                        echo 'Switching to requested version'
+                                        echo 'Switch to requested agent version = {params.apm_version}'
                                         sh(script: "git checkout v${params.apm_version}")
-                                        echo 'Building agent'
 
-                                        sh(script: "JAVA_HOME=${env.HUDSON_HOME}/.java/java11 ./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true")
-
-                                        echo("Post-build env:\nJAVA_HOME set to ${env.JAVA_HOME}")
-
+                                        echo 'Building agent with Java 11'
+                                        sh(script: "JAVA_HOME=${env.HUDSON_HOME}/.java/java11 ./mvnw --batch-mode clean install -DskipTests=true -Dmaven.javadoc.skip=true")
                                     }
                                 }
                                 whenTrue(Boolean.valueOf(params.agent_config)) {
@@ -86,7 +107,6 @@ pipeline {
                         }
                         stage('Provision test application') {
                             steps {
-                                echo 'Determining version to checkout'
                                 script {
                                     def app_branch = "main"
                                     def build_jdk_path = "${env.JAVA_HOME}"
@@ -97,7 +117,7 @@ pipeline {
                                         app_branch = "3450c3d99ecaaf46231feb2c404b72d1727517e1"
                                         build_jdk_path = sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
                                     }
-                                    echo "Installing test application from: ${app_branch}"
+                                    echo "Checkout test application from: ${app_branch}"
                                     gitCheckout(
                                         basedir: "${APP_BASE_DIR}",
                                         branch: "${app_branch}",
@@ -106,12 +126,66 @@ pipeline {
                                         shallow: false
                                     )
                                     echo "Building test application using JDK = ${build_jdk_path}"
-                                    withEnv(["JAVA_HOME=${build_jdk_path}"]){
-                                        sh(script: "./mvnw package")
-                                    }
+                                    sh(script: "JAVA_HOME=${build_jdk_path} ./mvnw --batch-mode package -DskipTests=true")
                                 }
                             }
                         }
+                        stage('Provision local metrics collection') {
+                                when {
+                                    expression {
+                                        return params.local_metrics
+                                    }
+                                }
+                                steps {
+                                    echo 'Enable local metric collection'
+                                    gitCheckout(
+                                        basedir: "${METRICS_BASE_DIR}",
+                                        branch: 'master',
+                                        repo: "https://github.com/pstadler/metrics.sh",
+                                        credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                                        shallow: false
+                                    )
+                                    sh(script: "touch metrics.out")
+                                    dir("${METRICS_BASE_DIR}"){
+                                        withEnv(["FILE_LOCATION=./metrics.out"]) {
+                                            sh(script: "./metrics.sh -r file &")
+                                        }
+                                    }
+                                }
+                            }
+                            stage('Application load') {
+                                steps {
+                                    echo 'Starting test application in background..'
+                                    dir("${APP_BASE_DIR}"){
+                                        // Launch app in background
+                                        withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY'){
+                                            echo "start application with JVM options '${params.jvm_options}'"
+                                            script {
+                                                if(env.JDK_MAJOR_VERSION == '7'){
+                                                    echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
+                                                    binaryPath = './target/petclinic.war'
+                                                } else {
+                                                    binaryPath = './target/spring-petclinic-*.jar'
+                                                }
+                                                sh(script: "java -jar -javaagent:${WORKSPACE}/${AGENT_BASE_DIR}/apm-agent-java/elastic-apm-agent/target/elastic-apm-agent-${params.apm_version}.jar -Delastic.apm.server_urls=${env.APM_SERVER_URL} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY} ${params.jvm_options} -XX:+FlightRecorder -XX:StartFlightRecording=filename=flight.jfr ${binaryPath} &")
+                                            }
+                                        }
+                                    }
+                                    echo 'Starting bandstand client..'
+                                    // Foreground the orchestrator script for execution control
+                                    withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
+                                        sh(script: ".ci/load/scripts/app.sh")
+                                    }
+                                }
+                            }
+                            stage('Collecting results') {
+                                steps {
+                                    echo "To view results, JMC is required. Get it here: https://jdk.java.net/jmc/"
+                                    archiveArtifacts(allowEmptyArchive: true,
+                                        artifacts: "${APP_BASE_DIR}/**/*.jfr,${METRICS_BASE_DIR}/**/*.out",
+                                        onlyIfSuccessful: false)
+                                }
+                            }
                     }
                 }
             }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -90,7 +90,7 @@ pipeline {
                                         shallow: false
                                     )
                                     dir("apm-agent-java"){
-                                        echo 'Switch to requested agent version = {params.apm_version}'
+                                        echo "Switch to requested agent version = ${params.apm_version}"
                                         sh(script: "git checkout v${params.apm_version}")
 
                                         echo 'Building agent with Java 11'

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -1,8 +1,4 @@
 // For documentation on this pipeline, please see the README.md in this directory
-
-def java_home_run = ''
-def java_home_build_agent = ''
-
 pipeline {
     agent { label 'linux && immutable' }
     environment {
@@ -18,11 +14,6 @@ pipeline {
         LOCUST_RUN_TIME = "${params.duration}"
         LOCUST_USERS = "${params.concurrent_requests}"
         LOCUST_IGNORE_ERRORS = "${params.ignore_application_errors}"
-        //
-        JAVA_HOME_RUN = '' // set at a later state depending on JDK
-        JAVA_HOME_BUILD_AGENT = "${env.HUDSON_HOME}/.java/java11" // agent should always be built with Java 11
-        JAVA_HOME_BUILD_APP = '' // set at a later state depending on JDK
-        JDK_MAJOR_VERSION = '' // set at a later state depending on JDK
     }
     options {
         timeout(time: 72, unit: 'HOURS')
@@ -57,23 +48,9 @@ pipeline {
                             steps {
                                 echo "Provisioning Java version: ${params.jvm_version}"
                                 script {
-                                    echo "--- 1"
-                                    java_home_run=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
-                                    env.JAVA_HOME_RUN=java_home_run
-                                    echo "env.JAVA_HOME_RUN = ${env.JAVA_HOME_RUN}"
-
-                                    echo "--- 2"
-                                    echo "${env.JDK_MAJOR_VERSION}"
-                                    env.JDK_MAJOR_VERSION=sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
-                                    echo "${env.JDK_MAJOR_VERSION}"
-
-                                    echo "--- 3"
-                                    env.JAVA_HOME_BUILD_APP=env.JAVA_HOME_RUN
-                                    if(env.JDK_MAJOR_VERSION == '7') {
-                                        // build application with a more recent JDK that don't have TLS issues
-                                        env.JAVA_HOME_BUILD_APP=sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
-                                    }
-                                    echo " build application with ${env.JAVA_HOME_BUILD_APP}"
+                                    def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
+                                    setEnvVar('JAVA_HOME', java_home)
+                                    echo("JAVA_HOME = ${env.JAVA_HOME}")
                                 }
                             }
                         }
@@ -92,7 +69,7 @@ pipeline {
                                         echo 'Switching to requested version'
                                         sh(script: "git checkout v${params.apm_version}")
                                         echo 'Building agent'
-                                        withEnv(["JAVA_HOME=${env.JAVA_HOME_BUILD_AGENT}"]){
+                                        withEnv(["JAVA_HOME=${env.HUDSON_HOME}/.java/java11"]){
                                             echo("Building the Agent with Java 11\nJAVA_HOME set to ${env.JAVA_HOME}")
                                             sh(script: './mvnw  clean install -DskipTests=true -Dmaven.javadoc.skip=true')
                                         }
@@ -113,9 +90,13 @@ pipeline {
                                 echo 'Determining version to checkout'
                                 script {
                                     def app_branch = "main"
-                                    if(env.JDK_MAJOR_VERSION == '7'){
+                                    def build_jdk_path = "${env.JAVA_HOME}"
+
+                                    def major_jdk_version = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
+                                    if(major_jdk_version == '7'){
                                         echo "Java 7.x detected. Installing compliant version of test application and JDK"
                                         app_branch = "3450c3d99ecaaf46231feb2c404b72d1727517e1"
+                                        build_jdk_path = sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
                                     }
                                     echo "Installing test application from: ${app_branch}"
                                     gitCheckout(
@@ -125,9 +106,8 @@ pipeline {
                                         credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                                         shallow: false
                                     )
-
-                                    echo "Building test application using JDK = ${env.JAVA_HOME_BUILD_APP}"
-                                    withEnv(["JAVA_HOME=${env.JAVA_HOME_BUILD_APP}"]){
+                                    echo "Building test application using JDK = ${build_jdk_path}"
+                                    withEnv(["JAVA_HOME=${build_jdk_path}"]){
                                         sh(script: "./mvnw package")
                                     }
                                 }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -70,8 +70,10 @@ pipeline {
                                         sh(script: "git checkout v${params.apm_version}")
                                         echo 'Building agent'
                                         withEnv(["JAVA_HOME=${env.HUDSON_HOME}/.java/java11"]){
-                                            echo("Building the Agent with Java 11\nJAVA_HOME set to ${env.JAVA_HOME}")
-                                            sh(script: './mvnw  clean install -DskipTests=true -Dmaven.javadoc.skip=true')
+                                            withEnv("PATH=${env.JAVA_HOME}/bin:$env.PATH"){
+                                                echo("Building the Agent with Java 11\nJAVA_HOME set to ${env.JAVA_HOME}")
+                                                sh(script: './mvnw  clean install -DskipTests=true -Dmaven.javadoc.skip=true')
+                                            }
                                         }
                                         echo("Post-build env:\nJAVA_HOME set to ${env.JAVA_HOME}")
 

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -1,4 +1,8 @@
 // For documentation on this pipeline, please see the README.md in this directory
+
+def java_home_run = ''
+def java_home_build_agent = ''
+
 pipeline {
     agent { label 'linux && immutable' }
     environment {
@@ -54,7 +58,9 @@ pipeline {
                                 echo "Provisioning Java version: ${params.jvm_version}"
                                 script {
                                     echo "--- 1"
-                                    env.JAVA_HOME_RUN=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
+                                    java_home_run=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
+                                    env.JAVA_HOME_RUN=java_home_run
+                                    echo "env.JAVA_HOME_RUN = ${env.JAVA_HOME_RUN}"
 
                                     echo "--- 2"
                                     echo "${env.JDK_MAJOR_VERSION}"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -69,12 +69,9 @@ pipeline {
                                         echo 'Switching to requested version'
                                         sh(script: "git checkout v${params.apm_version}")
                                         echo 'Building agent'
-                                        withEnv(["JAVA_HOME=${env.HUDSON_HOME}/.java/java11"]){
-                                            withEnv("PATH=${env.JAVA_HOME}/bin:$env.PATH"){
-                                                echo("Building the Agent with Java 11\nJAVA_HOME set to ${env.JAVA_HOME}")
-                                                sh(script: './mvnw  clean install -DskipTests=true -Dmaven.javadoc.skip=true')
-                                            }
-                                        }
+
+                                        sh(script: "JAVA_HOME=${env.HUDSON_HOME}/.java/java11 ./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true")
+
                                         echo("Post-build env:\nJAVA_HOME set to ${env.JAVA_HOME}")
 
                                     }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -44,31 +44,8 @@ pipeline {
     }
 
     stages {
-        stage('Pre-flight'){
-            steps {
-                echo 'Getting authentication information from Vault'
-                withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
-                    setEnvVar('SESSION_TOKEN', sh(script: ".ci/load/scripts/start.sh", returnStdout: true).trim())
-                }
-            }
-        }
         stage('Load test') {
             parallel {
-                stage('Load generation') {
-                    agent { label 'metal' }
-                    steps {
-                        withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
-                            echo 'Preparing load generation..'
-                            whenTrue(Boolean.valueOf(params.locustfile)) {
-                                echo 'Using user-supplied plan for load-generation with Locust'
-                                sh script: "echo \"${params.locustfile}\">.ci/load/scripts/locustfile.py"
-                            }
-                            catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                                sh(script: ".ci/load/scripts/load_agent.sh")
-                            }
-                        }
-                    }
-                }
                 stage('Test application') {
                     agent { label 'benchmarks' }
                     stages{
@@ -88,6 +65,7 @@ pipeline {
                                         app_build_jdk = sh(script: ".ci/load/scripts/fetch_sdk.sh zulu-8.0.272-linux", returnStdout: true).trim()
                                     }
                                     setEnvVar('JAVA_HOME_BUILD_APP', app_build_jdk)
+                                    echo " build application with ${env.JAVA_HOME_BUILD_APP}"
                                 }
                             }
                         }
@@ -147,62 +125,6 @@ pipeline {
                                         sh(script: "./mvnw package")
                                     }
                                 }
-                            }
-                        }
-                        stage('Provision local metrics collection') {
-                            when {
-                                expression { 
-                                    return params.local_metrics
-                                }
-                            }
-                            steps {
-                                echo 'Enable local metric collection'
-                                gitCheckout(
-                                    basedir: "${METRICS_BASE_DIR}",
-                                    branch: 'master',
-                                    repo: "https://github.com/pstadler/metrics.sh",
-                                    credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-                                    shallow: false
-                                )
-                                sh(script: "touch metrics.out")
-                                dir("${METRICS_BASE_DIR}"){
-                                    withEnv(["FILE_LOCATION=./metrics.out"]) {
-                                        sh(script: "./metrics.sh -r file &")
-                                    }
-                                }
-                            }
-                        }
-                        stage('Application load') {
-                            steps {
-                                echo 'Starting test application in background..'
-                                dir("${APP_BASE_DIR}"){
-                                    // Launch app in background
-                                    withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY'){
-                                        echo "start application with JVM options '${params.jvm_options}'"
-                                        script {
-                                            if(env.JDK_MAJOR_VERSION == '7'){
-                                                echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
-                                                binaryPath = './target/petclinic.war'
-                                            } else {
-                                                binaryPath = './target/spring-petclinic-*.jar'
-                                            }
-                                            sh(script: "java -jar -javaagent:${WORKSPACE}/${AGENT_BASE_DIR}/apm-agent-java/elastic-apm-agent/target/elastic-apm-agent-${params.apm_version}.jar -Delastic.apm.server_urls=${env.APM_SERVER_URL} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY} ${params.jvm_options} -XX:+FlightRecorder -XX:StartFlightRecording=filename=flight.jfr ${binaryPath} &")
-                                        }
-                                    }
-                                }
-                                echo 'Starting bandstand client..'
-                                // Foreground the orchestrator script for execution control
-                                withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
-                                    sh(script: ".ci/load/scripts/app.sh")
-                                }
-                            }
-                        }
-                        stage('Collecting results') {
-                            steps {
-                                echo "To view results, JMC is required. Get it here: https://jdk.java.net/jmc/"
-                                archiveArtifacts(allowEmptyArchive: true,
-                                    artifacts: "${APP_BASE_DIR}/**/*.jfr,${METRICS_BASE_DIR}/**/*.out",
-                                    onlyIfSuccessful: false)
                             }
                         }
                     }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -47,7 +47,6 @@ pipeline {
         stage('Load test') {
             parallel {
                 stage('Test application') {
-                    agent { label 'benchmarks' }
                     stages{
                         stage('Provision Java') {
                             steps {

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -51,10 +51,11 @@ pipeline {
                         stage('Provision Java') {
                             steps {
                                 echo "Provisioning Java version: ${params.jvm_version}"
-                                setEnvVar('ORIG_PATH', "$PATH")
-                                setEnvVar('JAVA_HOME', sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim())
-                                setEnvVar('JAVACMD', "${env.JAVA_HOME}/bin/java")
-                                setEnvVar('PATH', "${env.JAVA_HOME}/bin:$PATH")
+                                script {
+                                    def java_home=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
+                                    echo java_home
+                                }
+                                setEnvVar('JAVA_HOME',java_home) 
 
                                 setEnvVar('JDK_MAJOR_VERSION', sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim())
                                 script {
@@ -83,11 +84,9 @@ pipeline {
                                         echo 'Switching to requested version'
                                         sh(script: "git checkout v${params.apm_version}")
                                         echo 'Building agent'
-                                        withEnv(["JAVA_HOME=${env.JAVA_HOME_BUILD_AGENT}"]){
-                                            withEnv(["JAVACMD=${env.JAVA_HOME}/bin/java", "PATH=${env.JAVA_HOME}/bin:$ORIG_PATH"]){
-                                                echo("Building the Agent with Java 11\nJAVA_HOME set to ${env.JAVA_HOME}\nJAVACMD set to ${env.JAVACMD}\nPATH set to ${env.PATH}")
-                                                sh(script: './mvnw  clean install -DskipTests=true -Dmaven.javadoc.skip=true')
-                                            }
+                                        withEnv(["JAVA_HOME=${env.HUDSON_HOME}/.java/java11"]){
+                                            echo("Building the Agent with Java 11\nJAVA_HOME set to ${env.JAVA_HOME}")
+                                            sh(script: './mvnw  clean install -DskipTests=true -Dmaven.javadoc.skip=true')
                                         }
                                         echo("Post-build env:\nJAVA_HOME set to ${env.JAVA_HOME}\nJAVACMD set to ${env.JAVACMD}\nPATH set to ${env.PATH}")
 

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -52,12 +52,17 @@ pipeline {
                             steps {
                                 echo "Provisioning Java version: ${params.jvm_version}"
                                 script {
-                                    def java_home=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
-                                    echo java_home
-                                }
-                                setEnvVar('JAVA_HOME',java_home) 
+                                    echo "${JDK_MAJOR_VERSION}"
+                                    echo "${env.JDK_MAJOR_VERSION}"
 
-                                setEnvVar('JDK_MAJOR_VERSION', sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim())
+                                    JAVA_HOME=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
+                                    JDK_MAJOR_VERSION = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
+
+                                    echo "${JDK_MAJOR_VERSION}"
+                                    echo "${env.JDK_MAJOR_VERSION}"
+                                }
+
+
                                 script {
                                     def app_build_jdk = "${env.JAVA_HOME}"
                                     if("${env.JDK_MAJOR_VERSION}" == '7') {
@@ -88,7 +93,7 @@ pipeline {
                                             echo("Building the Agent with Java 11\nJAVA_HOME set to ${env.JAVA_HOME}")
                                             sh(script: './mvnw  clean install -DskipTests=true -Dmaven.javadoc.skip=true')
                                         }
-                                        echo("Post-build env:\nJAVA_HOME set to ${env.JAVA_HOME}\nJAVACMD set to ${env.JAVACMD}\nPATH set to ${env.PATH}")
+                                        echo("Post-build env:\nJAVA_HOME set to ${env.JAVA_HOME}")
 
                                     }
                                 }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -52,14 +52,14 @@ pipeline {
                             steps {
                                 echo "Provisioning Java version: ${params.jvm_version}"
                                 script {
-                                    echo "${JDK_MAJOR_VERSION}"
                                     echo "${env.JDK_MAJOR_VERSION}"
+                                    echo "${env.JAVA_HOME}"
 
-                                    JAVA_HOME=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
-                                    JDK_MAJOR_VERSION = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
+                                    env.JAVA_HOME=sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
+                                    env.JDK_MAJOR_VERSION = sh(script: ".ci/load/scripts/java_major.sh ${params.jvm_version}", returnStdout: true).trim()
 
-                                    echo "${JDK_MAJOR_VERSION}"
                                     echo "${env.JDK_MAJOR_VERSION}"
+                                    echo "${env.JAVA_HOME}"
                                 }
 
 

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -131,61 +131,61 @@ pipeline {
                             }
                         }
                         stage('Provision local metrics collection') {
-                                when {
-                                    expression {
-                                        return params.local_metrics
-                                    }
+                            when {
+                                expression {
+                                    return params.local_metrics
                                 }
-                                steps {
-                                    echo 'Enable local metric collection'
-                                    gitCheckout(
-                                        basedir: "${METRICS_BASE_DIR}",
-                                        branch: 'master',
-                                        repo: "https://github.com/pstadler/metrics.sh",
-                                        credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-                                        shallow: false
-                                    )
-                                    sh(script: "touch metrics.out")
-                                    dir("${METRICS_BASE_DIR}"){
-                                        withEnv(["FILE_LOCATION=./metrics.out"]) {
-                                            sh(script: "./metrics.sh -r file &")
-                                        }
+                            }
+                            steps {
+                                echo 'Enable local metric collection'
+                                gitCheckout(
+                                    basedir: "${METRICS_BASE_DIR}",
+                                    branch: 'master',
+                                    repo: "https://github.com/pstadler/metrics.sh",
+                                    credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                                    shallow: false
+                                )
+                                sh(script: "touch metrics.out")
+                                dir("${METRICS_BASE_DIR}"){
+                                    withEnv(["FILE_LOCATION=./metrics.out"]) {
+                                        sh(script: "./metrics.sh -r file &")
                                     }
                                 }
                             }
-                            stage('Application load') {
-                                steps {
-                                    echo 'Starting test application in background..'
-                                    dir("${APP_BASE_DIR}"){
-                                        // Launch app in background
-                                        withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY'){
-                                            echo "start application with JVM options '${params.jvm_options}'"
-                                            script {
-                                                if(env.JDK_MAJOR_VERSION == '7'){
-                                                    echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
-                                                    binaryPath = './target/petclinic.war'
-                                                } else {
-                                                    binaryPath = './target/spring-petclinic-*.jar'
-                                                }
-                                                sh(script: "java -jar -javaagent:${WORKSPACE}/${AGENT_BASE_DIR}/apm-agent-java/elastic-apm-agent/target/elastic-apm-agent-${params.apm_version}.jar -Delastic.apm.server_urls=${env.APM_SERVER_URL} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY} ${params.jvm_options} -XX:+FlightRecorder -XX:StartFlightRecording=filename=flight.jfr ${binaryPath} &")
+                        }
+                        stage('Application load') {
+                            steps {
+                                echo 'Starting test application in background..'
+                                dir("${APP_BASE_DIR}"){
+                                    // Launch app in background
+                                    withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY'){
+                                        echo "start application with JVM options '${params.jvm_options}'"
+                                        script {
+                                            if(env.JDK_MAJOR_VERSION == '7'){
+                                                echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
+                                                binaryPath = './target/petclinic.war'
+                                            } else {
+                                                binaryPath = './target/spring-petclinic-*.jar'
                                             }
+                                            sh(script: "java -jar -javaagent:${WORKSPACE}/${AGENT_BASE_DIR}/apm-agent-java/elastic-apm-agent/target/elastic-apm-agent-${params.apm_version}.jar -Delastic.apm.server_urls=${env.APM_SERVER_URL} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY} ${params.jvm_options} -XX:+FlightRecorder -XX:StartFlightRecording=filename=flight.jfr ${binaryPath} &")
                                         }
                                     }
-                                    echo 'Starting bandstand client..'
-                                    // Foreground the orchestrator script for execution control
-                                    withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
-                                        sh(script: ".ci/load/scripts/app.sh")
-                                    }
+                                }
+                                echo 'Starting bandstand client..'
+                                // Foreground the orchestrator script for execution control
+                                withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN'){
+                                    sh(script: ".ci/load/scripts/app.sh")
                                 }
                             }
-                            stage('Collecting results') {
-                                steps {
-                                    echo "To view results, JMC is required. Get it here: https://jdk.java.net/jmc/"
-                                    archiveArtifacts(allowEmptyArchive: true,
-                                        artifacts: "${APP_BASE_DIR}/**/*.jfr,${METRICS_BASE_DIR}/**/*.out",
-                                        onlyIfSuccessful: false)
-                                }
+                        }
+                        stage('Collecting results') {
+                            steps {
+                                echo "To view results, JMC is required. Get it here: https://jdk.java.net/jmc/"
+                                archiveArtifacts(allowEmptyArchive: true,
+                                    artifacts: "${APP_BASE_DIR}/**/*.jfr,${METRICS_BASE_DIR}/**/*.out",
+                                    onlyIfSuccessful: false)
                             }
+                        }
                     }
                 }
             }

--- a/.ci/load/scripts/java_major.sh
+++ b/.ci/load/scripts/java_major.sh
@@ -17,4 +17,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-echo $1 |cut -d '-' -f2|awk -F'\+|\.' '{print $1}'
+echo $1 |cut -d '-' -f2|awk -F'\\+|\\.' '{print $1}'


### PR DESCRIPTION
Fixes the current issues when trying to build with multiple JDK versions:

As a bonus, we now only need to set the `JAVA_HOME` environment variable when invoking maven directly in the `mvnw` invocation command.