### PR TITLE
Warn about using non-initialized tracer

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/GlobalTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/GlobalTracer.java
@@ -32,7 +32,7 @@ import java.util.Objects;
 public class GlobalTracer implements Tracer {
 
     private static final GlobalTracer INSTANCE = new GlobalTracer();
-    private volatile Tracer tracer = NoopTracer.INSTANCE;
+    private volatile Tracer tracer = new NoopTracer(TracerState.UNINITIALIZED);
 
     private GlobalTracer() {
     }
@@ -51,7 +51,9 @@ public class GlobalTracer implements Tracer {
     }
 
     public static ElasticApmTracer requireTracerImpl() {
-        return Objects.requireNonNull(getTracerImpl(), "Registered tracer is not an instance of ElasticApmTracer");
+        return Objects.requireNonNull(getTracerImpl(), "Elastic APM Agent is not initialized. Make sure to remove " +
+            "any classpath reference or explicit dependency of the agent. The agent should only be attached using the " +
+            "documented methods and never referenced otherwise.");
     }
 
     public static synchronized void setNoop() {
@@ -59,7 +61,7 @@ public class GlobalTracer implements Tracer {
         if (currentTracerState != TracerState.UNINITIALIZED && currentTracerState != TracerState.STOPPED) {
              throw new IllegalStateException("Can't override tracer as current tracer is already running");
         }
-        INSTANCE.tracer = NoopTracer.INSTANCE;
+        INSTANCE.tracer = new NoopTracer(currentTracerState);
     }
 
     public static synchronized void init(Tracer tracer) {
@@ -70,7 +72,7 @@ public class GlobalTracer implements Tracer {
     }
 
     public static boolean isNoop() {
-        return INSTANCE.tracer == NoopTracer.INSTANCE;
+        return INSTANCE.tracer instanceof NoopTracer;
     }
 
     @Nullable

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/NoopTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/NoopTracer.java
@@ -30,111 +30,143 @@ import javax.annotation.Nullable;
 
 class NoopTracer implements Tracer {
 
-    static final Tracer INSTANCE = new NoopTracer();
+    private static final String NON_INITIALIZED_ERROR_MESSAGE = "Attempting to trace using an uninitialized tracer. " +
+        "Make sure to remove any classpath reference or explicit dependency of the agent. The agent should only be " +
+        "attached using the documented methods and never referenced otherwise.";
 
-    private NoopTracer() {
+    private final TracerState tracerState;
+
+    NoopTracer(TracerState tracerState) {
+        this.tracerState = tracerState;
+    }
+
+    /**
+     * Throwing an error if the tracer was not yet initialized.
+     * This can support future capability to stop and reset the tracer after it was initialized, but assumes that no
+     * instrumentation should attempt to invoke any actual tracer operations prior to the first tracer initialization.
+     */
+    private void throwExceptionIfNotInitialized() {
+        if (tracerState == TracerState.UNINITIALIZED) {
+            throw new IllegalStateException(NON_INITIALIZED_ERROR_MESSAGE);
+        }
     }
 
     @Nullable
     @Override
     public Transaction startRootTransaction(@Nullable ClassLoader initiatingClassLoader) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public Transaction startRootTransaction(@Nullable ClassLoader initiatingClassLoader, long epochMicro) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public Transaction startRootTransaction(Sampler sampler, long epochMicros, @Nullable ClassLoader initiatingClassLoader) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, @Nullable ClassLoader initiatingClassLoader) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, @Nullable ClassLoader initiatingClassLoader, long epochMicros) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, Sampler sampler, long epochMicros, @Nullable ClassLoader initiatingClassLoader) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public <C> Transaction startChildTransaction(@Nullable C headerCarrier, BinaryHeaderGetter<C> binaryHeadersGetter, @Nullable ClassLoader initiatingClassLoader) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public <C> Transaction startChildTransaction(@Nullable C headerCarrier, BinaryHeaderGetter<C> binaryHeadersGetter, Sampler sampler, long epochMicros, @Nullable ClassLoader initiatingClassLoader) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public Transaction currentTransaction() {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public AbstractSpan<?> getActive() {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public Span getActiveSpan() {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Override
     public void captureAndReportException(@Nullable Throwable e, ClassLoader initiatingClassLoader) {
-
+        throwExceptionIfNotInitialized();
     }
 
     @Nullable
     @Override
     public String captureAndReportException(long epochMicros, @Nullable Throwable e, @Nullable AbstractSpan<?> parent) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public ErrorCapture captureException(@Nullable Throwable e, @Nullable AbstractSpan<?> parent, @Nullable ClassLoader initiatingClassLoader) {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Nullable
     @Override
     public Span getActiveExitSpan() {
+        throwExceptionIfNotInitialized();
         return null;
     }
 
     @Override
     public TracerState getState() {
-        return TracerState.UNINITIALIZED;
+        return tracerState;
     }
 
     @Override
     public void overrideServiceNameForClassLoader(@Nullable ClassLoader classLoader, @Nullable String serviceName) {
+        throwExceptionIfNotInitialized();
     }
 
     @Override
     public void stop() {
+        throw new UnsupportedOperationException("Cannot stop a noop tracer");
     }
 
     @Override
@@ -145,6 +177,7 @@ class NoopTracer implements Tracer {
     @Nullable
     @Override
     public Span createExitChildSpan() {
+        throwExceptionIfNotInitialized();
         return null;
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/NoopTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/NoopTracerTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.impl;
+
+import co.elastic.apm.agent.MockTracer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NoopTracerTest {
+
+    @Test
+    void testThrownException() {
+        GlobalTracer.init(new NoopTracer(Tracer.TracerState.UNINITIALIZED));
+        assertThat(GlobalTracer.isNoop()).isTrue();
+        assertThatIllegalStateException().isThrownBy(() -> GlobalTracer.get().currentTransaction());
+        assertThatIllegalStateException().isThrownBy(() -> GlobalTracer.get().startRootTransaction(getClass().getClassLoader()));
+        assertThatIllegalStateException().isThrownBy(() -> GlobalTracer.get().captureAndReportException(new Exception(), getClass().getClassLoader()));
+
+        // mimic tracer initialization and then stopping and setting a noop tracer
+        GlobalTracer.init(MockTracer.createRealTracer());
+        assertThat(GlobalTracer.isNoop()).isFalse();
+        assertThatThrownBy(GlobalTracer::setNoop).isInstanceOf(IllegalStateException.class);
+        GlobalTracer.get().stop();
+        GlobalTracer.setNoop();
+        assertThat(GlobalTracer.isNoop()).isTrue();
+
+        // now invoking tracing operations on the noop tracer is allowed
+        assertThat(GlobalTracer.get().currentTransaction()).isNull();
+        assertThat(GlobalTracer.get().startRootTransaction(null)).isNull();
+        assertThatNoException().isThrownBy(() -> GlobalTracer.get().captureAndReportException(new Exception(), getClass().getClassLoader()));
+    }
+}

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -10,6 +10,10 @@ Here are some guidelines how to find out what's going wrong.
 
 As a first step, please check if your stack is compatible with the currently <<supported-technologies,supported technologies>>.
 
+The most common source for tracing issues is an improper setup. Take the time to go over the <<setup, setup guidelines>>
+again and verify everything is configured as it should. In particular, make sure you are not referencing the agent jar
+from anywhere in your application's classpath and not using it as a "regular" dependency.
+
 Don't worry if you can't figure out what the problem is.
 Open a topic in the https://discuss.elastic.co/c/apm[APM discuss forum]
 and we will help you out.


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Warn when trying to invoke tracing operations before tracer initialization.
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my feature works
  - [x] I have added a description of the issue to the troubleshooting page
