### PR TITLE
Make sure trace context headers are added only once

### DIFF
--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/ApacheHttpAsyncClientInstrumentation.java
@@ -20,7 +20,6 @@ package co.elastic.apm.agent.httpclient;
 
 import co.elastic.apm.agent.http.client.HttpClientHelper;
 import co.elastic.apm.agent.httpclient.helper.ApacheHttpAsyncClientHelper;
-import co.elastic.apm.agent.httpclient.helper.RequestHeaderAccessor;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.sdk.advice.AssignTo;
@@ -102,11 +101,11 @@ public class ApacheHttpAsyncClientInstrumentation extends BaseApacheHttpClientIn
                     .withSubtype(HttpClientHelper.HTTP_SUBTYPE)
                     .activate();
 
-                wrappedProducer = asyncHelper.wrapRequestProducer(requestProducer, span, null, RequestHeaderAccessor.INSTANCE);
+                wrappedProducer = asyncHelper.wrapRequestProducer(requestProducer, span, null);
                 wrappedFutureCallback = asyncHelper.wrapFutureCallback(futureCallback, context, span);
                 responseFutureWrapped = true;
             } else {
-                wrappedProducer = asyncHelper.wrapRequestProducer(requestProducer, null, parent, RequestHeaderAccessor.INSTANCE);
+                wrappedProducer = asyncHelper.wrapRequestProducer(requestProducer, null, parent);
             }
             return new Object[]{wrappedProducer, wrappedFutureCallback, responseFutureWrapped, span};
         }

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/helper/ApacheHttpAsyncClientHelper.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/main/java/co/elastic/apm/agent/httpclient/helper/ApacheHttpAsyncClientHelper.java
@@ -20,11 +20,9 @@ package co.elastic.apm.agent.httpclient.helper;
 
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Span;
-import co.elastic.apm.agent.impl.transaction.TextHeaderSetter;
 import co.elastic.apm.agent.objectpool.Allocator;
 import co.elastic.apm.agent.objectpool.ObjectPool;
 import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
-import org.apache.http.HttpRequest;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.nio.protocol.HttpAsyncRequestProducer;
 import org.apache.http.protocol.HttpContext;
@@ -66,8 +64,8 @@ public class ApacheHttpAsyncClientHelper {
     }
 
     public HttpAsyncRequestProducer wrapRequestProducer(HttpAsyncRequestProducer requestProducer, @Nullable Span span,
-                                                        @Nullable AbstractSpan<?> parent, TextHeaderSetter<HttpRequest> headerSetter) {
-        return requestProducerWrapperObjectPool.createInstance().with(requestProducer, span, parent, headerSetter);
+                                                        @Nullable AbstractSpan<?> parent) {
+        return requestProducerWrapperObjectPool.createInstance().with(requestProducer, span, parent);
     }
 
     public <T> FutureCallback<T> wrapFutureCallback(FutureCallback<T> futureCallback, HttpContext context, Span span) {

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/GrpcHelper.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/GrpcHelper.java
@@ -26,6 +26,7 @@ import co.elastic.apm.agent.impl.transaction.Outcome;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TextHeaderGetter;
 import co.elastic.apm.agent.impl.transaction.TextHeaderSetter;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.sdk.weakmap.WeakMapSupplier;
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
@@ -350,7 +351,10 @@ public class GrpcHelper {
 
         clientCallListenerSpans.put(listener, span);
 
-        span.propagateTraceContext(headers, headerSetter);
+        if (!TraceContext.containsTraceContextTextHeaders(headers, headerGetter)) {
+            span.propagateTraceContext(headers, headerSetter);
+        }
+
         return span;
     }
 

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -46,8 +46,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static co.elastic.apm.agent.impl.transaction.TraceContext.W3C_TRACE_PARENT_TEXTUAL_HEADER_NAME;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.any;
 import static com.github.tomakehurst.wiremock.client.WireMock.anyRequestedFor;
@@ -114,14 +116,17 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
     public void testContextPropagationFromExitParent() {
         String path = "/";
         Span exitSpan = Objects.requireNonNull(Objects.requireNonNull(Objects.requireNonNull(tracer.currentTransaction()).createExitSpan()));
-        exitSpan.withType("custom").withSubtype("exit");
-        exitSpan.getContext().getDestination().withAddress("test-host").withPort(6000);
-        exitSpan.getContext().getDestination().getService().withResource("test-resource");
-        exitSpan.activate();
-        performGetWithinTransaction(path);
-        verifyTraceContextHeaders(exitSpan, path);
-        assertThat(reporter.getSpans()).isEmpty();
-        exitSpan.deactivate().end();
+        try {
+            exitSpan.withType("custom").withSubtype("exit");
+            exitSpan.getContext().getDestination().withAddress("test-host").withPort(6000);
+            exitSpan.getContext().getDestination().getService().withResource("test-resource");
+            exitSpan.activate();
+            performGetWithinTransaction(path);
+            verifyTraceContextHeaders(exitSpan, path);
+            assertThat(reporter.getSpans()).isEmpty();
+        } finally {
+            exitSpan.deactivate().end();
+        }
     }
 
     @Test
@@ -210,8 +215,20 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
                 assertThat(tmp).isNotEmpty();
             });
         loggedRequests.get().forEach(request -> {
-            assertThat(TraceContext.containsTraceContextTextHeaders(request, new HeaderAccessor())).isTrue();
+            assertThat(TraceContext.containsTraceContextTextHeaders(request, HeaderAccessor.INSTANCE)).isTrue();
+            AtomicInteger headerCount = new AtomicInteger();
+            HeaderAccessor.INSTANCE.forEach(
+                W3C_TRACE_PARENT_TEXTUAL_HEADER_NAME,
+                request,
+                headerCount,
+                (headerValue, state) -> state.incrementAndGet()
+            );
+            assertThat(headerCount.get()).isEqualTo(1);
             headerMap.forEach((key, value) -> assertThat(request.getHeader(key)).isEqualTo(value));
+            Transaction transaction = tracer.startChildTransaction(request, new HeaderAccessor(), AbstractHttpClientInstrumentationTest.class.getClassLoader());
+            assertThat(transaction).isNotNull();
+            assertThat(transaction.getTraceContext().getTraceId()).isEqualTo(span.getTraceContext().getTraceId());
+            assertThat(transaction.getTraceContext().getParentId()).isEqualTo(span.getTraceContext().getId());
         });
     }
 
