### PR TITLE
Always use English locale when formatting doubles (#1727)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -65,6 +65,7 @@ Even when matching on the main class name or on system properties,
 * Fixed log correlation for log4j2 - {pull}1720[#1720]
 * Fix apm-log4j1-plugin and apm-log4j2-plugin dependency on slf4j - {pull}1723[#1723]
 * Avoid systematic `MessageNotWriteableException` error logging, now only visible in `debug` - {pull}1715[#1715]
+* Fix rounded number format for non-english locales - {pull}1728[#1728]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/RoundedDoubleConverter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/RoundedDoubleConverter.java
@@ -28,7 +28,9 @@ import org.stagemonitor.configuration.converter.AbstractValueConverter;
 import org.stagemonitor.configuration.converter.DoubleValueConverter;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
+import java.util.Locale;
 
 public class RoundedDoubleConverter extends AbstractValueConverter<Double> {
 
@@ -51,7 +53,7 @@ public class RoundedDoubleConverter extends AbstractValueConverter<Double> {
         for (int i = 0; i < precisionDigits; i++) {
             format.append("#");
         }
-        this.numberFormat = new DecimalFormat(format.toString());
+        this.numberFormat = new DecimalFormat(format.toString(), DecimalFormatSymbols.getInstance(Locale.ENGLISH));
         this.precisionFactor = Math.pow(10, precisionDigits);
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/RoundedDoubleConverterTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/RoundedDoubleConverterTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.util.Locale;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -71,4 +73,21 @@ class RoundedDoubleConverterTest {
         assertThat(converted).isEqualTo(expected);
     }
 
+    @Test
+    void testNonEnglishLocale() {
+        Locale defaultLocale = Locale.getDefault();
+        try {
+            Locale.setDefault(Locale.GERMAN);
+
+            RoundedDoubleConverter converter = new RoundedDoubleConverter(4);
+
+            Double expected = Double.valueOf("0.0001");
+            Double converted = converter.convert("0.0001");
+
+            assertThat(converted).isEqualTo(expected);
+            assertThat(converter.toString(converted)).isEqualTo("0.0001");
+        } finally {
+            Locale.setDefault(defaultLocale);
+        }
+    }
 }


### PR DESCRIPTION
## What does this PR do?
Fixes #1727

## Checklist
- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)~
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
