### PR TITLE
jdk-httpserver instrumentation is not experimental anymore

### DIFF
--- a/apm-agent-plugins/apm-jdk-httpserver-plugin/src/main/java/co/elastic/apm/agent/httpserver/JdkHttpServerInstrumentation.java
+++ b/apm-agent-plugins/apm-jdk-httpserver-plugin/src/main/java/co/elastic/apm/agent/httpserver/JdkHttpServerInstrumentation.java
@@ -27,6 +27,6 @@ public abstract class JdkHttpServerInstrumentation extends ElasticApmInstrumenta
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        return Arrays.asList("jdk-httpserver", "experimental");
+        return Arrays.asList("jdk-httpserver");
     }
 }


### PR DESCRIPTION
## What does this PR do?
I am using the instrumentation and it works fine so I think it is ok to remove the experimental flag

## Checklist
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
