### PR TITLE
Fix serializing all stack trace frames

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,7 +43,7 @@ endif::[]
 
 [float]
 ===== Refactors
-* Migrate some plugins to indy dispatcher {pull}1405[1405] {pull}1394[#1394]
+* Migrate some plugins to indy dispatcher {pull}1405[#1405] {pull}1394[#1394]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,14 +35,15 @@ endif::[]
 [float]
 ===== Bug fixes
 * Fix small memory allocation regression introduced with tracestate header {pull}1508[#1508]
-* Fix `NullPointerException` from `WeakConcurrentMap.put` through the Elasticsearch client instrumentation - {pull}1531[1531]
-* Sending `transaction_id` and `parent_id` only for events that contain a valid `trace_id` as well - {pull}1537[1537]
+* Fix `NullPointerException` from `WeakConcurrentMap.put` through the Elasticsearch client instrumentation - {pull}1531[#1531]
+* Sending `transaction_id` and `parent_id` only for events that contain a valid `trace_id` as well - {pull}1537[#1537]
 * Fix `ClassNotFoundError` with old versions of Spring resttemplate {pull}1524[#1524]
-* Fix Micrometer-driven metrics validation errors by the APM Server when sending with illegal values - {pull}1559[1559]
+* Fix Micrometer-driven metrics validation errors by the APM Server when sending with illegal values - {pull}1559[#1559]
+* Serialize all stack trace frames when setting `stack_trace_limit=-1` instead of none - {pull}1571[#1571]
 
 [float]
 ===== Refactors
-* Migrate some plugins to indy dispatcher {pull}1405[1405] {pull}1394[1394]
+* Migrate some plugins to indy dispatcher {pull}1405[1405] {pull}1394[#1394]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -646,6 +646,9 @@ public class DslJsonSerializer implements PayloadSerializer {
         boolean topMostElasticApmPackagesSkipped = false;
         int collectedStackFrames = 0;
         int stackTraceLimit = stacktraceConfiguration.getStackTraceLimit();
+        if (stackTraceLimit < 0) {
+            stackTraceLimit = stacktrace.length;
+        }
         for (int i = 0; i < stacktrace.length && collectedStackFrames < stackTraceLimit; i++) {
             StackTraceElement stackTraceElement = stacktrace[i];
             // only skip the top most apm stack frames

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -148,6 +148,21 @@ class DslJsonSerializerTest {
     }
 
     @Test
+    void testErrorSerializationAllFrames() {
+        StacktraceConfiguration stacktraceConfiguration = mock(StacktraceConfiguration.class);
+        when(stacktraceConfiguration.getStackTraceLimit()).thenReturn(-1);
+        serializer = new DslJsonSerializer(stacktraceConfiguration, apmServerClient);
+
+        ErrorCapture error = new ErrorCapture(MockTracer.create()).withTimestamp(5000);
+        Exception exception = new Exception("test");
+        error.setException(exception);
+
+        JsonNode errorTree = readJsonString(serializer.toJsonString(error));
+        JsonNode stacktrace = checkException(errorTree.get("exception"), Exception.class, "test").get("stacktrace");
+        assertThat(stacktrace).hasSizeGreaterThan(15);
+    }
+
+    @Test
     void testErrorSerializationWithEmptyTraceId() {
         ElasticApmTracer tracer = MockTracer.create();
         Transaction transaction = new Transaction(tracer);


### PR DESCRIPTION

## What does this PR do?
closes #1570

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
