### PR TITLE
relativize method adds / to path(ZipPath implementation of Path inter…

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -93,6 +93,7 @@ Even when matching on the main class name or on system properties,
 * Fix micrometer serialization error - {pull}1741[#1741]
 * Optimize & avoid `ensureInstrumented` deadlock by skipping stack-frame computation for Java7+ bytecode - {pull}1758[#1758]
 * Fix instrumentation plugins loading on Windows - {pull}1671[#1671]
+* Fix replacing '/' to '.' in `PackageScanner#listClassNames` related to the `relativize` method of `com.sun.nio.zipfs.ZipPath` implementation of `java.nio.file.Path` - {pull}1785[#1785]
 
 [float]
 ===== Refactors

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
+* Fix another error related to instrumentation plugins loading on Windows - {pull}1785[#1785]
 
 [float]
 ===== Refactors
@@ -93,7 +94,6 @@ Even when matching on the main class name or on system properties,
 * Fix micrometer serialization error - {pull}1741[#1741]
 * Optimize & avoid `ensureInstrumented` deadlock by skipping stack-frame computation for Java7+ bytecode - {pull}1758[#1758]
 * Fix instrumentation plugins loading on Windows - {pull}1671[#1671]
-* Fix another error related to instrumentation plugins loading on Windows - {pull}1785[#1785]
 
 [float]
 ===== Refactors

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -93,7 +93,7 @@ Even when matching on the main class name or on system properties,
 * Fix micrometer serialization error - {pull}1741[#1741]
 * Optimize & avoid `ensureInstrumented` deadlock by skipping stack-frame computation for Java7+ bytecode - {pull}1758[#1758]
 * Fix instrumentation plugins loading on Windows - {pull}1671[#1671]
-* Fix replacing '/' to '.' in `PackageScanner#listClassNames` related to the `relativize` method of `com.sun.nio.zipfs.ZipPath` implementation of `java.nio.file.Path` - {pull}1785[#1785]
+* Fix another error related to instrumentation plugins loading on Windows - {pull}1785[#1785]
 
 [float]
 ===== Refactors

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
@@ -91,7 +91,9 @@ public class PackageScanner {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 if (file.toString().endsWith(".class")) {
-                    classNames.add(basePackage + "." + basePath.relativize(file).toString().replace(File.separatorChar, '.').replace('/', '.').replace(".class", ""));
+                    // We need to escape both the filesystem-specific separator and the explicit `/` separator that may be added by the relativize() implementation
+                    String classNameSuffix = basePath.relativize(file).toString().replace(File.separatorChar, '.').replace('/', '.').replace(".class", "");
+                    classNames.add(basePackage + "." + classNameSuffix);
                 }
                 return FileVisitResult.CONTINUE;
             }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
@@ -91,7 +91,7 @@ public class PackageScanner {
             @Override
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 if (file.toString().endsWith(".class")) {
-                    classNames.add(basePackage + "." + basePath.relativize(file).toString().replace(File.separatorChar, '.').replace(".class", ""));
+                    classNames.add(basePackage + "." + basePath.relativize(file).toString().replace(File.separatorChar, '.').replace('/', '.').replace(".class", ""));
                 }
                 return FileVisitResult.CONTINUE;
             }


### PR DESCRIPTION
## What does this PR do?
`relativize` method of `java.nio.file.Path` implementation `jdk.nio.zipfs.ZipPath` adds '/' :
```
        while (dotdots > 0) {
            result[pos++] = (byte)'.';
            result[pos++] = (byte)'.';
            if (pos < len)       // no tailing slash at the end
                result[pos++] = (byte)'/';
            dotdots--;
        }
```
So `replace` method not replaced '/' with '.' value. 
https://gist.github.com/kananindzya/f1ad4bfd978c9ed08436481b5ef86cb0
This bug reproduced only on windows, because on linux systems, `File.separatorChar` returns '/' value.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [X] This is a bugfix
  - [X] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
