### PR TITLE
[load-testing] fix java7 detection for azul JVM

### DIFF
--- a/.ci/load/Jenkinsfile
+++ b/.ci/load/Jenkinsfile
@@ -100,8 +100,7 @@ pipeline {
                     def binary_ext = 'jar'
 
                     def major_jdk_version = readJSON(file: "/tmp/${params.jvm_version}/jdk.json")['version']
-                    echo "JDK VERSION = ${major_jdk_version}"
-                    if(major_jdk_version == '7') {
+                    if(major_jdk_version.startsWith("7")) {
                         echo "Java 7.x detected. Installing compliant version of test application and JDK"
                         // We are using a recent Java8 JDK here to allow avoid TLS/SSL issues, the app will still
                         // target and run with Java 7.
@@ -197,7 +196,7 @@ pipeline {
 
                             def java_home = sh(script: ".ci/load/scripts/fetch_sdk.sh ${params.jvm_version}", returnStdout: true).trim()
                             def major_jdk_version = readJSON(file: "/tmp/${params.jvm_version}/jdk.json")['version']
-                            def is_java7 = major_jdk_version == '7';
+                            def is_java7 = major_jdk_version.startsWith("7")
 
                             sh(script: "${java_home}/bin/java -version");
 


### PR DESCRIPTION
Load-testing pipelines expects normalized version for JDKs, whereas they aren't.

This might require a separate PR to ask for proper normalization of the `version` and `revision` fields in the catalog, as it seems the values are not really consistent, and do not even match the ones returned by `java -version`.