### PR TITLE
Avoid serializing metric-sets with no samples

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ events. With the new `OVERRIDE` option, non-file logs can be ECS-reformatted aut
 * Load Spring AMQP plugin- {pull}1784[#1784]
 * Avoid `IllegalStateException` when multiple `tracestate` headers are used - {pull}1808[#1808]
 * Ensure CLI attach avoids `sudo` only when required and avoid blocking - {pull}1819[#1819]
+* Avoid sending metric-sets without samples, so to adhere to the intake API - {pull}1826[#1826]
 
 [float]
 ===== Refactors

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistryReporter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistryReporter.java
@@ -31,6 +31,7 @@ import co.elastic.apm.agent.metrics.MetricRegistry;
 import co.elastic.apm.agent.metrics.MetricSet;
 import co.elastic.apm.agent.report.Reporter;
 import co.elastic.apm.agent.report.ReporterConfiguration;
+import com.dslplatform.json.JsonWriter;
 
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -72,7 +73,12 @@ public class MetricRegistryReporter extends AbstractLifecycleListener implements
     @Override
     public void report(Map<? extends Labels, MetricSet> metricSets) {
         if (tracer.isRunning()) {
-            reporter.report(serializer.serialize(metricSets));
+            for (MetricSet metricSet : metricSets.values()) {
+                JsonWriter jw = serializer.serialize(metricSet);
+                if (jw != null) {
+                    reporter.report(jw);
+                }
+            }
         }
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistrySerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/MetricRegistrySerializer.java
@@ -25,13 +25,13 @@
 package co.elastic.apm.agent.report.serialize;
 
 import co.elastic.apm.agent.metrics.DoubleSupplier;
-import co.elastic.apm.agent.metrics.Labels;
 import co.elastic.apm.agent.metrics.MetricSet;
 import co.elastic.apm.agent.metrics.Timer;
 import com.dslplatform.json.DslJson;
 import com.dslplatform.json.JsonWriter;
 import com.dslplatform.json.NumberConverter;
 
+import javax.annotation.Nullable;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
@@ -40,28 +40,32 @@ public class MetricRegistrySerializer {
 
     private static final byte NEW_LINE = '\n';
 
+    private static final int BUFFER_SIZE_LIMIT = 2048;
+
     private final DslJson<Object> dslJson = new DslJson<>(new DslJson.Settings<>());
     private final StringBuilder replaceBuilder = new StringBuilder();
-    private int lastSize = 512;
+    private int maxSerializedSize = 512;
 
-    public JsonWriter serialize(Map<? extends Labels, MetricSet> metricSets) {
-        JsonWriter jw = dslJson.newWriter((int) (lastSize * 1.25));
-        serialize(metricSets, replaceBuilder, jw);
-        lastSize = jw.size();
-        return jw;
-    }
-
-    public static void serialize(Map<? extends Labels, MetricSet> metricSets, StringBuilder replaceBuilder, JsonWriter jw) {
+    /**
+     * Creates a JSON writer, serializes the given metric set into it and returns it. If the serialized metric-set
+     * does not contain samples, the method returns null.
+     * @param metricSet a metric-set to serialize
+     * @return the serialized metric-set or {@code null} if no samples were serialized
+     */
+    @Nullable
+    public JsonWriter serialize(MetricSet metricSet) {
+        JsonWriter jw = dslJson.newWriter(maxSerializedSize);
         final long timestamp = System.currentTimeMillis() * 1000;
-        for (MetricSet metricSet : metricSets.values()) {
-            if (metricSet.hasContent()) {
-                serializeMetricSet(metricSet, timestamp, replaceBuilder, jw);
-                jw.writeByte(NEW_LINE);
-            }
+        boolean hasSamples = serialize(metricSet, timestamp, replaceBuilder, jw);
+        if (hasSamples) {
+            maxSerializedSize = Math.max(Math.min(jw.size(), BUFFER_SIZE_LIMIT), maxSerializedSize);
+            return jw;
         }
+        return null;
     }
 
-    static void serializeMetricSet(MetricSet metricSet, long epochMicros, StringBuilder replaceBuilder, JsonWriter jw) {
+    private static boolean serialize(MetricSet metricSet, long epochMicros, StringBuilder replaceBuilder, JsonWriter jw) {
+        boolean hasSamples;
         jw.writeByte(JsonWriter.OBJECT_START);
         {
             DslJsonSerializer.writeFieldName("metricset", jw);
@@ -73,17 +77,20 @@ public class MetricRegistrySerializer {
                 DslJsonSerializer.serializeLabels(metricSet.getLabels(), replaceBuilder, jw);
                 DslJsonSerializer.writeFieldName("samples", jw);
                 jw.writeByte(JsonWriter.OBJECT_START);
-                boolean hasSamples = serializeGauges(metricSet.getGauges(), jw);
+                hasSamples = serializeGauges(metricSet.getGauges(), jw);
                 hasSamples |= serializeTimers(metricSet.getTimers(), hasSamples, jw);
-                serializeCounters(metricSet.getCounters(), hasSamples, jw);
+                hasSamples |= serializeCounters(metricSet.getCounters(), hasSamples, jw);
                 jw.writeByte(JsonWriter.OBJECT_END);
             }
             jw.writeByte(JsonWriter.OBJECT_END);
         }
         jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(NEW_LINE);
+        return hasSamples;
     }
 
     private static boolean serializeGauges(Map<String, DoubleSupplier> gauges, JsonWriter jw) {
+        boolean hasSamples = false;
         final int size = gauges.size();
         if (size > 0) {
             final Iterator<Map.Entry<String, DoubleSupplier>> iterator = gauges.entrySet().iterator();
@@ -95,6 +102,7 @@ public class MetricRegistrySerializer {
                 value = kv.getValue().get();
                 if (isValid(value)) {
                     serializeValue(kv.getKey(), value, jw);
+                    hasSamples = true;
                 }
             }
 
@@ -107,7 +115,7 @@ public class MetricRegistrySerializer {
                     serializeValue(kv.getKey(), value, jw);
                 }
             }
-            return true;
+            return hasSamples;
         }
         return false;
     }
@@ -126,8 +134,8 @@ public class MetricRegistrySerializer {
                     if (hasSamples) {
                         jw.writeByte(JsonWriter.COMMA);
                     }
-                    hasSamples = true;
                     serializeTimer(kv.getKey(), value, jw);
+                    hasSamples = true;
                 }
             }
 
@@ -144,7 +152,7 @@ public class MetricRegistrySerializer {
         return hasSamples;
     }
 
-    private static void serializeCounters(Map<String, AtomicLong> counters, boolean hasSamples, JsonWriter jw) {
+    private static boolean serializeCounters(Map<String, AtomicLong> counters, boolean hasSamples, JsonWriter jw) {
         final int size = counters.size();
         if (size > 0) {
             final Iterator<Map.Entry<String, AtomicLong>> iterator = counters.entrySet().iterator();
@@ -159,6 +167,7 @@ public class MetricRegistrySerializer {
                         jw.writeByte(JsonWriter.COMMA);
                     }
                     serializeCounter(kv.getKey(), value, jw);
+                    hasSamples = true;
                 }
             }
 
@@ -172,6 +181,7 @@ public class MetricRegistrySerializer {
                 }
             }
         }
+        return hasSamples;
     }
 
     private static void serializeCounter(String key, AtomicLong value, JsonWriter jw) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/MetricSetSerializationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/MetricSetSerializationTest.java
@@ -27,42 +27,42 @@ package co.elastic.apm.agent.report.serialize;
 import co.elastic.apm.agent.metrics.Labels;
 import co.elastic.apm.agent.metrics.MetricRegistry;
 import co.elastic.apm.agent.report.ReporterConfiguration;
-import com.dslplatform.json.DslJson;
 import com.dslplatform.json.JsonWriter;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nonnull;
-import java.io.IOException;
+import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 class MetricSetSerializationTest {
 
-    private JsonWriter jw = new DslJson<>().newWriter();
     private ObjectMapper objectMapper = new ObjectMapper();
     private MetricRegistry registry = new MetricRegistry(mock(ReporterConfiguration.class));
+    private MetricRegistrySerializer metricRegistrySerializer = new MetricRegistrySerializer();
 
     @Test
-    void testSerializeGauges() throws IOException {
+    void testSerializeGauges() throws Exception {
         final Labels.Mutable labels = Labels.Mutable.of("foo.bar", "baz");
         registry.add("foo.bar", labels, () -> 42);
         registry.add("bar.baz", labels, () -> 42);
 
-        final JsonNode jsonNode = reportAsJson(labels);
-
+        final JsonNode jsonNode = reportAsJson();
+        assertThat(jsonNode).isNotNull();
         assertThat(jsonNode.get("metricset").get("samples").get("foo.bar").get("value").doubleValue()).isEqualTo(42);
     }
 
     @Test
-    void testSerializeTimers() throws IOException {
+    void testSerializeTimers() throws Exception {
         final Labels.Mutable labels = Labels.Mutable.of("foo.bar", "baz");
 
         registry.updateTimer("foo.bar", labels, 42);
         registry.updateTimer("bar.baz", labels, 42, 2);
-        final JsonNode jsonNode = reportAsJson(labels);
+        final JsonNode jsonNode = reportAsJson();
+        assertThat(jsonNode).isNotNull();
         final JsonNode samples = jsonNode.get("metricset").get("samples");
         assertThat(samples.get("foo.bar.sum.us").get("value").doubleValue()).isEqualTo(42);
         assertThat(samples.get("foo.bar.count").get("value").doubleValue()).isEqualTo(1);
@@ -71,7 +71,7 @@ class MetricSetSerializationTest {
     }
 
     @Test
-    void testSerializeTimersWithTopLevelLabels() throws IOException {
+    void testSerializeTimersWithTopLevelLabels() throws Exception {
         final Labels.Mutable labels = Labels.Mutable.of("foo", "bar")
             .transactionName("foo")
             .transactionType("bar")
@@ -79,7 +79,8 @@ class MetricSetSerializationTest {
             .spanSubType("qux");
         registry.updateTimer("foo.bar", labels, 42);
 
-        final JsonNode jsonNode = reportAsJson(labels);
+        final JsonNode jsonNode = reportAsJson();
+        assertThat(jsonNode).isNotNull();
 
         final JsonNode metricset = jsonNode.get("metricset");
         assertThat(metricset.get("tags").get("foo").textValue()).isEqualTo("bar");
@@ -93,39 +94,45 @@ class MetricSetSerializationTest {
     }
 
     @Test
-    void testSerializeTimersReset() throws IOException {
+    void testSerializeTimersReset() throws Exception {
         final Labels.Mutable labels = Labels.Mutable.of("foo.bar", "baz");
         registry.updateTimer("foo.bar", labels, 42);
         registry.updateTimer("bar.baz", labels, 42, 2);
 
-        reportAsJson(labels);
+        reportAsJson();
 
         registry.updateTimer("foo.bar", labels, 42);
-        final JsonNode samples = reportAsJson(labels).get("metricset").get("samples");
+        JsonNode jsonNode = reportAsJson();
+        assertThat(jsonNode).isNotNull();
+        final JsonNode samples = jsonNode.get("metricset").get("samples");
 
         assertThat(samples.get("foo.bar.sum.us").get("value").doubleValue()).isEqualTo(42);
         assertThat(samples.get("foo.bar.count").get("value").doubleValue()).isEqualTo(1);
     }
 
     @Test
-    void testSerializeEmptyMetricSet() throws IOException {
+    void testSerializeEmptyMetricSet() throws Exception {
         final Labels.Mutable labels = Labels.Mutable.of("foo.bar", "baz");
         registry.updateTimer("foo.bar", labels, 42);
 
-        assertThat(reportAsJson(labels).get("metricset").get("samples")).isNotEmpty();
+        JsonNode jsonNode = reportAsJson();
+        assertThat(jsonNode).isNotNull();
+        assertThat(jsonNode.get("metricset").get("samples")).isNotEmpty();
 
-        assertThat(reportAsJson(labels).get("metricset").get("samples")).isEmpty();
+        assertThat(reportAsJson()).isNull();
     }
 
     @Test
-    void testNonFiniteSerialization() throws IOException {
+    void testNonFiniteSerialization() throws Exception {
         registry.add("valid", Labels.EMPTY, () -> 4.0);
         registry.add("infinite", Labels.EMPTY, () -> Double.POSITIVE_INFINITY);
         registry.add("NaN", Labels.EMPTY, () -> Double.NaN);
         registry.add("negative.infinite", Labels.EMPTY, () -> Double.NEGATIVE_INFINITY);
         registry.add("also.valid", Labels.EMPTY, () -> 5.0);
 
-        JsonNode samples = reportAsJson(Labels.EMPTY).get("metricset").get("samples");
+        JsonNode jsonNode = reportAsJson();
+        assertThat(jsonNode).isNotNull();
+        JsonNode samples = jsonNode.get("metricset").get("samples");
 
         assertThat(samples.size()).isEqualTo(2);
         assertThat(samples.get("valid").get("value").doubleValue()).isEqualTo(4.0);
@@ -133,55 +140,60 @@ class MetricSetSerializationTest {
     }
 
     @Test
-    void testNonFiniteCornerCasesSerialization() throws IOException {
+    void testNonFiniteCornerCasesSerialization() throws Exception {
         registry.add("infinite", Labels.EMPTY, () -> Double.POSITIVE_INFINITY);
         registry.add("NaN", Labels.EMPTY, () -> Double.NaN);
         registry.add("negative.infinite", Labels.EMPTY, () -> Double.NEGATIVE_INFINITY);
-
-        final JsonNode jsonNode = reportAsJson(Labels.EMPTY);
-
-        assertThat(jsonNode.get("metricset").get("samples")).isEmpty();
+        assertThat(reportAsJson()).isNull();
     }
 
     @Test
-    void serializeEmptyMetricSet() throws IOException {
+    void serializeEmptyMetricSet() throws Exception {
         registry.updateTimer("foo", Labels.EMPTY, 0, 0);
-
-        final JsonNode jsonNode = reportAsJson(Labels.EMPTY);
-
-        assertThat(jsonNode.get("metricset").get("samples")).isEmpty();
+        assertThat(reportAsJson()).isNull();
     }
 
     @Test
-    void testCounterReset() throws IOException {
+    void testCounterReset() throws Exception {
         registry.incrementCounter("foo", Labels.EMPTY);
 
-        JsonNode samples = reportAsJson(Labels.EMPTY).get("metricset").get("samples");
+        JsonNode jsonNode = reportAsJson();
+        assertThat(jsonNode).isNotNull();
+
+        JsonNode samples = jsonNode.get("metricset").get("samples");
         assertThat(samples.size()).isEqualTo(1);
         assertThat(samples.get("foo").get("value").intValue()).isOne();
 
-        assertThat(reportAsJson(Labels.EMPTY).get("metricset").get("samples")).hasSize(0);
+        assertThat(reportAsJson()).isNull();
     }
 
     @Test
-    void testTimerReset() throws IOException {
+    void testTimerReset() throws Exception {
         registry.updateTimer("foo", Labels.EMPTY, 1);
 
-        JsonNode samples = reportAsJson(Labels.EMPTY).get("metricset").get("samples");
+        JsonNode jsonNode = reportAsJson();
+        assertThat(jsonNode).isNotNull();
+        JsonNode samples = jsonNode.get("metricset").get("samples");
         assertThat(samples.size()).isEqualTo(2);
         assertThat(samples.get("foo.sum.us").get("value").intValue()).isOne();
         assertThat(samples.get("foo.count").get("value").intValue()).isOne();
 
-        assertThat(reportAsJson(Labels.EMPTY).get("metricset").get("samples")).hasSize(0);
+        assertThat(reportAsJson()).isNull();
     }
 
-    @Nonnull
-    private JsonNode reportAsJson(Labels labels) throws IOException {
-        registry.flipPhaseAndReport(metricSets -> MetricRegistrySerializer.serializeMetricSet(metricSets.get(labels), System.currentTimeMillis() * 1000, new StringBuilder(), jw));
-        final String jsonString = jw.toString();
-        System.out.println(jsonString);
-        final JsonNode json = objectMapper.readTree(jsonString);
-        jw.reset();
+    @Nullable
+    private JsonNode reportAsJson() throws Exception {
+        final CompletableFuture<JsonWriter> jwFuture = new CompletableFuture<>();
+        registry.flipPhaseAndReport(
+            metricSets -> jwFuture.complete(metricRegistrySerializer.serialize(metricSets.values().iterator().next()))
+        );
+        JsonNode json = null;
+        JsonWriter jw = jwFuture.getNow(null);
+        if (jw != null) {
+            final String jsonString = jw.toString();
+            System.out.println(jsonString);
+            json = objectMapper.readTree(jsonString);
+        }
         return json;
     }
 }

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
@@ -29,7 +29,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.37.0)",
+    value = "by gRPC proto compiler (version 1.38.0)",
     comments = "Source: rpc.proto")
 public final class HelloGrpc {
 

--- a/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
@@ -165,7 +165,13 @@ class JmxMetricTrackerTest {
     }
 
     private void printMetricSets() {
-        metricRegistry.flipPhaseAndReport(metricSets -> System.out.println(new MetricRegistrySerializer().serialize(metricSets).toString()));
+        metricRegistry.flipPhaseAndReport(
+            metricSets -> {
+                metricSets.values().forEach(
+                    metricSet -> System.out.println(new MetricRegistrySerializer().serialize(metricSet).toString())
+                );
+            }
+        );
     }
 
     private void setConfig(JmxMetric... jmxMetric) throws java.io.IOException {

--- a/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
@@ -57,13 +57,16 @@ public class MicrometerMeterRegistrySerializer {
 
     private static final byte NEW_LINE = (byte) '\n';
 
+    private static final int BUFFER_SIZE_LIMIT = 2048;
+
     private static final Logger logger = LoggerFactory.getLogger(MicrometerMeterRegistrySerializer.class);
 
     private final DslJson<Object> dslJson = new DslJson<>(new DslJson.Settings<>());
     private final StringBuilder replaceBuilder = new StringBuilder();
     private final MetricsConfiguration config;
     private final WeakConcurrentSet<Meter> internallyDisabledMeters = WeakMapSupplier.createSet();
-    private int previousSize = 0;
+
+    private int maxSerializedSize = 512;
 
     public MicrometerMeterRegistrySerializer(MetricsConfiguration config) {
         this.config = config;
@@ -73,15 +76,8 @@ public class MicrometerMeterRegistrySerializer {
         return internallyDisabledMeters;
     }
 
-    public JsonWriter serialize(final Map<Meter.Id, Meter> metersById, final long epochMicros) {
-        int newSize = (int) (Math.max(previousSize, 512) * 1.25);
-        JsonWriter jw = dslJson.newWriter(newSize);
-        serialize(metersById, epochMicros, replaceBuilder, jw);
-        previousSize = jw.size();
-        return jw;
-    }
-
-    void serialize(final Map<Meter.Id, Meter> metersById, final long epochMicros, final StringBuilder replaceBuilder, final JsonWriter jw) {
+    public List<JsonWriter> serialize(final Map<Meter.Id, Meter> metersById, final long epochMicros) {
+        List<JsonWriter> serializedMeters = new ArrayList<>();
         final Map<List<Tag>, List<Meter>> metersGroupedByTags = new HashMap<>();
         for (Map.Entry<Meter.Id, Meter> entry : metersById.entrySet()) {
             List<Tag> tags = entry.getKey().getTags();
@@ -93,12 +89,17 @@ public class MicrometerMeterRegistrySerializer {
             meters.add(entry.getValue());
         }
         for (Map.Entry<List<Tag>, List<Meter>> entry : metersGroupedByTags.entrySet()) {
-            serializeMetricSet(entry.getKey(), entry.getValue(), epochMicros, replaceBuilder, jw);
-            jw.writeByte(NEW_LINE);
+            JsonWriter jw = dslJson.newWriter(maxSerializedSize);
+            if (serializeMetricSet(entry.getKey(), entry.getValue(), epochMicros, replaceBuilder, jw)) {
+                serializedMeters.add(jw);
+                maxSerializedSize = Math.max(Math.min(jw.size(), BUFFER_SIZE_LIMIT), maxSerializedSize);
+            }
         }
+        return serializedMeters;
     }
 
-    void serializeMetricSet(List<Tag> tags, List<Meter> meters, long epochMicros, StringBuilder replaceBuilder, JsonWriter jw) {
+    boolean serializeMetricSet(List<Tag> tags, List<Meter> meters, long epochMicros, StringBuilder replaceBuilder, JsonWriter jw) {
+        boolean hasSamples = false;
         boolean dedotMetricName = config.isDedotCustomMetrics();
         jw.writeByte(JsonWriter.OBJECT_START);
         {
@@ -111,7 +112,6 @@ public class MicrometerMeterRegistrySerializer {
                 serializeTags(tags, replaceBuilder, jw);
                 DslJsonSerializer.writeFieldName("samples", jw);
                 jw.writeByte(JsonWriter.OBJECT_START);
-                boolean hasValue = false;
 
                 ClassLoader originalContextCL = Thread.currentThread().getContextClassLoader();
                 try {
@@ -125,25 +125,25 @@ public class MicrometerMeterRegistrySerializer {
                             Thread.currentThread().setContextClassLoader(meter.getClass().getClassLoader());
                             if (meter instanceof Timer) {
                                 Timer timer = (Timer) meter;
-                                hasValue = serializeTimer(jw, timer.getId(), timer.count(), timer.totalTime(TimeUnit.MICROSECONDS), hasValue, replaceBuilder, dedotMetricName);
+                                hasSamples = serializeTimer(jw, timer.getId(), timer.count(), timer.totalTime(TimeUnit.MICROSECONDS), hasSamples, replaceBuilder, dedotMetricName);
                             } else if (meter instanceof FunctionTimer) {
                                 FunctionTimer timer = (FunctionTimer) meter;
-                                hasValue = serializeTimer(jw, timer.getId(), (long) timer.count(), timer.totalTime(TimeUnit.MICROSECONDS), hasValue, replaceBuilder, dedotMetricName);
+                                hasSamples = serializeTimer(jw, timer.getId(), (long) timer.count(), timer.totalTime(TimeUnit.MICROSECONDS), hasSamples, replaceBuilder, dedotMetricName);
                             } else if (meter instanceof LongTaskTimer) {
                                 LongTaskTimer timer = (LongTaskTimer) meter;
-                                hasValue = serializeTimer(jw, timer.getId(), timer.activeTasks(), timer.duration(TimeUnit.MICROSECONDS), hasValue, replaceBuilder, dedotMetricName);
+                                hasSamples = serializeTimer(jw, timer.getId(), timer.activeTasks(), timer.duration(TimeUnit.MICROSECONDS), hasSamples, replaceBuilder, dedotMetricName);
                             } else if (meter instanceof DistributionSummary) {
                                 DistributionSummary timer = (DistributionSummary) meter;
-                                hasValue = serializeDistributionSummary(jw, timer.getId(), timer.count(), timer.totalAmount(), hasValue, replaceBuilder, dedotMetricName);
+                                hasSamples = serializeDistributionSummary(jw, timer.getId(), timer.count(), timer.totalAmount(), hasSamples, replaceBuilder, dedotMetricName);
                             } else if (meter instanceof Gauge) {
                                 Gauge gauge = (Gauge) meter;
-                                hasValue = serializeValue(gauge.getId(), gauge.value(), hasValue, jw, replaceBuilder, dedotMetricName);
+                                hasSamples = serializeValue(gauge.getId(), gauge.value(), hasSamples, jw, replaceBuilder, dedotMetricName);
                             } else if (meter instanceof Counter) {
                                 Counter counter = (Counter) meter;
-                                hasValue = serializeValue(counter.getId(), counter.count(), hasValue, jw, replaceBuilder, dedotMetricName);
+                                hasSamples = serializeValue(counter.getId(), counter.count(), hasSamples, jw, replaceBuilder, dedotMetricName);
                             } else if (meter instanceof FunctionCounter) {
                                 FunctionCounter counter = (FunctionCounter) meter;
-                                hasValue = serializeValue(counter.getId(), counter.count(), hasValue, jw, replaceBuilder, dedotMetricName);
+                                hasSamples = serializeValue(counter.getId(), counter.count(), hasSamples, jw, replaceBuilder, dedotMetricName);
                             }
                         } catch (Throwable throwable) {
                             String meterName = meter.getId().getName();
@@ -162,6 +162,8 @@ public class MicrometerMeterRegistrySerializer {
             jw.writeByte(JsonWriter.OBJECT_END);
         }
         jw.writeByte(JsonWriter.OBJECT_END);
+        jw.writeByte(NEW_LINE);
+        return hasSamples;
     }
 
     private static void serializeTags(List<Tag> tags, StringBuilder replaceBuilder, JsonWriter jw) {

--- a/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMetricsReporter.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMetricsReporter.java
@@ -32,6 +32,7 @@ import co.elastic.apm.agent.report.Reporter;
 import co.elastic.apm.agent.report.ReporterConfiguration;
 import co.elastic.apm.agent.sdk.weakmap.WeakMapSupplier;
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentSet;
+import com.dslplatform.json.JsonWriter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.composite.CompositeMeterRegistry;
@@ -99,7 +100,9 @@ public class MicrometerMetricsReporter implements Runnable, Closeable {
             registry.forEachMeter(meterConsumer);
         }
         logger.debug("Reporting {} meters", meterConsumer.meters.size());
-        reporter.report(serializer.serialize(meterConsumer.meters, timestamp));
+        for (JsonWriter serializedMetricSet : serializer.serialize(meterConsumer.meters, timestamp)) {
+            reporter.report(serializedMetricSet);
+        }
     }
 
     @Override

--- a/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMetricsReporterTest.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMetricsReporterTest.java
@@ -55,6 +55,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
@@ -68,7 +69,7 @@ class MicrometerMetricsReporterTest {
     private MeterRegistry meterRegistry;
     private MicrometerMetricsReporter metricsReporter;
     private MockReporter reporter;
-    private ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper = new ObjectMapper();
     private ElasticApmTracer tracer;
 
     @BeforeEach
@@ -104,6 +105,21 @@ class MicrometerMetricsReporterTest {
         assertThat(metricSet.get("metricset").get("tags").get("foo").textValue()).isEqualTo("bar");
         assertThat(metricSet.get("metricset").get("samples").get("counter").get("value").doubleValue()).isEqualTo(42);
         assertThat(metricSet.get("metricset").get("samples").get("gauge").get("value").doubleValue()).isEqualTo(42);
+    }
+
+    @Test
+    void testMultipleMetricSets() {
+        meterRegistry.counter("counter", List.of(Tag.of("foo", "bar"))).increment(42);
+        meterRegistry.gauge("gauge", List.of(Tag.of("foo", "baz")), 42, v -> 42);
+
+        List<JsonNode> metricSets = getMetricSets();
+        assertThat(metricSets).hasSize(2);
+        Optional<JsonNode> fooBar = metricSets.stream().filter(metricSet -> metricSet.get("metricset").get("tags").get("foo").textValue().equals("bar")).findAny();
+        assertThat(fooBar).isNotEmpty();
+        assertThat(fooBar.get().get("metricset").get("samples").get("counter").get("value").doubleValue()).isEqualTo(42);
+        Optional<JsonNode> fooBaz = metricSets.stream().filter(metricSet -> metricSet.get("metricset").get("tags").get("foo").textValue().equals("baz")).findAny();
+        assertThat(fooBaz).isNotEmpty();
+        assertThat(fooBaz.get().get("metricset").get("samples").get("gauge").get("value").doubleValue()).isEqualTo(42);
     }
 
     @Test
@@ -244,8 +260,7 @@ class MicrometerMetricsReporterTest {
         JsonNode metricSet = getSingleMetricSet();
         assertThat(metricSet.get("metricset").get("samples").get("gauge").get("value").doubleValue()).isEqualTo(42);
 
-        metricSet = getSingleMetricSet();
-        assertThat(metricSet.get("metricset").get("samples").get("gauge")).isNull();
+        assertThat(getMetricSets()).isEmpty();
     }
 
     @Test
@@ -348,23 +363,22 @@ class MicrometerMetricsReporterTest {
     }
 
     @Test
-    void tryExclusionOfFailedGauge_singleGauge() {
+    void testExclusionOfFailedGauge_singleGauge() {
         List<Tag> tags = List.of(Tag.of("foo", "bar"));
         meterRegistry.gauge("gauge1", tags, 42, v -> {
             throw new RuntimeException("Failed to read gauge value");
         });
         assertThat(metricsReporter.getFailedMeters()).isEmpty();
-        JsonNode metricSet = getSingleMetricSet();
-        assertThat(metricSet.get("metricset").get("samples"))
-            .describedAs("value of %s is not expected to be written to json", "gauge1")
+        assertThat(getMetricSets())
+            .describedAs("json should not be reported for gauge1")
             .isEmpty();
 
-        getSingleMetricSet();
+        getMetricSets();
         assertThat(metricsReporter.getFailedMeters().iterator().next().getId().getName()).isEqualTo("gauge1");
     }
 
     @Test
-    void tryExclusionOfFailedGauge_firstFails() {
+    void testExclusionOfFailedGauge_firstFails() {
         List<Tag> tags = List.of(Tag.of("foo", "bar"));
         meterRegistry.gauge("gauge1", tags, 42, v -> {
             throw new RuntimeException("Failed to read gauge value");
@@ -382,7 +396,7 @@ class MicrometerMetricsReporterTest {
     }
 
     @Test
-    void tryExclusionOfFailedGauge_secondFails() {
+    void testExclusionOfFailedGauge_secondFails() {
         List<Tag> tags = List.of(Tag.of("foo", "bar"));
         meterRegistry.gauge("gauge1", tags, 42, v -> 42D);
         meterRegistry.gauge("gauge2", tags, 42, v -> {
@@ -416,6 +430,19 @@ class MicrometerMetricsReporterTest {
             assertThat(metricSet.get("metricset").get("samples").get("custom-counter-2").get("value").doubleValue())
                 .isEqualTo(42D);
         }
+    }
+
+    @Test
+    void testNotReportingEmptySamples() {
+        List<Tag> invalidMetricTags = List.of(Tag.of("test", "invalid"));
+        meterRegistry.more().counter("custom-counter", invalidMetricTags, 42, v -> Double.NaN);
+        List<Tag> validMetricTags = List.of(Tag.of("test", "valid"));
+        meterRegistry.more().counter("custom-counter", validMetricTags, 42, v -> 42D);
+        List<JsonNode> metricSets = getMetricSets();
+        assertThat(metricSets)
+            .describedAs("json should not be reported for %s", invalidMetricTags)
+            .hasSize(1);
+        assertThat(metricSets.get(0).get("metricset").get("tags").get("test").textValue()).isEqualTo("valid");
     }
 
     @Test

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/ServletApiTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/ServletApiTestApp.java
@@ -225,7 +225,7 @@ public class ServletApiTestApp extends TestApp {
     private void testJmxMetrics(AbstractServletContainerIntegrationTest test) throws Exception {
         // metrics_interval is 1s
         await()
-            .pollDelay(Duration.ofMillis(500))
+            .pollDelay(Duration.ofMillis(1100))
             .until(() -> {
                 boolean hasMetricsets = !test.getEvents("metricset").isEmpty();
                 if (!hasMetricsets) {

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/ServletApiTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/ServletApiTestApp.java
@@ -223,21 +223,16 @@ public class ServletApiTestApp extends TestApp {
      * Especially WildFly is problematic see {@link co.elastic.apm.agent.jmx.ManagementFactoryInstrumentation}
      */
     private void testJmxMetrics(AbstractServletContainerIntegrationTest test) throws Exception {
-        // metrics_interval is 1s
         await()
-            .pollDelay(Duration.ofMillis(1100))
-            .until(() -> {
-                boolean hasMetricsets = !test.getEvents("metricset").isEmpty();
-                if (!hasMetricsets) {
-                    flush(test);
-                }
-                return hasMetricsets;
-            });
-        List<JsonNode> metricEvent = test.getEvents("metricset");
-        assertThat(metricEvent.stream()
-            .flatMap(metricset -> Streams.stream(metricset.get("samples").fieldNames()))
-            .distinct())
-            .contains("jvm.jmx.test_heap_metric.max");
+            // metrics_interval is 1s
+            .pollDelay(Duration.ofMillis(500))
+            .pollInterval(Duration.ofMillis(200))
+            .timeout(Duration.ofMillis(2000))
+            .untilAsserted(() -> assertThat(test.getEvents("metricset").stream()
+                .flatMap(metricset -> Streams.stream(metricset.get("samples").fieldNames()))
+                .distinct())
+                .contains("jvm.jmx.test_heap_metric.max")
+            );
     }
 
     private void testPublicApi(AbstractServletContainerIntegrationTest test) throws IOException, InterruptedException {


### PR DESCRIPTION
## What does this PR do?
Avoid sending metric-sets without samples, so to adhere to the intake API. 
Empty samples may occur, for example, if there are only invalid values for a metric-set.
Since we use the the `JsonWriter` object to report metrics, I just used a `JsonWriter` per metric-set and discarded such that include no samples.
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
  - [x] I have tested manually that Micrometer-based metrics are reported as expected
