### PR TITLE
Make non-default settings observable even in INFO

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
@@ -90,7 +90,7 @@ public class StartupInfo extends AbstractLifecycleListener {
     }
 
     private void logConfigWithNonDefaultValue(Logger logger, ConfigurationOption<?> option) {
-        logger.debug("{}: '{}' (source: {})", option.getKey(),
+        logger.info("{}: '{}' (source: {})", option.getKey(),
             option.isSensitive() ? "XXXX" : option.getValueAsSafeString(),
             option.getNameOfCurrentConfigurationSource());
 


### PR DESCRIPTION
## What does this PR do?

It is a proposal to log the settings which are not at default as INFO instead of DEBUG.

## Checklist

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
