### PR TITLE
chore: enable stale bot for pull requests

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,62 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 60
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels: []
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: true
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+
+# Label to use when marking as stale
+staleLabel: Stalled
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+    Hi!
+    We just realized that we haven't looked into this issue in a while. We're
+    sorry!
+    We're labeling this issue as `Stalled` to make it hit our filters and 
+    make sure we get back to it in as soon as possible. In the meantime, it'd
+    be extremely helpful if you could take a look at it as well and confirm its
+    relevance. A simple comment with a nice emoji will be enough `:+1`.
+    Thank you for your contribution!
+# Comment to post when removing the stale label.
+# unmarkComment: >
+#   Your comment here.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+    Hi!
+    This issue has been stale for a while and we're going to close it as part of
+    our cleanup procedure.
+    We appreciate your contribution and would like to apologize if we have not
+    been able to review it, due to the current heavy load of the team.
+    Feel free to re-open this issue if you think it should stay open.
+    Thank you for your contribution!
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: pulls
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+
+# issues:
+#   exemptLabels:
+#     - confirmed

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -23,14 +23,14 @@ exemptMilestones: true
 exemptAssignees: true
 
 # Label to use when marking as stale
-staleLabel: Stalled
+staleLabel: stalled
 
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
     Hi!
     We just realized that we haven't looked into this issue in a while. We're
     sorry!
-    We're labeling this issue as `Stalled` to make it hit our filters and 
+    We're labeling this issue as `stalled` to make it hit our filters and 
     make sure we get back to it in as soon as possible. In the meantime, it'd
     be extremely helpful if you could take a look at it as well and confirm its
     relevance. A simple comment with a nice emoji will be enough `:+1`.


### PR DESCRIPTION
## What

Enable [stale bot](https://github.com/probot/stale) to notify and then close the PRs that haven't had any activity for 74 days, a notification will be sent after 60 days and if nothing else happens they will get closed 14 days later.

## How it works

- Support `pull requests` only as stated
- It uses the `stalled` label to categorise the ones that have been informed without any activity in 60 days.
- Those `stalled` PRs will be closed if no further activity after 14 days.

### Issues

Relates to https://github.com/elastic/beats/pull/19157 and https://github.com/elastic/apm-agent-rum-js/pull/914


### Tasks

- [x] Agree if the proposal is good for the needs
- [ ] ask infra to enable it