### PR TITLE
Fix vertx test for 4.x

### DIFF
--- a/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/test/java/co/elastic/apm/agent/vertx/v3/VertxServerTest.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/test/java/co/elastic/apm/agent/vertx/v3/VertxServerTest.java
@@ -50,7 +50,7 @@ public class VertxServerTest extends CommonVertxWebTest {
     }
 
     @Override
-    protected String expectedVertxVersion() {
-        return "3.6";
+    protected int getMajorVersion() {
+        return 3;
     }
 }

--- a/apm-agent-plugins/apm-vertx/apm-vertx3-test-latest/src/test/java/co/elastic/apm/agent/vertx/v3/VertxServerTest.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx3-test-latest/src/test/java/co/elastic/apm/agent/vertx/v3/VertxServerTest.java
@@ -43,8 +43,7 @@ public class VertxServerTest extends CommonVertxWebTest {
     }
 
     @Override
-    protected String expectedVertxVersion() {
-        return "3.9";
+    protected int getMajorVersion() {
+        return 3;
     }
-
 }

--- a/apm-agent-plugins/apm-vertx/apm-vertx4-plugin/src/test/java/co/elastic/apm/agent/vertx/v4/VertxServerTest.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx4-plugin/src/test/java/co/elastic/apm/agent/vertx/v4/VertxServerTest.java
@@ -42,7 +42,7 @@ public class VertxServerTest extends CommonVertxWebTest {
     }
 
     @Override
-    protected String expectedVertxVersion() {
-        return "4.0";
+    protected int getMajorVersion() {
+        return 4;
     }
 }


### PR DESCRIPTION
## What does this PR do?

Fixes Vert.x tests that rely on exact version matching.

## Checklist

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
