### PR TITLE
[CI] Disable compatibility test matrix for unit tests on a PR basis

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -310,7 +310,6 @@ pipeline {
       when {
         beforeAgent true
         anyOf {
-          not { changeRequest() }
           expression { return params.compatibility_ci }
           expression { return env.GITHUB_COMMENT?.contains('compatibility tests') }
         }


### PR DESCRIPTION
## What does this PR do?

As stated, compatibility tests should not run on a PR basis.