@@ -280,6 +297,9 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
     protected abstract void performGet(String path) throws Exception;
 
     private static class HeaderAccessor implements TextHeaderGetter<LoggedRequest> {
+
+        static final HeaderAccessor INSTANCE = new HeaderAccessor();
+
         @Nullable
         @Override
         public String getFirstHeader(String headerName, LoggedRequest loggedRequest) {

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3ClientAsyncInstrumentation.java
@@ -22,6 +22,7 @@ import co.elastic.apm.agent.http.client.HttpClientHelper;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Outcome;
 import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.sdk.advice.AssignTo;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -82,15 +83,20 @@ public class OkHttp3ClientAsyncInstrumentation extends AbstractOkHttp3ClientInst
             Span span = HttpClientHelper.startHttpClientSpan(parent, request.method(), url.toString(), url.scheme(),
                 OkHttpClientHelper.computeHostName(url.host()), url.port());
 
-            Request.Builder builder = originalRequest.newBuilder();
             if (span != null) {
                 span.activate();
-                span.propagateTraceContext(builder, OkHttp3RequestHeaderSetter.INSTANCE);
-                request = builder.build();
-                callback = CallbackWrapperCreator.INSTANCE.wrap(callback, span);
-            } else {
-                parent.propagateTraceContext(builder, OkHttp3RequestHeaderSetter.INSTANCE);
-                request = builder.build();
+            }
+
+            if (!TraceContext.containsTraceContextTextHeaders(request, OkHttp3RequestHeaderGetter.INSTANCE)) {
+                Request.Builder builder = originalRequest.newBuilder();
+                if (span != null) {
+                    span.propagateTraceContext(builder, OkHttp3RequestHeaderSetter.INSTANCE);
+                    request = builder.build();
+                    callback = CallbackWrapperCreator.INSTANCE.wrap(callback, span);
+                } else {
+                    parent.propagateTraceContext(builder, OkHttp3RequestHeaderSetter.INSTANCE);
+                    request = builder.build();
+                }
             }
             return new Object[]{request, callback, span};
         }

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3RequestHeaderGetter.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttp3RequestHeaderGetter.java
@@ -16,20 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.resttemplate;
+package co.elastic.apm.agent.okhttp;
 
-import co.elastic.apm.agent.impl.transaction.TextHeaderSetter;
-import org.springframework.http.HttpRequest;
+import co.elastic.apm.agent.impl.transaction.AbstractHeaderGetter;
+import co.elastic.apm.agent.impl.transaction.TextHeaderGetter;
+import okhttp3.Headers;
+import okhttp3.Request;
 
-public class SpringRestRequestHeaderSetter implements TextHeaderSetter<HttpRequest> {
+import javax.annotation.Nullable;
 
-    public static final SpringRestRequestHeaderSetter INSTANCE = new SpringRestRequestHeaderSetter();
+public class OkHttp3RequestHeaderGetter extends AbstractHeaderGetter<String, Request> implements TextHeaderGetter<Request> {
 
+    public static final OkHttp3RequestHeaderGetter INSTANCE = new OkHttp3RequestHeaderGetter();
+
+    @Nullable
     @Override
-    public void setHeader(String headerName, String headerValue, HttpRequest request) {
-        if (!request.getHeaders().containsKey(headerName)) {
-            // the org.springframework.http.HttpRequest has only be introduced in 3.1.0
-            request.getHeaders().add(headerName, headerValue);
+    public String getFirstHeader(String headerName, Request carrier) {
+        Headers headers = carrier.headers();
+        if (headers == null) {
+            return null;
         }
+        return headers.get(headerName);
     }
 }

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpRequestHeaderGetter.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpRequestHeaderGetter.java
@@ -16,20 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.resttemplate;
+package co.elastic.apm.agent.okhttp;
 
-import co.elastic.apm.agent.impl.transaction.TextHeaderSetter;
-import org.springframework.http.HttpRequest;
+import co.elastic.apm.agent.impl.transaction.AbstractHeaderGetter;
+import co.elastic.apm.agent.impl.transaction.TextHeaderGetter;
+import com.squareup.okhttp.Headers;
+import com.squareup.okhttp.Request;
 
-public class SpringRestRequestHeaderSetter implements TextHeaderSetter<HttpRequest> {
+import javax.annotation.Nullable;
 
-    public static final SpringRestRequestHeaderSetter INSTANCE = new SpringRestRequestHeaderSetter();
+public class OkHttpRequestHeaderGetter extends AbstractHeaderGetter<String, Request> implements TextHeaderGetter<Request> {
 
+    public static final OkHttpRequestHeaderGetter INSTANCE = new OkHttpRequestHeaderGetter();
+
+    @Nullable
     @Override
-    public void setHeader(String headerName, String headerValue, HttpRequest request) {
-        if (!request.getHeaders().containsKey(headerName)) {
-            // the org.springframework.http.HttpRequest has only be introduced in 3.1.0
-            request.getHeaders().add(headerName, headerValue);
+    public String getFirstHeader(String headerName, Request carrier) {
+        Headers headers = carrier.headers();
+        if (headers == null) {
+            return null;
         }
+        return headers.get(headerName);
     }
 }

--- a/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-plugin/pom.xml
@@ -42,6 +42,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-okhttp-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.3.6</version>

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
@@ -80,12 +80,12 @@ public abstract class HttpUrlConnectionInstrumentation extends TracerAwareInstru
             if (span == null && !connected) {
                 final URL url = thiz.getURL();
                 span = HttpClientHelper.startHttpClientSpan(parent, thiz.getRequestMethod(), url.toString(), url.getProtocol(), url.getHost(), url.getPort());
-                if (span != null) {
-                    if (!TraceContext.containsTraceContextTextHeaders(thiz, UrlConnectionPropertyAccessor.instance())) {
+                if (!TraceContext.containsTraceContextTextHeaders(thiz, UrlConnectionPropertyAccessor.instance())) {
+                    if (span != null) {
                         span.propagateTraceContext(thiz, UrlConnectionPropertyAccessor.instance());
+                    } else {
+                        parent.propagateTraceContext(thiz, UrlConnectionPropertyAccessor.instance());
                     }
-                } else {
-                    parent.propagateTraceContext(thiz, UrlConnectionPropertyAccessor.instance());
                 }
             }
             if (span != null) {


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Make sure trace context headers are added only once to outgoing calls, even if the protocol supports multiple values per header (like in HTTP).
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->
- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
