### PR TITLE
Align span subtype for SqlServer

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -23,6 +23,10 @@ endif::[]
 [[release-notes-1.26.0]]
 ==== 1.26.0 - YYYY/MM/DD
 
+===== Potentially breaking changes
+* If you rely on Database span subtype and use Microsoft SQL Server, the span subtype has been changed from `sqlserver`
+to `mssql` to align with other agents.
+
 [float]
 ===== Features
 * Improved naming for Spring controllers - {pull}1906[#1906]
@@ -62,6 +66,7 @@ user to configure an arbitrary agent version that will be downloaded from maven 
 * Fix gRPC non-terminated (therefore non-reported) client spans - {pull}2067[#2067]
 * Fix Webflux response status code - {pull}1948[#1948]
 * Ensure path filtering is applied when Servlet path is not available - {pull}2099[#2099]
+* Align span subtype for MS SqlServer - {pull}2112[#2112]
 
 [float]
 ===== Refactorings

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
@@ -226,7 +226,7 @@ public class MockReporter implements Reporter {
                 }
             } else {
                 if (!allowUnlistedSubtype && hasSubtypes) {
-                    getMandatoryJson(subTypesJson, subType, String.format("span subtype '%s' is not allowed by the sped for type '%s'", subType, type));
+                    getMandatoryJson(subTypesJson, subType, String.format("span subtype '%s' is not allowed by the spec for type '%s'", subType, type));
                 }
             }
 

--- a/apm-agent-core/src/test/resources/json-specs/span_types.json
+++ b/apm-agent-core/src/test/resources/json-specs/span_types.json
@@ -141,7 +141,8 @@
       "mssql": {
         "__description": "Microsoft SQL Server",
         "__used_by": [
-          "nodejs"
+          "nodejs",
+          "java"
         ]
       },
       "mysql": {
@@ -183,9 +184,8 @@
         ]
       },
       "sqlserver": {
-        "__description": "Microsoft SQL Server",
+        "__description": "Microsoft SQL Server (deprecated, use mssql instead)",
         "__used_by": [
-          "java"
         ]
       },
       "unknown": {

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaData.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaData.java
@@ -430,7 +430,7 @@ public class ConnectionMetaData {
                 if (indexOfInstance > 0) {
                     host = host.substring(0, indexOfInstance);
                 }
-                return new ConnectionMetaData(dbVendor, host, port, instance, user);
+                return new ConnectionMetaData("mssql", host, port, instance, user);
             }
         },
 

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/JdbcDbIT.java
@@ -42,7 +42,7 @@ public class JdbcDbIT extends AbstractJdbcInstrumentationTest {
             {"jdbc:tc:postgresql:9://hostname/databasename", "postgresql"},
             {"jdbc:tc:postgresql:10://hostname/databasename", "postgresql"},
             {"jdbc:tc:mariadb:10://hostname/databasename", "mariadb"},
-            {"jdbc:tc:sqlserver:2017-CU12://hostname/databasename", "sqlserver"},
+            {"jdbc:tc:sqlserver:2017-CU12://hostname/databasename", "mssql"},
             {"jdbc:tc:db2:11.5.0.0a://hostname/databasename", "db2"},
             {"jdbc:tc:oracle://hostname/databasename", "oracle"},
         });

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaDataTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaDataTest.java
@@ -234,23 +234,23 @@ class ConnectionMetaDataTest {
     @Test
     void testSqlserver() {
         // https://docs.microsoft.com/en-us/sql/connect/jdbc/building-the-connection-url?view=sql-server-ver15
-        testUrl("jdbc:sqlserver://myhost\\instance:666", "sqlserver", "myhost", 666);
-        testUrl("jdbc:sqlserver://myhost\\instance:666;prop1=val1;prop2=val2", "sqlserver", "myhost", 666);
-        testUrl("jdbc:sqlserver://myhost:666", "sqlserver", "myhost", 666);
-        testUrl("jdbc:sqlserver://myhost:666;prop1=val1;prop2=val2", "sqlserver", "myhost", 666);
-        testUrl("jdbc:sqlserver://myhost\\instance", "sqlserver", "myhost", 1433);
-        testUrl("jdbc:sqlserver://myhost\\instance;prop1=val1;prop2=val2", "sqlserver", "myhost", 1433);
-        testUrl("jdbc:sqlserver://myhost", "sqlserver", "myhost", 1433);
-        testUrl("jdbc:sqlserver://myhost;prop1=val1;prop2=val2", "sqlserver", "myhost", 1433);
-        testUrl("jdbc:sqlserver://", "sqlserver", "localhost", 1433);
-        testUrl("jdbc:sqlserver://;prop1=val1;prop2=val2", "sqlserver", "localhost", 1433);
-        testUrl("jdbc:sqlserver://;", "sqlserver", "localhost", 1433);
-        testUrl("jdbc:sqlserver://;serverName=myhost", "sqlserver", "myhost", 1433);
-        testUrl("jdbc:sqlserver://;prop1=val1;serverName=myhost", "sqlserver", "myhost", 1433);
-        testUrl("jdbc:sqlserver://;serverName=myhost;prop1=val1", "sqlserver", "myhost", 1433);
-        testUrl("jdbc:sqlserver://;serverName=myhost\\instance;prop1=val1", "sqlserver", "myhost", 1433);
+        testUrl("jdbc:sqlserver://myhost\\instance:666", "mssql", "myhost", 666);
+        testUrl("jdbc:sqlserver://myhost\\instance:666;prop1=val1;prop2=val2", "mssql", "myhost", 666);
+        testUrl("jdbc:sqlserver://myhost:666", "mssql", "myhost", 666);
+        testUrl("jdbc:sqlserver://myhost:666;prop1=val1;prop2=val2", "mssql", "myhost", 666);
+        testUrl("jdbc:sqlserver://myhost\\instance", "mssql", "myhost", 1433);
+        testUrl("jdbc:sqlserver://myhost\\instance;prop1=val1;prop2=val2", "mssql", "myhost", 1433);
+        testUrl("jdbc:sqlserver://myhost", "mssql", "myhost", 1433);
+        testUrl("jdbc:sqlserver://myhost;prop1=val1;prop2=val2", "mssql", "myhost", 1433);
+        testUrl("jdbc:sqlserver://", "mssql", "localhost", 1433);
+        testUrl("jdbc:sqlserver://;prop1=val1;prop2=val2", "mssql", "localhost", 1433);
+        testUrl("jdbc:sqlserver://;", "mssql", "localhost", 1433);
+        testUrl("jdbc:sqlserver://;serverName=myhost", "mssql", "myhost", 1433);
+        testUrl("jdbc:sqlserver://;prop1=val1;serverName=myhost", "mssql", "myhost", 1433);
+        testUrl("jdbc:sqlserver://;serverName=myhost;prop1=val1", "mssql", "myhost", 1433);
+        testUrl("jdbc:sqlserver://;serverName=myhost\\instance;prop1=val1", "mssql", "myhost", 1433);
         testUrl("jdbc:sqlserver://;serverName=3ffe:8311:eeee:f70f:0:5eae:10.203.31.9\\instance;prop1=val1",
-            "sqlserver", "3ffe:8311:eeee:f70f:0:5eae:10.203.31.9", 1433);
+            "mssql", "3ffe:8311:eeee:f70f:0:5eae:10.203.31.9", 1433);
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

Align Java agent span subtype for MS SqlServer

This is a small breaking change as anyone relying on span type/subtype might have to adapt to the new value. 

Relates to https://github.com/elastic/apm/issues/502

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix