### PR TITLE
Fallback to TLS and quietly catch initialization error

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ configured through the <<config-cloud-provider, `cloud_provider`>> config option
 [float]
 ===== Bug fixes
 * Fixing crashes observed in Java 7 at sporadic timing by applying a few seconds delay on bootstrap - {pull}1594[#1594]
+* Fallback to using "TLS" `SSLContext` when "SSL" is not available - {pull}1633[#1633]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ssl/SslUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ssl/SslUtils.java
@@ -54,20 +54,30 @@ public class SslUtils {
     private static final SSLSocketFactory trustAllSocketFactory;
 
     static {
-        // default factory with certificate validation
-        validateSocketFactory = TLSFallbackSSLSocketFactory.wrapFactory(createSocketFactory(null));
+        SSLSocketFactory tmpSocketFactory = null;
+        try {
+            // default factory with certificate validation
+            //noinspection ConstantConditions
+            tmpSocketFactory = TLSFallbackSSLSocketFactory.wrapFactory(createSocketFactory(null));
+        } catch (Exception e) {
+            logger.warn("Failed to construct a Socket factory with the following error: \"" + e.getMessage() + "\". " +
+                "Agent communication with APM Server may not be able to authenticate the server certificate. " +
+                "See documentation for the \"verify_server_cert\" configuration option for optional workaround", e);
+        }
+        validateSocketFactory = tmpSocketFactory;
 
-        SSLSocketFactory tmpTrustAllSocketFactory = null;
+        tmpSocketFactory = null;
         // without certificate validation
         try {
             X509TrustManager trustAllTrustManager = createTrustAllTrustManager();
-            tmpTrustAllSocketFactory = TLSFallbackSSLSocketFactory.wrapFactory(createSocketFactory(new TrustManager[]{trustAllTrustManager}));
+            tmpSocketFactory = TLSFallbackSSLSocketFactory.wrapFactory(createSocketFactory(new TrustManager[]{trustAllTrustManager}));
         } catch (Exception e) {
             logger.info("Failed to construct a trust-all Socket factory with the following error: \"{}\". Agent communication " +
-                "with the APM server must verify the server certificates, meaning - the \"verify_server_cert\" configuration " +
+                "with the APM Server must verify the server certificate, meaning - the \"verify_server_cert\" configuration " +
                 "option must be set to \"true\"", e.getMessage());
+            logger.debug("Socket factory creation error stack trace: ", e);
         }
-        trustAllSocketFactory = tmpTrustAllSocketFactory;
+        trustAllSocketFactory = tmpSocketFactory;
 
         hostnameVerifier = new HostnameVerifier() {
             @Override
@@ -95,21 +105,16 @@ public class SslUtils {
     }
 
     @Nullable
-    private static SSLSocketFactory createSocketFactory(TrustManager[] trustAllCerts) {
+    private static SSLSocketFactory createSocketFactory(TrustManager[] trustAllCerts) throws NoSuchAlgorithmException, KeyManagementException {
+        SSLContext sslContext;
         try {
-            SSLContext sslContext;
-            try {
-                sslContext = SSLContext.getInstance("SSL");
-            } catch (NoSuchAlgorithmException e) {
-                logger.info("SSL is not supported, trying to use TLS instead.");
-                sslContext = SSLContext.getInstance("TLS");
-            }
-            sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
-            return sslContext.getSocketFactory();
-        } catch (NoSuchAlgorithmException | KeyManagementException e) {
-            logger.warn(e.getMessage(), e);
-            return null;
+            sslContext = SSLContext.getInstance("SSL");
+        } catch (NoSuchAlgorithmException e) {
+            logger.info("SSL is not supported, trying to use TLS instead.");
+            sslContext = SSLContext.getInstance("TLS");
         }
+        sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
+        return sslContext.getSocketFactory();
     }
 
     private static X509TrustManager createTrustAllTrustManager() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ssl/SslUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ssl/SslUtils.java
@@ -45,6 +45,8 @@ public class SslUtils {
 
     private static final HostnameVerifier hostnameVerifier;
 
+    private static boolean warningLogged = false;
+
     @Nullable
     private static final SSLSocketFactory validateSocketFactory;
 
@@ -52,11 +54,21 @@ public class SslUtils {
     private static final SSLSocketFactory trustAllSocketFactory;
 
     static {
-        X509TrustManager trustAllTrustManager = createTrustAllTrustManager();
         // default factory with certificate validation
         validateSocketFactory = TLSFallbackSSLSocketFactory.wrapFactory(createSocketFactory(null));
+
+        SSLSocketFactory tmpTrustAllSocketFactory = null;
         // without certificate validation
-        trustAllSocketFactory = TLSFallbackSSLSocketFactory.wrapFactory(createSocketFactory(new TrustManager[]{trustAllTrustManager}));
+        try {
+            X509TrustManager trustAllTrustManager = createTrustAllTrustManager();
+            tmpTrustAllSocketFactory = TLSFallbackSSLSocketFactory.wrapFactory(createSocketFactory(new TrustManager[]{trustAllTrustManager}));
+        } catch (Exception e) {
+            logger.info("Failed to construct a trust-all Socket factory with the following error: \"{}\". Agent communication " +
+                "with the APM server must verify the server certificates, meaning - the \"verify_server_cert\" configuration " +
+                "option must be set to \"true\"", e.getMessage());
+        }
+        trustAllSocketFactory = tmpTrustAllSocketFactory;
+
         hostnameVerifier = new HostnameVerifier() {
             @Override
             public boolean verify(String hostname, SSLSession session) {
@@ -71,20 +83,27 @@ public class SslUtils {
 
     @Nullable
     public static SSLSocketFactory getSSLSocketFactory(boolean validateCertificates) {
-        return validateCertificates ? validateSocketFactory : trustAllSocketFactory;
-    }
-
-    @Nullable
-    private static SSLSocketFactory createTrustAllSocketFactory(X509TrustManager trustAllTrustManager) {
-        // Create a trust manager that does not validate certificate chains
-
-        return createSocketFactory(new TrustManager[]{trustAllTrustManager});
+        if (validateCertificates) {
+            return validateSocketFactory;
+        }
+        if (trustAllSocketFactory == null && !warningLogged) {
+            logger.warn("The \"verify_server_cert\" configuration option is set to \"false\", but this agent may not be " +
+                "able to communicate with APM Server without verifying the server certificates.");
+            warningLogged = true;
+        }
+        return trustAllSocketFactory;
     }
 
     @Nullable
     private static SSLSocketFactory createSocketFactory(TrustManager[] trustAllCerts) {
         try {
-            SSLContext sslContext = SSLContext.getInstance("SSL");
+            SSLContext sslContext;
+            try {
+                sslContext = SSLContext.getInstance("SSL");
+            } catch (NoSuchAlgorithmException e) {
+                logger.info("SSL is not supported, trying to use TLS instead.");
+                sslContext = SSLContext.getInstance("TLS");
+            }
             sslContext.init(null, trustAllCerts, new java.security.SecureRandom());
             return sslContext.getSocketFactory();
         } catch (NoSuchAlgorithmException | KeyManagementException e) {


### PR DESCRIPTION
## What does this PR do?
Supports FIPS mode by defaulting to `TLS` if `SSL` is not supported and by quietly catching failure to create a trust-all `SocketFactory` (assuming that in this mode, APM Server certification verification is required).

Context: reported in our [forum](https://discuss.elastic.co/t/apm-agent-is-not-working-on-fips-enabled-java-application/261815).

This implementation should not change behaviour of any existing deployment when the agent is upgraded.
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] ~~I have added tests that would fail without this fix~~
  - [x] The fix was verified by the user who reported it
