### PR TITLE
Loading Advice classes lazily when required

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -125,7 +125,13 @@ public class ElasticApmAgent {
     private static final WeakConcurrentMap<Class<?>, Set<Collection<Class<? extends ElasticApmInstrumentation>>>> dynamicallyInstrumentedClasses = WeakMapSupplier.createMap();
     @Nullable
     private static File agentJarFile;
-    private static final Map<String, ClassLoader> pluginClassLoaderByAdviceClass = new ConcurrentHashMap<>();
+
+    /**
+     * A mapping from advice class name to the class loader that loaded the corresponding instrumentation.
+     * We need this in order to locate the advice class file. This implies that the advice class needs to be collocated
+     * with the corresponding instrumentation class.
+     */
+    private static final Map<String, ClassLoader> adviceClassName2instrumentationClassLoader = new ConcurrentHashMap<>();
 
     /**
      * Called reflectively by {@link AgentMain} to initialize the agent
@@ -240,8 +246,8 @@ public class ElasticApmAgent {
             }
         }
         for (ElasticApmInstrumentation apmInstrumentation : instrumentations) {
-            pluginClassLoaderByAdviceClass.put(
-                apmInstrumentation.getAdviceClass().getName(),
+            adviceClassName2instrumentationClassLoader.put(
+                apmInstrumentation.getAdviceClassName(),
                 ObjectUtils.systemClassLoaderIfNull(apmInstrumentation.getClass().getClassLoader()));
         }
         Runtime.getRuntime().addShutdownHook(new Thread(ThreadUtils.addElasticApmThreadPrefix("init-instrumentation-shutdown-hook")) {
@@ -427,7 +433,6 @@ public class ElasticApmAgent {
         // external plugins are always indy plugins
         if (!(instrumentation instanceof TracerAwareInstrumentation)
             || ((TracerAwareInstrumentation) instrumentation).indyPlugin()) {
-            validateAdvice(instrumentation.getAdviceClass());
             withCustomMapping = withCustomMapping.bootstrap(IndyBootstrap.getIndyBootstrapMethod(logger));
         }
         return new AgentBuilder.Transformer.ForAdvice(withCustomMapping)
@@ -452,7 +457,7 @@ public class ElasticApmAgent {
                         getOrCreateTimer(instrumentation.getClass()).addMethodMatchingDuration(System.nanoTime() - start);
                     }
                 }
-            }, instrumentation.getAdviceClass().getName())
+            }, instrumentation.getAdviceClassName())
             .include(ClassLoader.getSystemClassLoader(), instrumentation.getClass().getClassLoader())
             .withExceptionHandler(PRINTING);
     }
@@ -462,7 +467,7 @@ public class ElasticApmAgent {
      *
      * @param adviceClass the advice class
      */
-    private static void validateAdvice(Class<?> adviceClass) {
+    static void validateAdvice(Class<?> adviceClass) {
         String adviceClassName = adviceClass.getName();
         ClassLoader classLoader = adviceClass.getClassLoader();
         if (classLoader == null) {
@@ -719,8 +724,8 @@ public class ElasticApmAgent {
                     );
                     for (Class<? extends ElasticApmInstrumentation> instrumentationClass : instrumentationClasses) {
                         ElasticApmInstrumentation apmInstrumentation = instantiate(instrumentationClass);
-                        pluginClassLoaderByAdviceClass.put(
-                            apmInstrumentation.getAdviceClass().getName(),
+                        adviceClassName2instrumentationClassLoader.put(
+                            apmInstrumentation.getAdviceClassName(),
                             ObjectUtils.systemClassLoaderIfNull(instrumentationClass.getClassLoader()));
                         ElementMatcher.Junction<? super TypeDescription> typeMatcher = getTypeMatcher(classToInstrument, apmInstrumentation.getMethodMatcher(), none());
                         if (typeMatcher != null && isIncluded(apmInstrumentation, config)) {
@@ -815,8 +820,14 @@ public class ElasticApmAgent {
         return ObjectUtils.systemClassLoaderIfNull(ElasticApmAgent.class.getClassLoader());
     }
 
-    public static ClassLoader getClassLoader(String adviceClass) {
-        ClassLoader classLoader = pluginClassLoaderByAdviceClass.get(adviceClass);
+    /**
+     * Returns the class loader that loaded the instrumentation class corresponding the given advice class.
+     * We expect to be able to find the advice class file through this class loader.
+     * @param adviceClass name of the advice class
+     * @return class loader that can be used for the advice class file lookup
+     */
+    public static ClassLoader getInstrumentationClassLoader(String adviceClass) {
+        ClassLoader classLoader = adviceClassName2instrumentationClassLoader.get(adviceClass);
         if (classLoader == null) {
             throw new IllegalStateException("There's no mapping for key " + adviceClass);
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/TracerAwareInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/TracerAwareInstrumentation.java
@@ -28,9 +28,6 @@ import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.GlobalTracer;
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
-import co.elastic.apm.agent.sdk.advice.AssignTo;
-import co.elastic.apm.agent.sdk.state.GlobalThreadLocal;
-import net.bytebuddy.asm.Advice;
 
 /**
  * The constructor can optionally have a {@link ElasticApmTracer} parameter.
@@ -48,7 +45,7 @@ public abstract class TracerAwareInstrumentation extends ElasticApmInstrumentati
      * @deprecated Overriding this method means not the instrumentation is not an indy plugin.
      * The usage of non-indy plugins is deprecated.
      * @return whether to load the classes of this plugin in dedicated plugin class loaders (one for each unique class loader)
-     * and dispatch to the {@linkplain #getAdviceClass() advice} via an {@code INVOKEDYNAMIC} instruction.
+     * and dispatch to the {@linkplain #getAdviceClassName() advice} via an {@code INVOKEDYNAMIC} instruction.
      */
     @Deprecated
     public boolean indyPlugin() {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -425,33 +425,25 @@ class InstrumentationTest {
 
     @Test
     void testInlinedIndyAdvice() {
-        assertThatThrownBy(() -> ElasticApmAgent.initInstrumentation(tracer,
-            ByteBuddyAgent.install(),
-            Collections.singletonList(new InlinedIndyAdviceInstrumentation())))
+        assertThatThrownBy(() -> ElasticApmAgent.validateAdvice(InlinedIndyAdviceInstrumentation.class))
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void testAdviceInSubpackage() {
-        assertThatThrownBy(() -> ElasticApmAgent.initInstrumentation(tracer,
-            ByteBuddyAgent.install(),
-            Collections.singletonList(new AdviceInSubpackageInstrumentation())))
+        assertThatThrownBy(() -> ElasticApmAgent.validateAdvice(AdviceInSubpackageInstrumentation.class))
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void testAdviceWithAgentReturnType() {
-        assertThatThrownBy(() -> ElasticApmAgent.initInstrumentation(tracer,
-            ByteBuddyAgent.install(),
-            Collections.singletonList(new AgentTypeReturnInstrumentation())))
+        assertThatThrownBy(() -> ElasticApmAgent.validateAdvice(AgentTypeReturnInstrumentation.class))
             .isInstanceOf(IllegalStateException.class);
     }
 
     @Test
     void testAdviceWithAgentParameterType() {
-        assertThatThrownBy(() -> ElasticApmAgent.initInstrumentation(tracer,
-            ByteBuddyAgent.install(),
-            Collections.singletonList(new AgentTypeParameterInstrumentation())))
+        assertThatThrownBy(() -> ElasticApmAgent.validateAdvice(AgentTypeParameterInstrumentation.class))
             .isInstanceOf(IllegalStateException.class);
     }
 

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentation.java
@@ -53,8 +53,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 public class ApacheHttpAsyncClientInstrumentation extends BaseApacheHttpClientInstrumentation {
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ApacheHttpAsyncClientAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.httpclient.ApacheHttpAsyncClientInstrumentation$ApacheHttpAsyncClientAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientRedirectInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientRedirectInstrumentation.java
@@ -26,7 +26,6 @@ package co.elastic.apm.agent.httpclient;
 
 import co.elastic.apm.agent.httpclient.helper.RequestHeaderAccessor;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
-import co.elastic.apm.agent.sdk.advice.AssignTo;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
@@ -63,8 +62,8 @@ public class ApacheHttpAsyncClientRedirectInstrumentation extends BaseApacheHttp
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ApacheHttpAsyncClientRedirectAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.httpclient.ApacheHttpAsyncClientRedirectInstrumentation$ApacheHttpAsyncClientRedirectAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpClientInstrumentation.java
@@ -102,8 +102,8 @@ public class ApacheHttpClientInstrumentation extends BaseApacheHttpClientInstrum
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ApacheHttpClientAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.httpclient.ApacheHttpClientInstrumentation$ApacheHttpClientAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientInstrumentation.java
@@ -104,8 +104,8 @@ public class LegacyApacheHttpClientInstrumentation extends BaseApacheHttpClientI
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return LegacyApacheHttpClientAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.httpclient.LegacyApacheHttpClientInstrumentation$LegacyApacheHttpClientAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-cassandra/apm-cassandra3-plugin/src/main/java/co/elastic/apm/agent/cassandra3/Cassandra3Instrumentation.java
+++ b/apm-agent-plugins/apm-cassandra/apm-cassandra3-plugin/src/main/java/co/elastic/apm/agent/cassandra3/Cassandra3Instrumentation.java
@@ -80,8 +80,8 @@ public class Cassandra3Instrumentation extends TracerAwareInstrumentation {
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return Cassandra3Advice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.cassandra3.Cassandra3Instrumentation$Cassandra3Advice";
     }
 
     public static class Cassandra3Advice {

--- a/apm-agent-plugins/apm-cassandra/apm-cassandra4-plugin/src/main/java/co/elastic/apm/agent/cassandra4/Cassandra4Instrumentation.java
+++ b/apm-agent-plugins/apm-cassandra/apm-cassandra4-plugin/src/main/java/co/elastic/apm/agent/cassandra4/Cassandra4Instrumentation.java
@@ -84,8 +84,8 @@ public class Cassandra4Instrumentation extends TracerAwareInstrumentation {
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return Cassandra4Advice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.cassandra4.Cassandra4Instrumentation$Cassandra4Advice";
     }
 
     public static class Cassandra4Advice {

--- a/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/AlibabaMonitorFilterInstrumentation.java
+++ b/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/AlibabaMonitorFilterInstrumentation.java
@@ -82,8 +82,8 @@ public class AlibabaMonitorFilterInstrumentation extends AbstractAlibabaDubboIns
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return AlibabaMonitorFilterAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.dubbo.advice.AlibabaMonitorFilterAdvice";
     }
 
 }

--- a/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/AlibabaResponseFutureInstrumentation.java
+++ b/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/AlibabaResponseFutureInstrumentation.java
@@ -61,8 +61,8 @@ public class AlibabaResponseFutureInstrumentation extends AbstractAlibabaDubboIn
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return AlibabaResponseFutureAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.dubbo.AlibabaResponseFutureInstrumentation$AlibabaResponseFutureAdvice";
     }
 
     public static class AlibabaResponseFutureAdvice {

--- a/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/ApacheMonitorFilterInstrumentation.java
+++ b/apm-agent-plugins/apm-dubbo-plugin/src/main/java/co/elastic/apm/agent/dubbo/ApacheMonitorFilterInstrumentation.java
@@ -64,8 +64,8 @@ public class ApacheMonitorFilterInstrumentation extends AbstractDubboInstrumenta
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ApacheMonitorFilterAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.dubbo.advice.ApacheMonitorFilterAdvice";
     }
 
 }

--- a/apm-agent-plugins/apm-error-logging-plugin/src/main/java/co/elastic/apm/agent/errorlogging/AbstractLoggerErrorCapturingInstrumentation.java
+++ b/apm-agent-plugins/apm-error-logging-plugin/src/main/java/co/elastic/apm/agent/errorlogging/AbstractLoggerErrorCapturingInstrumentation.java
@@ -43,8 +43,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 public abstract class AbstractLoggerErrorCapturingInstrumentation extends TracerAwareInstrumentation {
 
     @Override
-    public Class<?> getAdviceClass() {
-        return LoggingAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.errorlogging.AbstractLoggerErrorCapturingInstrumentation$LoggingAdvice";
     }
 
     public static class LoggingAdvice {

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/src/main/java/co/elastic/apm/agent/es/restclient/v5_6/ElasticsearchClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/src/main/java/co/elastic/apm/agent/es/restclient/v5_6/ElasticsearchClientAsyncInstrumentation.java
@@ -52,8 +52,8 @@ public class ElasticsearchClientAsyncInstrumentation extends ElasticsearchRestCl
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ElasticsearchRestClientAsyncAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.es.restclient.v5_6.ElasticsearchClientAsyncInstrumentation$ElasticsearchRestClientAsyncAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/src/main/java/co/elastic/apm/agent/es/restclient/v5_6/ElasticsearchClientSyncInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/src/main/java/co/elastic/apm/agent/es/restclient/v5_6/ElasticsearchClientSyncInstrumentation.java
@@ -81,8 +81,8 @@ public class ElasticsearchClientSyncInstrumentation extends ElasticsearchRestCli
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ElasticsearchRestClientAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.es.restclient.v5_6.ElasticsearchClientSyncInstrumentation$ElasticsearchRestClientAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchClientAsyncInstrumentation.java
@@ -51,8 +51,8 @@ public class ElasticsearchClientAsyncInstrumentation extends ElasticsearchRestCl
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ElasticsearchRestClientAsyncAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.es.restclient.v6_4.ElasticsearchClientAsyncInstrumentation$ElasticsearchRestClientAsyncAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchClientSyncInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/es/restclient/v6_4/ElasticsearchClientSyncInstrumentation.java
@@ -50,8 +50,8 @@ public class ElasticsearchClientSyncInstrumentation extends ElasticsearchRestCli
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ElasticsearchRestClientSyncAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.es.restclient.v6_4.ElasticsearchClientSyncInstrumentation$ElasticsearchRestClientSyncAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-grails-plugin/src/main/java/co/elastic/apm/agent/grails/GrailsTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-grails-plugin/src/main/java/co/elastic/apm/agent/grails/GrailsTransactionNameInstrumentation.java
@@ -75,8 +75,8 @@ public class GrailsTransactionNameInstrumentation extends TracerAwareInstrumenta
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return HandlerAdapterAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.grails.GrailsTransactionNameInstrumentation$HandlerAdapterAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch5Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/src/main/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch5Instrumentation.java
@@ -48,8 +48,8 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 public class HibernateSearch5Instrumentation extends TracerAwareInstrumentation {
 
     @Override
-    public Class<?> getAdviceClass() {
-        return HibernateSearch5ExecuteAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.hibernatesearch.HibernateSearch5Instrumentation$HibernateSearch5ExecuteAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch6Instrumentation.java
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/src/main/java/co/elastic/apm/agent/hibernatesearch/HibernateSearch6Instrumentation.java
@@ -49,8 +49,8 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 public class HibernateSearch6Instrumentation extends TracerAwareInstrumentation {
 
     @Override
-    public Class<?> getAdviceClass() {
-        return Hibernate6ExecuteAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.hibernatesearch.HibernateSearch6Instrumentation$Hibernate6ExecuteAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageConsumerInstrumentation.java
@@ -83,8 +83,8 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return MessageConsumerAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.jms.JmsMessageConsumerInstrumentation$ReceiveInstrumentation$MessageConsumerAdvice";
         }
 
         public static class MessageConsumerAdvice extends BaseAdvice {
@@ -235,8 +235,8 @@ public abstract class JmsMessageConsumerInstrumentation extends BaseJmsInstrumen
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return ListenerWrappingAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.jms.JmsMessageConsumerInstrumentation$SetMessageListenerInstrumentation$ListenerWrappingAdvice";
         }
 
         public static class ListenerWrappingAdvice extends BaseAdvice {

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
@@ -63,8 +63,8 @@ public class JmsMessageListenerInstrumentation extends BaseJmsInstrumentation {
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return MessageListenerAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.jms.JmsMessageListenerInstrumentation$MessageListenerAdvice";
     }
 
     public static class MessageListenerAdvice extends BaseAdvice {

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageProducerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageProducerInstrumentation.java
@@ -79,8 +79,8 @@ public abstract class JmsMessageProducerInstrumentation extends BaseJmsInstrumen
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return MessageProducerNoDestinationAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.jms.JmsMessageProducerInstrumentation$JmsMessageProducerNoDestinationInstrumentation$MessageProducerNoDestinationAdvice";
         }
 
         public static class MessageProducerNoDestinationAdvice extends BaseAdvice {
@@ -122,8 +122,8 @@ public abstract class JmsMessageProducerInstrumentation extends BaseJmsInstrumen
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return MessageProducerWithDestinationAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.jms.JmsMessageProducerInstrumentation$JmsMessageProducerWithDestinationInstrumentation$MessageProducerWithDestinationAdvice";
         }
 
         public static class MessageProducerWithDestinationAdvice extends BaseAdvice {

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/test/java/co/elastic/apm/agent/jms/JmsMessagePropertyAccessorTest.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/test/java/co/elastic/apm/agent/jms/JmsMessagePropertyAccessorTest.java
@@ -1,3 +1,27 @@
+/*-
+ * #%L
+ * Elastic APM Java agent
+ * %%
+ * Copyright (C) 2018 - 2021 Elastic and contributors
+ * %%
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ * #L%
+ */
 package co.elastic.apm.agent.jms;
 
 import co.elastic.apm.agent.impl.transaction.TraceContext;

--- a/apm-agent-plugins/apm-jsf-plugin/src/main/java/co/elastic/apm/agent/jsf/JsfLifecycleInstrumentation.java
+++ b/apm-agent-plugins/apm-jsf-plugin/src/main/java/co/elastic/apm/agent/jsf/JsfLifecycleInstrumentation.java
@@ -90,8 +90,8 @@ public abstract class JsfLifecycleInstrumentation extends TracerAwareInstrumenta
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return JsfLifecycleExecuteAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.jsf.JsfLifecycleInstrumentation$JsfLifecycleExecuteInstrumentation$JsfLifecycleExecuteAdvice";
         }
 
         public static class JsfLifecycleExecuteAdvice {
@@ -163,8 +163,8 @@ public abstract class JsfLifecycleInstrumentation extends TracerAwareInstrumenta
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return JsfLifecycleRenderAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.jsf.JsfLifecycleInstrumentation$JsfLifecycleRenderInstrumentation$JsfLifecycleRenderAdvice";
         }
 
         public static class JsfLifecycleRenderAdvice {

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/main/java/co/elastic/apm/agent/kafka/KafkaConsumerInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/main/java/co/elastic/apm/agent/kafka/KafkaConsumerInstrumentation.java
@@ -55,8 +55,8 @@ public class KafkaConsumerInstrumentation extends BaseKafkaInstrumentation {
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return KafkaConsumerAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.kafka.KafkaConsumerInstrumentation$KafkaConsumerAdvice";
     }
 
     public static class KafkaConsumerAdvice {

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/main/java/co/elastic/apm/agent/kafka/KafkaProducerInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-base-plugin/src/main/java/co/elastic/apm/agent/kafka/KafkaProducerInstrumentation.java
@@ -68,8 +68,8 @@ public class KafkaProducerInstrumentation extends BaseKafkaInstrumentation {
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return KafkaProducerAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.kafka.KafkaProducerInstrumentation$KafkaProducerAdvice";
     }
 
     @SuppressWarnings("rawtypes")

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsIteratorInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsIteratorInstrumentation.java
@@ -60,8 +60,8 @@ public class ConsumerRecordsIteratorInstrumentation extends KafkaConsumerRecords
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ConsumerRecordsAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.kafka.ConsumerRecordsIteratorInstrumentation$ConsumerRecordsAdvice";
     }
 
     @SuppressWarnings("rawtypes")

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsRecordListInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsRecordListInstrumentation.java
@@ -61,8 +61,8 @@ public class ConsumerRecordsRecordListInstrumentation extends KafkaConsumerRecor
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ConsumerRecordsAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.kafka.ConsumerRecordsRecordListInstrumentation$ConsumerRecordsAdvice";
     }
 
     @SuppressWarnings("rawtypes")

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsRecordsInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/ConsumerRecordsRecordsInstrumentation.java
@@ -59,8 +59,8 @@ public class ConsumerRecordsRecordsInstrumentation extends KafkaConsumerRecordsI
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ConsumerRecordsAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.kafka.ConsumerRecordsRecordsInstrumentation$ConsumerRecordsAdvice";
     }
 
     @SuppressWarnings("rawtypes")

--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/KafkaProducerHeadersInstrumentation.java
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-headers-plugin/src/main/java/co/elastic/apm/agent/kafka/KafkaProducerHeadersInstrumentation.java
@@ -71,8 +71,8 @@ public class KafkaProducerHeadersInstrumentation extends BaseKafkaHeadersInstrum
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return KafkaProducerHeadersInstrumentation.KafkaProducerHeadersAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.kafka.KafkaProducerHeadersInstrumentation$KafkaProducerHeadersAdvice";
     }
 
     @SuppressWarnings("rawtypes")

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-log4j1-plugin/src/main/java/co/elastic/apm/agent/log4j1/Log4j1LogShadingInstrumentation.java
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-log4j1-plugin/src/main/java/co/elastic/apm/agent/log4j1/Log4j1LogShadingInstrumentation.java
@@ -69,8 +69,8 @@ public abstract class Log4j1LogShadingInstrumentation extends AbstractLogShading
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return Log4j1AppenderAppendAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.log4j1.Log4j1AppenderAppendAdvice";
         }
 
     }
@@ -86,8 +86,8 @@ public abstract class Log4j1LogShadingInstrumentation extends AbstractLogShading
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return Log4j1AppenderStopAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.log4j1.Log4j1AppenderStopAdvice";
         }
 
     }

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-log4j2-plugin/src/main/java/co/elastic/apm/agent/log4j2/Log4j2LogShadingInstrumentation.java
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-log4j2-plugin/src/main/java/co/elastic/apm/agent/log4j2/Log4j2LogShadingInstrumentation.java
@@ -68,8 +68,8 @@ public abstract class Log4j2LogShadingInstrumentation extends AbstractLogShading
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return Log4j2AppenderAppendAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.log4j2.Log4j2AppenderAppendAdvice";
         }
 
     }
@@ -85,8 +85,8 @@ public abstract class Log4j2LogShadingInstrumentation extends AbstractLogShading
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return Log4j2AppenderStopAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.log4j2.Log4j2AppenderStopAdvice";
         }
 
     }

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/LogbackLogShadingInstrumentation.java
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/LogbackLogShadingInstrumentation.java
@@ -68,8 +68,8 @@ public abstract class LogbackLogShadingInstrumentation extends AbstractLogShadin
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return LogbackAppenderAppendAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.logback.LogbackAppenderAppendAdvice";
         }
 
     }
@@ -85,8 +85,8 @@ public abstract class LogbackLogShadingInstrumentation extends AbstractLogShadin
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return LogbackAppenderStopAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.logback.LogbackAppenderStopAdvice";
         }
 
     }

--- a/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionCommandInstrumentation.java
+++ b/apm-agent-plugins/apm-mongoclient-plugin/src/main/java/co/elastic/apm/agent/mongoclient/ConnectionCommandInstrumentation.java
@@ -47,7 +47,7 @@ public class ConnectionCommandInstrumentation extends MongoClientInstrumentation
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ConnectionAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.mongoclient.ConnectionAdvice";
     }
 }

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentation.java
@@ -56,8 +56,8 @@ public class OkHttp3ClientAsyncInstrumentation extends AbstractOkHttp3ClientInst
     public static final Logger logger = LoggerFactory.getLogger(OkHttp3ClientAsyncInstrumentation.class);
 
     @Override
-    public Class<?> getAdviceClass() {
-        return OkHttpClient3ExecuteAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.okhttp.OkHttp3ClientAsyncInstrumentation$OkHttpClient3ExecuteAdvice";
     }
 
     public static class OkHttpClient3ExecuteAdvice {

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientInstrumentation.java
@@ -49,8 +49,8 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 public class OkHttp3ClientInstrumentation extends AbstractOkHttp3ClientInstrumentation {
 
     @Override
-    public Class<?> getAdviceClass() {
-        return OkHttpClient3ExecuteAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.okhttp.OkHttp3ClientInstrumentation$OkHttpClient3ExecuteAdvice";
     }
 
     public static class OkHttpClient3ExecuteAdvice {

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientAsyncInstrumentation.java
@@ -52,8 +52,8 @@ public class OkHttpClientAsyncInstrumentation extends AbstractOkHttpClientInstru
     public static final Logger logger = LoggerFactory.getLogger(OkHttpClientAsyncInstrumentation.class);
 
     @Override
-    public Class<?> getAdviceClass() {
-        return OkHttpClient3ExecuteAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.okhttp.OkHttpClientAsyncInstrumentation$OkHttpClient3ExecuteAdvice";
     }
 
     public static class OkHttpClient3ExecuteAdvice {

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientInstrumentation.java
@@ -46,8 +46,8 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 public class OkHttpClientInstrumentation extends AbstractOkHttpClientInstrumentation {
 
     @Override
-    public Class<?> getAdviceClass() {
-        return OkHttpClientExecuteAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.okhttp.OkHttpClientInstrumentation$OkHttpClientExecuteAdvice";
     }
 
     public static class OkHttpClientExecuteAdvice {

--- a/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/CommonsExecAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/CommonsExecAsyncInstrumentation.java
@@ -84,8 +84,8 @@ public class CommonsExecAsyncInstrumentation extends TracerAwareInstrumentation 
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return CommonsExecAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.process.CommonsExecAsyncInstrumentation$CommonsExecAdvice";
     }
 
     public static final class CommonsExecAdvice {

--- a/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/ProcessExitInstrumentation.java
+++ b/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/ProcessExitInstrumentation.java
@@ -24,7 +24,6 @@
  */
 package co.elastic.apm.agent.process;
 
-import co.elastic.apm.agent.impl.GlobalTracer;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -66,8 +65,8 @@ public abstract class ProcessExitInstrumentation extends BaseProcessInstrumentat
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return WaitForAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.process.ProcessExitInstrumentation$WaitFor$WaitForAdvice";
         }
 
         public static class WaitForAdvice {
@@ -104,8 +103,8 @@ public abstract class ProcessExitInstrumentation extends BaseProcessInstrumentat
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return DestroyAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.process.ProcessExitInstrumentation$Destroy$DestroyAdvice";
         }
 
         public static class DestroyAdvice {

--- a/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/ProcessStartInstrumentation.java
+++ b/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/ProcessStartInstrumentation.java
@@ -52,8 +52,8 @@ public class ProcessStartInstrumentation extends BaseProcessInstrumentation {
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ProcessBuilderStartAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.process.ProcessStartInstrumentation$ProcessBuilderStartAdvice";
     }
 
     public static class ProcessBuilderStartAdvice {

--- a/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartzjob/JobTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-quartz-job-plugin/src/main/java/co/elastic/apm/agent/quartzjob/JobTransactionNameInstrumentation.java
@@ -74,8 +74,8 @@ public class JobTransactionNameInstrumentation extends TracerAwareInstrumentatio
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return JobTransactionNameAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.quartzjob.JobTransactionNameAdvice";
     }
 
 }

--- a/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-plugin/src/main/java/co/elastic/apm/agent/rabbitmq/ConsumerInstrumentation.java
+++ b/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-plugin/src/main/java/co/elastic/apm/agent/rabbitmq/ConsumerInstrumentation.java
@@ -77,8 +77,8 @@ public class ConsumerInstrumentation extends RabbitmqBaseInstrumentation {
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return RabbitConsumerAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.rabbitmq.ConsumerInstrumentation$RabbitConsumerAdvice";
     }
 
     public static class RabbitConsumerAdvice {

--- a/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-spring/src/main/java/co/elastic/apm/agent/rabbitmq/SetMessageListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-spring/src/main/java/co/elastic/apm/agent/rabbitmq/SetMessageListenerInstrumentation.java
@@ -58,8 +58,8 @@ public class SetMessageListenerInstrumentation extends SpringBaseInstrumentation
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return MessageListenerContainerWrappingAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.rabbitmq.SetMessageListenerInstrumentation$MessageListenerContainerWrappingAdvice";
     }
 
     private static final MessageListenerHelper helper = new MessageListenerHelper();

--- a/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-spring/src/main/java/co/elastic/apm/agent/rabbitmq/SpringAmqpMessageListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-spring/src/main/java/co/elastic/apm/agent/rabbitmq/SpringAmqpMessageListenerInstrumentation.java
@@ -56,8 +56,8 @@ public class SpringAmqpMessageListenerInstrumentation extends SpringBaseInstrume
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return SpringAmqpMessageListenerAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.rabbitmq.SpringAmqpMessageListenerInstrumentation$SpringAmqpMessageListenerAdvice";
     }
 
     public static class SpringAmqpMessageListenerAdvice {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/AsyncInstrumentation.java
@@ -100,8 +100,8 @@ public abstract class AsyncInstrumentation extends AbstractServletInstrumentatio
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return StartAsyncAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.servlet.AsyncInstrumentation$StartAsyncInstrumentation$StartAsyncAdvice";
         }
 
         public static class StartAsyncAdvice {
@@ -138,8 +138,8 @@ public abstract class AsyncInstrumentation extends AbstractServletInstrumentatio
         }
 
         @Override
-        public Class<?> getAdviceClass() {
-            return AsyncContextStartAdvice.class;
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.servlet.AsyncInstrumentation$AsyncContextInstrumentation$AsyncContextStartAdvice";
         }
 
         public static class AsyncContextStartAdvice {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/FilterChainInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/FilterChainInstrumentation.java
@@ -60,8 +60,8 @@ public class FilterChainInstrumentation extends AbstractServletInstrumentation {
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ServletApiAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.servlet.ServletApiAdvice";
     }
 
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/RequestStreamRecordingInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/RequestStreamRecordingInstrumentation.java
@@ -71,8 +71,8 @@ public class RequestStreamRecordingInstrumentation extends AbstractServletInstru
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return GetInputStreamAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.servlet.RequestStreamRecordingInstrumentation$GetInputStreamAdvice";
     }
 
     public static class GetInputStreamAdvice {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletInstrumentation.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletInstrumentation.java
@@ -78,8 +78,8 @@ public class ServletInstrumentation extends AbstractServletInstrumentation {
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ServletApiAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.servlet.ServletApiAdvice";
     }
 
 }

--- a/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-plugin/src/main/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-plugin/src/main/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentation.java
@@ -67,8 +67,8 @@ public class SpringRestTemplateInstrumentation extends TracerAwareInstrumentatio
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return SpringRestTemplateAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.resttemplate.SpringRestTemplateAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/ExceptionHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/ExceptionHandlerInstrumentation.java
@@ -42,8 +42,8 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 public class ExceptionHandlerInstrumentation extends TracerAwareInstrumentation {
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ExceptionHandlerAdviceService.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.springwebmvc.ExceptionHandlerInstrumentation$ExceptionHandlerAdviceService";
     }
 
     public static class ExceptionHandlerAdviceService {

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringServiceNameInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringServiceNameInstrumentation.java
@@ -64,8 +64,8 @@ public class SpringServiceNameInstrumentation extends TracerAwareInstrumentation
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return SpringServiceNameAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.springwebmvc.SpringServiceNameInstrumentation$SpringServiceNameAdvice";
     }
 
     public static class SpringServiceNameAdvice {

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringTransactionNameInstrumentation.java
@@ -93,8 +93,8 @@ public class SpringTransactionNameInstrumentation extends TracerAwareInstrumenta
     }
 
     @Override
-    public Class<?> getAdviceClass() {
-        return HandlerAdapterAdvice.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.springwebmvc.SpringTransactionNameInstrumentation$HandlerAdapterAdvice";
     }
 
     @Override

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/ViewRenderInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/ViewRenderInstrumentation.java
@@ -53,8 +53,8 @@ public class ViewRenderInstrumentation extends TracerAwareInstrumentation {
     private static Map<String, String> subTypeCache = new ConcurrentHashMap<>();
 
     @Override
-    public Class<?> getAdviceClass() {
-        return ViewRenderAdviceService.class;
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.springwebmvc.ViewRenderInstrumentation$ViewRenderAdviceService";
     }
 
     public static class ViewRenderAdviceService {


### PR DESCRIPTION
One step in the direction of complete separation between Advice and Instrumentation classes.
Next step is extract Advice code from all Instrumentations to different classes and it would also make sense to put all advices in separate source files as well.