### PR TITLE
Improve test gRPC server startup log/errors

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/IOUtilsTest.java
@@ -200,8 +200,8 @@ class IOUtilsTest  {
                 return file;
             }));
         }
-        executorService.shutdown();
-        executorService.awaitTermination(1, TimeUnit.SECONDS);
+
+        ExecutorUtils.shutdownAndWaitTermination(executorService, 1, TimeUnit.SECONDS);
 
         for (Future<File> future : futureList) {
             assertThat(future.get()).isNotNull();


### PR DESCRIPTION
## What does this PR do?

- attempt to reduce flakyness for gRPC startup/shutdown by reusing common code in `ExecutorUtils`.
- improve logging to try helping diagnosis of future failures (if any).

