### PR TITLE
add 'update agent' to troubleshooting docs

### DIFF
--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -25,7 +25,7 @@ The logs should include everything from the application startup up until the fir
 Agent is updated frequently and releases are not strongly tied to other components in the stack.
 
 As a result, trying to update to the most recently released agent version is often the recommended first troubleshooting
-step. Also, between releases using the https://github.com/elastic/apm-agent-java/blob/master/README.md#snapshots[latest-snapshot] might also be relevant.
+step. If possible, trying the https://github.com/elastic/apm-agent-java/blob/master/README.md#snapshots[latest-snapshot] is even preferable as it would include fixes that are not yet released.
 
 See <<upgrading,upgrading documentation>> for more details.
 

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -19,6 +19,17 @@ Upload the *complete* logs to a service like https://gist.github.com.
 The logs should include everything from the application startup up until the first request has been executed.
 
 [float]
+[[trouble-shooting-use-latest-agent]]
+=== Updating to latest agent version
+
+Agent is updated frequently and releases are not strongly tied to other components in the stack.
+
+As a result, trying to update to the most recently released agent version is often the recommended first troubleshooting
+step. Also, between releases using the https://github.com/elastic/apm-agent-java/blob/master/README.md#snapshots[latest-snapshot] might also be relevant.
+
+See <<upgrading,upgrading documentation>> for more details.
+
+[float]
 [[trouble-shooting-additional-agent]]
 === Running alongside other agents
 Like many other Java agents, our agent instruments classes by injecting bytecode into them on runtime. Our bytecode

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -24,7 +24,7 @@ The logs should include everything from the application startup up until the fir
 
 Agent is updated frequently and releases are not strongly tied to other components in the stack.
 
-As a result, trying to update to the most recently released agent version is often the recommended first troubleshooting
+Therefore, trying to update to the most recently released agent version is often the recommended first troubleshooting
 step. If possible, trying the https://github.com/elastic/apm-agent-java/blob/master/README.md#snapshots[latest-snapshot] is even preferable as it would include fixes that are not yet released.
 
 See <<upgrading,upgrading documentation>> for more details.


### PR DESCRIPTION
## What does this PR do?

Closes https://github.com/elastic/apm-agent-java/issues/1832

Update troubleshooting documentation to instruct to updating agent to latest version as first step.

