### PR TITLE
ci: fix stable branch creation locally

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -316,7 +316,7 @@ pipeline {
           setupAPMGitEmail(global: false)
           sh(label: "checkout ${BRANCH_NAME} branch", script: "git checkout -f '${BRANCH_NAME}'")
           sh(label: 'rebase stable', script: """
-            git rev-parse --quiet --verify stable && git checkout stable || git checkout -b stable
+            git checkout -b stable --force
             git rebase '${BRANCH_NAME}'
           """)
           gitPush()


### PR DESCRIPTION
## What does this PR do?

Force the git checkout in a new branch otherwise it's a detached reference.

## Why 

It seems the tests I ran in the PR didn't try all the possible scenarios (https://github.com/elastic/apm-agent-java/pull/1771#issuecomment-822367611)


 :/


![image](https://user-images.githubusercontent.com/2871786/115268581-5287cb80-a132-11eb-9b42-035dc7f7cd6e.png)
