### PR TITLE
Guarding from null host in Apache legacy HTTP client

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -68,6 +68,7 @@ Even when matching on the main class name or on system properties,
 * Fix apm-log4j1-plugin and apm-log4j2-plugin dependency on slf4j - {pull}1723[#1723]
 * Avoid systematic `MessageNotWriteableException` error logging, now only visible in `debug` - {pull}1715[#1715]
 * Fix rounded number format for non-english locales - {pull}1728[#1728]
+* Fix `NullPointerException` on legacy Apache client instrumentation when host is `null` - {pull}1746[#1746]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientInstrumentation.java
@@ -56,7 +56,7 @@ public class LegacyApacheHttpClientInstrumentation extends BaseApacheHttpClientI
     public static class LegacyApacheHttpClientAdvice {
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-        public static Object onBeforeExecute(@Advice.Argument(0) HttpHost host,
+        public static Object onBeforeExecute(@Advice.Argument(0) @Nullable HttpHost host,
                                              @Advice.Argument(1) HttpRequest request) {
             final AbstractSpan<?> parent = tracer.getActive();
             if (parent == null) {
@@ -66,7 +66,8 @@ public class LegacyApacheHttpClientInstrumentation extends BaseApacheHttpClientI
                 return null;
             }
             HttpUriRequest uriRequest = (HttpUriRequest) request;
-            Span span = HttpClientHelper.startHttpClientSpan(parent, uriRequest.getMethod(), uriRequest.getURI(), host.getHostName());
+            String hostName = (host != null) ? host.getHostName() : null;
+            Span span = HttpClientHelper.startHttpClientSpan(parent, uriRequest.getMethod(), uriRequest.getURI(), hostName);
             if (span != null) {
                 span.activate();
                 span.propagateTraceContext(request, RequestHeaderAccessor.INSTANCE);


### PR DESCRIPTION
## What does this PR do?
Fixing a reported issue:
```
java.lang.NullPointerException
at co.elastic.apm.agent.httpclient.LegacyApacheHttpClientInstrumentation$LegacyApacheHttpClientAdvice.onBeforeExecute(LegacyApacheHttpClientInstrumentation.java:69)
at org.apache.http.impl.client.DefaultRequestDirector.execute(DefaultRequestDirector.java:367)
at org.apache.http.impl.client.AbstractHttpClient.doExecute(AbstractHttpClient.java:835)
at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83)
at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108)
at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:56)
...
```

If the `HttpRequest` argument in the instrumented method is `null`, we should not get to the line producing the NPE, so I just added a null-check for the `host` argument. If it is `null`, we can still call `HttpClientHelper#startHttpClientSpan()` with a `null` hostname and it will take the hostname from the URI instead.