### PR TITLE
synchronize schema spec

### DIFF
--- a/apm-agent-core/src/test/resources/apm-server-schema/current/error.json
+++ b/apm-agent-core/src/test/resources/apm-server-schema/current/error.json
@@ -147,6 +147,13 @@
                   "maxLength": 1024
                 }
               }
+            },
+            "routing_key": {
+              "description": "RoutingKey holds the optional routing key of the received message as set on the queuing system, such as in RabbitMQ.",
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         },

--- a/apm-agent-core/src/test/resources/apm-server-schema/current/span.json
+++ b/apm-agent-core/src/test/resources/apm-server-schema/current/span.json
@@ -320,6 +320,13 @@
                   "maxLength": 1024
                 }
               }
+            },
+            "routing_key": {
+              "description": "RoutingKey holds the optional routing key of the received message as set on the queuing system, such as in RabbitMQ.",
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         },

--- a/apm-agent-core/src/test/resources/apm-server-schema/current/transaction.json
+++ b/apm-agent-core/src/test/resources/apm-server-schema/current/transaction.json
@@ -146,6 +146,13 @@
                   "maxLength": 1024
                 }
               }
+            },
+            "routing_key": {
+              "description": "RoutingKey holds the optional routing key of the received message as set on the queuing system, such as in RabbitMQ.",
+              "type": [
+                "null",
+                "string"
+              ]
             }
           }
         },


### PR DESCRIPTION
### What
  APM agent json schema automatic sync

  ### Why
  *Changeset*
* https://github.com/elastic/apm-server/commit/527987315 intake: Add `context.message.routing_key` to API (https://github.com/elastic/apm-server/pull/6177)