### PR TITLE
Work-around for Jackson & instrumentation issues on Java15+

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/JsonUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/JsonUtils.java
@@ -18,12 +18,35 @@
  */
 package co.elastic.apm.agent;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+import java.io.IOException;
+import java.nio.CharBuffer;
 
 public class JsonUtils {
 
-    private static final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper;
+
+    static {
+        objectMapper = new ObjectMapper();
+
+        // using default serializer for CharBuffer will try to make some properties accessible using introspection
+        // which fails with Java 15+ and we don't need in practice, thus using a custom serializer allows to avoid this.
+        SimpleModule module = new SimpleModule();
+        module.addSerializer(CharBuffer.class, new StdSerializer<CharBuffer>(CharBuffer.class) {
+
+            @Override
+            public void serialize(CharBuffer charBuffer, JsonGenerator jsonGenerator, SerializerProvider serializerProvider) throws IOException {
+                jsonGenerator.writeString(charBuffer.toString());
+            }
+        });
+        objectMapper.registerModule(module);
+    }
 
     public static JsonNode toJson(Object o) {
         return objectMapper.valueToTree(o);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -294,7 +294,7 @@ class InstrumentationTest {
     }
 
     @Test
-    @DisabledOnJre(JRE.JAVA_15)
+    @DisabledOnJre(JRE.JAVA_15) // https://github.com/elastic/apm-agent-java/issues/1944
     void testPatchClassFileVersionJava5ToJava7() {
         // loading classes compiled with bytecode level 49 (Java 6)
         new org.slf4j.event.SubstituteLoggingEvent();
@@ -314,7 +314,7 @@ class InstrumentationTest {
     }
 
     @Test
-    @DisabledOnJre(JRE.JAVA_15)
+    @DisabledOnJre(JRE.JAVA_15) // https://github.com/elastic/apm-agent-java/issues/1944
     void testPatchClassFileVersionJava5ToJava7CommonsMath() {
         org.apache.commons.math3.stat.StatUtils.max(new double[]{3.14});
 
@@ -333,7 +333,7 @@ class InstrumentationTest {
     }
 
     @Test
-    @DisabledOnJre(JRE.JAVA_15)
+    @DisabledOnJre(JRE.JAVA_15) // https://github.com/elastic/apm-agent-java/issues/1944
     void testPatchClassFileVersionJava4ToJava7CommonsMath() {
         org.apache.log4j.LogManager.exists("not");
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -43,6 +43,8 @@ import org.apache.commons.pool2.impl.CallStackUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.slf4j.event.SubstituteLoggingEvent;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
@@ -292,6 +294,7 @@ class InstrumentationTest {
     }
 
     @Test
+    @DisabledOnJre(JRE.JAVA_15)
     void testPatchClassFileVersionJava5ToJava7() {
         // loading classes compiled with bytecode level 49 (Java 6)
         new org.slf4j.event.SubstituteLoggingEvent();
@@ -311,6 +314,7 @@ class InstrumentationTest {
     }
 
     @Test
+    @DisabledOnJre(JRE.JAVA_15)
     void testPatchClassFileVersionJava5ToJava7CommonsMath() {
         org.apache.commons.math3.stat.StatUtils.max(new double[]{3.14});
 
@@ -329,6 +333,7 @@ class InstrumentationTest {
     }
 
     @Test
+    @DisabledOnJre(JRE.JAVA_15)
     void testPatchClassFileVersionJava4ToJava7CommonsMath() {
         org.apache.log4j.LogManager.exists("not");
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/ContainerInfoTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/payload/ContainerInfoTest.java
@@ -19,6 +19,8 @@
 package co.elastic.apm.agent.impl.payload;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 
 import javax.annotation.Nullable;
 
@@ -117,6 +119,7 @@ public class ContainerInfoTest {
     }
 
     @Test
+    @DisabledOnJre({JRE.JAVA_15, JRE.JAVA_16}) // https://github.com/elastic/apm-agent-java/issues/1942
     void testKubernetesDownwardApi() throws Exception {
         String line = "1:name=systemd:/kubepods/besteffort/pode9b90526-f47d-11e8-b2a5-080027b9f4fb/15aa6e53-b09a-40c7-8558-c6c31e36c88a";
         String containerId = "15aa6e53-b09a-40c7-8558-c6c31e36c88a";

--- a/apm-agent-plugins/apm-grails-plugin/pom.xml
+++ b/apm-agent-plugins/apm-grails-plugin/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
             <groupId>org.grails</groupId>
             <artifactId>grails-web-mvc</artifactId>
-            <version>4.0.3</version>
+            <version>4.1.0.M4</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <version.error_prone>2.2.0</version.error_prone>
         <version.h2>1.4.196</version.h2>
         <!-- jackson 2.12.x is the latest branch with Java 7 compatibility -->
-        <version.jackson>2.12.4</version.jackson>
+        <version.jackson>[2.12.4,2.12.99999)</version.jackson>
         <version.junit-jupiter>5.7.2</version.junit-jupiter>
         <version.junit.vintage>4.13.2</version.junit.vintage>
         <version.junit-vintage-engine>5.7.2</version.junit-vintage-engine>

--- a/pom.xml
+++ b/pom.xml
@@ -96,8 +96,7 @@
         <!-- -dependencies versions -->
         <version.error_prone>2.2.0</version.error_prone>
         <version.h2>1.4.196</version.h2>
-        <!-- jackson 2.12.x is the latest branch with Java 7 compatibility -->
-        <version.jackson>[2.12.4,2.12.99999)</version.jackson>
+        <version.jackson>[2.10.0,)</version.jackson>
         <version.junit-jupiter>5.7.2</version.junit-jupiter>
         <version.junit.vintage>4.13.2</version.junit.vintage>
         <version.junit-vintage-engine>5.7.2</version.junit-vintage-engine>
@@ -357,6 +356,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,8 @@
         <!-- -dependencies versions -->
         <version.error_prone>2.2.0</version.error_prone>
         <version.h2>1.4.196</version.h2>
-        <version.jackson>[2.10.0,)</version.jackson>
+        <!-- jackson 2.12.x is the latest branch with Java 7 compatibility -->
+        <version.jackson>2.12.4</version.jackson>
         <version.junit-jupiter>5.7.2</version.junit-jupiter>
         <version.junit.vintage>4.13.2</version.junit.vintage>
         <version.junit-vintage-engine>5.7.2</version.junit-vintage-engine>


### PR DESCRIPTION
## What does this PR do?

Work-around for compatibility issue with Jackson JSON serialization on Java 15 and 16.
~~Also, rollback jackson version to 2.12.x branch to ensure Java7 compatibility (2.13.x is built with Java 8) ([see doc](https://github.com/FasterXML/jackson#active-developed-jackson-2x-branches))~~
