### PR TITLE
[DOCS] Fixes broken links

### DIFF
--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -320,6 +320,7 @@ There are cases where you would want to use the agent only to collect and ship m
 In such cases, you may set the <<config-instrument, `instrument`>> config option to `false`. By doing so, the agent will
 minimize its effect on the application, while still collecting and sending metrics to the APM Server.
 
+[float]
 [[metrics-micrometer]]
 === Micrometer metrics
 


### PR DESCRIPTION
## What does this PR do?

Forward-fits https://github.com/elastic/apm-agent-java/pull/1836

The same situation exists in the master branch, though it doesn't cause the doc build to fail at this point. If the restructuring of content was intentional, this fix might not be required in this branch.