### PR TITLE
Enabling ECS log reformatting for Logback using LayoutWrappingEncoder

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -48,6 +48,7 @@ setting `disable_instrumentations=jdbc` would disable jdbc and also enable exper
 ===== Bug fixes
 * Fix NPE with `null` binary header values + properly serialize them - {pull}1842[#1842]
 * Fix `ListenerExecutionFailedException` when using Spring AMQP's ReplyTo container - {pull}1872[#1872]
+* Enabling log ECS reformatting when using Logback configured with `LayoutWrappingEncoder` and a pattern layout - {pull}1879[#1879]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-log-shader-plugin-common/src/main/java/co/elastic/apm/agent/log/shader/AbstractEcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-log-shader-plugin-common/src/main/java/co/elastic/apm/agent/log/shader/AbstractEcsReformattingHelper.java
@@ -39,6 +39,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 /**
  * The abstract Log shading helper- loaded as part of the agent core (agent CL / bootstrap CL / System CL).
@@ -313,11 +314,16 @@ public abstract class AbstractEcsReformattingHelper<A, F> {
         F formatter = getFormatterFrom(originalAppender);
         return !isShadingAppender(originalAppender) &&
             !isEcsFormatter(formatter) &&
-            WildcardMatcher.anyMatch(loggingConfiguration.getLogEcsFormatterAllowList(), formatter.getClass().getName()) != null;
+            isAllowedFormatter(formatter, loggingConfiguration.getLogEcsFormatterAllowList());
+    }
+
+    protected boolean isAllowedFormatter(F formatter, List<WildcardMatcher> allowList) {
+        return WildcardMatcher.anyMatch(allowList, formatter.getClass().getName()) != null;
     }
 
     /**
      * Looks up an ECS-formatter to override logging events in the given appender
+     *
      * @param originalAppender the original log appender
      * @return an ECS-formatter if such is mapped to the provide appender and the caller should override, or {@code null}
      */

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/LogbackEcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/LogbackEcsReformattingHelper.java
@@ -29,14 +29,17 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.FileAppender;
 import ch.qos.logback.core.OutputStreamAppender;
 import ch.qos.logback.core.encoder.Encoder;
+import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import ch.qos.logback.core.rolling.FixedWindowRollingPolicy;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.SizeBasedTriggeringPolicy;
 import co.elastic.apm.agent.log.shader.AbstractEcsReformattingHelper;
 import co.elastic.apm.agent.log.shader.Utils;
+import co.elastic.apm.agent.matcher.WildcardMatcher;
 import co.elastic.logging.logback.EcsEncoder;
 
 import javax.annotation.Nullable;
+import java.util.List;
 
 class LogbackEcsReformattingHelper extends AbstractEcsReformattingHelper<OutputStreamAppender<ILoggingEvent>, Encoder<ILoggingEvent>> {
 
@@ -56,6 +59,14 @@ class LogbackEcsReformattingHelper extends AbstractEcsReformattingHelper<OutputS
             ((EcsEncoder) encoder).init(appender.getOutputStream());
         }
         appender.setEncoder(encoder);
+    }
+
+    @Override
+    protected boolean isAllowedFormatter(Encoder<ILoggingEvent> formatter, List<WildcardMatcher> allowList) {
+        if (formatter instanceof LayoutWrappingEncoder<?>) {
+            return WildcardMatcher.anyMatch(allowList, ((LayoutWrappingEncoder<?>) formatter).getLayout().getClass().getName()) != null;
+        }
+        return super.isAllowedFormatter(formatter, allowList);
     }
 
     @Override

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/test/resources/logback.xml
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/test/resources/logback.xml
@@ -15,6 +15,14 @@
         <file>target/logback.log</file>
         <append>false</append>
         <immediateFlush>true</immediateFlush>
+        <!-- Allows testing the special logic for LayoutWrappingEncoder -->
+        <!--
+        <encoder class="ch.qos.logback.core.encoder.LayoutWrappingEncoder">
+            <layout class="ch.qos.logback.classic.PatternLayout">
+                <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'} %thread %-5level %logger{36} %msg%n</pattern>
+            </layout>
+        </encoder>
+        -->
         <encoder>
             <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSS'Z'} %thread %-5level %logger{36} %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Reported in [our forum](https://discuss.elastic.co/t/log-ecs-reformatting-not-reformatting-all-logfiles/276532/4): when configuring Logback to use `LayoutWrappingEncoder` with a pattern layout, reformatting doesn't work due to the way we check against our allow-list of formatters.
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->
- [ ] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix (disabled by default, can be enabled by commenting out)
