### PR TITLE
Remove extra allocation for legacy servers

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -1184,7 +1184,12 @@ public class DslJsonSerializer implements PayloadSerializer {
             writeField("port", port);
         } else {
             // serialize as a string for compatibility
-            writeField("port", Integer.toString(port));
+            // doing it in low-level to avoid allocation
+            writeFieldName("port", jw);
+            jw.writeByte(QUOTE);
+            NumberConverter.serialize(port, jw);
+            jw.writeByte(QUOTE);
+            jw.writeByte(COMMA);
         }
         writeField("pathname", url.getPathname());
         writeField("search", url.getSearch());


### PR DESCRIPTION
## What does this PR do?

Improvement on https://github.com/elastic/apm-agent-java/pull/1889
Removes extra allocation for legacy servers.

Thanks @felixbarny for the idea.

