### PR TITLE
Remove gRPC Helper class from Instrumentation

### DIFF
--- a/apm-agent-plugins/apm-cassandra/apm-cassandra4-plugin/pom.xml
+++ b/apm-agent-plugins/apm-cassandra/apm-cassandra4-plugin/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
             <groupId>com.datastax.oss</groupId>
             <artifactId>java-driver-core</artifactId>
-            <version>4.11.0</version>
+            <version>4.11.1</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/apm-agent-plugins/apm-cassandra/apm-cassandra4-plugin/src/test/java/co/elastic/apm/agent/cassandra/Cassandra4InstrumentationIT.java
+++ b/apm-agent-plugins/apm-cassandra/apm-cassandra4-plugin/src/test/java/co/elastic/apm/agent/cassandra/Cassandra4InstrumentationIT.java
@@ -74,7 +74,7 @@ class Cassandra4InstrumentationIT extends AbstractInstrumentationTest {
     }
 
     private static CqlSession getSession(String keyspace) {
-        DriverConfigLoader configLoader = DefaultDriverConfigLoader.builder()
+        DriverConfigLoader configLoader = DriverConfigLoader.programmaticBuilder()
             .withDuration(DefaultDriverOption.REQUEST_TIMEOUT, Duration.ofSeconds(0))
             .build();
         return CqlSession.builder()

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/BaseInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/BaseInstrumentation.java
@@ -35,8 +35,6 @@ import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 
 public abstract class BaseInstrumentation extends TracerAwareInstrumentation {
 
-    protected static final GrpcHelper helper = new GrpcHelper();
-
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
         return nameStartsWith("io.grpc");

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ChannelInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ChannelInstrumentation.java
@@ -34,15 +34,14 @@ import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import net.bytebuddy.matcher.ElementMatchers;
 
 import javax.annotation.Nullable;
 
-import static net.bytebuddy.matcher.ElementMatchers.*;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 /**
  * Instruments {@link Channel#newCall(MethodDescriptor, CallOptions)} to add channel authority (host+port) to the span
@@ -75,7 +74,7 @@ public class ChannelInstrumentation extends BaseInstrumentation {
     public static Object onEnter(@Advice.This Channel channel,
                                  @Advice.Argument(0) MethodDescriptor<?, ?> method) {
 
-        return helper.startSpan(tracer.getActive(), method, channel.authority());
+        return GrpcHelper.getInstance().startSpan(tracer.getActive(), method, channel.authority());
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
@@ -83,7 +82,7 @@ public class ChannelInstrumentation extends BaseInstrumentation {
                               @Advice.Enter @Nullable Object span) {
 
         if (span instanceof Span) {
-            helper.registerSpan(clientCall, (Span) span);
+            GrpcHelper.getInstance().registerSpan(clientCall, (Span) span);
         }
     }
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ClientCallImplInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ClientCallImplInstrumentation.java
@@ -92,21 +92,21 @@ public abstract class ClientCallImplInstrumentation extends BaseInstrumentation 
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object onEnter(@Advice.This ClientCall<?, ?> clientCall,
-                                      @Advice.Argument(0) ClientCall.Listener<?> listener,
-                                      @Advice.Argument(1) Metadata headers) {
+                                     @Advice.Argument(0) ClientCall.Listener<?> listener,
+                                     @Advice.Argument(1) Metadata headers) {
 
             DynamicTransformer.Accessor.get().ensureInstrumented(listener.getClass(), RESPONSE_LISTENER_INSTRUMENTATIONS);
 
-            return helper.clientCallStartEnter(clientCall, listener, headers);
+            return GrpcHelper.getInstance().clientCallStartEnter(clientCall, listener, headers);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
         public static void onExit(@Advice.Argument(0) ClientCall.Listener<?> listener,
-                                   @Advice.Thrown @Nullable Throwable thrown,
-                                   @Advice.Enter @Nullable Object span) {
+                                  @Advice.Thrown @Nullable Throwable thrown,
+                                  @Advice.Enter @Nullable Object span) {
 
             if (span != null) {
-                helper.clientCallStartExit(listener, thrown);
+                GrpcHelper.getInstance().clientCallStartExit(listener, thrown);
             }
         }
 
@@ -140,7 +140,7 @@ public abstract class ClientCallImplInstrumentation extends BaseInstrumentation 
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object onEnter(@Advice.This ClientCall.Listener<?> listener) {
-            return helper.enterClientListenerMethod(listener);
+            return GrpcHelper.getInstance().enterClientListenerMethod(listener);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
@@ -150,7 +150,7 @@ public abstract class ClientCallImplInstrumentation extends BaseInstrumentation 
                                   @Advice.Enter @Nullable Object span) {
 
             if (span instanceof Span) {
-                helper.exitClientListenerMethod(thrown, listener, (Span) span, status);
+                GrpcHelper.getInstance().exitClientListenerMethod(thrown, listener, (Span) span, status);
             }
         }
 
@@ -177,7 +177,7 @@ public abstract class ClientCallImplInstrumentation extends BaseInstrumentation 
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object onEnter(@Advice.This ClientCall.Listener<?> listener) {
-            return helper.enterClientListenerMethod(listener);
+            return GrpcHelper.getInstance().enterClientListenerMethod(listener);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
@@ -186,7 +186,7 @@ public abstract class ClientCallImplInstrumentation extends BaseInstrumentation 
                                   @Advice.Enter @Nullable Object span) {
 
             if (span instanceof Span) {
-                helper.exitClientListenerMethod(thrown, listener, (Span) span, null);
+                GrpcHelper.getInstance().exitClientListenerMethod(thrown, listener, (Span) span, null);
             }
         }
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/GrpcHelper.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/GrpcHelper.java
@@ -52,6 +52,12 @@ public class GrpcHelper {
 
     private static final String FRAMEWORK_NAME = "gRPC";
 
+    private static final GrpcHelper INSTANCE = new GrpcHelper();
+
+    public static GrpcHelper getInstance() {
+        return INSTANCE;
+    }
+
     /**
      * Map of all in-flight {@link Span} with {@link ClientCall} instance as key.
      */
@@ -176,7 +182,7 @@ public class GrpcHelper {
     }
 
     public static Outcome toClientOutcome(@Nullable Status status) {
-        if( status == null || !status.isOk()){
+        if (status == null || !status.isOk()) {
             return Outcome.FAILURE;
         } else {
             return Outcome.SUCCESS;

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallHandlerInstrumentation.java
@@ -57,10 +57,10 @@ public class ServerCallHandlerInstrumentation extends BaseInstrumentation {
     @Nullable
     @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
     public static Object onEnter(@Advice.Origin Class<?> clazz,
-                                  @Advice.Argument(0) ServerCall<?, ?> serverCall,
-                                  @Advice.Argument(1) Metadata headers) {
+                                 @Advice.Argument(0) ServerCall<?, ?> serverCall,
+                                 @Advice.Argument(1) Metadata headers) {
 
-        return helper.startTransaction(tracer, clazz.getClassLoader(), serverCall, headers);
+        return GrpcHelper.getInstance().startTransaction(tracer, clazz.getClassLoader(), serverCall, headers);
     }
 
     @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
@@ -80,7 +80,7 @@ public class ServerCallHandlerInstrumentation extends BaseInstrumentation {
         }
 
         if (listener != null) {
-            helper.registerTransaction(serverCall, listener, transaction);
+            GrpcHelper.getInstance().registerTransaction(serverCall, listener, transaction);
         }
 
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallInstrumentation.java
@@ -68,6 +68,6 @@ public class ServerCallInstrumentation extends BaseInstrumentation {
                               @Advice.This ServerCall<?, ?> serverCall,
                               @Advice.Argument(0) Status status) {
 
-        helper.exitServerCall(status, thrown, serverCall);
+        GrpcHelper.getInstance().exitServerCall(status, thrown, serverCall);
     }
 }

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
@@ -77,7 +77,7 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object onEnter(@Advice.This ServerCall.Listener<?> listener) {
-            return helper.enterServerListenerMethod(listener);
+            return GrpcHelper.getInstance().enterServerListenerMethod(listener);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
@@ -86,7 +86,7 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
                                   @Advice.Enter @Nullable Object transaction) {
 
             if (transaction instanceof Transaction) {
-                helper.exitServerListenerMethod(thrown, listener, (Transaction) transaction, null);
+                GrpcHelper.getInstance().exitServerListenerMethod(thrown, listener, (Transaction) transaction, null);
             }
         }
     }
@@ -108,7 +108,7 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object onEnter(@Advice.This ServerCall.Listener<?> listener) {
-            return helper.enterServerListenerMethod(listener);
+            return GrpcHelper.getInstance().enterServerListenerMethod(listener);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
@@ -117,7 +117,7 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
                                   @Advice.Enter @Nullable Object transaction) {
 
             if (transaction instanceof Transaction) {
-                helper.exitServerListenerMethod(thrown, listener, (Transaction) transaction, Status.CANCELLED);
+                GrpcHelper.getInstance().exitServerListenerMethod(thrown, listener, (Transaction) transaction, Status.CANCELLED);
             }
         }
     }
@@ -139,7 +139,7 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object onEnter(@Advice.This ServerCall.Listener<?> listener) {
-            return helper.enterServerListenerMethod(listener);
+            return GrpcHelper.getInstance().enterServerListenerMethod(listener);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
@@ -148,7 +148,7 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
                                   @Advice.Enter @Nullable Object transaction) {
 
             if (transaction instanceof Transaction) {
-                helper.exitServerListenerMethod(thrown, listener, (Transaction) transaction, Status.OK);
+                GrpcHelper.getInstance().exitServerListenerMethod(thrown, listener, (Transaction) transaction, Status.OK);
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Removes `GrpcHelper` class loading from `*Instrumentation` class in order to prevent eager-loading of gRPC types in the bootstrap classloader. In practice, it only worked thanks to lazy-loading of types that made `GrpcHelper` class being loaded in the proper class-loader.

## Checklist


- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
