### PR TITLE
gRPC instrumentation fix and refactoring

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,11 +30,13 @@ endif::[]
 ** Automatically sets `service.node.name` in all log events if set through agent configuration
 ** Add `log_ecs_reformatting_additional_fields` option to support arbitrary fields in logs
 ** Automatically serialize markers as tags where relevant (log4j2 and logback)
+* gRPC spans (client and server) can detect errors or cancellation through custom listeners - {pull}2067[#2067]
 
 [float]
 ===== Bug fixes
 * Fix failure to parse some forms of the `Implementation-Version` property from jar manifest files - {pull}1931[#1931]
 * Ensure single value for context-propagation header - {pull}1937[#1937]
+* Fix gRPC non-terminated (therefore non-reported) client spans - {pull}2067[#2067]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/pom.xml
@@ -37,7 +37,12 @@
             <version>${grpc.version}</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty-shaded</artifactId>
+            <version>${grpc.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-java</artifactId>

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/BaseInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/BaseInstrumentation.java
@@ -19,20 +19,11 @@
 package co.elastic.apm.agent.grpc;
 
 import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
-import net.bytebuddy.description.NamedElement;
-import net.bytebuddy.matcher.ElementMatcher;
 
 import java.util.Collection;
 import java.util.Collections;
 
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
-
 public abstract class BaseInstrumentation extends TracerAwareInstrumentation {
-
-    @Override
-    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("io.grpc");
-    }
 
     @Override
     public final Collection<String> getInstrumentationGroupNames() {

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ChannelInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ChannelInstrumentation.java
@@ -35,7 +35,6 @@ import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 
 /**
  * Instruments {@link Channel#newCall(MethodDescriptor, CallOptions)} to add channel authority (host+port) to the span
@@ -45,12 +44,7 @@ public class ChannelInstrumentation extends BaseInstrumentation {
 
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("io.grpc")
-            .and(nameContains("Channel"))
-            // for recent versions (found with 1.35), this implementation creates extra spans
-            // that are not necessary. As those aren't nested, the "active" and "exit span" do not allow to properly
-            // ignore those internal spans
-            .and(not(nameContains("io.grpc.internal.ManagedChannelImpl$RealChannel")));
+        return nameStartsWith("io.grpc").and(nameContains("Channel"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ClientCallListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ClientCallListenerInstrumentation.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.grpc;
+
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.sdk.DynamicTransformer;
+import io.grpc.ClientCall;
+import io.grpc.Metadata;
+import io.grpc.Status;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+
+import static net.bytebuddy.matcher.ElementMatchers.any;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+
+public abstract class ClientCallListenerInstrumentation extends BaseInstrumentation {
+
+    /**
+     * Overridden in {@link DynamicTransformer#ensureInstrumented(Class, Collection)},
+     * based on the type of the {@linkplain ClientCall.Listener} implementation class.
+     */
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return any();
+    }
+
+    /**
+     * Instruments {@link ClientCall.Listener#onClose(Status, Metadata)} )} to capture any thrown exception and end current span
+     */
+    public static class Close extends ClientCallListenerInstrumentation {
+
+        @Override
+        public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+            return named("onClose");
+        }
+
+        @Override
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.grpc.ClientCallListenerInstrumentation$Close$CloseAdvice";
+        }
+
+        public static class CloseAdvice {
+
+            @Nullable
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static Object onEnter(@Advice.This ClientCall.Listener<?> listener) {
+                return GrpcHelper.getInstance().enterClientListenerMethod(listener);
+            }
+
+            @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+            public static void onExit(@Advice.This ClientCall.Listener<?> listener,
+                                      @Advice.Argument(0) Status status,
+                                      @Advice.Thrown @Nullable Throwable thrown,
+                                      @Advice.Enter @Nullable Object span) {
+
+                GrpcHelper.getInstance().exitClientListenerMethod(thrown, listener, (Span) span, status);
+            }
+        }
+    }
+
+    /**
+     * Generic call listener method to handle span activation and capturing exceptions.
+     * Instruments:
+     * <ul>
+     *     <li>{@link ClientCall.Listener#onMessage(Object)}</li>
+     *     <li>{@link ClientCall.Listener#onHeaders}</li>
+     *     <li>{@link ClientCall.Listener#onReady}</li>
+     * </ul>
+     */
+    public static class OtherListenerMethod extends ClientCallListenerInstrumentation {
+
+        @Override
+        public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+            return named("onMessage")
+                .or(named("onHeaders"))
+                .or(named("onReady"));
+        }
+
+        @Override
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.grpc.ClientCallListenerInstrumentation$OtherListenerMethod$OtherMethodAdvice";
+        }
+
+        public static class OtherMethodAdvice {
+
+            @Nullable
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static Object onEnter(@Advice.This ClientCall.Listener<?> listener) {
+                return GrpcHelper.getInstance().enterClientListenerMethod(listener);
+            }
+
+            @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+            public static void onExit(@Advice.This ClientCall.Listener<?> listener,
+                                      @Advice.Thrown @Nullable Throwable thrown,
+                                      @Advice.Enter @Nullable Object span) {
+
+                GrpcHelper.getInstance().exitClientListenerMethod(thrown, listener, (Span) span, null);
+            }
+        }
+    }
+}

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/DelayedClientCallInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/DelayedClientCallInstrumentation.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.grpc;
+
+import io.grpc.ClientCall;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+/**
+ * Instruments {@code io.grpc.internal.DelayedClientCall#setRealCall(ClientCall)} (introduced in 1.32) to replace the
+ * placeholder {@code DelayedClientCall} instance with the real client call.
+ * {@code setRealCall()} was chosen over {@code setCall()} because it ensures atomicity.
+ * We need to do it this way because prior to 1.35, the creation of the real client call instance could be nested
+ * within the creation of the {@code DelayedClientCall}, in which case a single client span would have been created
+ * for both and we need to replace the mapped key. In later versions, the real and delayed client call instances are
+ * created on different stacks, leading to a span per client call, in which case we need to discard the one
+ * corresponding the delayed call.
+ */
+public class DelayedClientCallInstrumentation extends BaseInstrumentation {
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named("io.grpc.internal.DelayedClientCall");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named("setRealCall").and(takesArgument(0, named("io.grpc.ClientCall")));
+    }
+
+    @Override
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.grpc.DelayedClientCallInstrumentation$DelayedClientCallAdvice";
+    }
+
+    public static class DelayedClientCallAdvice {
+        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+        public static void onEnter(@Advice.This ClientCall<?, ?> placeholderClientCall,
+                                   @Advice.Argument(0) ClientCall<?, ?> realClientCall) {
+
+            GrpcHelper.getInstance().replaceClientCallRegistration(placeholderClientCall, realClientCall);
+        }
+    }
+}

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/GrpcHelper.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/GrpcHelper.java
@@ -372,8 +372,8 @@ public class GrpcHelper {
      *     </li>
      *     <li>
      *         a single span was created and either mapped for both the placeholder and the real call (theoretical),
-     *         in which case we need to do nothing, or mapped only to the placeholder, in which to add a mapping for
-     *         the real client call
+     *         in which case we need to do nothing, or mapped only to the placeholder, in which case we need to add a
+     *         span mapping for the real client call
      *     </li>
      * </ul>
      *

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/GrpcHelper.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/GrpcHelper.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.apm.agent.grpc;
 
+import co.elastic.apm.agent.impl.GlobalTracer;
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.transaction.AbstractHeaderGetter;
@@ -30,6 +31,7 @@ import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.sdk.weakmap.WeakMapSupplier;
 import com.blogspot.mydailyjava.weaklockfree.WeakConcurrentMap;
+import io.grpc.CallOptions;
 import io.grpc.ClientCall;
 import io.grpc.Metadata;
 import io.grpc.MethodDescriptor;
@@ -42,6 +44,9 @@ import javax.annotation.Nullable;
  * Helper class for gRPC client and server calls.
  */
 public class GrpcHelper {
+
+    // todo - replace all accesses to active span with usages of GlobalTracer
+    // todo - replace all maps with values of type Span to SpanConcurrentHashMap
 
     static String GRPC = "grpc";
 
@@ -57,6 +62,11 @@ public class GrpcHelper {
      * Map of all in-flight {@link Span} with {@link ClientCall} instance as key.
      */
     private final WeakConcurrentMap<ClientCall<?, ?>, Span> clientCallSpans;
+
+    /**
+     * Map of all in-flight {@link Span} with {@link ClientCall} instance as key.
+     */
+    private final WeakConcurrentMap<ClientCall<?, ?>, Span> delayedClientCallSpans;
 
     /**
      * Map of all in-flight {@link Span} with {@link ClientCall.Listener} instance as key.
@@ -83,6 +93,7 @@ public class GrpcHelper {
 
     public GrpcHelper() {
         clientCallSpans = WeakMapSupplier.createMap();
+        delayedClientCallSpans = WeakMapSupplier.createMap();
         clientCallListenerSpans = WeakMapSupplier.createMap();
 
         serverListenerTransactions = WeakMapSupplier.createMap();
@@ -143,7 +154,6 @@ public class GrpcHelper {
     public void registerTransaction(ServerCall<?, ?> serverCall, ServerCall.Listener<?> listener, Transaction transaction) {
         serverCallTransactions.put(serverCall, transaction);
         serverListenerTransactions.put(listener, transaction);
-
         transaction.deactivate();
     }
 
@@ -266,9 +276,10 @@ public class GrpcHelper {
     // exit span management (client part)
 
     /**
+     * Called at the entry to {@link io.grpc.Channel#newCall(MethodDescriptor, CallOptions)}.
      * Starts a client exit span.
      * <br>
-     * This is the first method called during a client call execution, the next is {@link #registerSpan(ClientCall, Span)}.
+     * This is the first method called during a client call execution, the next is {@link #onClientCallCreationExit(ClientCall, Span)}.
      *
      * @param parent    parent transaction, or parent span provided by {@link Tracer#getActive()}.
      * @param method    method descriptor
@@ -276,9 +287,9 @@ public class GrpcHelper {
      * @return client call span (activated) or {@literal null} if not within an exit span.
      */
     @Nullable
-    public Span startSpan(@Nullable AbstractSpan<?> parent,
-                          @Nullable MethodDescriptor<?, ?> method,
-                          @Nullable String authority) {
+    public Span onClientCallCreationEntry(@Nullable AbstractSpan<?> parent,
+                                          @Nullable MethodDescriptor<?, ?> method,
+                                          @Nullable String authority) {
 
         if (null == parent) {
             return null;
@@ -312,25 +323,83 @@ public class GrpcHelper {
     }
 
     /**
+     * Called at the exit from {@link io.grpc.Channel#newCall(MethodDescriptor, CallOptions)}.
      * Registers (and deactivates) span in internal storage for lookup by client call.
      * <br>
-     * This is the 2cnd method called during client call execution, the next is {@link #clientCallStartEnter(ClientCall, ClientCall.Listener, Metadata)}.
+     * This is the 2nd method called during client call execution, the next is {@link #clientCallStartEnter(ClientCall, ClientCall.Listener, Metadata)}.
      *
-     * @param clientCall client call
-     * @param span       span
+     * @param clientCall    client call
+     * @param spanFromEntry span created at {@link #onClientCallCreationEntry(AbstractSpan, MethodDescriptor, String)}
      */
-    public void registerSpan(@Nullable ClientCall<?, ?> clientCall, Span span) {
+    public void onClientCallCreationExit(@Nullable ClientCall<?, ?> clientCall, @Nullable Span spanFromEntry) {
         if (clientCall != null) {
-            clientCallSpans.put(clientCall, span);
+            Span spanToMap = spanFromEntry;
+            if (spanToMap == null) {
+                // handling nested newCall() invocations - we still want to map the client call to the same span
+                Span tmp = GlobalTracer.get().getActiveSpan();
+                if (tmp != null && tmp.getSubtype() != null && tmp.getSubtype().equals(GRPC) && tmp.isExit()) {
+                    spanToMap = tmp;
+                }
+            }
+
+            if (spanToMap != null && !spanToMap.isDiscarded()) {
+                // io.grpc.internal.DelayedClientCall was introduced in 1.32 as a temporary placeholder for client calls
+                // that eventually refer to the real client call, but when they are first created
+                Class<?> clientCallClass = clientCall.getClass();
+                if (clientCallClass.getName().equals("io.grpc.internal.DelayedClientCall") ||
+                    clientCallClass.getSuperclass().getName().equals("io.grpc.internal.DelayedClientCall")) {
+                    delayedClientCallSpans.put(clientCall, spanToMap);
+                } else {
+                    clientCallSpans.put(clientCall, spanToMap);
+                }
+            }
         }
-        span.deactivate();
+
+        if (spanFromEntry != null) {
+            spanFromEntry.deactivate();
+        }
+    }
+
+    /**
+     * Fixes the span mapping for the "real" client call based on the span that is already mapped to the corresponding
+     * placeholder {@code io.grpc.internal.DelayedClientCall}.
+     * <br>
+     * This replacement must take into account two options:
+     * <ul>
+     *     <li>
+     *         a span was created for each the placeholder and the real call, in which case we use the placeholder span
+     *         (which was created first) and discard the one created for the real call
+     *     </li>
+     *     <li>
+     *         a single span was created and either mapped for both the placeholder and the real call (theoretical),
+     *         in which case we need to do nothing, or mapped only to the placeholder, in which to add a mapping for
+     *         the real client call
+     *     </li>
+     * </ul>
+     *
+     * @param placeholderClientCall may be created as part of the gRPC channel implementation to be replaced later with
+     *                              the real client call
+     * @param realClientCall        the client call instance that represents the actual client call
+     */
+    public void replaceClientCallRegistration(ClientCall<?, ?> placeholderClientCall, ClientCall<?, ?> realClientCall) {
+        Span spanOfPlaceholder = delayedClientCallSpans.remove(placeholderClientCall);
+        if (spanOfPlaceholder != null) {
+            Span spanOfRealClientCall = clientCallSpans.remove(realClientCall);
+            if (spanOfRealClientCall != spanOfPlaceholder) {
+                spanOfRealClientCall
+                    .requestDiscarding()
+                    // no need to deactivate
+                    .end();
+            }
+            clientCallSpans.put(realClientCall, spanOfPlaceholder);
+        }
     }
 
     /**
      * Starts client call and switch to client call listener instrumentation.
      * <br>
      * This is the 3rd method called during client call execution, the next in sequence is
-     * {@link #clientCallStartExit(ClientCall.Listener, Throwable)}.
+     * {@link #clientCallStartExit(Span, ClientCall.Listener, Throwable)}.
      *
      * @param clientCall client call
      * @param listener   client call listener
@@ -355,24 +424,27 @@ public class GrpcHelper {
             span.propagateTraceContext(headers, headerSetter);
         }
 
-        return span;
+        return span.activate();
     }
 
     /**
      * Performs client call start cleanup in case of exception
      *
-     * @param listener client call listener
-     * @param thrown   thrown exception
+     * @param spanFromEntry span created by {@link #clientCallStartEnter(ClientCall, ClientCall.Listener, Metadata)}
+     * @param listener      client call listener
+     * @param thrown        thrown exception
      */
-    public void clientCallStartExit(ClientCall.Listener<?> listener, @Nullable Throwable thrown) {
-        if (thrown == null) {
-            return;
+    public void clientCallStartExit(@Nullable Span spanFromEntry, ClientCall.Listener<?> listener, @Nullable Throwable thrown) {
+        if (spanFromEntry != null) {
+            spanFromEntry.deactivate();
         }
-        // when there is an exception, we have to end span and perform some cleanup
-        Span span = clientCallListenerSpans.remove(listener);
-        if (span != null) {
-            span.withOutcome(Outcome.FAILURE)
-                .end();
+        if (thrown != null) {
+            // when there is an exception, we have to end span and perform some cleanup
+            clientCallListenerSpans.remove(listener);
+            if (spanFromEntry != null) {
+                spanFromEntry.withOutcome(Outcome.FAILURE)
+                    .end();
+            }
         }
     }
 
@@ -386,7 +458,12 @@ public class GrpcHelper {
     public Span enterClientListenerMethod(ClientCall.Listener<?> listener) {
         Span span = clientCallListenerSpans.get(listener);
         if (span != null) {
-            span.activate();
+            if (span == GlobalTracer.get().getActiveSpan()) {
+                // avoid duplicated activation and invocation on nested listener method calls
+                span = null;
+            } else {
+                span.activate();
+            }
         }
         return span;
     }
@@ -420,7 +497,6 @@ public class GrpcHelper {
         if (lastCall) {
             clientCallListenerSpans.remove(listener);
         }
-
     }
 
     private class GrpcHeaderSetter implements TextHeaderSetter<Metadata> {
@@ -429,7 +505,6 @@ public class GrpcHelper {
         public void setHeader(String headerName, String headerValue, Metadata carrier) {
             carrier.put(getHeader(headerName), headerValue);
         }
-
     }
 
     private class GrpcHeaderGetter extends AbstractHeaderGetter<String, Metadata> implements TextHeaderGetter<Metadata> {

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallHandlerInstrumentation.java
@@ -22,6 +22,7 @@ import co.elastic.apm.agent.impl.transaction.Transaction;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -29,6 +30,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import javax.annotation.Nullable;
 
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**
@@ -36,6 +38,11 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  * transaction.
  */
 public class ServerCallHandlerInstrumentation extends BaseInstrumentation {
+
+    @Override
+    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+        return nameStartsWith("io.grpc");
+    }
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallInstrumentation.java
@@ -54,11 +54,19 @@ public class ServerCallInstrumentation extends BaseInstrumentation {
         return named("close");
     }
 
-    @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
-    public static void onExit(@Advice.Thrown @Nullable Throwable thrown,
-                              @Advice.This ServerCall<?, ?> serverCall,
-                              @Advice.Argument(0) Status status) {
+    @Override
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.grpc.ServerCallInstrumentation$ServerCallAdvice";
+    }
 
-        GrpcHelper.getInstance().exitServerCall(status, thrown, serverCall);
+    public static class ServerCallAdvice {
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+        public static void onExit(@Advice.Thrown @Nullable Throwable thrown,
+                                  @Advice.This ServerCall<?, ?> serverCall,
+                                  @Advice.Argument(0) Status status) {
+
+            GrpcHelper.getInstance().exitServerCall(status, thrown, serverCall);
+        }
     }
 }

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallInstrumentation.java
@@ -18,20 +18,20 @@
  */
 package co.elastic.apm.agent.grpc;
 
+import co.elastic.apm.agent.sdk.DynamicTransformer;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 import javax.annotation.Nullable;
 
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
-import static net.bytebuddy.matcher.ElementMatchers.nameContains;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import java.util.Collection;
+
+import static net.bytebuddy.matcher.ElementMatchers.any;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**
@@ -40,16 +40,13 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  */
 public class ServerCallInstrumentation extends BaseInstrumentation {
 
-    @Override
-    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("io.grpc")
-            .and(nameContains("ServerCall"));
-    }
-
+    /**
+     * Overridden in {@link DynamicTransformer#ensureInstrumented(Class, Collection)},
+     * based on the type of the {@linkplain ServerCall} implementation class.
+     */
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        // pre-filtering is used to make this quite fast and limited to gRPC packages
-        return hasSuperType(named("io.grpc.ServerCall"));
+        return any();
     }
 
     @Override

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
@@ -74,19 +74,27 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
                 .or(named("onHalfClose"));
         }
 
-        @Nullable
-        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-        public static Object onEnter(@Advice.This ServerCall.Listener<?> listener) {
-            return GrpcHelper.getInstance().enterServerListenerMethod(listener);
+        @Override
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.grpc.ServerCallListenerInstrumentation$OtherMethod$OtherMethodAdvice";
         }
 
-        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
-        public static void onExit(@Advice.Thrown @Nullable Throwable thrown,
-                                  @Advice.This ServerCall.Listener<?> listener,
-                                  @Advice.Enter @Nullable Object transaction) {
+        public static class OtherMethodAdvice {
 
-            if (transaction instanceof Transaction) {
-                GrpcHelper.getInstance().exitServerListenerMethod(thrown, listener, (Transaction) transaction, null);
+            @Nullable
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static Object onEnter(@Advice.This ServerCall.Listener<?> listener) {
+                return GrpcHelper.getInstance().enterServerListenerMethod(listener);
+            }
+
+            @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+            public static void onExit(@Advice.Thrown @Nullable Throwable thrown,
+                                      @Advice.This ServerCall.Listener<?> listener,
+                                      @Advice.Enter @Nullable Object transaction) {
+
+                if (transaction instanceof Transaction) {
+                    GrpcHelper.getInstance().exitServerListenerMethod(thrown, listener, (Transaction) transaction, null);
+                }
             }
         }
     }
@@ -101,19 +109,27 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
             return named("onCancel");
         }
 
-        @Nullable
-        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-        public static Object onEnter(@Advice.This ServerCall.Listener<?> listener) {
-            return GrpcHelper.getInstance().enterServerListenerMethod(listener);
+        @Override
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.grpc.ServerCallListenerInstrumentation$OnCancel$OnCancelAdvice";
         }
 
-        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
-        public static void onExit(@Advice.Thrown @Nullable Throwable thrown,
-                                  @Advice.This ServerCall.Listener<?> listener,
-                                  @Advice.Enter @Nullable Object transaction) {
+        public static class OnCancelAdvice {
 
-            if (transaction instanceof Transaction) {
-                GrpcHelper.getInstance().exitServerListenerMethod(thrown, listener, (Transaction) transaction, Status.CANCELLED);
+            @Nullable
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static Object onEnter(@Advice.This ServerCall.Listener<?> listener) {
+                return GrpcHelper.getInstance().enterServerListenerMethod(listener);
+            }
+
+            @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+            public static void onExit(@Advice.Thrown @Nullable Throwable thrown,
+                                      @Advice.This ServerCall.Listener<?> listener,
+                                      @Advice.Enter @Nullable Object transaction) {
+
+                if (transaction instanceof Transaction) {
+                    GrpcHelper.getInstance().exitServerListenerMethod(thrown, listener, (Transaction) transaction, Status.CANCELLED);
+                }
             }
         }
     }
@@ -128,21 +144,28 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
             return named("onComplete");
         }
 
-        @Nullable
-        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-        public static Object onEnter(@Advice.This ServerCall.Listener<?> listener) {
-            return GrpcHelper.getInstance().enterServerListenerMethod(listener);
+        @Override
+        public String getAdviceClassName() {
+            return "co.elastic.apm.agent.grpc.ServerCallListenerInstrumentation$OnComplete$OnCompleteAdvice";
         }
 
-        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
-        public static void onExit(@Advice.Thrown @Nullable Throwable thrown,
-                                  @Advice.This ServerCall.Listener<?> listener,
-                                  @Advice.Enter @Nullable Object transaction) {
+        public static class OnCompleteAdvice {
 
-            if (transaction instanceof Transaction) {
-                GrpcHelper.getInstance().exitServerListenerMethod(thrown, listener, (Transaction) transaction, Status.OK);
+            @Nullable
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static Object onEnter(@Advice.This ServerCall.Listener<?> listener) {
+                return GrpcHelper.getInstance().enterServerListenerMethod(listener);
+            }
+
+            @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+            public static void onExit(@Advice.Thrown @Nullable Throwable thrown,
+                                      @Advice.This ServerCall.Listener<?> listener,
+                                      @Advice.Enter @Nullable Object transaction) {
+
+                if (transaction instanceof Transaction) {
+                    GrpcHelper.getInstance().exitServerListenerMethod(thrown, listener, (Transaction) transaction, Status.OK);
+                }
             }
         }
     }
-
 }

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
@@ -19,18 +19,19 @@
 package co.elastic.apm.agent.grpc;
 
 import co.elastic.apm.agent.impl.transaction.Transaction;
+import co.elastic.apm.agent.sdk.DynamicTransformer;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 import javax.annotation.Nullable;
 
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import java.util.Collection;
+
+import static net.bytebuddy.matcher.ElementMatchers.any;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**
@@ -47,15 +48,13 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  */
 public abstract class ServerCallListenerInstrumentation extends BaseInstrumentation {
 
-    @Override
-    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("io.grpc");
-    }
-
+    /**
+     * Overridden in {@link DynamicTransformer#ensureInstrumented(Class, Collection)},
+     * based on the type of the {@linkplain ServerCall.Listener} implementation class.
+     */
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        // pre-filtering is used to make this quite fast and limited to gRPC packages
-        return hasSuperType(named("io.grpc.ServerCall$Listener"));
+        return any();
     }
 
     /**

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/java/co/elastic/apm/agent/grpc/ServerCallListenerInstrumentation.java
@@ -22,6 +22,7 @@ import co.elastic.apm.agent.impl.transaction.Transaction;
 import io.grpc.ServerCall;
 import io.grpc.Status;
 import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -29,6 +30,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import javax.annotation.Nullable;
 
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**
@@ -44,6 +46,11 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  * </ul>
  */
 public abstract class ServerCallListenerInstrumentation extends BaseInstrumentation {
+
+    @Override
+    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+        return nameStartsWith("io.grpc");
+    }
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
@@ -86,11 +93,7 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
     }
 
     /**
-     * Instruments implementations of {@link ServerCall.Listener}
-     * <ul>
-     *     <li>{@link ServerCall.Listener#onCancel()}</li>
-     * </ul>
-     * <p>
+     * Instruments {@link ServerCall.Listener#onCancel()}
      */
     public static class OnCancel extends ServerCallListenerInstrumentation {
 
@@ -117,11 +120,7 @@ public abstract class ServerCallListenerInstrumentation extends BaseInstrumentat
     }
 
     /**
-     * Instruments implementations of {@link ServerCall.Listener}
-     * <ul>
-     *     <li>{@link ServerCall.Listener#onComplete()}</li>
-     * </ul>
-     * <p>
+     * Instruments {@link ServerCall.Listener#onComplete()}
      */
     public static class OnComplete extends ServerCallListenerInstrumentation {
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -1,12 +1,8 @@
 # gRPC server part
-co.elastic.apm.agent.grpc.ServerCallListenerInstrumentation$OtherMethod
-co.elastic.apm.agent.grpc.ServerCallListenerInstrumentation$OnCancel
-co.elastic.apm.agent.grpc.ServerCallListenerInstrumentation$OnComplete
-
-
 co.elastic.apm.agent.grpc.ServerCallHandlerInstrumentation
-co.elastic.apm.agent.grpc.ServerCallInstrumentation
 
 # gRPC client part
 co.elastic.apm.agent.grpc.ChannelInstrumentation
 co.elastic.apm.agent.grpc.DelayedClientCallInstrumentation
+
+# All other instrumentations are applied through ensureInstrumented

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -9,4 +9,4 @@ co.elastic.apm.agent.grpc.ServerCallInstrumentation
 
 # gRPC client part
 co.elastic.apm.agent.grpc.ChannelInstrumentation
-co.elastic.apm.agent.grpc.ClientCallImplInstrumentation$Start
+co.elastic.apm.agent.grpc.DelayedClientCallInstrumentation

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/AbstractGrpcClientInstrumentationTest.java
@@ -26,7 +26,6 @@ import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -156,7 +155,6 @@ public abstract class AbstractGrpcClientInstrumentationTest extends AbstractInst
     }
 
     @Test
-    @Disabled // disabled for now as it's flaky on CI
     void serverStreamingCallShouldBeIgnored() {
         String s = app.sayHelloServerStreaming("alice", 5);
         assertThat(s)

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/HelloClient.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/HelloClient.java
@@ -27,7 +27,6 @@ import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
 import io.grpc.MethodDescriptor;
 import io.grpc.StatusRuntimeException;
-import io.grpc.elastic.test.TestClientCallImpl;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/HelloServer.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/HelloServer.java
@@ -26,7 +26,6 @@ import io.grpc.ServerCall;
 import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
-import io.grpc.elastic.test.TestServerListener;
 import io.grpc.stub.StreamObserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/TestClientCallImpl.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/TestClientCallImpl.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.grpc.elastic.test;
+package co.elastic.apm.agent.grpc.testapp;
 
 import io.grpc.Attributes;
 import io.grpc.ClientCall;
@@ -38,7 +38,7 @@ public class TestClientCallImpl<ReqT, RespT> extends ClientCall<ReqT, RespT> {
     }
 
     @Override
-    public void start(Listener<RespT> listener, Metadata headers) {
+    public void start(final Listener<RespT> listener, Metadata headers) {
         throwExceptionIfRequired("start");
         clientCall.start(new TestListener(listener), headers);
     }

--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/TestServerListener.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/testapp/TestServerListener.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package io.grpc.elastic.test;
+package co.elastic.apm.agent.grpc.testapp;
 
 import io.grpc.ServerCall;
 

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
@@ -23,8 +23,9 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.39.0)",
+    value = "by gRPC proto compiler (version 1.40.0)",
     comments = "Source: rpc.proto")
+@io.grpc.stub.annotations.GrpcGenerated
 public final class HelloGrpc {
 
   private HelloGrpc() {}

--- a/apm-agent-plugins/apm-grpc/pom.xml
+++ b/apm-agent-plugins/apm-grpc/pom.xml
@@ -25,7 +25,7 @@
         <module>apm-grpc-plugin</module>
         <module>apm-grpc-test-1.6.1</module>
         <!-- other intermediate gRPC versions that have been tested : 1.7.1, 1,9.1, 1.13.2, 1.22.0, 1.23.0, 1.27.1 -->
-       <module>apm-grpc-test-latest</module>
+        <module>apm-grpc-test-latest</module>
    </modules>
 
     <build>


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
This PR started as a fix to an issue reported in [the forum](https://discuss.elastic.co/t/java-grpc-client-not-ending-spans-and-not-reporting-to-apm/280643).

The issue is related to a change we did when tests of gRPC version 1.35 started failing due to duplicated client spans. In order to get rid of the extra span, we excluded `io.grpc.internal.ManagedChannelImpl$RealChannel` from our `ChannelInstrumentation`. However, this broke other scenarios, so this PR restores instrumentation of said channel and adds special handling for the `io.grpc.internal.DelayedClientCall` (added in 1.32) instead. This new client call type is created as a placeholder and starts going through the client call lifecycle, but at some point (different between 1.32 and 1.35) it starts referring to the real client call and delegate invocations to it. The new lifecycle management allows creation of duplicated spans, but when `io.grpc.internal.DelayedClientCall`s are used, their corresponding spans replace the ones created for the "real" calls once they are set as the delegate of the placeholder call, and the spans created for the real calls are discarded.

In addition, we now use `ensureInstrumented` to instrument client calls, server calls, client listeners and server listeners. By doing that, we can both be very efficient in type matching and still support custom types. While customer client/server calls are sort of edge case, custom listeners are probably more expected. Our tests now include custom client call and client/server listeners.

Lastly, I refactored all instrumentations to extract advice methods into separate (inner) classes, so to ensure proper dependencies visibility.

In a separate PR I intend to apply some enhancements to `SpanConcurrentHashMap` and then replace all maps within `GrpcHelper` with such.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] The reporting user confirmed general functionality and resolution of the reported issue