### PR TITLE
Add OpenTracing Tracer resolving through ServiceLoader

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ to assist with such efforts.
 the <<config-log-ecs-reformatting>> config option. This allows effortless ingestion of logs to Elasticsearch without
 any further configuration. Supports log4j1, log4j2 and Logback. {pull}1261[#1261]
 * Add support to Spring AMQP - {pull}1657[#1657]
+* Adds the ability to automatically configure usage of the OpenTracing bridge in systems using ServiceLoader - {pull}1708[#1708]
 
 [float]
 ===== Bug fixes

--- a/apm-opentracing/pom.xml
+++ b/apm-opentracing/pom.xml
@@ -46,6 +46,14 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- https://github.com/opentracing-contrib/java-tracerresolver -->
+        <dependency>
+            <groupId>io.opentracing.contrib</groupId>
+            <artifactId>opentracing-tracerresolver</artifactId>
+            <version>0.1.8</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apm-opentracing/src/main/resources/META-INF/services/io.opentracing.Tracer
+++ b/apm-opentracing/src/main/resources/META-INF/services/io.opentracing.Tracer
@@ -1,0 +1,1 @@
+co.elastic.apm.opentracing.ElasticApmTracer

--- a/apm-opentracing/src/test/java/co/elastic/apm/opentracing/TracerResolverTest.java
+++ b/apm-opentracing/src/test/java/co/elastic/apm/opentracing/TracerResolverTest.java
@@ -1,0 +1,40 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2021 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
+package co.elastic.apm.opentracing;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TracerResolverTest {
+    @Test
+    void testTracerResolver() {
+        Tracer tracer = TracerResolver.resolveTracer();
+        assertThat(tracer).isNotNull();
+        assertThat(tracer.getClass().getName()).isEqualTo(ElasticApmTracer.class.getName());
+    }
+}

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -86,6 +86,12 @@ import io.opentracing.Tracer;
 Tracer tracer = new ElasticApmTracer();
 ----
 
+Since version 1.22.0, the OpenTracing bridge supports `Tracer` lookup and initialization through the ServiceLoader mechanism.
+An example for a system that relies on this capability is https://github.com/opentracing-contrib/java-tracerresolver[tracer-resolver],
+which is used by various OpenTracing libraries, for example the
+https://camel.apache.org/components/3.7.x/others/opentracing.html[Apache Camel OpenTracing component].
+When such is used, no code changes are required, only the addition of dependencies for the OpenTracing library and
+the Elastic OpenTracing bridge.
 
 [float]
 [[elastic-apm-tags]]


### PR DESCRIPTION
## What does this PR do?
Adds the ability to automatically configure usage of Elastic's OpenTracing bridge in systems using ServiceLoader. An example for such system is [tracer-resolver](https://github.com/opentracing-contrib/java-tracerresolver), which is used by various OpenTracing libraries, for example the [Apache Camel OpenTracing component](https://camel.apache.org/components/3.7.x/others/opentracing.html).
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have made corresponding changes to the documentation
