### PR TITLE
fix redisson driver java15+ incompatibility

### DIFF
--- a/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/pom.xml
@@ -32,7 +32,8 @@
         <dependency>
             <groupId>org.redisson</groupId>
             <artifactId>redisson</artifactId>
-            <version>3.12.3</version>
+            <!-- note: previous versions don't work with Java 15+ -->
+            <version>3.13.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/src/test/java/co/elastic/apm/agent/redis/redisson/RedissonInstrumentationTest.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redisson-plugin/src/test/java/co/elastic/apm/agent/redis/redisson/RedissonInstrumentationTest.java
@@ -146,6 +146,6 @@ class RedissonInstrumentationTest extends AbstractRedisInstrumentationTest {
         lock.lock();
         lock.unlock();
 
-        assertTransactionWithRedisSpans("EVAL", "EVAL");
+        assertTransactionWithRedisSpans("EVAL... [bulk]", "EVAL... [bulk]");
     }
 }


### PR DESCRIPTION
## What does this PR do?

Redisson redis client does trigger `java.lang.reflect.InaccessibleObjectException` exceptions with Java 15+, updating to a 3.13.x version solves the issue.

```
java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.math.BigInteger java.math.BigDecimal.intVal accessible: module java.base does not "opens java.math" to unnamed module @4d76f3f8
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:357)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Field.checkCanSetAccessible(Field.java:177)
	at java.base/java.lang.reflect.Field.setAccessible(Field.java:171)
	at org.nustaq.serialization.FSTClazzInfo.createFieldInfo(FSTClazzInfo.java:512)
	at org.nustaq.serialization.FSTClazzInfo.createFields(FSTClazzInfo.java:368)
	at org.nustaq.serialization.FSTClazzInfo.<init>(FSTClazzInfo.java:129)
	at org.nustaq.serialization.FSTClazzInfoRegistry.getCLInfo(FSTClazzInfoRegistry.java:129)
	at org.nustaq.serialization.FSTClazzNameRegistry.addClassMapping(FSTClazzNameRegistry.java:98)
	at org.nustaq.serialization.FSTClazzNameRegistry.registerClassNoLookup(FSTClazzNameRegistry.java:85)
	at org.nustaq.serialization.FSTClazzNameRegistry.registerClass(FSTClazzNameRegistry.java:81)
	at org.nustaq.serialization.FSTConfiguration.addDefaultClazzes(FSTConfiguration.java:814)
	at org.nustaq.serialization.FSTConfiguration.initDefaultFstConfigurationInternal(FSTConfiguration.java:477)
	at org.nustaq.serialization.FSTConfiguration.createDefaultConfiguration(FSTConfiguration.java:472)
	at org.nustaq.serialization.FSTConfiguration.createDefaultConfiguration(FSTConfiguration.java:464)
	at org.redisson.codec.FstCodec.<init>(FstCodec.java:182)
	at org.redisson.config.Config.<init>(Config.java:105)
	at org.redisson.Redisson.<init>(Redisson.java:57)
	at org.redisson.Redisson.create(Redisson.java:99)
	at co.elastic.apm.agent.redis.redisson.RedissonInstrumentationTest.setUp(RedissonInstrumentationTest.java:54)

```