### PR TITLE
Added Support for JBoss Logging to the log correlation plugin

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -60,6 +60,7 @@ By default, the VM arguments are not printed, but only when the `-a`/`--list-vma
 Even when matching on the main class name or on system properties,
 ** Checks the Java version before attaching to avoid attachment on unsupported JVMs.
 * Cassandra instrumentation - {pull}1712[#1712]
+* Log correlation supports JBoss Logging - {pull}1737[#1737]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-log-correlation-plugin/pom.xml
+++ b/apm-agent-plugins/apm-log-correlation-plugin/pom.xml
@@ -36,6 +36,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+            <version>3.4.1.Final</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-error-logging-plugin</artifactId>
             <version>${project.version}</version>

--- a/apm-agent-plugins/apm-log-correlation-plugin/src/main/java/co/elastic/apm/agent/mdc/MdcActivationListener.java
+++ b/apm-agent-plugins/apm-log-correlation-plugin/src/main/java/co/elastic/apm/agent/mdc/MdcActivationListener.java
@@ -46,6 +46,7 @@ public class MdcActivationListener implements ActivationListener {
     private static final String LOG4J_MDC = "org.apache.log4j.MDC";
     // prevents the shade plugin from relocating org.apache.logging.log4j.ThreadContext to co.elastic.apm.agent.shaded.apache.logging.log4j.ThreadContext
     private static final String LOG4J2_MDC = "org!apache!logging!log4j!ThreadContext".replace('!', '.');
+    private static final String JBOSS_LOGGING_MDC = "org.jboss.logging.MDC";
 
     private static final String TRACE_ID = "trace.id";
     private static final String TRANSACTION_ID = "transaction.id";
@@ -94,6 +95,19 @@ public class MdcActivationListener implements ActivationListener {
                     return NOOP;
                 }
             }
+        }),
+        new WeakKeySoftValueLoadingCache<>(new WeakKeySoftValueLoadingCache.ValueSupplier<ClassLoader, MethodHandle>() {
+            @Nullable
+            @Override
+            public MethodHandle get(ClassLoader classLoader) {
+                try {
+                    return MethodHandles.lookup()
+                        .findStatic(classLoader.loadClass(JBOSS_LOGGING_MDC), "put", MethodType.methodType(Object.class, String.class, Object.class));
+                } catch (Exception e) {
+                    logger.debug("Class loader " + classLoader + " cannot load JBoss Logging API", e);
+                    return NOOP;
+                }
+            }
         })
     };
 
@@ -131,6 +145,19 @@ public class MdcActivationListener implements ActivationListener {
                 try {
                     return MethodHandles.lookup()
                         .findStatic(classLoader.loadClass(LOG4J2_MDC), "remove", MethodType.methodType(void.class, String.class));
+                } catch (Exception ignore) {
+                    // No need to log - logged already when populated the put cache
+                    return NOOP;
+                }
+            }
+        }),
+        new WeakKeySoftValueLoadingCache<>(new WeakKeySoftValueLoadingCache.ValueSupplier<ClassLoader, MethodHandle>() {
+            @Nullable
+            @Override
+            public MethodHandle get(ClassLoader classLoader) {
+                try {
+                    return MethodHandles.lookup()
+                        .findStatic(classLoader.loadClass(JBOSS_LOGGING_MDC), "remove", MethodType.methodType(void.class, String.class));
                 } catch (Exception ignore) {
                     // No need to log - logged already when populated the put cache
                     return NOOP;

--- a/apm-agent-plugins/apm-log-correlation-plugin/src/test/java/co/elastic/apm/agent/mdc/MdcActivationListenerIT.java
+++ b/apm-agent-plugins/apm-log-correlation-plugin/src/test/java/co/elastic/apm/agent/mdc/MdcActivationListenerIT.java
@@ -82,6 +82,7 @@ class MdcActivationListenerIT {
         MDC.clear();
         org.apache.log4j.MDC.clear();
         ThreadContext.clearAll();
+        org.jboss.logging.MDC.clear();
         loggingConfiguration = config.getConfig(LoggingConfiguration.class);
     }
 
@@ -158,11 +159,13 @@ class MdcActivationListenerIT {
     private void assertMdcErrorIdIsEmpty() {
         assertThat(MDC.get("error.id")).isNull();
         assertThat(org.apache.log4j.MDC.get("error.id")).isNull();
+        assertThat(org.jboss.logging.MDC.get("error.id")).isNull();
     }
 
     private Answer<Void> assertMdcErrorIdIsNotEmpty() {
         assertThat(MDC.get("error.id")).isNotBlank();
         assertThat(org.apache.log4j.MDC.get("error.id")).isNotNull();
+        assertThat(org.jboss.logging.MDC.get("error.id")).isNotNull();
         return null;
     }
 }

--- a/apm-agent-plugins/apm-log-correlation-plugin/src/test/java/co/elastic/apm/agent/mdc/MdcActivationListenerTest.java
+++ b/apm-agent-plugins/apm-log-correlation-plugin/src/test/java/co/elastic/apm/agent/mdc/MdcActivationListenerTest.java
@@ -59,6 +59,7 @@ class MdcActivationListenerTest extends AbstractInstrumentationTest {
         MDC.clear();
         org.apache.log4j.MDC.clear();
         ThreadContext.clearAll();
+        org.jboss.logging.MDC.clear();
         loggingConfiguration = config.getConfig(LoggingConfiguration.class);
     }
 
@@ -275,6 +276,8 @@ class MdcActivationListenerTest extends AbstractInstrumentationTest {
         assertThat(MDC.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
         assertThat(ThreadContext.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
         assertThat(ThreadContext.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
+        assertThat(org.jboss.logging.MDC.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
+        assertThat(org.jboss.logging.MDC.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
         if (log4jMdcWorking == Boolean.TRUE) {
             assertThat(org.apache.log4j.MDC.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
             assertThat(org.apache.log4j.MDC.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
@@ -286,6 +289,8 @@ class MdcActivationListenerTest extends AbstractInstrumentationTest {
         assertThat(MDC.get("transaction.id")).isNull();
         assertThat(ThreadContext.get("trace.id")).isNull();
         assertThat(ThreadContext.get("transaction.id")).isNull();
+        assertThat(org.jboss.logging.MDC.get("trace.id")).isNull();
+        assertThat(org.jboss.logging.MDC.get("transaction.id")).isNull();
         if (log4jMdcWorking == Boolean.TRUE) {
             assertThat(org.apache.log4j.MDC.get("transaction.id")).isNull();
             assertThat(org.apache.log4j.MDC.get("trace.id")).isNull();

--- a/apm-agent-plugins/apm-log-correlation-plugin/src/test/java/co/elastic/apm/agent/mdc/MdcActivationListenerTest.java
+++ b/apm-agent-plugins/apm-log-correlation-plugin/src/test/java/co/elastic/apm/agent/mdc/MdcActivationListenerTest.java
@@ -37,11 +37,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -56,10 +60,8 @@ class MdcActivationListenerTest extends AbstractInstrumentationTest {
     void setUp() {
         org.apache.log4j.MDC.put("test", true);
         log4jMdcWorking = (Boolean) org.apache.log4j.MDC.get("test");
-        MDC.clear();
-        org.apache.log4j.MDC.clear();
-        ThreadContext.clearAll();
-        org.jboss.logging.MDC.clear();
+
+        forAllMdc(MdcImpl::clear);
         loggingConfiguration = config.getConfig(LoggingConfiguration.class);
     }
 
@@ -271,30 +273,56 @@ class MdcActivationListenerTest extends AbstractInstrumentationTest {
         assertThat(loggingConfiguration.isLogCorrelationEnabled()).isTrue();
     }
 
-    private void assertMdcIsSet(AbstractSpan span) {
-        assertThat(MDC.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
-        assertThat(MDC.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
-        assertThat(ThreadContext.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
-        assertThat(ThreadContext.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
-        assertThat(org.jboss.logging.MDC.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
-        assertThat(org.jboss.logging.MDC.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
-        if (log4jMdcWorking == Boolean.TRUE) {
-            assertThat(org.apache.log4j.MDC.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
-            assertThat(org.apache.log4j.MDC.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
+    private void assertMdcIsSet(AbstractSpan<?> span) {
+        forAllMdc(mdc -> {
+            assertThat(mdc.get("trace.id")).isEqualTo(span.getTraceContext().getTraceId().toString());
+            assertThat(mdc.get("transaction.id")).isEqualTo(span.getTraceContext().getTransactionId().toString());
+        });
+    }
+
+    private enum MdcImpl {
+        Slf4j(
+            MDC::get,
+            MDC::clear),
+        Log4j1(
+            k -> (String) org.apache.log4j.MDC.get(k),
+            org.apache.log4j.MDC::clear),
+        Log4j2(
+            ThreadContext::get,
+            ThreadContext::clearAll),
+        JbossLogging(
+            k -> (String) org.jboss.logging.MDC.get(k),
+            org.jboss.logging.MDC::clear);
+
+        private final Function<String, String> get;
+        private final Runnable clear;
+
+        MdcImpl(Function<String, String> get, Runnable clear) {
+            this.get = get;
+            this.clear = clear;
+        }
+
+        @Nullable
+        String get(String key) {
+            return get.apply(key);
+        }
+
+        void clear() {
+            clear.run();
         }
     }
 
     private void assertMdcIsEmpty() {
-        assertThat(MDC.get("trace.id")).isNull();
-        assertThat(MDC.get("transaction.id")).isNull();
-        assertThat(ThreadContext.get("trace.id")).isNull();
-        assertThat(ThreadContext.get("transaction.id")).isNull();
-        assertThat(org.jboss.logging.MDC.get("trace.id")).isNull();
-        assertThat(org.jboss.logging.MDC.get("transaction.id")).isNull();
-        if (log4jMdcWorking == Boolean.TRUE) {
-            assertThat(org.apache.log4j.MDC.get("transaction.id")).isNull();
-            assertThat(org.apache.log4j.MDC.get("trace.id")).isNull();
-        }
+        forAllMdc(mdc -> {
+            assertThat(mdc.get("trace.id")).isNull();
+            assertThat(mdc.get("transaction.id")).isNull();
+        });
+    }
+
+    private void forAllMdc(Consumer<MdcImpl> task) {
+        Stream.of(MdcImpl.values())
+            .filter(mdc -> mdc != MdcImpl.Log4j1 || log4jMdcWorking)
+            .forEach(task);
     }
 
 }

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -474,6 +474,13 @@ ECS Reformatting - 1.22.0
 ECS-compatible format (since 1.22.0, experimental)
 |1.22.0
 
+|JBoss Logging
+|3.0.0+
+|When <<config-enable-log-correlation>> is set to `true`,
+the agent will add a http://javadox.com/org.jboss.logging/jboss-logging/3.3.0.Final/org/jboss/logging/MDC.html[MDC]
+entry for `trace.id` and `transaction.id`. See the <<config-enable-log-correlation>> configuration option for more details.
+|1.23.0
+
 |===
 
 [float]


### PR DESCRIPTION
## What does this PR do?
Fixes #1734

## Checklist
- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] I have added info about JBoss logging to the [relevant section](https://www.elastic.co/guide/en/apm/agent/java/current/supported-technologies-details.html#supported-logging-frameworks) in the supported technologies page
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
