### PR TITLE
prevent NPE when capturing headers

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
+* Fix NPE with `null` binary header values + properly serialize them - {pull}1842[#1842]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Headers.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Headers.java
@@ -40,26 +40,26 @@ public class Headers implements Recyclable, Iterable<Headers.Header> {
     private final NoGarbageIterator iterator = new NoGarbageIterator();
 
     /**
-     * Adds text header. Will ignore {@literal null} keys and values
+     * Adds text header.
      *
-     * @param key   header key
-     * @param value header value
+     * @param key   header key, will be ignored if {@literal null}
+     * @param value header value, can be {@literal null}
      */
     public void add(@Nullable String key, @Nullable String value) {
-        if (key == null || value == null) {
+        if (key == null) {
             return;
         }
         textHeaders.add(key, value);
     }
 
     /**
-     * Adds binary header. Will ignore {@literal null} keys and values
+     * Adds binary header.
      *
-     * @param key   header key
-     * @param value header value
+     * @param key   header key, will be ignored if {@literal null}
+     * @param value header value, can be {@literal null}
      */
     public void add(@Nullable String key, @Nullable byte[] value) {
-        if (key == null || value == null) {
+        if (key == null) {
             return;
         }
         binaryHeaders.add(key, value);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Headers.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Headers.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -39,12 +39,30 @@ public class Headers implements Recyclable, Iterable<Headers.Header> {
     private final BinaryHeaderMap binaryHeaders = new BinaryHeaderMap();
     private final NoGarbageIterator iterator = new NoGarbageIterator();
 
-    public void add(String key, String value) {
+    /**
+     * Adds text header. Will ignore {@literal null} keys and values
+     *
+     * @param key   header key
+     * @param value header value
+     */
+    public void add(@Nullable String key, @Nullable String value) {
+        if (key == null || value == null) {
+            return;
+        }
         textHeaders.add(key, value);
     }
 
-    public boolean add(String key, byte[] value) {
-        return binaryHeaders.add(key, value);
+    /**
+     * Adds binary header. Will ignore {@literal null} keys and values
+     *
+     * @param key   header key
+     * @param value header value
+     */
+    public void add(@Nullable String key, @Nullable byte[] value) {
+        if (key == null || value == null) {
+            return;
+        }
+        binaryHeaders.add(key, value);
     }
 
     @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Message.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/context/Message.java
@@ -118,12 +118,12 @@ public class Message implements Recyclable {
         }
     }
 
-    public Message addHeader(String key, String value) {
+    public Message addHeader(@Nullable String key, @Nullable String value) {
         headers.add(key, value);
         return this;
     }
 
-    public Message addHeader(String key, byte[] value) {
+    public Message addHeader(@Nullable String key, @Nullable byte[] value) {
         headers.add(key, value);
         return this;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/BinaryHeaderMap.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/BinaryHeaderMap.java
@@ -51,6 +51,8 @@ public class BinaryHeaderMap implements Recyclable, Iterable<BinaryHeaderMap.Ent
 
     private static final Logger logger = LoggerFactory.getLogger(BinaryHeaderMap.class);
 
+    static final int INITIAL_CAPACITY = 10;
+
     private CharBuffer valueBuffer;
     /**
      * Ordered list of keys
@@ -67,8 +69,8 @@ public class BinaryHeaderMap implements Recyclable, Iterable<BinaryHeaderMap.Ent
 
     public BinaryHeaderMap() {
         valueBuffer = CharBuffer.allocate(64);
-        keys = new ArrayList<>(10);
-        valueLengths = new int[10];
+        keys = new ArrayList<>(INITIAL_CAPACITY);
+        valueLengths = new int[INITIAL_CAPACITY];
         iterator = new NoGarbageIterator();
     }
 
@@ -83,9 +85,7 @@ public class BinaryHeaderMap implements Recyclable, Iterable<BinaryHeaderMap.Ent
     public boolean add(String key, @Nullable byte[] value) {
         boolean result;
         if (value == null) {
-            int size = keys.size();
-            keys.add(key);
-            valueLengths[size] = -1;
+            addNewEntry(key, -1);
             return true;
         }
 
@@ -103,16 +103,26 @@ public class BinaryHeaderMap implements Recyclable, Iterable<BinaryHeaderMap.Ent
             ((Buffer) valueBuffer).limit(valuesPos);
             result = false;
         } else {
-            int size = keys.size();
-            keys.add(key);
-            if (size == valueLengths.length) {
-                enlargeValueLengths();
-            }
-            valueLengths[size] = valueBuffer.position() - valuesPos;
+            addNewEntry(key, valueBuffer.position() - valuesPos);
             result = true;
         }
 
         return result;
+    }
+
+    /**
+     * Adds a new entry and increase storage capacity if needed
+     *
+     * @param key         key
+     * @param valueLength value length
+     */
+    private void addNewEntry(String key, int valueLength) {
+        int size = keys.size();
+        keys.add(key);
+        if (size == valueLengths.length) {
+            enlargeValueLengths();
+        }
+        valueLengths[size] = valueLength;
     }
 
     private boolean enlargeBuffer() {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/HeadersTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/HeadersTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -106,5 +106,22 @@ class HeadersTest {
             numItems++;
         }
         assertThat(numItems).isEqualTo(6);
+    }
+
+    @Test
+    void tryNullKeyOrValues() {
+        headers.resetState();
+
+        headers.add(null, "value");
+        headers.add("key", (String) null);
+        headers.add(null, (String) null);
+
+        headers.add(null, new byte[0]);
+        headers.add("key", (byte[]) null);
+        headers.add(null, (byte[]) null);
+
+        assertThat(headers.isEmpty())
+            .describedAs("nothing should be added to map")
+            .isTrue();
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/HeadersTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/HeadersTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -109,19 +110,19 @@ class HeadersTest {
     }
 
     @Test
-    void tryNullKeyOrValues() {
+    void testNullKeysAndValues() {
         headers.resetState();
 
-        headers.add(null, "value");
-        headers.add("key", (String) null);
-        headers.add(null, (String) null);
+        headers.add(null, "null-key-text-value");
+        headers.add("text-null-value", (String) null);
 
-        headers.add(null, new byte[0]);
-        headers.add("key", (byte[]) null);
-        headers.add(null, (byte[]) null);
+        headers.add(null, "null-key-binary-value".getBytes(StandardCharsets.UTF_8));
+        headers.add("binary-null-value", (byte[]) null);
 
-        assertThat(headers.isEmpty())
-            .describedAs("nothing should be added to map")
-            .isTrue();
+        assertThat(headers.size()).isEqualTo(2);
+        headers.forEach(h->{
+            assertThat(h).isNotNull();
+            assertThat(h.getValue()).isNull();
+        });
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -34,6 +34,7 @@ import co.elastic.apm.agent.impl.MetaData;
 import co.elastic.apm.agent.impl.MetaDataMock;
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.impl.context.AbstractContext;
+import co.elastic.apm.agent.impl.context.Headers;
 import co.elastic.apm.agent.impl.context.Request;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.payload.Agent;
@@ -284,7 +285,7 @@ class DslJsonSerializerTest {
     }
 
     @Test
-    void testNullHeaders() {
+    void testNullTransactionHeaders() {
         Transaction transaction = new Transaction(MockTracer.create());
         transaction.getContext().getRequest().addHeader("foo", (String) null);
         transaction.getContext().getRequest().addHeader("baz", (Enumeration<String>) null);
@@ -295,6 +296,36 @@ class DslJsonSerializerTest {
         assertThat(jsonNode.get("context").get("request").get("headers").get("baz")).isNull();
         // should a null value sneak in, it should not break
         assertThat(jsonNode.get("context").get("request").get("headers").get("bar").isNull()).isTrue();
+    }
+
+    @Test
+    void testMessageHeaders() {
+        Span span = new Span(MockTracer.create());
+        span.getTraceContext().asRootSpan(ConstantSampler.of(true));
+        span.withType("messaging").withSubtype("kafka");
+
+        Headers headers = span.getContext().getMessage().getHeaders();
+
+        headers.add("null-string-value", (String) null);
+        headers.add("string-value", "as-is");
+
+        headers.add("null-binary-value", (byte[]) null);
+        headers.add("binary-value", "binary-value".getBytes(StandardCharsets.UTF_8));
+
+        JsonNode jsonNode = readJsonString(serializer.toJsonString(span));
+        JsonNode jsonHeaders = jsonNode.get("context").get("message").get("headers");
+        assertThat(jsonHeaders.get("null-string-value"))
+            .describedAs("null value string header should be serialized")
+            .isNotNull();
+        assertThat(jsonHeaders.get("null-string-value").isNull()).isTrue();
+        assertThat(jsonHeaders.get("string-value").asText()).isEqualTo("as-is");
+
+        assertThat(jsonHeaders.get("null-binary-value"))
+            .describedAs("null value binary header should be serialized")
+            .isNotNull();
+        assertThat(jsonHeaders.get("null-binary-value").isNull())
+            .isTrue();
+        assertThat(jsonHeaders.get("binary-value").asText()).isEqualTo("binary-value");
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/BinaryHeaderMapTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/BinaryHeaderMapTest.java
@@ -64,6 +64,31 @@ class BinaryHeaderMapTest {
     }
 
     @Test
+    void testCapacityIncrease() {
+        // we don't have access to actual capacity
+        // thus we just add more than the initial capacity and ensure it's consistent
+        int targetSize = BinaryHeaderMap.INITIAL_CAPACITY * 10;
+        for (int i = 0; i < targetSize; i++) {
+            byte[] value = (i % 5 == 0) ? null : RandomStringUtils.randomAlphanumeric(32).getBytes();
+            headerMap.add(String.format("key_%d", i), value);
+            assertThat(headerMap.size()).isEqualTo(i + 1);
+        }
+
+        int index = 0;
+        for (BinaryHeaderMap.Entry entry : headerMap) {
+            assertThat(entry.getKey()).isEqualTo("key_%d", index);
+            if (index % 5 == 0) {
+                assertThat(entry.getValue()).isNull();
+            } else {
+                assertThat(entry.getValue()).isNotEmpty();
+            }
+            index++;
+        }
+        assertThat(index).isEqualTo(targetSize);
+
+    }
+
+    @Test
     void testLongHeader() {
         final String longRandomString = RandomStringUtils.randomAlphanumeric(DslJsonSerializer.MAX_VALUE_LENGTH + 1);
         headerMap.add("long", longRandomString.getBytes());

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/BinaryHeaderMapTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/BinaryHeaderMapTest.java
@@ -11,9 +11,9 @@
  * the Apache License, Version 2.0 (the "License"); you may
  * not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -46,13 +46,21 @@ class BinaryHeaderMapTest {
     @Test
     void testOneEntry() {
         headerMap.add("foo", "bar".getBytes());
-        int numElements = 0;
-        for (BinaryHeaderMap.Entry entry : headerMap) {
-            numElements++;
-            assertThat(entry.getKey()).isEqualTo("foo");
-            assertThat(entry.getValue().toString()).isEqualTo("bar");
-        }
-        assertThat(numElements).isEqualTo(1);
+        assertThat(headerMap).hasSize(1);
+        headerMap.forEach(e -> {
+            assertThat(e.getKey()).isEqualTo("foo");
+            assertThat(e.getValue().toString()).isEqualTo("bar");
+        });
+    }
+
+    @Test
+    void testNullValue() {
+        headerMap.add("key", null);
+        assertThat(headerMap.size()).isEqualTo(1);
+        headerMap.iterator().forEachRemaining(e -> {
+            assertThat(e.getKey()).isEqualTo("key");
+            assertThat(e.getValue()).isNull();
+        });
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

Fixes #1840 

## Checklist

- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix

## For reviewer:

- [ ] Do we have any usage of `null` header names or keys in practice ? While the underlying maps may allow for `null` values, I *think* that it would not make any sense to try capturing those.
