### PR TITLE
[release] use the vault secret/role credentials explicitly

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -278,7 +278,7 @@ pipeline {
               withEnv(["SONATYPE_FALLBACK=1"]) {
                 sh(label: "Build Docker image", script: "./scripts/jenkins/build_docker.sh")
                   // Get Docker registry credentials
-                  dockerLogin(secret: "${ELASTIC_DOCKER_SECRET}", registry: 'docker.elastic.co')
+                  dockerLogin(secret: "${ELASTIC_DOCKER_SECRET}", registry: 'docker.elastic.co', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id')
                   sh(label: "Push Docker image", script: "./scripts/jenkins/push_docker.sh")
               }
             }


### PR DESCRIPTION
## What does this PR do?

Credentials where the release run do not match what we use in other CI instances, so let's override the default ones with the ones which are defined.

Fixes

![image](https://user-images.githubusercontent.com/2871786/133646244-d02cc435-edaa-41da-a019-875199d23f97.png)


Requires https://github.com/elastic/apm-pipeline-library/pull/1282