### PR TITLE
Fixing GlobalThreadLocal to use per-thread default values

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -62,6 +62,7 @@ user to configure an arbitrary agent version that will be downloaded from maven 
 * Fix gRPC non-terminated (therefore non-reported) client spans - {pull}2067[#2067]
 * Fix Webflux response status code - {pull}1948[#1948]
 * Ensure path filtering is applied when Servlet path is not available - {pull}2099[#2099]
+* Fix potential destination host corruption in OkHttp client spans - {pull}2118[#2118]
 
 [float]
 ===== Refactorings

--- a/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/state/GlobalThreadLocalTest.java
+++ b/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/state/GlobalThreadLocalTest.java
@@ -94,8 +94,7 @@ public class GlobalThreadLocalTest {
         future = executor.submit(threadLocal::getAndRemove);
         // we can rely on that because we use a single thread executor
         assertThat(future.get()).isEqualTo("worker");
-        future = executor.submit(threadLocal::getAndRemove);
-        // we can rely on that because we use a single thread executor
+        future = executor.submit((Callable<Object>) threadLocal::get);
         assertThat(future.get()).isNull();
 
         assertThat(threadLocal.getAndRemove()).isEqualTo("main");

--- a/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/state/GlobalThreadLocalTest.java
+++ b/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/state/GlobalThreadLocalTest.java
@@ -20,12 +20,103 @@ package co.elastic.apm.agent.sdk.state;
 
 import org.junit.jupiter.api.Test;
 
+import javax.annotation.Nullable;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 public class GlobalThreadLocalTest {
 
-    GlobalThreadLocal<String> threadLocal = GlobalThreadLocal.get(GlobalThreadLocalTest.class, "test");
+    private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     @Test
     void setNullValueShouldNotThrow() {
-        threadLocal.set(null);
+        GlobalThreadLocal.get(GlobalThreadLocalTest.class, "setNullValueShouldNotThrow").set(null);
+    }
+
+    @Test
+    void testNonConstantDefaultValue() throws ExecutionException, InterruptedException {
+        final GlobalThreadLocal<Object> threadLocal = GlobalThreadLocal.get(
+            GlobalThreadLocalTest.class,
+            "testNonConstantDefaultValue",
+            new ObjectValueSupplier()
+        );
+        Object mainThreadDefaultValue = threadLocal.get();
+        assertThat(mainThreadDefaultValue).isNotNull();
+        Future<Object> future = executor.submit((Callable<Object>) threadLocal::get);
+        assertThat(future.get()).isNotEqualTo(mainThreadDefaultValue);
+    }
+
+    @Test
+    void testConstantDefaultValue() throws ExecutionException, InterruptedException {
+        final GlobalThreadLocal<Object> threadLocal = GlobalThreadLocal.get(
+            GlobalThreadLocalTest.class,
+            "testConstantDefaultValue",
+            new ConstantValueSupplier()
+        );
+        Object mainThreadDefaultValue = threadLocal.get();
+        assertThat(mainThreadDefaultValue).isNotNull();
+        Future<Object> future = executor.submit((Callable<Object>) threadLocal::get);
+        assertThat(future.get()).isEqualTo(mainThreadDefaultValue);
+    }
+
+    @Test
+    void testNullDefaultValue() {
+        final GlobalThreadLocal<Object> threadLocal = GlobalThreadLocal.get(
+            GlobalThreadLocalTest.class,
+            "testNullDefaultValue",
+            null
+        );
+        assertThat(threadLocal.get()).isNull();
+    }
+
+    @Test
+    void testNonDefaultValue() throws ExecutionException, InterruptedException {
+        final GlobalThreadLocal<Object> threadLocal = GlobalThreadLocal.get(
+            GlobalThreadLocalTest.class,
+            "testNonDefaultValue",
+            null
+        );
+
+        threadLocal.set("main");
+        assertThat(threadLocal.get()).isEqualTo("main");
+
+        Future<Object> future = executor.submit(() -> {
+            threadLocal.set("worker");
+            return threadLocal.get();
+        });
+        assertThat(future.get()).isEqualTo("worker");
+
+        future = executor.submit(threadLocal::getAndRemove);
+        // we can rely on that because we use a single thread executor
+        assertThat(future.get()).isEqualTo("worker");
+        future = executor.submit(threadLocal::getAndRemove);
+        // we can rely on that because we use a single thread executor
+        assertThat(future.get()).isNull();
+
+        assertThat(threadLocal.getAndRemove()).isEqualTo("main");
+        assertThat(threadLocal.get()).isNull();
+    }
+
+    private static class ObjectValueSupplier implements GlobalThreadLocal.DefaultValueSupplier<Object> {
+        @Nullable
+        @Override
+        public Object getDefaultValueForThread() {
+            return new Object();
+        }
+    }
+
+    private static class ConstantValueSupplier implements GlobalThreadLocal.DefaultValueSupplier<Object> {
+        private final Object defaultValue = new Object();
+
+        @Nullable
+        @Override
+        public Object getDefaultValueForThread() {
+            return defaultValue;
+        }
     }
 }

--- a/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/state/GlobalThreadLocalTest.java
+++ b/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/state/GlobalThreadLocalTest.java
@@ -20,7 +20,6 @@ package co.elastic.apm.agent.sdk.state;
 
 import org.junit.jupiter.api.Test;
 
-import javax.annotation.Nullable;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -43,7 +42,7 @@ public class GlobalThreadLocalTest {
         final GlobalThreadLocal<Object> threadLocal = GlobalThreadLocal.get(
             GlobalThreadLocalTest.class,
             "testNonConstantDefaultValue",
-            new ObjectValueSupplier()
+            Object::new
         );
         Object mainThreadDefaultValue = threadLocal.get();
         assertThat(mainThreadDefaultValue).isNotNull();
@@ -53,10 +52,11 @@ public class GlobalThreadLocalTest {
 
     @Test
     void testConstantDefaultValue() throws ExecutionException, InterruptedException {
+        final Object constant = new Object();
         final GlobalThreadLocal<Object> threadLocal = GlobalThreadLocal.get(
             GlobalThreadLocalTest.class,
             "testConstantDefaultValue",
-            new ConstantValueSupplier()
+            () -> constant
         );
         Object mainThreadDefaultValue = threadLocal.get();
         assertThat(mainThreadDefaultValue).isNotNull();
@@ -99,23 +99,5 @@ public class GlobalThreadLocalTest {
 
         assertThat(threadLocal.getAndRemove()).isEqualTo("main");
         assertThat(threadLocal.get()).isNull();
-    }
-
-    private static class ObjectValueSupplier implements GlobalThreadLocal.DefaultValueSupplier<Object> {
-        @Nullable
-        @Override
-        public Object getDefaultValueForThread() {
-            return new Object();
-        }
-    }
-
-    private static class ConstantValueSupplier implements GlobalThreadLocal.DefaultValueSupplier<Object> {
-        private final Object defaultValue = new Object();
-
-        @Nullable
-        @Override
-        public Object getDefaultValueForThread() {
-            return defaultValue;
-        }
     }
 }

--- a/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientHelper.java
+++ b/apm-agent-plugins/apm-okhttp-plugin/src/main/java/co/elastic/apm/agent/okhttp/OkHttpClientHelper.java
@@ -27,7 +27,16 @@ public class OkHttpClientHelper {
     /**
      * Used to avoid allocations when calculating destination host name.
      */
-    public static final GlobalThreadLocal<StringBuilder> destinationHostName = GlobalThreadLocal.get(OkHttpClientHelper.class, "destinationHostName", new StringBuilder());
+    public static final GlobalThreadLocal<StringBuilder> destinationHostName =
+        GlobalThreadLocal.get(
+            OkHttpClientHelper.class,
+            "destinationHostName",
+            new GlobalThreadLocal.DefaultValueSupplier<StringBuilder>() {
+                @Override
+                public StringBuilder getDefaultValueForThread() {
+                    return new StringBuilder();
+                }
+            });
 
     /**
      * NOTE: this method returns a StringBuilder instance that is kept as this class's ThreadLocal. Callers of this


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Closes #2117 
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
