### PR TITLE
Added support for excluding classes from classes_excluded_from_instrumentation_default

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -92,6 +92,7 @@ import java.util.concurrent.TimeUnit;
 import static co.elastic.apm.agent.bci.bytebuddy.ClassLoaderNameMatcher.classLoaderWithName;
 import static co.elastic.apm.agent.bci.bytebuddy.ClassLoaderNameMatcher.isReflectionClassLoader;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.anyMatch;
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.anyMatchExcept;
 import static net.bytebuddy.asm.Advice.ExceptionHandler.Default.PRINTING;
 import static net.bytebuddy.matcher.ElementMatchers.any;
 import static net.bytebuddy.matcher.ElementMatchers.is;
@@ -305,7 +306,7 @@ public class ElasticApmAgent {
             .with(TypeValidation.of(logger.isDebugEnabled()))
             .with(FailSafeDeclaredMethodsCompiler.INSTANCE);
         AgentBuilder agentBuilder = getAgentBuilder(
-            byteBuddy, coreConfiguration, logger, descriptionStrategy, premain, coreConfiguration.isTypePoolCacheEnabled()
+            byteBuddy, coreConfiguration, logger, instrumentations, descriptionStrategy, premain, coreConfiguration.isTypePoolCacheEnabled()
         );
         int numberOfAdvices = 0;
         for (final ElasticApmInstrumentation advice : instrumentations) {
@@ -618,8 +619,16 @@ public class ElasticApmAgent {
     }
 
     private static AgentBuilder getAgentBuilder(final ByteBuddy byteBuddy, final CoreConfiguration coreConfiguration, final Logger logger,
-                                                final AgentBuilder.DescriptionStrategy descriptionStrategy, final boolean premain,
-                                                final boolean useTypePoolCache) {
+                                                final Iterable<ElasticApmInstrumentation> instrumentations, final AgentBuilder.DescriptionStrategy descriptionStrategy,
+                                                final boolean premain, final boolean useTypePoolCache) {
+        ArrayList<ElementMatcher<? super NamedElement>> includeDefaultExcludedClassesMatchers = new ArrayList<>();
+        for (ElasticApmInstrumentation apmInstrumentation : instrumentations) {
+            ElementMatcher<? super NamedElement> matcher = apmInstrumentation.getTypeMatcherIncludeDefaultExcludedClasses();
+            if (matcher == null) {
+                continue;
+            }
+            includeDefaultExcludedClassesMatchers.add(matcher);
+        }
         AgentBuilder.LocationStrategy locationStrategy = AgentBuilder.LocationStrategy.ForClassLoader.WEAK;
         if (agentJarFile != null) {
             try {
@@ -678,7 +687,7 @@ public class ElasticApmAgent {
             .or(nameStartsWith("com.contrastsecurity."))
             .or(nameContains("javassist"))
             .or(nameContains(".asm."))
-            .or(anyMatch(coreConfiguration.getDefaultClassesExcludedFromInstrumentation()))
+            .or(anyMatchExcept(coreConfiguration.getDefaultClassesExcludedFromInstrumentation(), includeDefaultExcludedClassesMatchers))
             .or(anyMatch(coreConfiguration.getClassesExcludedFromInstrumentation()))
             .disableClassFormatChanges();
     }
@@ -732,19 +741,24 @@ public class ElasticApmAgent {
                     appliedInstrumentations = Collections.unmodifiableSet(appliedInstrumentations);
                     dynamicallyInstrumentedClasses.put(classToInstrument, appliedInstrumentations);
 
+                    List<ElasticApmInstrumentation> instrumentations = new ArrayList<>(instrumentationClasses.size());
+                    for (Class<? extends ElasticApmInstrumentation> instrumentationClass : instrumentationClasses) {
+                        ElasticApmInstrumentation apmInstrumentation = instantiate(instrumentationClass);
+                        adviceClassName2instrumentationClassLoader.put(
+                            apmInstrumentation.getAdviceClassName(),
+                            ObjectUtils.systemClassLoaderIfNull(instrumentationClass.getClassLoader()));
+                        instrumentations.add(apmInstrumentation);
+                    }
+
                     CoreConfiguration config = tracer.getConfig(CoreConfiguration.class);
                     final Logger logger = LoggerFactory.getLogger(ElasticApmAgent.class);
                     final ByteBuddy byteBuddy = new ByteBuddy()
                         .with(TypeValidation.of(logger.isDebugEnabled()))
                         .with(FailSafeDeclaredMethodsCompiler.INSTANCE);
                     AgentBuilder agentBuilder = getAgentBuilder(
-                        byteBuddy, config, logger, AgentBuilder.DescriptionStrategy.Default.POOL_ONLY, false, false
+                        byteBuddy, config, logger, instrumentations, AgentBuilder.DescriptionStrategy.Default.POOL_ONLY, false, false
                     );
-                    for (Class<? extends ElasticApmInstrumentation> instrumentationClass : instrumentationClasses) {
-                        ElasticApmInstrumentation apmInstrumentation = instantiate(instrumentationClass);
-                        adviceClassName2instrumentationClassLoader.put(
-                            apmInstrumentation.getAdviceClassName(),
-                            ObjectUtils.systemClassLoaderIfNull(instrumentationClass.getClassLoader()));
+                    for (ElasticApmInstrumentation apmInstrumentation : instrumentations) {
                         ElementMatcher.Junction<? super TypeDescription> typeMatcher = getTypeMatcher(classToInstrument, apmInstrumentation.getMethodMatcher(), none());
                         if (typeMatcher != null && isIncluded(apmInstrumentation, config)) {
                             agentBuilder = applyAdvice(tracer, agentBuilder, apmInstrumentation, typeMatcher.and(apmInstrumentation.getTypeMatcher()));

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchers.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchers.java
@@ -254,6 +254,28 @@ public class CustomElementMatchers {
         };
     }
 
+    public static ElementMatcher.Junction<NamedElement> anyMatchExcept(final List<WildcardMatcher> matchers, final List<ElementMatcher<? super NamedElement>> excepts) {
+        return new ElementMatcher.Junction.AbstractBase<NamedElement>() {
+            @Override
+            public boolean matches(NamedElement target) {
+                if (WildcardMatcher.isAnyMatch(matchers, target.getActualName())) {
+                    for (ElementMatcher<? super NamedElement> except : excepts) {
+                        if (except.matches(target)) {
+                            return false;
+                        }
+                    }
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public String toString() {
+                return "matches((" + matchers + ") except (" + excepts + "))";
+            }
+        };
+    }
+
     public static ElementMatcher.Junction<AnnotationSource> annotationMatches(final String annotationWildcard) {
         return AnnotationMatcher.annotationMatcher(annotationWildcard);
     }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchersTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchersTest.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.apm.agent.bci.bytebuddy;
 
+import co.elastic.apm.agent.matcher.WildcardMatcher;
 import net.bytebuddy.description.type.TypeDescription;
 import org.apache.http.client.HttpClient;
 import org.junit.jupiter.api.Test;
@@ -31,13 +32,23 @@ import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.List;
 
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.anyMatchExcept;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.implementationVersionLte;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPackage;
+import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class CustomElementMatchersTest {
+
+    @Test
+    void testAnyMatchExcept() {
+        final TypeDescription thisClass = TypeDescription.ForLoadedType.of(getClass());
+        assertThat(anyMatchExcept(List.of(WildcardMatcher.valueOf("co.elastic.apm.agent*")), List.of(none())).matches(thisClass)).isTrue();
+        assertThat(anyMatchExcept(List.of(WildcardMatcher.valueOf("co.elastic.apm.agent*")), List.of(named("co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchersTest"))).matches(thisClass)).isFalse();
+        assertThat(anyMatchExcept(List.of(WildcardMatcher.valueOf("co.elastic.apm.agent*")), List.of(none(), named("co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchersTest"))).matches(thisClass)).isFalse();
+    }
 
     @Test
     void testIncludedPackages() {

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/ElasticApmInstrumentation.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/ElasticApmInstrumentation.java
@@ -92,6 +92,15 @@ import static net.bytebuddy.matcher.ElementMatchers.any;
  */
 public abstract class ElasticApmInstrumentation {
     /**
+     * The type matcher selects types which should be considered for instrumentation although they are excluded by the
+     * configuration classes_excluded_from_instrumentation_default.
+     */
+    @Nullable
+    public ElementMatcher<? super NamedElement> getTypeMatcherIncludeDefaultExcludedClasses() {
+        return null;
+    }
+
+    /**
      * Pre-select candidates solely based on the class name for the slower {@link #getTypeMatcher()},
      * at the expense of potential false negative matches.
      * <p>


### PR DESCRIPTION
## What does this PR do?
Fixes #1919

## Checklist
- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation