### PR TITLE
[CI] Download maven dependencies firstly

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 source /usr/local/bin/bash_standard_lib.sh
 
+JAVA_HOME=$HOME/.java/java11 \
+  ./mvnw dependency:go-offline --fail-never -q -B
+
 JAVA_HOME=$HOME/.java/java11 ./mvnw clean verify \
   --fail-never -q -B \
   -Dmaven.javadoc.skip=true \

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -9,7 +9,7 @@ JAVA_HOME=$HOME/.java/java11 ./mvnw clean verify \
   -Dmaven.javadoc.skip=true \
   -Dhttps.protocols=TLSv1.2 \
   -Dmaven.wagon.http.retryHandler.count=3 \
-  -Dhttp.keepAlive=false \
+  -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 \
   -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
 
 if [ -x "$(command -v docker)" ]; then

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,9 +85,7 @@ pipeline {
                 sh label: 'Size .m2', returnStatus: true, script: 'du -hs .m2'
               }
               dir("${BASE_DIR}"){
-                retryWithSleep(retries: 3, seconds: 10, backoff: true) {
-                  sh label: 'mvn dependencies', script: './mvnw dependency:go-offline'
-                }
+                sh label: 'mvn dependencies', script: './mvnw -q dependency:go-offline --fail-never'
                 sh label: 'mvn install', script: "./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true"
                 sh label: 'mvn license', script: "./mvnw license:aggregate-third-party-report -Dlicense.excludedGroups=^co\\.elastic\\."
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,7 +85,7 @@ pipeline {
                 sh label: 'Size .m2', returnStatus: true, script: 'du -hs .m2'
               }
               dir("${BASE_DIR}"){
-                retryWithSleep(retries: 2, seconds: 10, backoff: true) {
+                retryWithSleep(retries: 3, seconds: 10, backoff: true) {
                   sh label: 'mvn dependencies', script: './mvnw dependency:go-offline'
                 }
                 sh label: 'mvn install', script: "./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
     issueCommentTrigger('(?i).*(?:jenkins\\W+)?run\\W+(?:the\\W+)?(?:benchmark\\W+)?tests(?:\\W+please)?.*')
   }
   parameters {
-    string(name: 'MAVEN_CONFIG', defaultValue: '-V -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false', description: 'Additional maven options.')
+    string(name: 'MAVEN_CONFIG', defaultValue: '-V -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -Dhttps.protocols=TLSv1.2 -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=25', description: 'Additional maven options.')
     booleanParam(name: 'Run_As_Master_Branch', defaultValue: false, description: 'Allow to run any steps on a PR, some steps normally only run on master branch.')
     booleanParam(name: 'test_ci', defaultValue: true, description: 'Enable test')
     booleanParam(name: 'smoketests_ci', defaultValue: true, description: 'Enable Smoke tests')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -85,6 +85,9 @@ pipeline {
                 sh label: 'Size .m2', returnStatus: true, script: 'du -hs .m2'
               }
               dir("${BASE_DIR}"){
+                retryWithSleep(retries: 2, seconds: 10, backoff: true) {
+                  sh label: 'mvn dependencies', script: './mvnw dependency:go-offline'
+                }
                 sh label: 'mvn install', script: "./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true"
                 sh label: 'mvn license', script: "./mvnw license:aggregate-third-party-report -Dlicense.excludedGroups=^co\\.elastic\\."
               }


### PR DESCRIPTION
## What does this PR do?

* Use [go-offline](https://maven.apache.org/plugins/maven-dependency-plugin/go-offline-mojo.html) prebuild to fetch all the dependencies.
* Set `maven.wagon.httpconnectionManager.ttlSeconds` to 25 seconds and `maven.wagon.http.retryHandler.count` to 3 retries.

## Why

I still see issues related to the connection reset :/ 

## Further details

The documentation for `maven.wagon.httpconnectionManager.ttlSeconds` is available in the source code:
* https://github.com/apache/maven-wagon/blob/wagon-3.4.1/wagon-providers/wagon-http-shared/src/main/java/org/apache/maven/wagon/shared/http/AbstractHttpClientWagon.java#L297-L305

Documentation for `maven.wagon.http.retryHandler.count` is in https://maven.apache.org/wagon/wagon-providers/wagon-http/


This is similar to the change made in Pulsar: apache/pulsar#8386
