### PR TITLE
JBoss JMX notification work-around

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -59,9 +59,10 @@ Elasticsearch's REST client - {pull}1883[#1883]
 * Fix NPE with `null` binary header values + properly serialize them - {pull}1842[#1842]
 * Fix `ListenerExecutionFailedException` when using Spring AMQP's ReplyTo container - {pull}1872[#1872]
 * Enabling log ECS reformatting when using Logback configured with `LayoutWrappingEncoder` and a pattern layout - {pull}1879[#1879]
-* Fix NPE with Webflux + context propagation headers - {pull}1871[1871]
+* Fix NPE with Webflux + context propagation headers - {pull}1871[#1871]
 * Fix `ClassCastException` with `ConnnectionMetaData` and multiple classloaders - {pull}1864[#1864]
 * Fix NPE in `co.elastic.apm.agent.servlet.helper.ServletTransactionCreationHelper.getClassloader` - {pull}1861[#1861]
+* Fix for Jboss JMX unexpected notifications - {pull}1895[#1895]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
@@ -210,7 +210,7 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
 
             private boolean matchesJbossStatisticsPool(ObjectName beanName, ObjectName metricName, MBeanServer server) {
                 String asDomain = "jboss.as";
-                String exprDomain = "jboss.as.expr__";
+                String exprDomain = "jboss.as.expr";
 
                 if (!asDomain.equals(metricName.getDomain())) {
                     // only relevant for metrics in 'jboss.as' domain

--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
@@ -224,8 +224,9 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
 
                 // On JBoos EAP 7.3.0 and 7.1.0, we have similar behaviors
                 // - notification can be on `jboss.as.expr` or `jboss.as` domain, but we registered `jboss.as`
-                // - notification on `jboss.as.expr` seems to be setup-dependant
+                // - notification on `jboss.as.expr` seems to be setup-dependant and might be optional
                 // - notification bean will miss the `statistics=pool` property
+                // - when we get one of those "close but not 100% identical", the beans we usually look for are available
                 //
                 // We just do an extra lookup to check that the MBean we are looking for is actually present
                 // thus in the worst case it just means few extra lookups.

--- a/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricTrackerTest.java
@@ -50,7 +50,7 @@ class JmxMetricTrackerTest {
     }
 
     @AfterEach
-    void cleanup(){
+    void cleanup() {
         tracer.stop();
     }
 


### PR DESCRIPTION
## What does this PR do?

Jboss has unexpected JMX Beans registration notifications, we have to work-around as the configuration set through agent JMX configuration does not 100% match notifications sent by the MBeanServer.

This extends  #1258 by also reusing notifications on `jboss.as` domain as it appears that `jboss.as.expr` might be optional.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
  - [x] Manual testing with Jboss 7.3.0 and 7.1.0 that are known to require this work-around.
