### PR TITLE
Improved capturing of logged exceptions when using Log4j2

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ endif::[]
 
 [float]
 ===== Features
+* Improved capturing of logged exceptions when using Log4j2 {pull}2139[#2139]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-error-logging-plugin/pom.xml
+++ b/apm-agent-plugins/apm-error-logging-plugin/pom.xml
@@ -15,4 +15,13 @@
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${version.log4j}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-error-logging-plugin/src/main/java/co/elastic/apm/agent/errorlogging/AbstractLoggerErrorCapturingInstrumentation.java
+++ b/apm-agent-plugins/apm-error-logging-plugin/src/main/java/co/elastic/apm/agent/errorlogging/AbstractLoggerErrorCapturingInstrumentation.java
@@ -80,8 +80,7 @@ public abstract class AbstractLoggerErrorCapturingInstrumentation extends Tracer
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
         return named("error")
-            .and(takesArgument(0, named("java.lang.String"))
-                .and(takesArgument(1, named("java.lang.Throwable"))));
+            .and(takesArgument(1, named("java.lang.Throwable")));
     }
 
     @Override

--- a/apm-agent-plugins/apm-error-logging-plugin/src/test/java/co/elastic/apm/agent/errorlogging/Log4j2LoggerErrorCapturingInstrumentationTest.java
+++ b/apm-agent-plugins/apm-error-logging-plugin/src/test/java/co/elastic/apm/agent/errorlogging/Log4j2LoggerErrorCapturingInstrumentationTest.java
@@ -20,6 +20,7 @@ package co.elastic.apm.agent.errorlogging;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.message.ParameterizedMessageFactory;
 import org.junit.jupiter.api.Test;
 
 class Log4j2LoggerErrorCapturingInstrumentationTest extends AbstractErrorLoggingInstrumentationTest {
@@ -27,9 +28,15 @@ class Log4j2LoggerErrorCapturingInstrumentationTest extends AbstractErrorLogging
     private static final Logger logger = LogManager.getLogger(Log4j2LoggerErrorCapturingInstrumentationTest.class);
 
     @Test
-    void captureException() {
+    void captureExceptionWithStringMessage() {
         logger.error("exception captured", new RuntimeException("some business exception"));
         verifyThatExceptionCaptured(1, "some business exception", RuntimeException.class);
     }
 
+
+    @Test
+    void captureExceptionWithMessageMessage() {
+        logger.error(ParameterizedMessageFactory.INSTANCE.newMessage("exception captured with parameter {}", "foo"), new RuntimeException("some business exception"));
+        verifyThatExceptionCaptured(1, "some business exception", RuntimeException.class);
+    }
 }


### PR DESCRIPTION
## What does this PR do?
There are multiple overloaded versions of Logger.error(message, cause) for Log4j 2, so relaxe the method matcher a bit

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
