### PR TITLE
Mark async_profiler_safe_mode as dynamic

### DIFF
--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -70,7 +70,7 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
     private final ConfigurationOption<Integer> asyncProfilerSafeMode = ConfigurationOption.<Integer>integerOption()
         .key("async_profiler_safe_mode")
         .configurationCategory(PROFILING_CATEGORY)
-        .dynamic(false)
+        .dynamic(true)
         .description("Can be used for analysis: the Async Profiler's area that deals with recovering stack trace frames \n" +
             "is known to be sensitive in some systems. It is used as a bit mask using values are between 0 and 31, \n" +
             "where 0 enables all recovery attempts and 31 disables all five (corresponding 1, 2, 4, 8 and 16).")


### PR DESCRIPTION
As the option is read each time a profiling session starts, it just needs to be marked as dynamic.