### PR TITLE
Improve load testing PR

### DIFF
--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -188,10 +188,7 @@ pipeline {
 
                         script {
                             try {
-                                withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY') {
-
-                                    // writing sensitive values to configuration
-                                    writeFile(file: "${WORKSPACE}/agent_config.properties", text: "\nserver_urls=${env.APM_SERVER_URL}\nsecret_token=${env.ELASTIC_APM_API_KEY}\n")
+                                withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'ELASTIC_APM_SERVER_URLS', pass_var_name: 'ELASTIC_APM_SECRET_TOKEN') {
 
                                     echo "start application with JVM options '${params.jvm_options}'"
 

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
                     setEnvVar('SESSION_TOKEN', sh(script: ".ci/load/scripts/start.sh", returnStdout: true).trim())
                 }
 
-                stash('scripts', '.ci/load/**')
+                stash(name:'scripts', includes: '.ci/load/**')
             }
         }
         stage('Build agent') {

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -226,33 +226,33 @@ pipeline {
                             cmd = "${cmd} -jar ${app_binary}"
                             cmd = "${cmd} > ${WORKSPACE}/app.log &"
 
-                            // we use try/catch here to always capture log files
-                            try {
-                                withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'ELASTIC_APM_SERVER_URLS', pass_var_name: 'ELASTIC_APM_SECRET_TOKEN') {
-                                    sh(script: "${cmd}")
-                                }
+                            withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'ELASTIC_APM_SERVER_URLS', pass_var_name: 'ELASTIC_APM_SECRET_TOKEN') {
+                                sh(script: "${cmd}")
+                            }
 
-                                // Foreground the orchestrator script for execution control
-                                echo 'Starting bandstand client..'
-                                withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
-                                    sh(script: ".ci/load/scripts/app.sh")
-                                }
-                            } finally {
-                                // always remove configuration so we don't leave user-input
-                                sh(script: "rm -f ${WORKSPACE}/agent_config.properties")
-
-                                // always capture log files
-                                echo "Collect results"
-                                archiveArtifacts(
-                                        artifacts: "*.log,*.jfr,metrics.out",
-                                        allowEmptyArchive: true,
-                                        onlyIfSuccessful: false)
+                            // Foreground the orchestrator script for execution control
+                            echo 'Starting bandstand client..'
+                            withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
+                                sh(script: ".ci/load/scripts/app.sh")
                             }
 
                         }
                     }
                 }
             }
