### PR TITLE
Null check return advices

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ endif::[]
 * Serialize all stack trace frames when setting `stack_trace_limit=-1` instead of none - {pull}1571[#1571]
 * Fix `UnsupportedOperationException` when calling `ServletContext.getClassLoader()` - {pull}1576[#1576]
 * Fix improper request body capturing - {pull}1579[#1579]
+* avoid `NullPointerException` due to null return values instrumentation advices - {pull}1601[#1601]
 
 [float]
 ===== Refactors

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ These live templates can be pasted in Preferences > Editor > Live Templates > ot
 
 **`enter`**
 ```xml
-<template name="enter" value="@Advice.OnMethodEnter(suppress = Throwable.class, inline = false)&#10;public static void onEnter() {&#10;    $END$&#10;}" description="Adds @OnMethodEnter advice" toReformat="false" toShortenFQNames="true">
+<template name="enter" value="@Advice.OnMethodEnter(suppress = Throwable.class, inline = false)&#10;public static void onEnter() {&#10;    $END$&#10;}" description="Adds @OnMethodEnter advice" toReformat="true" toShortenFQNames="true">
   <context>
     <option name="JAVA_DECLARATION" value="true" />
   </context>
@@ -91,17 +91,17 @@ These live templates can be pasted in Preferences > Editor > Live Templates > ot
 **`exit`**
 
 ```xml
-<template name="exit" value="@Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)&#10;public static void onExit(@Advice.Thrown Throwable thrown) {&#10;    $END$&#10;}" description="Adds @OnMethodExit advice" toReformat="false" toShortenFQNames="true">
-  <context>
-    <option name="JAVA_DECLARATION" value="true" />
-  </context>
+<template name="exit" value="@Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)&#10;public static void onExit(@Advice.Thrown @Nullable Throwable thrown, @Advice.Return @Nullable Object returnValue) {&#10;    $END$&#10;}" description="Adds @OnMethodExit advice" toReformat="true" toShortenFQNames="true">
+    <context>
+        <option name="JAVA_DECLARATION" value="true" />
+    </context>
 </template>
 ```
 
 
 **`logger`**
 ```xml
-<template name="logger" value="private static final Logger logger = LoggerFactory.getLogger($CLASS_NAME$.class);" description="" toReformat="false" toShortenFQNames="true">
+<template name="logger" value="private static final Logger logger = LoggerFactory.getLogger($CLASS_NAME$.class);" description="" toReformat="true" toShortenFQNames="true">
   <variable name="CLASS_NAME" expression="className()" defaultValue="" alwaysStopAt="true" />
   <context>
     <option name="JAVA_DECLARATION" value="true" />
@@ -121,7 +121,7 @@ These live templates can be pasted in Preferences > Editor > Live Templates > ot
 
 **`at`**
 ```xml
-<template name="at" value="assertThat($EXPR$)$END$;" description="assertJ assert expression" toReformat="false" toShortenFQNames="true" useStaticImport="true">
+<template name="at" value="assertThat($EXPR$)$END$;" description="assertJ assert expression" toReformat="true" toShortenFQNames="true" useStaticImport="true">
   <variable name="EXPR" expression="" defaultValue="" alwaysStopAt="true" />
   <context>
     <option name="JAVA_STATEMENT" value="true" />

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/AbstractSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/AbstractSpanInstrumentation.java
@@ -183,7 +183,7 @@ public class AbstractSpanInstrumentation extends ApiInstrumentation {
         @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
         public static String captureException(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Object context,
                                               @Advice.Argument(0) Throwable t,
-                                              @Advice.Return String returnValue) {
+                                              @Advice.Return @Nullable String returnValue) {
             if (context instanceof AbstractSpan<?>) {
                 return ((AbstractSpan<?>) context).captureExceptionAndGetErrorId(t);
             } else {
@@ -217,10 +217,11 @@ public class AbstractSpanInstrumentation extends ApiInstrumentation {
             super(named("getId").and(takesArguments(0)));
         }
 
+        @Nullable
         @AssignTo.Return
         @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
         public static String getId(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Object context,
-                                   @Advice.Return String returnValue) {
+                                   @Advice.Return @Nullable String returnValue) {
             if (context instanceof AbstractSpan<?>) {
                 return ((AbstractSpan<?>) context).getTraceContext().getId().toString();
             } else {
@@ -234,10 +235,11 @@ public class AbstractSpanInstrumentation extends ApiInstrumentation {
             super(named("getTraceId").and(takesArguments(0)));
         }
 
+        @Nullable
         @AssignTo.Return
         @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
         public static String getTraceId(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Object context,
-                                        @Advice.Return String returnValue) {
+                                        @Advice.Return @Nullable String returnValue) {
             if (context instanceof AbstractSpan<?>) {
                 return ((AbstractSpan<?>) context).getTraceContext().getTraceId().toString();
             } else {
@@ -253,7 +255,8 @@ public class AbstractSpanInstrumentation extends ApiInstrumentation {
 
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static void addLabel(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Object context,
-                                    @Advice.Argument(0) String key, @Nullable @Advice.Argument(1) String value) {
+                                    @Advice.Argument(0) String key,
+                                    @Advice.Argument(1) @Nullable String value) {
             if (value != null && context instanceof AbstractSpan) {
                 ((AbstractSpan<?>) context).addLabel(key, value);
             }
@@ -267,7 +270,8 @@ public class AbstractSpanInstrumentation extends ApiInstrumentation {
 
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static void addLabel(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Object context,
-                                    @Advice.Argument(0) String key, @Nullable @Advice.Argument(1) Number value) {
+                                    @Advice.Argument(0) String key,
+                                    @Advice.Argument(1) @Nullable Number value) {
             if (value != null && context instanceof AbstractSpan) {
                 ((AbstractSpan<?>) context).addLabel(key, value);
             }
@@ -281,7 +285,8 @@ public class AbstractSpanInstrumentation extends ApiInstrumentation {
 
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static void addLabel(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Object context,
-                                    @Advice.Argument(0) String key, @Nullable @Advice.Argument(1) Boolean value) {
+                                    @Advice.Argument(0) String key,
+                                    @Advice.Argument(1) @Nullable Boolean value) {
             if (value != null && context instanceof AbstractSpan) {
                 ((AbstractSpan<?>) context).addLabel(key, value);
             }

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/LegacySpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/LegacySpanInstrumentation.java
@@ -151,10 +151,11 @@ public class LegacySpanInstrumentation extends ApiInstrumentation {
             super(named("getId").and(takesArguments(0)));
         }
 
+        @Nullable
         @AssignTo.Return
         @Advice.OnMethodExit(inline = false)
         public static String getId(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Object span,
-                                   @Advice.Return String returnValue) {
+                                   @Advice.Return @Nullable String returnValue) {
             if (span instanceof Span) {
                 return ((Span) span).getTraceContext().getId().toString();
             } else {
@@ -168,10 +169,11 @@ public class LegacySpanInstrumentation extends ApiInstrumentation {
             super(named("getTraceId").and(takesArguments(0)));
         }
 
+        @Nullable
         @AssignTo.Return
         @Advice.OnMethodExit(inline = false)
         public static String getTraceId(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Object span,
-                                        @Advice.Return String returnValue) {
+                                        @Advice.Return @Nullable String returnValue) {
             if (span instanceof Span) {
                 return ((Span) span).getTraceContext().getTraceId().toString();
             } else {

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TransactionInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TransactionInstrumentation.java
@@ -78,10 +78,11 @@ public class TransactionInstrumentation extends ApiInstrumentation {
             super(named("ensureParentId"));
         }
 
+        @Nullable
         @AssignTo.Return
         @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
         public static String ensureParentId(@Advice.FieldValue(value = "span", typing = Assigner.Typing.DYNAMIC) Object transaction,
-                                            @Advice.Return String returnValue) {
+                                            @Advice.Return @Nullable String returnValue) {
             if (transaction instanceof Transaction) {
                 final TraceContext traceContext = ((Transaction) transaction).getTraceContext();
                 Id parentId = traceContext.getParentId();

--- a/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/advice/ApacheMonitorFilterAdvice.java
+++ b/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/advice/ApacheMonitorFilterAdvice.java
@@ -92,10 +92,10 @@ public class ApacheMonitorFilterAdvice {
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class)
     public static void onExitFilterInvoke(@Advice.Argument(1) Invocation invocation,
-                                          @Advice.Return Result result,
-                                          @Nullable @Advice.Local("span") final Span span,
-                                          @Advice.Thrown Throwable t,
-                                          @Nullable @Advice.Local("transaction") Transaction transaction) {
+                                          @Advice.Return @Nullable Result result,
+                                          @Advice.Local("span") @Nullable final Span span,
+                                          @Advice.Thrown @Nullable Throwable t,
+                                          @Advice.Local("transaction") @Nullable Transaction transaction) {
 
         RpcContext context = RpcContext.getContext();
         AbstractSpan<?> actualSpan = span != null ? span : transaction;

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallHandlerInstrumentation.java
@@ -65,9 +65,9 @@ public class ServerCallHandlerInstrumentation extends BaseInstrumentation {
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
     public static void onExit(@Advice.Thrown @Nullable Throwable thrown,
-                               @Advice.Argument(0) ServerCall<?, ?> serverCall,
-                               @Advice.Return ServerCall.Listener<?> listener,
-                               @Advice.Enter @Nullable Object enterTransaction) {
+                              @Advice.Argument(0) ServerCall<?, ?> serverCall,
+                              @Advice.Return @Nullable ServerCall.Listener<?> listener,
+                              @Advice.Enter @Nullable Object enterTransaction) {
 
         if (!(enterTransaction instanceof Transaction)) {
             return;
@@ -79,7 +79,11 @@ public class ServerCallHandlerInstrumentation extends BaseInstrumentation {
             return;
         }
 
-        helper.registerTransaction(serverCall, listener, transaction);
+        if (listener != null) {
+            helper.registerTransaction(serverCall, listener, transaction);
+        }
+
+
     }
 
 }

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloGrpc.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloGrpc.java
@@ -2,7 +2,7 @@
  * #%L
  * Elastic APM Java agent
  * %%
- * Copyright (C) 2018 - 2020 Elastic and contributors
+ * Copyright (C) 2018 - 2021 Elastic and contributors
  * %%
  * Licensed to Elasticsearch B.V. under one or more contributor
  * license agreements. See the NOTICE file distributed with

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloReply.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloReply.java
@@ -2,7 +2,7 @@
  * #%L
  * Elastic APM Java agent
  * %%
- * Copyright (C) 2018 - 2020 Elastic and contributors
+ * Copyright (C) 2018 - 2021 Elastic and contributors
  * %%
  * Licensed to Elasticsearch B.V. under one or more contributor
  * license agreements. See the NOTICE file distributed with

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloReplyOrBuilder.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloReplyOrBuilder.java
@@ -2,7 +2,7 @@
  * #%L
  * Elastic APM Java agent
  * %%
- * Copyright (C) 2018 - 2020 Elastic and contributors
+ * Copyright (C) 2018 - 2021 Elastic and contributors
  * %%
  * Licensed to Elasticsearch B.V. under one or more contributor
  * license agreements. See the NOTICE file distributed with

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloRequest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloRequest.java
@@ -2,7 +2,7 @@
  * #%L
  * Elastic APM Java agent
  * %%
- * Copyright (C) 2018 - 2020 Elastic and contributors
+ * Copyright (C) 2018 - 2021 Elastic and contributors
  * %%
  * Licensed to Elasticsearch B.V. under one or more contributor
  * license agreements. See the NOTICE file distributed with

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloRequestOrBuilder.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/HelloRequestOrBuilder.java
@@ -2,7 +2,7 @@
  * #%L
  * Elastic APM Java agent
  * %%
- * Copyright (C) 2018 - 2020 Elastic and contributors
+ * Copyright (C) 2018 - 2021 Elastic and contributors
  * %%
  * Licensed to Elasticsearch B.V. under one or more contributor
  * license agreements. See the NOTICE file distributed with

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/Rpc.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-1.6.1/src/test/java/co/elastic/apm/agent/grpc/v1_6_1/testapp/generated/Rpc.java
@@ -2,7 +2,7 @@
  * #%L
  * Elastic APM Java agent
  * %%
- * Copyright (C) 2018 - 2020 Elastic and contributors
+ * Copyright (C) 2018 - 2021 Elastic and contributors
  * %%
  * Licensed to Elasticsearch B.V. under one or more contributor
  * license agreements. See the NOTICE file distributed with

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/ConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/ConnectionInstrumentation.java
@@ -30,6 +30,7 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
+import javax.annotation.Nullable;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 
@@ -50,9 +51,12 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 public class ConnectionInstrumentation extends JdbcInstrumentation {
 
     @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
-    public static void storeSql(@Advice.Return PreparedStatement statement,
+    public static void storeSql(@Advice.Return @Nullable PreparedStatement statement,
                                 @Advice.Argument(0) String sql) {
-        getJdbcHelper().mapStatementToSql(statement, sql);
+        if (statement != null) { // might be null if exception is thrown
+            getJdbcHelper().mapStatementToSql(statement, sql);
+        }
+
     }
 
     @Override

--- a/apm-agent-plugins/apm-jdk-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-jdk-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpClientAsyncInstrumentation.java
@@ -77,6 +77,8 @@ public class HttpClientAsyncInstrumentation extends AbstractHttpClientInstrument
             if (completableFuture == null) {
                 span.captureException(t)
                     .end();
+
+                return;
             }
 
             completableFuture.whenComplete((response, throwable) -> {

--- a/apm-agent-plugins/apm-jdk-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpRequestHeadersInstrumentation.java
+++ b/apm-agent-plugins/apm-jdk-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/HttpRequestHeadersInstrumentation.java
@@ -33,6 +33,7 @@ import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.net.http.HttpHeaders;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -60,12 +61,13 @@ public class HttpRequestHeadersInstrumentation extends AbstractHttpClientInstrum
         return named("headers").and(returns(named("java.net.http.HttpHeaders")));
     }
 
-    @Nonnull
+
+    @Nullable
     @AssignTo.Return
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
-    public static HttpHeaders onAfterExecute(@Advice.Return @Nonnull final HttpHeaders httpHeaders) {
+    public static HttpHeaders onAfterExecute(@Advice.Return @Nullable final HttpHeaders httpHeaders) {
         Span span = tracer.getActiveSpan();
-        if (span == null) {
+        if (span == null || httpHeaders == null) { // in case of thrown exception return value might be null
             return httpHeaders;
         }
         Map<String, List<String>> headersMap = new LinkedHashMap<>(httpHeaders.map());

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
@@ -152,7 +152,7 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
                                             @Advice.Origin("#m") String methodName,
                                             @Advice.Enter @Nullable final Object abstractSpanObj,
                                             @Advice.Return @Nullable final Message message,
-                                            @Advice.Thrown final Throwable throwable) {
+                                            @Advice.Thrown @Nullable final Throwable throwable) {
                 AbstractSpan<?> abstractSpan = null;
                 if (abstractSpanObj instanceof AbstractSpan<?>) {
                     abstractSpan = (AbstractSpan<?>) abstractSpanObj;

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsIteratorInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsIteratorInstrumentation.java
@@ -70,15 +70,15 @@ public class ConsumerRecordsIteratorInstrumentation extends KafkaConsumerRecords
         @Nullable
         @AssignTo.Return
         @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-        public static Iterator<ConsumerRecord> wrapIterator(@Nullable @Advice.Return final Iterator<ConsumerRecord> iterator) {
-            if (!tracer.isRunning() || tracer.currentTransaction() != null) {
+        public static Iterator<ConsumerRecord> wrapIterator(@Advice.Return @Nullable final Iterator<ConsumerRecord> iterator) {
+            if (!tracer.isRunning() || tracer.currentTransaction() != null || iterator == null) {
                 return iterator;
             }
 
             //noinspection ConstantConditions,rawtypes
             KafkaInstrumentationHeadersHelper<ConsumerRecord, ProducerRecord> kafkaInstrumentationHelper =
                 kafkaInstrHeadersHelperManager.getForClassLoaderOfClass(KafkaProducer.class);
-            if (iterator != null && kafkaInstrumentationHelper != null) {
+            if (kafkaInstrumentationHelper != null) {
                 return kafkaInstrumentationHelper.wrapConsumerRecordIterator(iterator);
             }
             return iterator;

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsRecordListInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsRecordListInstrumentation.java
@@ -71,15 +71,15 @@ public class ConsumerRecordsRecordListInstrumentation extends KafkaConsumerRecor
         @Nullable
         @AssignTo.Return
         @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-        public static List<ConsumerRecord> wrapRecordList(@Nullable @Advice.Return final List<ConsumerRecord> list) {
-            if (!tracer.isRunning() || tracer.currentTransaction() != null) {
+        public static List<ConsumerRecord> wrapRecordList(@Advice.Return @Nullable final List<ConsumerRecord> list) {
+            if (!tracer.isRunning() || tracer.currentTransaction() != null || list == null) {
                 return list;
             }
 
             //noinspection ConstantConditions,rawtypes
             KafkaInstrumentationHeadersHelper<ConsumerRecord, ProducerRecord> kafkaInstrumentationHelper =
                 kafkaInstrHeadersHelperManager.getForClassLoaderOfClass(KafkaProducer.class);
-            if (list != null && kafkaInstrumentationHelper != null) {
+            if (kafkaInstrumentationHelper != null) {
                 return kafkaInstrumentationHelper.wrapConsumerRecordList(list);
             }
             return list;

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsRecordsInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsRecordsInstrumentation.java
@@ -69,15 +69,15 @@ public class ConsumerRecordsRecordsInstrumentation extends KafkaConsumerRecordsI
         @Nullable
         @AssignTo.Return
         @Advice.OnMethodExit(onThrowable = Throwable.class, suppress = Throwable.class)
-        public static Iterable<ConsumerRecord> wrapIterable(@Nullable @Advice.Return final Iterable<ConsumerRecord> iterable) {
-            if (!tracer.isRunning() || tracer.currentTransaction() != null) {
+        public static Iterable<ConsumerRecord> wrapIterablfe(@Advice.Return @Nullable final Iterable<ConsumerRecord> iterable) {
+            if (!tracer.isRunning() || tracer.currentTransaction() != null || iterable == null) {
                 return iterable;
             }
 
             //noinspection ConstantConditions,rawtypes
             KafkaInstrumentationHeadersHelper<ConsumerRecord, ProducerRecord> kafkaInstrumentationHelper =
                 kafkaInstrHeadersHelperManager.getForClassLoaderOfClass(KafkaProducer.class);
-            if (iterable != null && kafkaInstrumentationHelper != null) {
+            if (kafkaInstrumentationHelper != null) {
                 return kafkaInstrumentationHelper.wrapConsumerRecordIterable(iterable);
             }
             return iterable;

--- a/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/ProcessStartInstrumentation.java
+++ b/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/ProcessStartInstrumentation.java
@@ -24,7 +24,6 @@
  */
 package co.elastic.apm.agent.process;
 
-import co.elastic.apm.agent.impl.GlobalTracer;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -61,7 +60,7 @@ public class ProcessStartInstrumentation extends BaseProcessInstrumentation {
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
         public static void onExit(@Advice.This ProcessBuilder processBuilder,
-                                  @Advice.Return Process process,
+                                  @Advice.Return @Nullable Process process,
                                   @Advice.Thrown @Nullable Throwable t) {
 
             AbstractSpan<?> parentSpan = tracer.getActive();
@@ -74,7 +73,12 @@ public class ProcessStartInstrumentation extends BaseProcessInstrumentation {
                 parentSpan.captureException(t);
             }
 
-            ProcessHelper.startProcess(parentSpan, process, processBuilder.command());
+            if (process != null) {
+                // when an exception is thrown, there is no return value
+                ProcessHelper.startProcess(parentSpan, process, processBuilder.command());
+            }
+
+
         }
     }
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
@@ -108,7 +108,10 @@ public abstract class AsyncInstrumentation extends AbstractServletInstrumentatio
             private static final AsyncContextAdviceHelper<AsyncContext> asyncHelper = new AsyncContextAdviceHelperImpl(GlobalTracer.requireTracerImpl());
 
             @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
-            public static void onExitStartAsync(@Advice.Return AsyncContext asyncContext) {
+            public static void onExitStartAsync(@Advice.Return @Nullable AsyncContext asyncContext) {
+                if (asyncContext == null) {
+                    return;
+                }
                 asyncHelper.onExitStartAsync(asyncContext);
             }
         }


### PR DESCRIPTION
## What does this PR do?

For exit method advices:
- thrown exception can be null or not (if an exception has been thrown or not)
- return value can be null when an exception is thrown

Thus as a good practice all exit method advices should:
- have BOTH of those parameters annotated with `@Nullable`
- ensure proper handling of those null values

This PR:
- adds missing annotations on advice parameters
- adds a few extra missing null checks

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix