### PR TITLE
Shade byte-buddy in attacher jar

### DIFF
--- a/apm-agent-attach/pom.xml
+++ b/apm-agent-attach/pom.xml
@@ -106,6 +106,52 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>shade-dependencies</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <keepDependenciesWithProvidedScope>true</keepDependenciesWithProvidedScope>
+                            <createSourcesJar>true</createSourcesJar>
+                            <shadeSourcesContent>true</shadeSourcesContent>
+                            <shadedArtifactId>${project.artifactId}</shadedArtifactId>
+                            <filters>
+                                <filter>
+                                    <artifact>net.bytebuddy:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>net.java.dev.jna:*</exclude>
+                                </excludes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>net.bytebuddy</pattern>
+                                    <shadedPattern>co.elastic.apm.attach.bytebuddy</shadedPattern>
+                                </relocation>
+                            </relocations>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                                    <resource>META-INF/LICENSE</resource>
+                                    <file>${apm-agent-parent.base.dir}/LICENSE</file>
+                                </transformer>
+                            </transformers>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -520,6 +520,18 @@
                 <version>2.5.0</version>
                 <scope>test</scope>
             </dependency>
+
+            <!-- ensures that we always rely on a single bytebuddy version -->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${version.byte-buddy}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>${version.byte-buddy}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## What does this PR do?

Since version 1.23.0, the attacher jar does not embeds bytebuddy dependency anymore.

This becomes an issue when a different version of bytebuddy is on the application classpath (for example through an hibernate dependency) as it makes the attach fail with a similar stack trace:

```
Exception in thread "main" java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:48)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:87)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:50)
        at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:51)
Caused by: java.lang.NoClassDefFoundError: net/bytebuddy/agent/ByteBuddyAgent$AttachmentProvider$ForEmulatedAttachment
        at co.elastic.apm.attach.ElasticAttachmentProvider.init(ElasticAttachmentProvider.java:39)
        at co.elastic.apm.attach.ElasticAttachmentProvider.get(ElasticAttachmentProvider.java:60)
        at co.elastic.apm.attach.ElasticApmAttacher.attach(ElasticApmAttacher.java:162)
        at co.elastic.apm.attach.ElasticApmAttacher.attach(ElasticApmAttacher.java:148)
        at co.elastic.apm.attach.ElasticApmAttacher.attach(ElasticApmAttacher.java:110)
        at co.elastic.apm.attach.ElasticApmAttacher.attach(ElasticApmAttacher.java:63)
        at org.springframework.samples.petclinic.PetClinicApplication.main(PetClinicApplication.java:34)
        ... 8 more
Caused by: java.lang.ClassNotFoundException: net.bytebuddy.agent.ByteBuddyAgent$AttachmentProvider$ForEmulatedAttachment
        at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:471)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
        at org.springframework.boot.loader.LaunchedURLClassLoader.loadClass(LaunchedURLClassLoader.java:93)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
        ... 15 morev
```

## Checklist

- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
