### PR TITLE
log4j2 vulnerability - excluding SMTP appender from build

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,10 @@ setting `disable_instrumentations=jdbc` would disable jdbc and also enable exper
 ** Previously, by default `disable_instrumentations` contained `experimental`
 ** Now by default `disable_instrumentations` is empty and `enable_experimental_instrumentations=false`
 ** Set `disable_instrumentations=true` to enable experimental instrumentations
+* Eliminating concerns related to log4j2 vulnerability - https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle.
+We cannot upgrade to version above 2.12.1 because this is the last version of log4j that is compatible with Java 7.
+Instead, we exclude the SMTP appender (which is the vulnerable one) from our artifacts. Note that older versions of
+our agent are not vulnerable as well, as the SMTP appender was never used, this is only to further reduce our users' concerns.
 
 [float]
 ===== Bug fixes

--- a/apm-agent-attach-cli/pom.xml
+++ b/apm-agent-attach-cli/pom.xml
@@ -90,6 +90,16 @@
                                         <exclude>elastic-apm-agent.jar</exclude>
                                     </excludes>
                                 </filter>
+                                <filter>
+                                    <artifact>org.apache.logging.log4j:log4j-core</artifact>
+                                    <!--
+                                    Eliminating exposure to the log4j2 vulnerability related to the SMTP appender -
+                                    https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle
+                                    -->
+                                    <excludes>
+                                        <exclude>org/apache/logging/log4j/core/appender/SmtpAppender.class</exclude>
+                                    </excludes>
+                                </filter>
                             </filters>
                             <transformers>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -388,6 +388,16 @@
                                     </excludes>
                                 </filter>
                                 <filter>
+                                    <artifact>org.apache.logging.log4j:log4j-core</artifact>
+                                    <!--
+                                    Eliminating exposure to the log4j2 vulnerability related to the SMTP appender -
+                                    https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle
+                                    -->
+                                    <excludes>
+                                        <exclude>org/apache/logging/log4j/core/appender/SmtpAppender.class</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
                                     <artifact>org.hdrhistogram:HdrHistogram</artifact>
                                     <!--
                                     Currently, we only need this single class.

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,9 @@
         <version.logback>1.2.3</version.logback>
         <version.okhttp>4.9.1</version.okhttp>
         <version.slf4j>1.7.31</version.slf4j>
-        <!-- this is the last version of log4j that is compatible with Java 7 -->
+        <!-- this is the last version of log4j that is compatible with Java 7. Due to a known vulnerability
+        (https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle), the SMTP appender is
+         excluded from the build and not packaged into the agent artifacts -->
         <version.log4j>2.12.1</version.log4j>
         <version.log4j2-ecs-layout>1.0.1</version.log4j2-ecs-layout>
         <version.spring>5.0.15.RELEASE</version.spring>


### PR DESCRIPTION
## Checklist
- [x] excluding from the agent jar
- [x] excluding from the attach cli jar
- [x] adding a note within the pom property defining the used log4j version
- [x] added to CHANGELOG