### PR TITLE
changed File.separator* to System.getProperty("file.separator") so that the runtime uses the correct character

### DIFF
--- a/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/UserRegistry.java
+++ b/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/UserRegistry.java
@@ -160,9 +160,9 @@ public class UserRegistry {
 
         public static String getCurrentJvm() {
             return System.getProperty("java.home") +
-                File.separator +
+                System.getProperty("file.separator")  +
                 "bin" +
-                File.separator +
+                System.getProperty("file.separator") +
                 "java" +
                 (Platform.isWindows() ? ".exe" : "");
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/ProcessFactory.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/payload/ProcessFactory.java
@@ -94,7 +94,8 @@ public interface ProcessFactory {
 
         private String getTitle() {
             String javaHome = java.lang.System.getProperty("java.home");
-            final String title = javaHome + File.separator + "bin" + File.separator + "java";
+            final String title = javaHome + System.getProperty("file.separator") + 
+                    "bin" + System.getProperty("file.separator") + "java";
             if (java.lang.System.getProperty("os.name").startsWith("Win")) {
                 return title + ".exe";
             }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/CGroupMetrics.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/CGroupMetrics.java
@@ -173,13 +173,13 @@ public class CGroupMetrics extends AbstractLifecycleListener {
     private CgroupFiles createCgroup2Files(String cgroupLine, File rootCgroupFsPath) throws IOException {
         final String[] cgroupLineParts = StringUtils.split(cgroupLine, ':');
         String sliceSubdir = cgroupLineParts[cgroupLineParts.length - 1];
-        File maxMemoryFile = new File(rootCgroupFsPath, sliceSubdir + File.separatorChar + CGROUP2_MAX_MEMORY);
+        File maxMemoryFile = new File(rootCgroupFsPath, sliceSubdir + System.getProperty("file.separator") + CGROUP2_MAX_MEMORY);
         if (maxMemoryFile.canRead()) {
             maxMemoryFile = getMaxMemoryFile(maxMemoryFile, CGROUP2_UNLIMITED);
             return new CgroupFiles(
                 maxMemoryFile,
-                new File(rootCgroupFsPath, sliceSubdir + File.separator + CGROUP2_USED_MEMORY),
-                new File(rootCgroupFsPath, sliceSubdir + File.separator + CGROUP_MEMORY_STAT)
+                new File(rootCgroupFsPath, sliceSubdir + System.getProperty("file.separator") + CGROUP2_USED_MEMORY),
+                new File(rootCgroupFsPath, sliceSubdir + System.getProperty("file.separator") + CGROUP_MEMORY_STAT)
             );
         }
         return null;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
@@ -86,7 +86,7 @@ public class PackageScanner {
             public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
                 if (file.toString().endsWith(".class")) {
                     // We need to escape both the filesystem-specific separator and the explicit `/` separator that may be added by the relativize() implementation
-                    String classNameSuffix = basePath.relativize(file).toString().replace(File.separatorChar, '.').replace('/', '.').replace(".class", "");
+                    String classNameSuffix = basePath.relativize(file).toString().replace(System.getProperty("file.separator"), ".").replace('/', '.').replace(".class", "");
                     classNames.add(basePackage + "." + classNameSuffix);
                 }
                 return FileVisitResult.CONTINUE;

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-log-shader-plugin-common/src/test/java/co/elastic/apm/agent/log/shader/UtilsTest.java
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-log-shader-plugin-common/src/test/java/co/elastic/apm/agent/log/shader/UtilsTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.when;
 
 public class UtilsTest extends AbstractInstrumentationTest {
 
-    private static final String fileSeparator = File.separator;
+    private static final String fileSeparator = System.getProperty("file.separator");
 
     @Nullable
     private final String logEcsFormattingDestinationDir = config.getConfig(LoggingConfiguration.class).getLogEcsFormattingDestinationDir();

--- a/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/ProcessHelper.java
+++ b/apm-agent-plugins/apm-process-plugin/src/main/java/co/elastic/apm/agent/process/ProcessHelper.java
@@ -75,7 +75,7 @@ class ProcessHelper {
     }
 
     private static String getBinaryName(String processName) {
-        int lastSeparator = processName.lastIndexOf(File.separatorChar);
+        int lastSeparator = processName.lastIndexOf(System.getProperty("file.separator"));
         return lastSeparator < 0 ? processName : processName.substring(lastSeparator + 1);
     }
 


### PR DESCRIPTION
## What does this PR do?
All `File.separator*` clauses changed to `System.getProperty("file.separator")`

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
