### PR TITLE
Prevent public API related spans from being recycled

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,8 @@ endif::[]
 * Support for inheritance of public API annotations - {pull}1805[#1805]
 * JDBC instrumentation sets context.db.instance - {pull}1820[#1820]
 * Add support for Vert.x web client- {pull}1824[#1824]
+* Avoid recycling of spans and transactions that are using through the public API, so to avoid
+reference-counting-related errors - {pull}1859[#1859]
 
 [float]
 ===== Bug fixes

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,7 +93,8 @@ pipeline {
               stash allowEmpty: true, name: 'build', useDefaultExcludes: false
               archiveArtifacts allowEmptyArchive: true,
                 artifacts: "${BASE_DIR}/elastic-apm-agent/target/elastic-apm-agent-*.jar,${BASE_DIR}/apm-agent-attach/target/apm-agent-attach-*.jar,\
-                      ${BASE_DIR}/apm-agent-attach-cli/target/apm-agent-attach-cli-*.jar,${BASE_DIR}/target/site/aggregate-third-party-report.html",
+                      ${BASE_DIR}/apm-agent-attach-cli/target/apm-agent-attach-cli-*.jar,${BASE_DIR}/apm-agent-api/target/apm-agent-api-*.jar,\
+                      ${BASE_DIR}/target/site/aggregate-third-party-report.html",
                 onlyIfSuccessful: true
             }
           }

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/AbstractSpanImpl.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/AbstractSpanImpl.java
@@ -35,6 +35,11 @@ abstract class AbstractSpanImpl implements Span {
 
     AbstractSpanImpl(@Nonnull Object span) {
         this.span = span;
+        initialize(span);
+    }
+
+    private void initialize(@Nonnull Object span) {
+        // co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$InitializeInstrumentation
     }
 
     @Nonnull

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/AbstractSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/AbstractSpanInstrumentation.java
@@ -132,6 +132,17 @@ public class AbstractSpanInstrumentation extends ApiInstrumentation {
         }
     }
 
+    public static class InitializeInstrumentation extends AbstractSpanInstrumentation {
+        public InitializeInstrumentation() {
+            super(named("initialize").and(takesArgument(0, Object.class)));
+        }
+
+        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+        public static void incrementReferences(@Advice.Argument(0) Object span) {
+            ((AbstractSpan<?>) span).incrementReferences();
+        }
+    }
+
     public static class SetStartTimestampInstrumentation extends AbstractSpanInstrumentation {
         public SetStartTimestampInstrumentation() {
             super(named("doSetStartTimestamp").and(takesArguments(long.class)));

--- a/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-api-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -11,6 +11,7 @@ co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$SetNameInstrumentatio
 co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$SetTypeInstrumentation
 co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$SetTypesInstrumentation
 co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$DoCreateSpanInstrumentation
+co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$InitializeInstrumentation
 co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$SetStartTimestampInstrumentation
 co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$SetOutcomeInstrumentation
 co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$EndInstrumentation

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/AbstractApiTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/AbstractApiTest.java
@@ -1,0 +1,14 @@
+package co.elastic.apm;
+
+import co.elastic.apm.agent.AbstractInstrumentationTest;
+import org.junit.Before;
+import org.junit.jupiter.api.BeforeEach;
+
+public class AbstractApiTest extends AbstractInstrumentationTest {
+
+    @Before
+    @BeforeEach
+    public void disableRecycling() {
+        disableRecyclingValidation();
+    }
+}

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/pluginapi/SpanInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/pluginapi/SpanInstrumentationTest.java
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.agent.pluginapi;
 
-import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.AbstractApiTest;
 import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.api.ElasticApm;
@@ -42,7 +42,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class SpanInstrumentationTest extends AbstractInstrumentationTest {
+class SpanInstrumentationTest extends AbstractApiTest {
 
     private static final SecureRandom random = new SecureRandom();
 

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/pluginapi/TransactionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/agent/pluginapi/TransactionInstrumentationTest.java
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.agent.pluginapi;
 
-import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.AbstractApiTest;
 import co.elastic.apm.agent.impl.TracerInternalApiUtils;
 import co.elastic.apm.api.ElasticApm;
 import co.elastic.apm.api.Outcome;
@@ -38,7 +38,7 @@ import java.security.SecureRandom;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class TransactionInstrumentationTest extends AbstractInstrumentationTest {
+class TransactionInstrumentationTest extends AbstractApiTest {
 
     private static final SecureRandom random = new SecureRandom();
 
@@ -193,7 +193,7 @@ class TransactionInstrumentationTest extends AbstractInstrumentationTest {
     public void testAgentPaused() {
         // end current transaction first
         endTransaction();
-        reporter.reset();
+        reporter.resetWithoutRecycling();
 
         TracerInternalApiUtils.pauseTracer(tracer);
         int transactionCount = objectPoolFactory.getTransactionPool().getRequestedObjectCount();

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationApiTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationApiTest.java
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.api;
 
-import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.AbstractApiTest;
 import co.elastic.apm.agent.impl.TracerInternalApiUtils;
 import co.elastic.apm.agent.impl.transaction.Span;
 import org.junit.jupiter.api.Test;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class AnnotationApiTest extends AbstractInstrumentationTest {
+class AnnotationApiTest extends AbstractApiTest {
 
     @Test
     void testCaptureTransactionAnnotation() {

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationInheritanceTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationInheritanceTest.java
@@ -51,7 +51,7 @@ class AnnotationInheritanceTest {
 
     @AfterEach
     void cleanup() {
-        reporter.reset();
+        reporter.resetWithoutRecycling();
     }
 
     private void init(boolean annotationInheritanceEnabled) {

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/BlockingQueueContextPropagationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/BlockingQueueContextPropagationTest.java
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.api;
 
-import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.AbstractApiTest;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -39,7 +39,7 @@ import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class BlockingQueueContextPropagationTest extends AbstractInstrumentationTest {
+public class BlockingQueueContextPropagationTest extends AbstractApiTest {
 
     private static BlockingQueue<ElasticApmQueueElementWrapper<CompletableFuture<String>>> blockingQueue;
     private static ExecutorService executorService;

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/ElasticApmApiInstrumentationTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/ElasticApmApiInstrumentationTest.java
@@ -24,7 +24,7 @@
  */
 package co.elastic.apm.api;
 
-import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.AbstractApiTest;
 import co.elastic.apm.agent.impl.Scope;
 import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
 import co.elastic.apm.agent.impl.TracerInternalApiUtils;
@@ -37,7 +37,7 @@ import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class ElasticApmApiInstrumentationTest extends AbstractInstrumentationTest {
+class ElasticApmApiInstrumentationTest extends AbstractApiTest {
 
     @Test
     void testCreateTransaction() {

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/OutcomeTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/OutcomeTest.java
@@ -50,6 +50,4 @@ class OutcomeTest {
             .map(Enum::name)
             .collect(Collectors.toSet());
     }
-
-
 }

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_x/src/test/java/co/elastic/apm/agent/es/restclient/v7_x/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_x/src/test/java/co/elastic/apm/agent/es/restclient/v7_x/ElasticsearchRestClientInstrumentationIT.java
@@ -68,7 +68,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -133,9 +132,7 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractEs6_4Clien
         // This ends the span synchronously
         cancellable.cancel();
 
-        List<Span> spans = reporter.getSpans();
-        assertThat(spans).hasSize(1);
-        Span searchSpan = spans.get(0);
+        Span searchSpan = reporter.getFirstSpan(500);
         validateSpanContent(searchSpan, String.format("Elasticsearch: POST /%s/_search", INDEX), -1, "POST");
 
         assertThat(searchSpan.getOutcome())

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
@@ -72,6 +72,7 @@ public abstract class AbstractServerInstrumentationTest extends AbstractInstrume
     void beforeEach() {
         assertThat(reporter.getTransactions()).isEmpty();
         client = getClient();
+        disableRecyclingValidation();
     }
 
     @AfterEach

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
@@ -72,7 +72,6 @@ public abstract class AbstractServerInstrumentationTest extends AbstractInstrume
     void beforeEach() {
         assertThat(reporter.getTransactions()).isEmpty();
         client = getClient();
-        disableRecyclingValidation();
     }
 
     @AfterEach

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/pom.xml
@@ -37,13 +37,6 @@
     </dependencyManagement>
 
     <dependencies>
-
-        <dependency>
-            <groupId>co.elastic.apm</groupId>
-            <artifactId>apm-agent-api</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingAnnotated.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingAnnotated.java
@@ -24,8 +24,10 @@
  */
 package co.elastic.apm.agent.springwebflux.testapp;
 
-import co.elastic.apm.api.ElasticApm;
-import co.elastic.apm.api.Transaction;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.GlobalTracer;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -149,11 +151,13 @@ public class GreetingAnnotated {
         log.debug("enter customTransactionName");
         try {
             // transaction should be active, even if we are outside of the Mono/Flux execution
-            Transaction transaction = Objects.requireNonNull(ElasticApm.currentTransaction(), "active transaction is required");
-            transaction.setName("user-provided-name");
+            ElasticApmTracer tracer = GlobalTracer.requireTracerImpl();
+            Transaction transaction = Objects.requireNonNull(tracer.currentTransaction(), "active transaction is required");
+            // This mimics setting the name through the public API. We cannot use the public API if we want to test span recycling
+            transaction.withName("user-provided-name", AbstractSpan.PRIO_USER_SUPPLIED);
 
 
-            return greetingHandler.helloMessage("transaction=" + ElasticApm.currentTransaction().getId());
+            return greetingHandler.helloMessage("transaction=" + Objects.requireNonNull(tracer.currentTransaction()).getTraceContext().getId());
         } finally {
             log.debug("exit customTransactionName");
         }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingFunctional.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingFunctional.java
@@ -24,8 +24,10 @@
  */
 package co.elastic.apm.agent.springwebflux.testapp;
 
-import co.elastic.apm.api.ElasticApm;
-import co.elastic.apm.api.Transaction;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.GlobalTracer;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Transaction;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
@@ -79,9 +81,11 @@ public class GreetingFunctional {
             .GET("/functional/duration", accept(MediaType.TEXT_PLAIN), request -> response(greetingHandler.duration(getDuration(request))))
             // custom transaction name set through API
             .GET("/functional/custom-transaction-name", accept(MediaType.TEXT_PLAIN), request -> {
-                Transaction transaction = Objects.requireNonNull(ElasticApm.currentTransaction(), "active transaction is required");
-                transaction.setName("user-provided-name");
-                return response(greetingHandler.helloMessage("transaction=" + ElasticApm.currentTransaction().getId()));
+                ElasticApmTracer tracer = GlobalTracer.requireTracerImpl();
+                Transaction transaction = Objects.requireNonNull(tracer.currentTransaction(), "active transaction is required");
+                // This mimics setting the name through the public API. We cannot use the public API if we want to test span recycling
+                transaction.withName("user-provided-name", AbstractSpan.PRIO_USER_SUPPLIED);
+                return response(greetingHandler.helloMessage("transaction=" + Objects.requireNonNull(tracer.currentTransaction()).getTraceContext().getId()));
             })
             .GET("/functional/child-flux", accept(MediaType.TEXT_PLAIN), request -> ServerResponse.ok()
                 .body(greetingHandler.childSpans(getCount(request), getDelay(request), getDuration(request)), String.class

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingHandler.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingHandler.java
@@ -24,8 +24,8 @@
  */
 package co.elastic.apm.agent.springwebflux.testapp;
 
-import co.elastic.apm.api.ElasticApm;
-import co.elastic.apm.api.Span;
+import co.elastic.apm.agent.impl.GlobalTracer;
+import co.elastic.apm.agent.impl.transaction.Span;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
@@ -35,6 +35,7 @@ import reactor.core.scheduler.Schedulers;
 
 import javax.annotation.Nullable;
 import java.time.Duration;
+import java.util.Objects;
 import java.util.Optional;
 
 @Component
@@ -69,8 +70,8 @@ public class GreetingHandler {
             .delayElements(Duration.ofMillis(delayMillis))
             .map(i -> String.format("child %d", i))
             .doOnNext(name -> {
-                Span span = ElasticApm.currentTransaction().startSpan();
-                span.setName(String.format("%s id=%s", name, span.getId()));
+                Span span = Objects.requireNonNull(GlobalTracer.requireTracerImpl().currentTransaction()).createSpan();
+                span.withName(String.format("%s id=%s", name, span.getTraceContext().getId()));
                 try {
                     fakeWork(durationMillis);
                 } finally {

--- a/apm-agent-plugins/apm-vertx/apm-vertx-common/src/test/java/co/elastic/apm/agent/vertx/helper/AbstractVertxWebTest.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx-common/src/test/java/co/elastic/apm/agent/vertx/helper/AbstractVertxWebTest.java
@@ -67,7 +67,6 @@ public abstract class AbstractVertxWebTest extends AbstractInstrumentationTest {
     void setUp() {
         webConfiguration = tracer.getConfig(WebConfiguration.class);
         coreConfiguration = tracer.getConfig(CoreConfiguration.class);
-        disableRecyclingValidation();
     }
 
     @Nullable

--- a/apm-agent-plugins/apm-vertx/apm-vertx-common/src/test/java/co/elastic/apm/agent/vertx/helper/AbstractVertxWebTest.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx-common/src/test/java/co/elastic/apm/agent/vertx/helper/AbstractVertxWebTest.java
@@ -67,6 +67,7 @@ public abstract class AbstractVertxWebTest extends AbstractInstrumentationTest {
     void setUp() {
         webConfiguration = tracer.getConfig(WebConfiguration.class);
         coreConfiguration = tracer.getConfig(CoreConfiguration.class);
+        disableRecyclingValidation();
     }
 
     @Nullable

--- a/apm-agent-plugins/apm-vertx/apm-vertx-common/src/test/java/co/elastic/apm/agent/vertx/helper/HandlerWithCustomNamedSpan.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx-common/src/test/java/co/elastic/apm/agent/vertx/helper/HandlerWithCustomNamedSpan.java
@@ -24,9 +24,8 @@
  */
 package co.elastic.apm.agent.vertx.helper;
 
-import co.elastic.apm.api.ElasticApm;
-import co.elastic.apm.api.Scope;
-import co.elastic.apm.api.Span;
+import co.elastic.apm.agent.impl.GlobalTracer;
+import co.elastic.apm.agent.impl.transaction.Span;
 import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 
@@ -44,11 +43,10 @@ public class HandlerWithCustomNamedSpan implements Handler<Void> {
 
     @Override
     public void handle(Void v) {
-        Span child = ElasticApm.currentSpan().startSpan();
-        child.setName(spanName + "-child-span");
-        try (Scope ignored = child.activate()) {
-            handler.handle(routingContext);
-        }
-        child.end();
+        Span child = GlobalTracer.requireTracerImpl().getActive().createSpan();
+        child.withName(spanName + "-child-span");
+        child.activate();
+        handler.handle(routingContext);
+        child.deactivate().end();
     }
 }

--- a/apm-agent-plugins/apm-vertx/pom.xml
+++ b/apm-agent-plugins/apm-vertx/pom.xml
@@ -45,18 +45,6 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apm-agent-api</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apm-api-plugin</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/integration-tests/external-plugin-test/external-plugin/src/test/java/co/elastic/apm/agent/plugin/PluginInstrumentationTest.java
+++ b/integration-tests/external-plugin-test/external-plugin/src/test/java/co/elastic/apm/agent/plugin/PluginInstrumentationTest.java
@@ -28,6 +28,7 @@ import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.plugin.test.TestClass;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.Objects;
@@ -47,6 +48,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * from a real external plugin this constraint does not apply.
  */
 class PluginInstrumentationTest extends AbstractInstrumentationTest {
+
+    @BeforeEach
+    void disableObjectRecyclingAssertion() {
+        disableRecyclingValidation();
+    }
 
     @Test
     void testTransactionCreation() {


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
In order to work around misuse of the public activation API, related spans will not be recycled. 
This way we can ensure there is no improper usage of recycled-and-still-referenced span objects at the cost of creating some garbage.
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] ~~I have made corresponding changes to the documentation~~

I decided not to add anything to the documentation about that, as I think it would only cause confusion.
