### PR TITLE
Restoring instrumentation to io.grpc.internal.ManagedChannelImpl

### DIFF
--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ChannelInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ChannelInstrumentation.java
@@ -35,7 +35,6 @@ import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 
 /**
  * Instruments {@link Channel#newCall(MethodDescriptor, CallOptions)} to add channel authority (host+port) to the span
@@ -45,12 +44,7 @@ public class ChannelInstrumentation extends BaseInstrumentation {
 
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("io.grpc")
-            .and(nameContains("Channel"))
-            // for recent versions (found with 1.35), this implementation creates extra spans
-            // that are not necessary. As those aren't nested, the "active" and "exit span" do not allow to properly
-            // ignore those internal spans
-            .and(not(nameContains("io.grpc.internal.ManagedChannelImpl$RealChannel")));
+        return nameStartsWith("io.grpc").and(nameContains("Channel"));
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Attempting to fix failure to capture gRPC client spans. Context: https://discuss.elastic.co/t/java-grpc-client-not-ending-spans-and-not-reporting-to-apm/280643.

The first stage is just to restore the instrumentation of this `Channel` implementation, but it means client tests for latest version will fail. If we see the issue is resolved when restoring this instrumentation, next step would be to find a way to exclude the extra span.
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
