### PR TITLE
[CI] Run hourly to look for head changes

### DIFF
--- a/.ci/jobs/apm-agent-java-mbp.yml
+++ b/.ci/jobs/apm-agent-java-mbp.yml
@@ -42,3 +42,4 @@
             timeout: '15'
             use-author: true
             wipe-workspace: 'True'
+    periodic-folder-trigger: 1h


### PR DESCRIPTION
## What does this PR do?

Automatically trigger any builds for any PRs that got a change in their head target from once a week to every hour if required
This will not update the PR but the workspace where the build happens in the CI. In other words, the build merges the PR with its Target branch before running anything.

It has been configured to run hourly to avoid any issues with the GitHub API quota, we could stress a bit more to run every 30 minutes, but let's see if this approach is somehow interesting to you. 

## Why

This will ensure PRs are always ready to merge, even if they have not been updated with the latest changes.
