### PR TITLE
Release: nexus step manually for the time being

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -158,15 +158,9 @@ pipeline {
         }
         stage('Nexus release') {
           steps {
-            script {
-              dir("${BASE_DIR}"){
-                withSecretVault(secret: 'secret/apm-team/ci/nexus', user_var_name: '__unused__', pass_var_name: 'SPID', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id'){
-                  def foundStagingId = nexusFindStagingId(stagingProfileId: "${SPID}", groupId: "co.elastic.apm")
-                  nexusCloseStagingRepository(stagingProfileId: "${SPID}", stagingId: foundStagingId)
-                  nexusReleaseStagingRepository(stagingProfileId: "${SPID}", stagingId: foundStagingId)
-                }
-              }
-            }
+            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be published in Nexus",
+                         body: "Please go to (<https://oss.sonatype.org/|here>) to proceed with the manual nexus release. Login details in LastPass")
+            input(message: "Go to https://oss.sonatype.or and proceed with the steps to close and release the staging artifact.")
           }
         }
         stage('Branch creation') {

--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -160,7 +160,7 @@ pipeline {
           steps {
             notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be published in Nexus",
                          body: "Please go to (<https://oss.sonatype.org/|here>) to proceed with the manual nexus release. Login details in LastPass")
-            input(message: "Go to https://oss.sonatype.or and proceed with the steps to close and release the staging artifact.")
+            input(message: "Go to https://oss.sonatype.org and proceed with the steps to close and release the staging artifact.")
           }
         }
         stage('Branch creation') {


### PR DESCRIPTION
## What does this PR do?

As long as the 401 error happens, let's unblock the release process and allow the pipeline to drive the steps in a way that the nexus interaction is still manual.

It's not ideal, but it might help to validate all the steps and then we can plan what to do next.
