### PR TITLE
ci: use stable branch instead tags

### DIFF
--- a/.ci/jobs/apm-agent-java-mbp.yml
+++ b/.ci/jobs/apm-agent-java-mbp.yml
@@ -13,6 +13,7 @@
             discover-pr-forks-trust: permission
             discover-pr-origin: merge-current
             discover-tags: true
+            head-filter-regex: '^(?!stable).*$'
             notification-context: 'apm-ci'
             repo: apm-agent-java
             repo-owner: elastic

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -316,7 +316,7 @@ pipeline {
           setupAPMGitEmail(global: false)
           sh(label: "checkout ${BRANCH_NAME} branch", script: "git checkout -f '${BRANCH_NAME}'")
           sh(label: 'rebase latest', script: """
-            git checkout latest
+            git rev-parse --quiet --verify latest && git checkout latest || git checkout -b latest
             git rebase '${BRANCH_NAME}'
           """)
           gitPush()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,7 +315,11 @@ pipeline {
         dir("${BASE_DIR}"){
           setupAPMGitEmail(global: false)
           sh(label: "checkout ${BRANCH_NAME} branch", script: "git checkout -f '${BRANCH_NAME}'")
-          gitCreateTag(tag: 'stable', tagArgs: '--force', pushArgs: '--force')
+          sh(label: 'rebase latest', script: """
+            git checkout latest
+            git rebase '${BRANCH_NAME}'
+          """)
+          gitPush()
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -315,8 +315,8 @@ pipeline {
         dir("${BASE_DIR}"){
           setupAPMGitEmail(global: false)
           sh(label: "checkout ${BRANCH_NAME} branch", script: "git checkout -f '${BRANCH_NAME}'")
-          sh(label: 'rebase latest', script: """
-            git rev-parse --quiet --verify latest && git checkout latest || git checkout -b latest
+          sh(label: 'rebase stable', script: """
+            git rev-parse --quiet --verify stable && git checkout stable || git checkout -b stable
             git rebase '${BRANCH_NAME}'
           """)
           gitPush()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,22 @@ pipeline {
             }
           }
         }
+        stage('Stable') {
+          options { skipDefaultCheckout() }
+          steps {
+            deleteDir()
+            unstash 'source'
+            dir("${BASE_DIR}"){
+              setupAPMGitEmail(global: false)
+              sh(label: "checkout master branch", script: "git checkout -f 'master'")
+              sh(label: 'rebase latest', script: """
+                git rev-parse --quiet --verify latest && git checkout latest || git checkout -b latest
+                git rebase 'master'
+              """)
+              gitPush()
+            }
+          }
+        }
         /**
         Build on a linux environment.
         */
@@ -302,25 +318,6 @@ pipeline {
                            string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
                            string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
         githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
-      }
-    }
-    stage('Stable') {
-      options { skipDefaultCheckout() }
-      when {
-        branch 'master'
-      }
-      steps {
-        deleteDir()
-        unstash 'source'
-        dir("${BASE_DIR}"){
-          setupAPMGitEmail(global: false)
-          sh(label: "checkout ${BRANCH_NAME} branch", script: "git checkout -f '${BRANCH_NAME}'")
-          sh(label: 'rebase latest', script: """
-            git rev-parse --quiet --verify latest && git checkout latest || git checkout -b latest
-            git rebase '${BRANCH_NAME}'
-          """)
-          gitPush()
-        }
       }
     }
     stage('AfterRelease') {


### PR DESCRIPTION
## What does this PR do?

Use a branch instead of a tag to avoid the RSS issues with tags/releases in GitHub