### PR TITLE
Avoid reusing grpc port for reliability

### DIFF
--- a/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/GrpcTest.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-plugin/src/test/java/co/elastic/apm/agent/grpc/GrpcTest.java
@@ -24,11 +24,8 @@ import co.elastic.apm.agent.testutils.TestPort;
 
 public class GrpcTest {
 
-    private static final int PORT = TestPort.getAvailableRandomPort();
-    private static final String HOST = "localhost";
-
-    public static GrpcApp getApp(GrpcAppProvider provider){
-        return provider.getGrpcApp(HOST, PORT);
+    public static GrpcApp getApp(GrpcAppProvider provider) {
+        return provider.getGrpcApp("localhost", TestPort.getAvailableRandomPort());
     }
 
 }


### PR DESCRIPTION
## What does this PR do?

When running gRPC tests in CI, the application port is being reused unless it's not available, for example due to a `failed to bind` error.

We can observe this by a simple `starting grpc server on port` on the build logs in CI.
This PR attempts to avoid this by not trying to reuse port when starting the grpc server.

```
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 27575
... 27575
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 27575
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 55074
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 58505
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 1819
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 45002
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 52264
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 34650
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 17372
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 60916
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 19523
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 10805
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 56063
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 27575
... 27575
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 27575
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 13426
... 13426
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 13426
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 24005
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 52041
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 45392
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 41993
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 23572
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 29149
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 49099
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 21593
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 16709
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 57201
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 2849
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 13426
... 13426
[main] INFO  co.elastic.apm.agent.grpc.testapp.HelloServer - starting grpc server on port 13426

```

## Checklist