+        }
+    }
+    post {
+        always {
+            // always remove configuration so we don't leave user-input
+            sh(script: "rm -f ${WORKSPACE}/agent_config.properties")
+
+            // always capture log files
+            echo "Collect results and logs"
+            archiveArtifacts(
+                    artifacts: "*.log,*.jfr,metrics.out",
+                    allowEmptyArchive: true,
+                    onlyIfSuccessful: false)
         }
     }
 }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -197,6 +197,7 @@ pipeline {
                             cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
                             cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
                             cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
+                            cmd = "${cmd} -Delastic.apm.service_name=load-testing"
                             cmd = "${cmd} -Delastic.apm.global_labels=build_number=${env.BUILD_NUMBER}"
                             if (is_java7) {
                                 // BOTH properties are REQUIRED here, the cipher suite may be available but not

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -36,6 +36,9 @@ pipeline {
         text(name: "locustfile", "defaultValue": "", description: "Locust load-generator plan")
         booleanParam(name: "local_metrics", description: "Enable local metrics collection?", defaultValue: false)
         booleanParam(name: "ignore_application_errors", description: "Instruct the load generator to ignore non-2xx errors on exit", defaultValue: true)
+        booleanParam(name: "log_compilation", description: "Enable JIT compilation debug (verbose)", defaultValue: false)
+        booleanParam(name: "jfr", description: "Enable Java Flight Recorder (not supported by all JVMs)", defaultValue: false)
+        booleanParam(name: "attach_agent", description: "Attach APM agent, set to 'false' to disable agent completely", defaultValue: true)
     }
     stages {
         stage('Pre-flight') {
@@ -194,11 +197,15 @@ pipeline {
                             sh(script: "${java_home}/bin/java -version");
 
                             def cmd = "${java_home}/bin/java "
-                            cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
-                            cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
-                            cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
-                            cmd = "${cmd} -Delastic.apm.service_name=load-testing"
-                            cmd = "${cmd} -Delastic.apm.global_labels=build_number=${env.BUILD_NUMBER}"
+
+                            if (params.attach_agent) {
+                                cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
+                                cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
+                                cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
+                                cmd = "${cmd} -Delastic.apm.service_name=load-testing"
+                                cmd = "${cmd} -Delastic.apm.global_labels=build_number=${env.BUILD_NUMBER}"
+                            }
+
                             if (is_java7) {
                                 // BOTH properties are REQUIRED here, the cipher suite may be available but not
                                 // enabled by default
@@ -219,15 +226,17 @@ pipeline {
                             cmd = "${cmd} -Xloggc:${WORKSPACE}/gc.log"
 
                             // compilation log
-                            /* disabled for now, we should maybe add a pipeline parameter to enable it on-demand
-                            cmd = "${cmd} -XX:+UnlockDiagnosticVMOptions"
-                            cmd = "${cmd} -XX:+PrintCompilation"
-                            cmd = "${cmd} -XX:+LogCompilation"
-                            cmd = "${cmd} -XX:LogFile=${WORKSPACE}/compilation.log"h
-                             */
+                            if (params.log_compilation) {
+                                cmd = "${cmd} -XX:+UnlockDiagnosticVMOptions"
+                                cmd = "${cmd} -XX:+LogCompilation"
+                                cmd = "${cmd} -XX:LogFile=${WORKSPACE}/compilation.log"
+                            }
 
-                            // flight recorder disabled for now as not compatible with older JDKs
-                            // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
+                            // flight recorder is not supported on all JDKs
+                            if(params.jfr) {
+                                cmd = "${cmd} -XX:+FlightRecorder"
+                                cmd = "${cmd} -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
+                            }
 
                             def app_binary = "${WORKSPACE}/app.jar"
                             if (is_java7) {

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -214,7 +214,7 @@ pipeline {
                                     // flight recorder disabled for now as not compatible with older JDKs
                                     // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
                                     cmd = "${cmd} -jar ${app_binary}"
-                                    cmd = "${cmd} > ${WORKSPACE}/app.log & echo \$? > ${WORKSPACE}/app.pid"
+                                    cmd = "${cmd} > ${WORKSPACE}/app.log &"
                                     echo "CMD = ${cmd}"
                                     sh(script: "${cmd}")
                                 }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
                         }
 
                         // remove previous log files in workspace (if any)
-                        sh(script: "rm ${WORKSPACE}/*.log")
+                        sh(script: "rm -f ${WORKSPACE}/*.log")
 
                         unstash('scripts')
                         unstash('app')
@@ -185,72 +185,70 @@ pipeline {
                         echo "Starting test application in background.. with JVM = ${params.jvm_version}"
 
                         script {
+                            echo "start application with JVM options '${params.jvm_options}'"
+
+                            def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
+                            def major_jdk_version = readJSON(file: "/tmp/${params.jvm_version}/jdk.json")['version']
+
+                            def app_binary = "${WORKSPACE}/app.jar"
+                            if (major_jdk_version == '7') {
+                                echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
+                                app_binary = "${WORKSPACE}/app.war"
+                            }
+
+                            sh(script: "${java_home}/bin/java -version");
+
+                            def cmd = "${java_home}/bin/java "
+                            cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
+                            cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
+                            cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
+                            cmd = "${cmd} ${params.jvm_options}"
+
+                            // Crash reports in case things go wrong
+                            cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid.log"
+
+                            // GC log
+                            cmd = "${cmd} -XX:+PrintGCDetails"
+                            cmd = "${cmd} -XX:+PrintGCTimeStamps"
+                            cmd = "${cmd} -XX:+PrintTenuringDistribution"
+                            cmd = "${cmd} -Xloggc:${WORKSPACE}/gc.log"
+
+                            // compilation log
+                            /* disabled for now, we should maybe add a pipeline parameter to enable it on-demand
+                            cmd = "${cmd} -XX:+UnlockDiagnosticVMOptions"
+                            cmd = "${cmd} -XX:+PrintCompilation"
+                            cmd = "${cmd} -XX:+LogCompilation"
+                            cmd = "${cmd} -XX:LogFile=${WORKSPACE}/compilation.log"h
+                             */
+
+                            // flight recorder disabled for now as not compatible with older JDKs
+                            // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
+                            cmd = "${cmd} -jar ${app_binary}"
+                            cmd = "${cmd} > ${WORKSPACE}/app.log &"
+
+                            // we use try/catch here to always capture log files
                             try {
                                 withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'ELASTIC_APM_SERVER_URLS', pass_var_name: 'ELASTIC_APM_SECRET_TOKEN') {
+                                    sh(script: "${cmd}")
+                                }
 
-                                    echo "start application with JVM options '${params.jvm_options}'"
-
-                                    def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
-                                    def major_jdk_version = readJSON(file: "/tmp/${params.jvm_version}/jdk.json")['version']
-
-                                    def app_binary = "${WORKSPACE}/app.jar"
-                                    if (major_jdk_version == '7') {
-                                        echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
-                                        app_binary = "${WORKSPACE}/app.war"
-                                    }
-
-                                    sh(script: "${java_home}/bin/java -version");
-
-                                    dir("${APP_BASE_DIR}") {
-                                        def cmd = "${java_home}/bin/java "
-                                        cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
-                                        cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
-                                        cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
-                                        cmd = "${cmd} ${params.jvm_options}"
-
-                                        // Crash reports in case things go wrong
-                                        cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid.log"
-
-                                        // GC log
-                                        cmd = "${cmd} -XX:+PrintGCDetails"
-                                        cmd = "${cmd} -XX:+PrintGCTimeStamps"
-                                        cmd = "${cmd} -XX:+PrintTenuringDistribution"
-                                        cmd = "${cmd} -Xloggc:${WORKSPACE}/gc.log"
-
-                                        // compilation log
-                                        /* disabled for now, we should maybe add a pipeline parameter to enable it on-demand
-                                        cmd = "${cmd} -XX:+UnlockDiagnosticVMOptions"
-                                        cmd = "${cmd} -XX:+PrintCompilation"
-                                        cmd = "${cmd} -XX:+LogCompilation"
-                                        cmd = "${cmd} -XX:LogFile=${WORKSPACE}/compilation.log"h
-                                         */
-
-                                        // flight recorder disabled for now as not compatible with older JDKs
-                                        // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
-                                        cmd = "${cmd} -jar ${app_binary}"
-                                        cmd = "${cmd} > ${WORKSPACE}/app.log &"
-                                        sh(script: "${cmd}")
-                                    }
-
-                                    // we use try/catch here to always capture log files
-                                    try {
-                                        // Foreground the orchestrator script for execution control
-                                        echo 'Starting bandstand client..'
-                                        withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
-                                            sh(script: ".ci/load/scripts/app.sh")
-                                        }
-                                    } finally {
-                                        echo "Collect results"
-                                        archiveArtifacts(
-                                                artifacts: "*.log,*.jfr,metrics.out",
-                                                allowEmptyArchive: true,
-                                                onlyIfSuccessful: false)
-                                    }
-
+                                // Foreground the orchestrator script for execution control
+                                echo 'Starting bandstand client..'
+                                withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
+                                    sh(script: ".ci/load/scripts/app.sh")
                                 }
                             } finally {
+                                // always remove configuration so we don't leave user-input
                                 sh(script: "rm -f ${WORKSPACE}/agent_config.properties")
+
+                                // always capture log files
+                                echo "Collect results"
+                                archiveArtifacts(
+                                        artifacts: "*.log,*.jfr,metrics.out",
+                                        allowEmptyArchive: true,
+                                        onlyIfSuccessful: false)
                             }
+
                         }
                     }
                 }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -54,6 +54,12 @@ pipeline {
         }
         stage('Build agent') {
             agent { label 'benchmarks' }
+            when {
+                expression {
+                    // when not using agent, building is not required
+                    return params.attach_agent
+                }
+            }
             steps {
                 echo 'Checking out master branch'
                 gitCheckout(
@@ -180,7 +186,6 @@ pipeline {
 
                         unstash('scripts')
                         unstash('app')
-                        unstash('agent')
 
                         echo "Starting test application in background.. with JVM = ${params.jvm_version}"
 
@@ -199,6 +204,8 @@ pipeline {
                             def cmd = "${java_home}/bin/java "
 
                             if (params.attach_agent) {
+                                unstash('agent')
+
                                 cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
                                 cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
                                 cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -203,7 +203,7 @@ pipeline {
                                     cmd = "${cmd} ${params.jvm_options}"
 
                                     // Crash reports in case things go wrong
-                                    cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid%p.log"
+                                    cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid_%p.log"
 
                                     // GC log
                                     cmd = "${cmd} -XX:+PrintGCDetails"
@@ -214,7 +214,7 @@ pipeline {
                                     // flight recorder disabled for now as not compatible with older JDKs
                                     // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
                                     cmd = "${cmd} -jar ${app_binary}"
-                                    cmd = "${cmd} > ${WORKSPACE}/app.log &"
+                                    cmd = "${cmd} > ${WORKSPACE}/app.log & echo \$? > ${WORKSPACE}/app.pid"
                                     echo "CMD = ${cmd}"
                                     sh(script: "${cmd}")
                                 }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -212,6 +212,12 @@ pipeline {
                                     cmd = "${cmd} -XX:+PrintTenuringDistribution"
                                     cmd = "${cmd} -Xloggc:${WORKSPACE}/gc_%p.log"
 
+                                    // compilation log
+                                    cmd = "${cmd} -XX:+UnlockDiagnosticVMOptions"
+                                    cmd = "${cmd} -XX:+PrintCompilation"
+                                    cmd = "${cmd} -XX:+LogCompilation"
+                                    cmd = "${cmd} -XX:LogFile=${WORKSPACE}/compilation.log"
+
                                     // flight recorder disabled for now as not compatible with older JDKs
                                     // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
                                     cmd = "${cmd} -jar ${app_binary}"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -209,7 +209,8 @@ pipeline {
                             cmd = "${cmd} ${params.jvm_options}"
 
                             // Crash reports in case things go wrong
-                            cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid.log"
+                            // keep PID in file, as it won't be overwritten if file exists
+                            cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid%p.log"
 
                             // GC log
                             cmd = "${cmd} -XX:+PrintGCDetails"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -197,6 +197,7 @@ pipeline {
                             cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
                             cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
                             cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
+                            cmd = "${cmd} -Delastic.apm.global_labels=build_number=${env.BUILD_NUMBER}"
                             if (is_java7) {
                                 // BOTH properties are REQUIRED here, the cipher suite may be available but not
                                 // enabled by default

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -182,7 +182,7 @@ pipeline {
                         echo "Starting test application in background.. with JVM = ${params.jvm_version}"
 
                         // force kill any remaining app instance to ensure app can start
-                        sh(script: ".ci/load/scripts/app.sh stopAppForce")
+                        sh(script: ".ci/load/scripts/app.sh stopApp")
 
                         script {
                             echo "start application with JVM options '${params.jvm_options}'"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -40,8 +40,7 @@ pipeline {
     stages {
         stage('Pre-flight') {
             steps {
-                checkout scm
-                // gitCheckout(basedir: '.', githubNotifyFirstTimeContributor: true, shallow: false)
+                gitCheckout(basedir: '.', githubNotifyFirstTimeContributor: true, shallow: false)
                 echo 'Getting authentication information from Vault'
                 withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
                     setEnvVar('SESSION_TOKEN', sh(script: ".ci/load/scripts/start.sh", returnStdout: true).trim())

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -194,7 +194,16 @@ pipeline {
                                     cmd = "${cmd} -Delastic.apm.server_urls=${env.APM_SERVER_URL}"
                                     cmd = "${cmd} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY}"
                                     cmd = "${cmd} ${params.jvm_options}"
+
+                                    // Crash reports in case things go wrong
                                     cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid%p.log"
+
+                                    // GC log
+                                    cmd = "${cmd} -XX:+PrintGCDetails"
+                                    cmd = "${cmd} -XX:+PrintGCTimeStamps"
+                                    cmd = "${cmd} -XX:+PrintTenuringDistribution"
+                                    cmd = "${cmd} -Xloggc:${WORKSPACE}/gc_%p.log"
+
                                     // flight recorder disabled for now as not compatible with older JDKs
                                     // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
                                     cmd = "${cmd} -jar ${app_binary}"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -195,6 +195,8 @@ pipeline {
                             cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
                             cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
                             if (is_java7) {
+                                // BOTH properties are REQUIRED here, the cipher suite may be available but not
+                                // enabled by default
                                 echo "Detected Java 7.x using TLSv1.2 + enable cipher suite"
                                 cmd = "${cmd} -Dhttps.protocols=TLSv1.2"
                                 cmd = "${cmd} -Dhttps.cipherSuites=TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -47,17 +47,6 @@ pipeline {
                 }
             }
         }
-        stage('Provision JDK') {
-            agent { label 'benchmarks' }
-            steps {
-                echo "Provisioning Java version: ${params.jvm_version}"
-                script {
-                    def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
-                    setEnvVar('JAVA_HOME', java_home)
-                    echo("JAVA_HOME = ${env.JAVA_HOME}")
-                }
-            }
-        }
         stage('Build agent') {
             agent { label 'benchmarks' }
             steps {
@@ -101,7 +90,7 @@ pipeline {
             steps {
                 script {
                     def app_branch = "main"
-                    def build_jdk_path = "${env.JAVA_HOME}"
+                    def build_jdk_path = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
                     def binary_ext = 'jar'
 
                     def major_jdk_version = readJSON(file: "/tmp/${params.jvm_version}/jdk.json")['version']
@@ -188,18 +177,19 @@ pipeline {
                             unstash('agent')
 
                             script {
-
+                                def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
                                 def major_jdk_version = readJSON(file: "/tmp/${params.jvm_version}/jdk.json")['version']
+
                                 def app_binary = "${WORKSPACE}/app.jar"
                                 if (major_jdk_version == '7') {
                                     echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
                                     app_binary = "${WORKSPACE}/app.war"
                                 }
 
-                                sh(script: "${env.JAVA_HOME}/bin/java -version");
+                                sh(script: "${java_home}/bin/java -version");
 
                                 dir("${APP_BASE_DIR}") {
-                                    def cmd = "${env.JAVA_HOME}/bin/java "
+                                    def cmd = "${java_home}/bin/java "
                                     cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
                                     cmd = "${cmd} -Delastic.apm.server_urls=${env.APM_SERVER_URL}"
                                     cmd = "${cmd} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY}"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -194,6 +194,10 @@ pipeline {
                             cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
                             cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
                             cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
+                            if (is_java7) {
+                                echo "Detected Java 7.x using TLSv1.2"
+                                cmd = "${cmd} -Dhttps.protocols=TLSv1.2"
+                            }
                             cmd = "${cmd} ${params.jvm_options}"
 
                             // Crash reports in case things go wrong
@@ -218,13 +222,8 @@ pipeline {
 
                             def app_binary = "${WORKSPACE}/app.jar"
                             if (is_java7) {
-                                echo "Detected Java 7.x using application packaged as a .war file + force TLSv1.2"
+                                echo "Detected Java 7.x using application packaged as a .war file"
                                 app_binary = "${WORKSPACE}/app.war"
-
-                                // Note that we have to use exactly this value, using '-Dhttps.protocols=TLSv1.1,TLSv1.2'
-                                // does NOT work
-                                cmd = "${cmd} -Dhttps.protocols=TLSv1.2"
-
                             }
 
                             cmd = "${cmd} -jar ${app_binary}"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -246,6 +246,9 @@ pipeline {
                     }
                     post {
                         always {
+                            // stop the running application in case it hasn't been properly stopped
+                            sh(script: ".ci/load/scripts/app.sh stopApp")
+
                             // always remove configuration so we don't leave user-input
                             sh(script: "rm -f ${WORKSPACE}/agent_config.properties")
 

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -172,9 +172,7 @@ pipeline {
                         // create agent configuration
                         whenTrue(Boolean.valueOf(params.agent_config)) {
                             echo 'Writing user-supplied agent configuration'
-                            dir("${AGENT_BASE_DIR}") {
-                                sh script: "echo \"${params.agent_config}\" >> ${WORKSPACE}/agent_config.properties"
-                            }
+                            writeFile(file: "${WORKSPACE}/agent_config.properties", text: "${params.agent_config}")
                         }
 
                         // remove previous log files in workspace (if any)
@@ -251,7 +249,7 @@ pipeline {
 
                                 }
                             } finally {
-                                sh(script: "rm ${WORKSPACE}/agent_config.properties")
+                                sh(script: "rm -f ${WORKSPACE}/agent_config.properties")
                             }
                         }
                     }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -220,24 +220,25 @@ pipeline {
                                 }
 
                             }
-                            echo 'Starting bandstand client..'
-                            // Foreground the orchestrator script for execution control
-                            withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
-                                sh(script: ".ci/load/scripts/app.sh")
+
+                            // we use try/catch here to
+                            try {
+                                // Foreground the orchestrator script for execution control
+                                echo 'Starting bandstand client..'
+                                withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
+                                    sh(script: ".ci/load/scripts/app.sh")
+                                }
+                            } finally {
+                                echo "Collect results"
+                                archiveArtifacts(
+                                        artifacts: "*.log,*.jfr,metrics.out",
+                                        allowEmptyArchive: true,
+                                        onlyIfSuccessful: false)
                             }
+
                         }
                     }
                 }
-            }
-        }
-        stage('Collect results') {
-            agent { label 'benchmarks' }
-            steps {
-                echo "To view results, JMC is required. Get it here: https://jdk.java.net/jmc/"
-                archiveArtifacts(
-                    artifacts: "*.log,*.jfr,metrics.out",
-                    allowEmptyArchive: true,
-                    onlyIfSuccessful: false)
             }
         }
     }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -208,13 +208,13 @@ pipeline {
                                     cmd = "${cmd} ${params.jvm_options}"
 
                                     // Crash reports in case things go wrong
-                                    cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid_%p.log"
+                                    cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid.log"
 
                                     // GC log
                                     cmd = "${cmd} -XX:+PrintGCDetails"
                                     cmd = "${cmd} -XX:+PrintGCTimeStamps"
                                     cmd = "${cmd} -XX:+PrintTenuringDistribution"
-                                    cmd = "${cmd} -Xloggc:${WORKSPACE}/gc_%p.log"
+                                    cmd = "${cmd} -Xloggc:${WORKSPACE}/gc.log"
 
                                     // compilation log
                                     cmd = "${cmd} -XX:+UnlockDiagnosticVMOptions"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -181,6 +181,9 @@ pipeline {
 
                         echo "Starting test application in background.. with JVM = ${params.jvm_version}"
 
+                        // force kill any remaining app instance to ensure app can start
+                        sh(script: ".ci/load/scripts/app.sh stopAppForce")
+
                         script {
                             echo "start application with JVM options '${params.jvm_options}'"
 

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -220,10 +220,12 @@ pipeline {
                                         cmd = "${cmd} -Xloggc:${WORKSPACE}/gc.log"
 
                                         // compilation log
+                                        /* disabled for now, we should maybe add a pipeline parameter to enable it on-demand
                                         cmd = "${cmd} -XX:+UnlockDiagnosticVMOptions"
                                         cmd = "${cmd} -XX:+PrintCompilation"
                                         cmd = "${cmd} -XX:+LogCompilation"
-                                        cmd = "${cmd} -XX:LogFile=${WORKSPACE}/compilation.log"
+                                        cmd = "${cmd} -XX:LogFile=${WORKSPACE}/compilation.log"h
+                                         */
 
                                         // flight recorder disabled for now as not compatible with older JDKs
                                         // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -195,8 +195,9 @@ pipeline {
                             cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
                             cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
                             if (is_java7) {
-                                echo "Detected Java 7.x using TLSv1.2"
+                                echo "Detected Java 7.x using TLSv1.2 + enable cipher suite"
                                 cmd = "${cmd} -Dhttps.protocols=TLSv1.2"
+                                cmd = "${cmd} -Dhttps.cipherSuites=TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256"
                             }
                             cmd = "${cmd} ${params.jvm_options}"
 

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -170,10 +170,7 @@ pipeline {
                     steps {
 
                         // create agent configuration
-                        whenTrue(Boolean.valueOf(params.agent_config)) {
-                            echo 'Writing user-supplied agent configuration'
-                            writeFile(file: "${WORKSPACE}/agent_config.properties", text: "${params.agent_config}")
-                        }
+                        writeFile(file: "${WORKSPACE}/agent_config.properties", text: "${params.agent_config}")
 
                         // remove previous log files in workspace (if any)
                         sh(script: "rm -f ${WORKSPACE}/*.log ${WORKSPACE}/*.pid")

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -40,7 +40,8 @@ pipeline {
     stages {
         stage('Pre-flight') {
             steps {
-                gitCheckout(basedir: '.', githubNotifyFirstTimeContributor: true, shallow: false)
+                checkout scm
+                // gitCheckout(basedir: '.', githubNotifyFirstTimeContributor: true, shallow: false)
                 echo 'Getting authentication information from Vault'
                 withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
                     setEnvVar('SESSION_TOKEN', sh(script: ".ci/load/scripts/start.sh", returnStdout: true).trim())

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -176,6 +176,10 @@ pipeline {
                 stage('Run app') {
                     agent { label 'benchmarks' }
                     steps {
+
+                        // remove previous log files in workspace (if any)
+                        sh(script: "rm ${WORKSPACE}/*.log")
+
                         unstash('scripts')
                         unstash('app')
                         unstash('agent')

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -186,12 +186,7 @@ pipeline {
 
                             def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
                             def major_jdk_version = readJSON(file: "/tmp/${params.jvm_version}/jdk.json")['version']
-
-                            def app_binary = "${WORKSPACE}/app.jar"
-                            if (major_jdk_version == '7') {
-                                echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
-                                app_binary = "${WORKSPACE}/app.war"
-                            }
+                            def is_java7 = major_jdk_version == '7';
 
                             sh(script: "${java_home}/bin/java -version");
 
@@ -220,6 +215,18 @@ pipeline {
 
                             // flight recorder disabled for now as not compatible with older JDKs
                             // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
+
+                            def app_binary = "${WORKSPACE}/app.jar"
+                            if (is_java7) {
+                                echo "Detected Java 7.x using application packaged as a .war file + force TLSv1.2"
+                                app_binary = "${WORKSPACE}/app.war"
+
+                                // Note that we have to use exactly this value, using '-Dhttps.protocols=TLSv1.1,TLSv1.2'
+                                // does NOT work
+                                cmd = "${cmd} -Dhttps.protocols=TLSv1.2"
+
+                            }
+
                             cmd = "${cmd} -jar ${app_binary}"
                             cmd = "${cmd} > ${WORKSPACE}/app.log &"
 

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -79,13 +79,6 @@ pipeline {
                         onlyIfSuccessful: false)
 
                 stash(name: "agent", includes: "elastic-apm-agent.jar")
-
-                whenTrue(Boolean.valueOf(params.agent_config)) {
-                    echo 'Writing user-supplied agent configuration'
-                    dir("${AGENT_BASE_DIR}") {
-                        sh script: "echo \"${params.agent_config}\">custom_config.cfg"
-                     }
-                }
             }
         }
         stage('Build test application') {
@@ -177,6 +170,14 @@ pipeline {
                     agent { label 'benchmarks' }
                     steps {
 
+                        // create agent configuration
+                        whenTrue(Boolean.valueOf(params.agent_config)) {
+                            echo 'Writing user-supplied agent configuration'
+                            dir("${AGENT_BASE_DIR}") {
+                                sh script: "echo \"${params.agent_config}\" >> ${WORKSPACE}/agent_config.properties"
+                            }
+                        }
+
                         // remove previous log files in workspace (if any)
                         sh(script: "rm ${WORKSPACE}/*.log")
 
@@ -185,7 +186,13 @@ pipeline {
                         unstash('agent')
 
                         echo "Starting test application in background.. with JVM = ${params.jvm_version}"
-                        withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY') {
+
+                        try {
+                            withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY') {
+
+                            // writing sensitive values to configuration
+                            writeFile(file: "${WORKSPACE}/agent_config.properties", text: "\nserver_urls=${env.APM_SERVER_URL}\nsecret_token=${env.ELASTIC_APM_API_KEY}\n")
+
                             echo "start application with JVM options '${params.jvm_options}'"
 
                             script {
@@ -203,8 +210,7 @@ pipeline {
                                 dir("${APP_BASE_DIR}") {
                                     def cmd = "${java_home}/bin/java "
                                     cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
-                                    cmd = "${cmd} -Delastic.apm.server_urls=${env.APM_SERVER_URL}"
-                                    cmd = "${cmd} -Delastic.apm.secret_token=${env.ELASTIC_APM_API_KEY}"
+                                    cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
                                     cmd = "${cmd} ${params.jvm_options}"
 
                                     // Crash reports in case things go wrong
@@ -226,7 +232,6 @@ pipeline {
                                     // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
                                     cmd = "${cmd} -jar ${app_binary}"
                                     cmd = "${cmd} > ${WORKSPACE}/app.log &"
-                                    echo "CMD = ${cmd}"
                                     sh(script: "${cmd}")
                                 }
 
@@ -247,6 +252,9 @@ pipeline {
 
                             }
 
+                            }
+                        } finally {
+                            sh(script: "rm ${WORKSPACE}/agent_config.properties")
                         }
                     }
                 }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -187,74 +187,73 @@ pipeline {
 
                         echo "Starting test application in background.. with JVM = ${params.jvm_version}"
 
-                        try {
-                            withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY') {
+                        script {
+                            try {
+                                withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY') {
 
-                            // writing sensitive values to configuration
-                            writeFile(file: "${WORKSPACE}/agent_config.properties", text: "\nserver_urls=${env.APM_SERVER_URL}\nsecret_token=${env.ELASTIC_APM_API_KEY}\n")
+                                    // writing sensitive values to configuration
+                                    writeFile(file: "${WORKSPACE}/agent_config.properties", text: "\nserver_urls=${env.APM_SERVER_URL}\nsecret_token=${env.ELASTIC_APM_API_KEY}\n")
 
-                            echo "start application with JVM options '${params.jvm_options}'"
+                                    echo "start application with JVM options '${params.jvm_options}'"
 
-                            script {
-                                def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
-                                def major_jdk_version = readJSON(file: "/tmp/${params.jvm_version}/jdk.json")['version']
+                                    def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
+                                    def major_jdk_version = readJSON(file: "/tmp/${params.jvm_version}/jdk.json")['version']
 
-                                def app_binary = "${WORKSPACE}/app.jar"
-                                if (major_jdk_version == '7') {
-                                    echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
-                                    app_binary = "${WORKSPACE}/app.war"
-                                }
-
-                                sh(script: "${java_home}/bin/java -version");
-
-                                dir("${APP_BASE_DIR}") {
-                                    def cmd = "${java_home}/bin/java "
-                                    cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
-                                    cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
-                                    cmd = "${cmd} ${params.jvm_options}"
-
-                                    // Crash reports in case things go wrong
-                                    cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid.log"
-
-                                    // GC log
-                                    cmd = "${cmd} -XX:+PrintGCDetails"
-                                    cmd = "${cmd} -XX:+PrintGCTimeStamps"
-                                    cmd = "${cmd} -XX:+PrintTenuringDistribution"
-                                    cmd = "${cmd} -Xloggc:${WORKSPACE}/gc.log"
-
-                                    // compilation log
-                                    cmd = "${cmd} -XX:+UnlockDiagnosticVMOptions"
-                                    cmd = "${cmd} -XX:+PrintCompilation"
-                                    cmd = "${cmd} -XX:+LogCompilation"
-                                    cmd = "${cmd} -XX:LogFile=${WORKSPACE}/compilation.log"
-
-                                    // flight recorder disabled for now as not compatible with older JDKs
-                                    // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
-                                    cmd = "${cmd} -jar ${app_binary}"
-                                    cmd = "${cmd} > ${WORKSPACE}/app.log &"
-                                    sh(script: "${cmd}")
-                                }
-
-                                // we use try/catch here to always capture log files
-                                try {
-                                    // Foreground the orchestrator script for execution control
-                                    echo 'Starting bandstand client..'
-                                    withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
-                                        sh(script: ".ci/load/scripts/app.sh")
+                                    def app_binary = "${WORKSPACE}/app.jar"
+                                    if (major_jdk_version == '7') {
+                                        echo "Detected 7.x Java version. Switching to 7.x compat mode and calling .war"
+                                        app_binary = "${WORKSPACE}/app.war"
                                     }
-                                } finally {
-                                    echo "Collect results"
-                                    archiveArtifacts(
-                                            artifacts: "*.log,*.jfr,metrics.out",
-                                            allowEmptyArchive: true,
-                                            onlyIfSuccessful: false)
+
+                                    sh(script: "${java_home}/bin/java -version");
+
+                                    dir("${APP_BASE_DIR}") {
+                                        def cmd = "${java_home}/bin/java "
+                                        cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
+                                        cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
+                                        cmd = "${cmd} ${params.jvm_options}"
+
+                                        // Crash reports in case things go wrong
+                                        cmd = "${cmd} -XX:ErrorFile=${WORKSPACE}/hs_err_pid.log"
+
+                                        // GC log
+                                        cmd = "${cmd} -XX:+PrintGCDetails"
+                                        cmd = "${cmd} -XX:+PrintGCTimeStamps"
+                                        cmd = "${cmd} -XX:+PrintTenuringDistribution"
+                                        cmd = "${cmd} -Xloggc:${WORKSPACE}/gc.log"
+
+                                        // compilation log
+                                        cmd = "${cmd} -XX:+UnlockDiagnosticVMOptions"
+                                        cmd = "${cmd} -XX:+PrintCompilation"
+                                        cmd = "${cmd} -XX:+LogCompilation"
+                                        cmd = "${cmd} -XX:LogFile=${WORKSPACE}/compilation.log"
+
+                                        // flight recorder disabled for now as not compatible with older JDKs
+                                        // cmd = "${cmd} -XX:+FlightRecorder -XX:StartFlightRecording=filename=${WORKSPACE}/flight.jfr"
+                                        cmd = "${cmd} -jar ${app_binary}"
+                                        cmd = "${cmd} > ${WORKSPACE}/app.log &"
+                                        sh(script: "${cmd}")
+                                    }
+
+                                    // we use try/catch here to always capture log files
+                                    try {
+                                        // Foreground the orchestrator script for execution control
+                                        echo 'Starting bandstand client..'
+                                        withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
+                                            sh(script: ".ci/load/scripts/app.sh")
+                                        }
+                                    } finally {
+                                        echo "Collect results"
+                                        archiveArtifacts(
+                                                artifacts: "*.log,*.jfr,metrics.out",
+                                                allowEmptyArchive: true,
+                                                onlyIfSuccessful: false)
+                                    }
+
                                 }
-
+                            } finally {
+                                sh(script: "rm ${WORKSPACE}/agent_config.properties")
                             }
-
-                            }
-                        } finally {
-                            sh(script: "rm ${WORKSPACE}/agent_config.properties")
                         }
                     }
                 }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -45,6 +45,8 @@ pipeline {
                 withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
                     setEnvVar('SESSION_TOKEN', sh(script: ".ci/load/scripts/start.sh", returnStdout: true).trim())
                 }
+
+                stash('scripts', '.ci/load/**')
             }
         }
         stage('Build agent') {
@@ -88,6 +90,8 @@ pipeline {
         stage('Build test application') {
             agent { label 'benchmarks' }
             steps {
+                unstash('scripts')
+
                 script {
                     def app_branch = "main"
                     def build_jdk_path = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
@@ -155,6 +159,8 @@ pipeline {
                     agent { label 'metal' }
                     steps {
                         echo 'Preparing load generation..'
+                        unstash('scripts')
+
                         withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
                             whenTrue(Boolean.valueOf(params.locustfile)) {
                                 echo 'Using user-supplied plan for load-generation with Locust'
@@ -169,12 +175,13 @@ pipeline {
                 stage('Run app') {
                     agent { label 'benchmarks' }
                     steps {
+                        unstash('scripts')
+                        unstash('app')
+                        unstash('agent')
+
                         echo "Starting test application in background.. with JVM = ${params.jvm_version}"
                         withSecretVault(secret: 'secret/apm-team/ci/apm-load-test-server', user_var_name: 'APM_SERVER_URL', pass_var_name: 'ELASTIC_APM_API_KEY') {
                             echo "start application with JVM options '${params.jvm_options}'"
-
-                            unstash('app')
-                            unstash('agent')
 
                             script {
                                 def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -176,7 +176,7 @@ pipeline {
                         }
 
                         // remove previous log files in workspace (if any)
-                        sh(script: "rm -f ${WORKSPACE}/*.log")
+                        sh(script: "rm -f ${WORKSPACE}/*.log ${WORKSPACE}/*.pid")
 
                         unstash('scripts')
                         unstash('app')
@@ -238,21 +238,22 @@ pipeline {
 
                         }
                     }
+                    post {
+                        always {
+                            // always remove configuration so we don't leave user-input
+                            sh(script: "rm -f ${WORKSPACE}/agent_config.properties")
+
+                            // always capture log files
+                            echo "Collect results and logs"
+                            archiveArtifacts(
+                                    artifacts: "*.log,*.jfr,metrics.out",
+                                    allowEmptyArchive: true,
+                                    onlyIfSuccessful: false)
+                        }
+                    }
                 }
             }
         }
     }
-    post {
-        always {
-            // always remove configuration so we don't leave user-input
-            sh(script: "rm -f ${WORKSPACE}/agent_config.properties")
 
-            // always capture log files
-            echo "Collect results and logs"
-            archiveArtifacts(
-                    artifacts: "*.log,*.jfr,metrics.out",
-                    allowEmptyArchive: true,
-                    onlyIfSuccessful: false)
-        }
-    }
 }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -219,21 +219,21 @@ pipeline {
                                     sh(script: "${cmd}")
                                 }
 
-                            }
-
-                            // we use try/catch here to
-                            try {
-                                // Foreground the orchestrator script for execution control
-                                echo 'Starting bandstand client..'
-                                withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
-                                    sh(script: ".ci/load/scripts/app.sh")
+                                // we use try/catch here to always capture log files
+                                try {
+                                    // Foreground the orchestrator script for execution control
+                                    echo 'Starting bandstand client..'
+                                    withSecretVault(secret: 'secret/apm-team/ci/bandstand', user_var_name: 'APP_TOKEN_TYPE', pass_var_name: 'APP_TOKEN') {
+                                        sh(script: ".ci/load/scripts/app.sh")
+                                    }
+                                } finally {
+                                    echo "Collect results"
+                                    archiveArtifacts(
+                                            artifacts: "*.log,*.jfr,metrics.out",
+                                            allowEmptyArchive: true,
+                                            onlyIfSuccessful: false)
                                 }
-                            } finally {
-                                echo "Collect results"
-                                archiveArtifacts(
-                                        artifacts: "*.log,*.jfr,metrics.out",
-                                        allowEmptyArchive: true,
-                                        onlyIfSuccessful: false)
+
                             }
 
                         }

--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -207,6 +207,7 @@ pipeline {
                                         def cmd = "${java_home}/bin/java "
                                         cmd = "${cmd} -javaagent:${WORKSPACE}/elastic-apm-agent.jar"
                                         cmd = "${cmd} -Delastic.apm.config_file=${WORKSPACE}/agent_config.properties"
+                                        cmd = "${cmd} -Delastic.apm.log_file=${WORKSPACE}/agent.log"
                                         cmd = "${cmd} ${params.jvm_options}"
 
                                         // Crash reports in case things go wrong

--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -145,7 +145,7 @@ function checkLoadGenFinish(){
 
 
 function stopApp() {
-    ps -ef|egrep 'app\.[wj]ar'|egrep java|awk '{print $2}'|xargs kill
+    ps -ef|egrep 'app\.[wj]ar'|egrep java|awk '{print $2}'|xargs kill -9
 }
 
 function tearDown() {
@@ -163,10 +163,6 @@ function tearDown() {
 case "${1:-}" in
   stopApp)
     stopApp
-    exit 0
-    ;;
-  stopAppForce)
-    lsof -i :${APP_PORT} | grep LISTEN | awk '{print $2}' | xargs kill -9
     exit 0
     ;;
 esac

--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -170,4 +170,18 @@ waitForApp
 sendAppReady
 waitForLoadGenState 'ready'
 waitForLoadGenState 'stopped'
-stopApp
+
+if [ '' = "$(getAppPids)" ]; then
+  echo "abnormal application stop detected, stop load injection"
+  # application crashed or stopped before we intentionally stopped it
+  # end the load injection
+    curl -s -X POST -H "Content-Type: application/json" -d \
+    "{\"app_token\": \""$APP_TOKEN"\", \
+    \"session_token\": \""$SESSION_TOKEN"\", \
+    \"service\": \"load_generation\", \
+    \"hostname\": \"test_app\", \
+    \"port\": \"8080\"}" \
+    $ORCH_URL/api/stop
+else
+      stopApp
+fi

--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -160,15 +160,22 @@ function tearDown() {
     done
 }
 
-if [ "${1:-}" == "stopApp" ]; then
-  stopApp
-  exit 0
-fi
+case "${1:-}" in
+  stopApp)
+    stopApp
+    exit 0
+    ;;
+  stopAppForce)
+    lsof -i :${APP_PORT} | grep LISTEN | awk '{print $2}' | xargs kill -9
+    exit 0
+    ;;
+esac
 
 if [ ! $DEBUG_MODE ]; then
     trap "tearDown" ERR EXIT
     setUp
 fi
+
 waitForApp
 sendAppReady
 waitForLoad

--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -160,7 +160,7 @@ function tearDown() {
     done
 }
 
-if [ $1 == "stopApp" ]; then
+if [ "${1:-}" == "stopApp" ]; then
   stopApp
   exit 0
 fi

--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -145,7 +145,12 @@ function checkLoadGenFinish(){
 
 
 function stopApp() {
-    ps -ef|egrep petclinic|egrep java|awk '{print $2}'|xargs kill
+    if [ -f app.pid ]
+    then
+      kill "$(cat app.pid)"
+    else
+      ps -ef|egrep 'app\.[wj]ar'|egrep java|awk '{print $2}'|xargs kill
+    fi
 }
 
 function tearDown() {

--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -145,12 +145,7 @@ function checkLoadGenFinish(){
 
 
 function stopApp() {
-    if [ -f app.pid ]
-    then
-      kill "$(cat app.pid)"
-    else
-      ps -ef|egrep 'app\.[wj]ar'|egrep java|awk '{print $2}'|xargs kill
-    fi
+    ps -ef|egrep 'app\.[wj]ar'|egrep java|awk '{print $2}'|xargs kill
 }
 
 function tearDown() {

--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -145,7 +145,9 @@ function checkLoadGenFinish(){
 
 
 function stopApp() {
-    ps -ef|egrep 'app\.[wj]ar'|egrep java|awk '{print $2}'|xargs kill -9
+    for pid in $(ps -ef|egrep 'app\.[wj]ar'|egrep java|awk '{print $2}'); do
+      kill -9 "${pid}"
+    done
 }
 
 function tearDown() {

--- a/.ci/load/scripts/app.sh
+++ b/.ci/load/scripts/app.sh
@@ -160,6 +160,11 @@ function tearDown() {
     done
 }
 
+if [ $1 == "stopApp" ]; then
+  stopApp
+  exit 0
+fi
+
 if [ ! $DEBUG_MODE ]; then
     trap "tearDown" ERR EXIT
     setUp

--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -65,7 +65,13 @@ JDK_ARCHIVE="${JDK_FOLDER}/${SDK_FILENAME}"
 if [[ ! -f "${JDK_ARCHIVE}" ]]
 then
   curl -s -o "${JDK_ARCHIVE}" "${SDK_URL}"
-  tar xfz "${JDK_ARCHIVE}" -C "${JDK_FOLDER}"
+  if [ "${JDK_ARCHIVE: -4}" == ".zip" ]
+  then
+      unzip "${JDK_ARCHIVE}" -d "${JDK_FOLDER}"
+  else
+      tar xfz "${JDK_ARCHIVE}" -C "${JDK_FOLDER}"
+  fi
+
 fi
 
 # JDK is stored within a sub-folder

--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -75,4 +75,9 @@ then
 fi
 
 # JDK is stored within a sub-folder
-find "${JDK_FOLDER}" -maxdepth 1 -mindepth 1 -type d
+SUB_FOLDER="$(find "${JDK_FOLDER}" -maxdepth 1 -mindepth 1 -type d)"
+if [[ ! -d ${SUB_FOLDER} ]]
+then
+  echo "JDK sub-folder not found in ${JDK_FOLDER}"
+  exit 2
+fi

--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -39,7 +39,7 @@
 # 3. tar    [https://www.gnu.org/software/tar/]
 # ================================================================
 
-#set -exuo pipefail
+set -euo pipefail
 
 CATALOG_URL="https://jvm-catalog.elastic.co/jdks/tags/linux,x86_64"
 JDK_ID="${1}"
@@ -50,6 +50,12 @@ JDK_JSON="${JDK_FOLDER}/jdk.json"
 mkdir -p "${JDK_FOLDER}"
 
 curl -s "${CATALOG_URL}" | jq ".[] | select(.id==\"${JDK_ID}\")" > "${JDK_JSON}"
+if [ ! -s "${JDK_JSON}" ]
+then
+  echo "unknown JDK ID = ${JDK_ID}"
+  exit 1
+fi
+
 read -d'\n' -r SDK_URL SDK_FILENAME <<<$(jq -Mr '.url, .filename' < "${JDK_JSON}")
 
 JDK_ARCHIVE="${JDK_FOLDER}/${SDK_FILENAME}"

--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -67,7 +67,7 @@ then
   curl -s -o "${JDK_ARCHIVE}" "${SDK_URL}"
   if [ "${JDK_ARCHIVE: -4}" == ".zip" ]
   then
-      unzip "${JDK_ARCHIVE}" -d "${JDK_FOLDER}"
+      unzip -qq "${JDK_ARCHIVE}" -d "${JDK_FOLDER}"
   else
       tar xfz "${JDK_ARCHIVE}" -C "${JDK_FOLDER}"
   fi

--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -39,7 +39,7 @@
 # 3. tar    [https://www.gnu.org/software/tar/]
 # ================================================================
 
-set -euo pipefail
+#set -euo pipefail
 
 CATALOG_URL="https://jvm-catalog.elastic.co/jdks/tags/linux,x86_64"
 JDK_ID="${1}"

--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -74,6 +74,8 @@ then
 
 fi
 
+set -x
+
 # JDK is stored within a sub-folder
 SUB_FOLDER="$(find "${JDK_FOLDER}" -maxdepth 1 -mindepth 1 -type d)"
 if [[ ! -d "${SUB_FOLDER}" ]]

--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -80,7 +80,8 @@ set -x
 SUB_FOLDER="$(find "${JDK_FOLDER}" -maxdepth 1 -mindepth 1 -type d)"
 if [[ ! -d "${SUB_FOLDER}" ]]
 then
-  echo "JDK sub-folder not found in ${JDK_FOLDER}"
+  echo "JDK sub-folder not found in ${JDK_FOLDER}, cleaning up"
+  rm -rf "${JDK_FOLDER}"
   exit 2
 fi
 

--- a/.ci/load/scripts/fetch_sdk.sh
+++ b/.ci/load/scripts/fetch_sdk.sh
@@ -76,8 +76,10 @@ fi
 
 # JDK is stored within a sub-folder
 SUB_FOLDER="$(find "${JDK_FOLDER}" -maxdepth 1 -mindepth 1 -type d)"
-if [[ ! -d ${SUB_FOLDER} ]]
+if [[ ! -d "${SUB_FOLDER}" ]]
 then
   echo "JDK sub-folder not found in ${JDK_FOLDER}"
   exit 2
 fi
+
+echo "${SUB_FOLDER}"

--- a/.ci/load/scripts/load_agent.sh
+++ b/.ci/load/scripts/load_agent.sh
@@ -24,7 +24,7 @@ POLL_FREQ=1
 LOCUST_LOCUSTFILE="../locust.py"
 LOCUST_PRINT_STATS=1
 
-if [ $LOCUST_IGNORE_ERRORS = "true" ]; then
+if [ "${LOCUST_IGNORE_ERRORS:-}" = "true" ]; then
     export LOCUST_EXIT_CODE_ON_ERROR=0
 else
     export LOCUST_EXIT_CODE_ON_ERROR=1
@@ -120,7 +120,15 @@ function startLoad() {
     \"hostname\": \"test_app\", \
     \"port\": \"8080\"}" \
     $ORCH_URL/api/ready 
-    docker run -e "LOCUST_EXIT_CODE_ON_ERROR=$LOCUST_EXIT_CODE_ON_ERROR" -e "LOCUST_HOST=$LOCUST_HOST" -e "LOCUST_RUN_TIME=$LOCUST_RUN_TIME" -e "LOCUST_USERS=$LOCUST_USERS" -p 8089:8089 -v ${PWD}/.ci/load/scripts:/locust locustio/locust -f /locust/locustfile.py --headless
+    docker run \
+        -e "LOCUST_EXIT_CODE_ON_ERROR=$LOCUST_EXIT_CODE_ON_ERROR" \
+        -e "LOCUST_HOST=$LOCUST_HOST" \
+        -e "LOCUST_RUN_TIME=$LOCUST_RUN_TIME" \
+        -e "LOCUST_USERS=$LOCUST_USERS" \
+        -p 8089:8089 \
+        -v ${PWD}/.ci/load/scripts:/locust \
+        locustio/locust \
+        -f /locust/locustfile.py --headless
 }
 
 

--- a/.ci/load/scripts/locustfile.py
+++ b/.ci/load/scripts/locustfile.py
@@ -1,6 +1,5 @@
 from locust import HttpUser, task, constant_pacing
 
-
 class QuickstartUser(HttpUser):
     wait_time = constant_pacing(1)
 
@@ -16,3 +15,17 @@ class QuickstartUser(HttpUser):
     @task(3)
     def gen_error(self):
         self.client.get("/oups")
+
+@events.quitting.add_listener
+def _(environment, **kw):
+    if environment.stats.total.fail_ratio > 30:
+        logging.error("Test failed due to failure ratio > 30%")
+        environment.process_exit_code = 1
+    elif environment.stats.total.avg_response_time > 200:
+        logging.error("Test failed due to average response time ratio > 200 ms")
+        environment.process_exit_code = 1
+    elif environment.stats.total.get_response_time_percentile(0.95) > 800:
+        logging.error("Test failed due to 95th percentile response time > 800 ms")
+        environment.process_exit_code = 1
+    else:
+        environment.process_exit_code = 0

--- a/.ci/load/scripts/locustfile.py
+++ b/.ci/load/scripts/locustfile.py
@@ -18,7 +18,7 @@ class QuickstartUser(HttpUser):
         with self.client.get("/oups", catch_response=True) as response:
             if response.status_code == 500:
                 response.success()
-            else
+            else:
                 response.failure()
 
 @events.quitting.add_listener

--- a/.ci/load/scripts/locustfile.py
+++ b/.ci/load/scripts/locustfile.py
@@ -19,4 +19,4 @@ class QuickstartUser(HttpUser):
             if response.status_code == 500:
                 response.success()
             else:
-                response.failure()
+                response.failure('unexpected status code = {}'.format(response.status_code))

--- a/.ci/load/scripts/locustfile.py
+++ b/.ci/load/scripts/locustfile.py
@@ -14,7 +14,12 @@ class QuickstartUser(HttpUser):
 
     @task(3)
     def gen_error(self):
-        self.client.get("/oups")
+        # because 500 error is expected, we treat any other result as failure
+        with self.client.get("/oups", catch_response=True) as response:
+            if response.status_code == 500:
+                response.success()
+            else
+                response.failure()
 
 @events.quitting.add_listener
 def _(environment, **kw):

--- a/.ci/load/scripts/locustfile.py
+++ b/.ci/load/scripts/locustfile.py
@@ -20,17 +20,3 @@ class QuickstartUser(HttpUser):
                 response.success()
             else:
                 response.failure()
-
-@events.quitting.add_listener
-def _(environment, **kw):
-    if environment.stats.total.fail_ratio > 30:
-        logging.error("Test failed due to failure ratio > 30%")
-        environment.process_exit_code = 1
-    elif environment.stats.total.avg_response_time > 200:
-        logging.error("Test failed due to average response time ratio > 200 ms")
-        environment.process_exit_code = 1
-    elif environment.stats.total.get_response_time_percentile(0.95) > 800:
-        logging.error("Test failed due to 95th percentile response time > 800 ms")
-        environment.process_exit_code = 1
-    else:
-        environment.process_exit_code = 0


### PR DESCRIPTION
## Goals
- being able to run tests with reliability
- support Java 7u80
- capture results (log files, crash reports, ...) for investigation/analysis

----

### Security
- use environement variables for APM credentials

### Reliability
- provision JDK as part of build/run steps to ensure it's on the same host
- ensure that app is stopped and result files collected even in case of failure/aborted job.
- properly stash/unstash files for execution accross multiple hosts
- force TLSv1.2 for Java7 otherwise can't connect to apm server on cloud

### Performance
- store downloaded JDKs in /tmp and reuse them if available
- try to stop the load-testing when App JVM crashes (does not work yet, would be nice as an improvement)