### PR TITLE
Check minimal JFR size before parsing

### DIFF
--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -55,7 +55,7 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
             "The inferred spans are created after a profiling session has ended.\n" +
             "This means there is a delay between the regular and the inferred spans being visible in the UI.\n" +
             "\n" +
-            "NOTE: This feature is not available on Windows")
+            "NOTE: This feature is not available on Windows and on OpenJ9")
         .dynamic(true)
         .tags("added[1.15.0]", "experimental")
         .buildWithDefault(false);

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/asyncprofiler/AsyncProfiler.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/asyncprofiler/AsyncProfiler.java
@@ -39,6 +39,7 @@
  */
 package co.elastic.apm.agent.profiler.asyncprofiler;
 
+import co.elastic.apm.agent.premain.JvmRuntimeInfo;
 import co.elastic.apm.agent.util.IOUtils;
 
 import javax.annotation.Nullable;
@@ -71,6 +72,10 @@ public class AsyncProfiler {
         }
         synchronized (AsyncProfiler.class) {
             if (instance == null) {
+                if (JvmRuntimeInfo.ofCurrentVM().isJ9VM()) {
+                    throw new IllegalStateException("OpenJ9 JVMs are not supported by async profiler. Please set " +
+                        "profiling_inferred_spans_enabled to false");
+                }
                 try {
                     loadNativeLibrary(profilerLibDirectory);
                 } catch (UnsatisfiedLinkError e) {

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/asyncprofiler/JfrParser.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/asyncprofiler/JfrParser.java
@@ -108,8 +108,8 @@ public class JfrParser implements Recyclable {
         bufferedFile.setFile(file);
         long fileSize = bufferedFile.size();
         if (fileSize < 16) {
-            logger.debug("Not parsing {}, as it's size ({}) is less than the minimum", file, fileSize);
-            return;
+            throw new IllegalStateException("Unexpected sampling profiler error, everything else should work as expected. " +
+                "Please report to us with as many details, including OS and JVM details.");
         }
         logger.debug("Parsing {} ({} bytes)", file, fileSize);
         bufferedFile.ensureRemaining(16, 16);

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/asyncprofiler/JfrParser.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/asyncprofiler/JfrParser.java
@@ -107,6 +107,10 @@ public class JfrParser implements Recyclable {
         this.includedClasses = includedClasses;
         bufferedFile.setFile(file);
         long fileSize = bufferedFile.size();
+        if (fileSize < 16) {
+            logger.debug("Not parsing {}, as it's size ({}) is less than the minimum", file, fileSize);
+            return;
+        }
         logger.debug("Parsing {} ({} bytes)", file, fileSize);
         bufferedFile.ensureRemaining(16, 16);
         for (byte magicByte : MAGIC_BYTES) {

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1930,7 +1930,7 @@ The <<config-profiling-inferred-spans-sampling-interval, `profiling_inferred_spa
 The inferred spans are created after a profiling session has ended.
 This means there is a delay between the regular and the inferred spans being visible in the UI.
 
-NOTE: This feature is not available on Windows
+NOTE: This feature is not available on Windows and on OpenJ9
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
 
@@ -3528,7 +3528,7 @@ The default unit for this option is `ms`.
 # The inferred spans are created after a profiling session has ended.
 # This means there is a delay between the regular and the inferred spans being visible in the UI.
 # 
-# NOTE: This feature is not available on Windows
+# NOTE: This feature is not available on Windows and on OpenJ9
 #
 # This setting can be changed at runtime
 # Type: Boolean

--- a/docs/method-monitoring.asciidoc
+++ b/docs/method-monitoring.asciidoc
@@ -17,7 +17,7 @@ periodically recording running methods with a sampling-based profiler.
 
 {y} Very low overhead. +
 {y} No code changes required. +
-{n} Does not work on Windows. +
+{n} Does not work on Windows and on OpenJ9. +
 {n} The duration of profiler-inferred spans are not exact measurements, only estimates.
 
 <<method-sampling-based,Learn more>>
@@ -62,7 +62,8 @@ Use a configuration option to specify additional methods to instrument.
 === Sampling-based profiler
 
 experimental::[]
-added::[1.14.0]
+
+NOTE: this feature is not supported on Windows and on OpenJ9
 
 Instead of recording every event, leverage the agent's built-in integration with
 https://github.com/jvm-profiling-tools/async-profiler[async-profiler]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -53,7 +53,7 @@ the agent does not capture transactions.
 
 |IBM J9 VM
 |8 service refresh 5+ (build 2.9 or 8.0.5.0)
-|
+|<<method-sampling-based,Sampling profiler>> is not supported
 
 |HP-UX JVM
 | 7.0.10+, 8.0.02+


### PR DESCRIPTION
Context: https://discuss.elastic.co/t/apm-profiler-stopping-with-https-discuss-elastic-co-c-apm-on-latest-adoptopenjdk-openjdk8-openj9-alpine-slim/273428