### PR TITLE
classloader check on global tracer init

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ endif::[]
 * gRPC spans (client and server) can detect errors or cancellation through custom listeners - {pull}2067[#2067]
 * Add `-download-agent-version` to the agent <<setup-attach-cli-usage-options, attach CLI tool options>>, allowing the
 user to configure an arbitrary agent version that will be downloaded from maven and attached - {pull}1959[#1959]
+* Add extra check to detect improper agent setup - {pull}2076[#2076]
 
 [float]
 ===== Bug fixes


### PR DESCRIPTION
## What does this PR do?

Fixes #1555

Ensures that the agent will throw an exception when agent has been added to application dependencies (and thus that the agent is not being loaded from the bootstrap classloader). While exception will likely break the application, it makes it obvious that there is a setup issue that requires immediate action.

## Checklist

- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)

## Implementation checklist
- [x] ensure tests run properly with this extra check
- [x] manual testing with sample application with packaged agent as dependency using `Class.forname(...)` that tries to load agent `GlobalTracer`.