### PR TITLE
[1.x][DOCS] Fixes broken links

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -320,6 +320,7 @@ There are cases where you would want to use the agent only to collect and ship m
 In such cases, you may set the <<config-instrument, `instrument`>> config option to `false`. By doing so, the agent will
 minimize its effect on the application, while still collecting and sending metrics to the APM Server.
 
+[float]
 [[metrics-micrometer]]
 === Micrometer metrics
 


### PR DESCRIPTION
## What does this PR do?

Related to https://github.com/elastic/apm-agent-java/pull/1539

Fixes the following broken links:

> 08:07:28 INFO:build_docs:Bad cross-document links:
08:07:28 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elastic-stack/7.10/observability-highlights.html contains broken links to:
08:07:28 INFO:build_docs:   - en/apm/agent/java/current/metrics.html#metrics-micrometer
08:07:28 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/observability/7.10/whats-new.html contains broken links to:
08:07:28 INFO:build_docs:   - en/apm/agent/java/current/metrics.html#metrics-micrometer

Which seems to have occurred because the micrometer section had been split to a separate page:

![image](https://user-images.githubusercontent.com/26471269/120216094-6a4f7680-c1eb-11eb-84da-be1fc21319c8.png)

This PR adds a float attribute so that it's no longer a separate page.
