### PR TITLE
added workaround setting for redis IT

### DIFF
--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/test/java/co/elastic/apm/agent/redis/AbstractRedisInstrumentationTest.java
@@ -68,6 +68,8 @@ public abstract class AbstractRedisInstrumentationTest extends AbstractInstrumen
     public final void initRedis() throws IOException {
         redisPort = getAvailablePort();
         server = RedisServer.builder()
+            // workaround https://github.com/kstyrc/embedded-redis/issues/51
+            .setting("maxmemory 128M")
             .setting("bind 127.0.0.1")
             .port(redisPort)
             .build();


### PR DESCRIPTION
## What does this PR do?
closes #1778 

## Checklist

- [X] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)

## result 
IT work success only with mingw64(git bash) app, os windows 10 pro

## description:
there are were problems:
1. Sometimes testcontainers cannot communicate with docker. Workaround: run `netcfg -d`
https://github.com/testcontainers/testcontainers-java/issues/3422
2. running tests through docker wsl2 causes some kind of failure during long work. And using hyper-v gives docker stability
3. running `mvn clean verify` via intellij idea(2021.1) fails with error
Failed to execute goal org.codehaus.mojo:animal-sniffer-maven-plugin:1.17:check (signature-check) on project apm-agent-plugin-sdk: Execution signature-check of goal org.codehaus.mojo:animal-sniffer-maven-plugin:1.17:check failed.
I opened issue for this: https://youtrack.jetbrains.com/issue/IDEA-269868 

detected flaky tests:

VertxServerTest - java.net.BindException: Address already in use: bind
[ERROR] Tests run: 20, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 4.352 s <<< FAILURE! - in co.elastic.apm.agent.vertx.v3.VertxServerTest
[ERROR] testUnknownRoute  Time elapsed: 0.026 s  <<< ERROR!
java.net.BindException: Address already in use: bind
	at java.base/sun.nio.ch.Net.bind0(Native Method)
	at java.base/sun.nio.ch.Net.bind(Net.java:455)
	at java.base/sun.nio.ch.Net.bind(Net.java:447)
	at java.base/sun.nio.ch.ServerSocketChannelImpl.bind(ServerSocketChannelImpl.java:227)
	at io.netty.channel.socket.nio.NioServerSocketChannel.doBind(NioServerSocketChannel.java:130)
	at io.netty.channel.AbstractChannel$AbstractUnsafe.bind(AbstractChannel.java:558)
	at io.netty.channel.DefaultChannelPipeline$HeadContext.bind(DefaultChannelPipeline.java:1358)
	at io.netty.channel.AbstractChannelHandlerContext.invokeBind(AbstractChannelHandlerContext.java:501)
	at io.netty.channel.AbstractChannelHandlerContext.bind(AbstractChannelHandlerContext.java:486)
	at io.netty.channel.DefaultChannelPipeline.bind(DefaultChannelPipeline.java:1019)
	at io.netty.channel.AbstractChannel.bind(AbstractChannel.java:254)
	at io.netty.bootstrap.AbstractBootstrap$2.run(AbstractBootstrap.java:366)
	at io.netty.util.concurrent.AbstractEventExecutor.safeExecute(AbstractEventExecutor.java:163)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasksFrom(SingleThreadEventExecutor.java:380)
	at io.netty.util.concurrent.SingleThreadEventExecutor.runAllTasks(SingleThreadEventExecutor.java:355)
	at io.netty.channel.nio.NioEventLoop.run(NioEventLoop.java:453)
	at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:897)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:834)
[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   VertxServerTest.testUnknownRoute » Bind Address already in use: bind
[INFO] 