### PR TITLE
Revert "ci: fix stable branch creation locally"

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -316,7 +316,7 @@ pipeline {
           setupAPMGitEmail(global: false)
           sh(label: "checkout ${BRANCH_NAME} branch", script: "git checkout -f '${BRANCH_NAME}'")
           sh(label: 'rebase stable', script: """
-            git checkout -b stable --force
+            git rev-parse --quiet --verify stable && git checkout stable || git checkout -b stable
             git rebase '${BRANCH_NAME}'
           """)
           gitPush()


### PR DESCRIPTION
Reverts elastic/apm-agent-java#1775

### Rationale

Concurrent builds can produce errors when pushing an obsoleted update:

![image](https://user-images.githubusercontent.com/2871786/115696560-b8ef3280-a35a-11eb-8a56-862930eb51c7.png)
