### PR TITLE
[DOC] Details about the body capture maximum size.

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -296,6 +296,9 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "\n" +
             "This option is case-insensitive.\n" +
             "\n" +
+            "NOTE: Currently, the body length is limited to 10000 characters and it is not configurable." +
+            "If the body size exceeds the limit, it will be truncated." +
+            "\n" +
             "NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.\n" +
             "The option <<config-capture-body-content-types>> determines which content types are captured.\n" +
             "\n" +

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -296,8 +296,8 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "\n" +
             "This option is case-insensitive.\n" +
             "\n" +
-            "NOTE: Currently, the body length is limited to 10000 characters and it is not configurable." +
-            "If the body size exceeds the limit, it will be truncated." +
+            "NOTE: Currently, the body length is limited to 10000 characters and it is not configurable. \n" +
+            "If the body size exceeds the limit, it will be truncated. \n" +
             "\n" +
             "NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.\n" +
             "The option <<config-capture-body-content-types>> determines which content types are captured.\n" +

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -813,8 +813,6 @@ If the HTTP request or the message has a body and this setting is disabled, the 
 
 This option is case-insensitive.
 
-NOTE: Currently, the body length is limited to 10000 characters and it is not configurable. If the body size exceeds the limit, it will be truncated.
-
 NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.
 The option <<config-capture-body-content-types>> determines which content types are captured.
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -813,6 +813,9 @@ If the HTTP request or the message has a body and this setting is disabled, the 
 
 This option is case-insensitive.
 
+NOTE: Currently, the body length is limited to 10000 characters and it is not configurable. 
+If the body size exceeds the limit, it will be truncated. 
+
 NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.
 The option <<config-capture-body-content-types>> determines which content types are captured.
 
@@ -2912,6 +2915,9 @@ The default unit for this option is `ms`.
 # If the HTTP request or the message has a body and this setting is disabled, the body will be shown as [REDACTED].
 # 
 # This option is case-insensitive.
+# 
+# NOTE: Currently, the body length is limited to 10000 characters and it is not configurable. 
+# If the body size exceeds the limit, it will be truncated. 
 # 
 # NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.
 # The option <<config-capture-body-content-types>> determines which content types are captured.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -813,6 +813,8 @@ If the HTTP request or the message has a body and this setting is disabled, the 
 
 This option is case-insensitive.
 
+NOTE: Currently, the body length is limited to 10000 characters and it is not configurable. If the body size exceeds the limit, it will be truncated.
+
 NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.
 The option <<config-capture-body-content-types>> determines which content types are captured.
 


### PR DESCRIPTION
## What does this PR do?

Adds more details about the body capture.

According to https://github.com/elastic/apm-agent-java/blob/a040f5ad380a5bd401f26ccebdf71b61a2630970/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java#L102 we limit the body capture to 10k characters long.

The unit test shows the body will be truncated: https://github.com/elastic/apm-agent-java/blob/d7de9d2298c71c9dc5bc3ff55001b4a72f40f7fd/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/TestRequestBodyCapturing.java#L165

## Checklist

- [x] This is a documentation change
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)~ Not worth a changelog entry

To the reviewer:
- [ ] Please review if this is correct
- [ ] Please backport to applicable versions
