### PR TITLE
properly handle exception on ServletContext.getClassLoader()

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ endif::[]
 * Fix `ClassNotFoundError` with old versions of Spring resttemplate {pull}1524[#1524]
 * Fix Micrometer-driven metrics validation errors by the APM Server when sending with illegal values - {pull}1559[#1559]
 * Serialize all stack trace frames when setting `stack_trace_limit=-1` instead of none - {pull}1571[#1571]
+* Fix `UnsupportedOperationException` when calling `ServletContext.getClassLoader()` - {pull}1576[#1576]
 
 [float]
 ===== Refactors

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -100,21 +100,9 @@ public class ServletApiAdvice {
                 if (Boolean.TRUE != excluded.get()) {
                     ServletContext servletContext = servletRequest.getServletContext();
                     if (servletContext != null) {
-
-                        // getClassloader might throw UnsupportedOperationException
-                        // see Section 4.4 of the Servlet 3.0 specification
-                        ClassLoader classLoader = null;
-                        try {
-                            ClassLoader servletClassloader = servletContext.getClassLoader();
-                            if (servletClassloader != null) {
-                                classLoader = servletClassloader;
-                            }
-                        } catch (UnsupportedOperationException e) {
-                            // silently ignored
-                        }
-
+                        ClassLoader cl = servletTransactionCreationHelper.getClassloader(servletContext);
                         // this makes sure service name discovery also works when attaching at runtime
-                        determineServiceName(servletContext.getServletContextName(), classLoader, servletContext.getContextPath());
+                        determineServiceName(servletContext.getServletContextName(), cl, servletContext.getContextPath());
 
                     }
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -100,9 +100,9 @@ public class ServletApiAdvice {
                 if (Boolean.TRUE != excluded.get()) {
                     ServletContext servletContext = servletRequest.getServletContext();
                     if (servletContext != null) {
-                        ClassLoader cl = servletTransactionCreationHelper.getClassloader(servletContext);
+                        ClassLoader servletCL = servletTransactionCreationHelper.getClassloader(servletContext);
                         // this makes sure service name discovery also works when attaching at runtime
-                        determineServiceName(servletContext.getServletContextName(), cl, servletContext.getContextPath());
+                        determineServiceName(servletContext.getServletContextName(), servletCL, servletContext.getContextPath());
 
                     }
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -100,8 +100,22 @@ public class ServletApiAdvice {
                 if (Boolean.TRUE != excluded.get()) {
                     ServletContext servletContext = servletRequest.getServletContext();
                     if (servletContext != null) {
+
+                        // getClassloader might throw UnsupportedOperationException
+                        // see Section 4.4 of the Servlet 3.0 specification
+                        ClassLoader classLoader = null;
+                        try {
+                            ClassLoader servletClassloader = servletContext.getClassLoader();
+                            if (servletClassloader != null) {
+                                classLoader = servletClassloader;
+                            }
+                        } catch (UnsupportedOperationException e) {
+                            // silently ignored
+                        }
+
                         // this makes sure service name discovery also works when attaching at runtime
-                        determineServiceName(servletContext.getServletContextName(), servletContext.getClassLoader(), servletContext.getContextPath());
+                        determineServiceName(servletContext.getServletContextName(), classLoader, servletContext.getContextPath());
+
                     }
 
                     Transaction transaction = servletTransactionCreationHelper.createAndActivateTransaction(request);


### PR DESCRIPTION
## What does this PR do?

The fix applied in #1464 did not covered all cases, this change makes sure that all calls to `ServletContext#getClassLoader()` are properly wrapped in a try/catch to avoid potential `UnsupportedOperationException`.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix