### PR TITLE
[CI] fix release job version prompt

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -108,34 +108,25 @@ pipeline {
             }
           }
         }
-        stage('Review project version') {
+        stage('Set release version') {
           steps {
             dir("${BASE_DIR}"){
               script {
-                def ver = mvnVersion(showQualifiers: true)
-                def should_continue = input(message: "Current version is ${ver}", parameters: [
-                  [
-                    $class: 'ChoiceParameterDefinition',
-                    name: "You are about to release version ${ver - '-SNAPSHOT'}. Do you wish to update the version?",
-                    "choices": ["Yes", "No"],
-                    description: "Selecting 'Yes' will allow you to select the new version in the next step."
-                  ]
-                ])
-                if (should_continue == 'Yes'){
-                  def new_version = input(message: "Please enter version to change to:", parameters:
-                    [
-                      [
-                        $class: 'StringParameterDefinition',
-                        defaultValue: "${ver}",
-                        description: 'We will update the project version in all pom.xml files. Set this to your desired <release-version>-SNAPSHOT (for example 1.2.3-SNAPSHOT if you want to release version 1.2.3).', name: 'New Version'
-                      ]
-                    ]
-                  )
-                  sh(label: "mavenVersionUpdate", script: "./mvnw --batch-mode release:update-versions -DdevelopmentVersion=${new_version}")
-                  sh(script: "git commit -a -m 'Version bump'")
-                  gitPush()
+                def snapshot_version = mvnVersion(showQualifiers: true)
+                def release_version = snapshot_version.minus('-SNAPSHOT')
+                def user_release_version = input(message: "Please enter version to release:", parameters: [[
+                    $class: 'StringParameterDefinition',
+                    name: 'Release version',
+                    defaultValue: "${release_version}",
+                    description: "Current project version is ${snapshot_version}, will be released as ${release_version} if unchanged. Input release version without '-SNAPSHOT' suffix"
+                  ]])
+                if( release_version.equals(user_release_version) ) {
+                    echo "changing project version '${snapshot_version}' not required to release ${release_version}"
                 } else {
-                  echo "Skipping version update"
+                    echo "changing project version from '${snapshot_version}' to '${user_release_version}' to prepare release ${user_release_version}."
+                    sh(label: "mavenVersionUpdate", script: "./mvnw --batch-mode release:update-versions -DdevelopmentVersion=${user_release_version}-SNAPSHOT")
+                    sh(script: "git commit -a -m 'Version bump ${ver}'")
+                    gitPush()
                 }
               }
             }


### PR DESCRIPTION
## What does this PR do?

- do not prompt for Yes/No if version change is required
- directly prompt for the target release version (with default derived from current -SNAPSHOT project version)
- do not call `mvn` nor try to push any git commit if not required to (fails as there is nothing to push otherwise).