### PR TITLE
Fix ignore on request path

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,13 +24,12 @@ endif::[]
 ==== 1.27.0 - YYYY/MM/DD
 
 [float]
-===== Breaking changes
+===== Potentially breaking changes
 * `transaction_ignore_urls` now relies on full request URL path - {pull}2146[#2146]
 ** On a typical application server like Tomcat, deploying an `app.war` application to the non-ROOT context makes it accessible with `http://localhost:8080/app/`
 ** Ignoring the whole webapp through `/app/*` was not possible until now.
-** We can now ignore a whole webapp through `/app/*`.
-** Existing configuration needs to be updated to include the deployment context, thus for example `/static/*.js` used to
-exclude known static files in all applications might be changed to `/app/static/*.js`.
+** Existing configuration may need to be updated to include the deployment context, thus for example `/static/*.js` used to
+exclude known static files in all applications might be changed to `/app/static/*.js` or `*/static/*.js`.
 ** It only impacts prefix patterns due to the additional context path in pattern.
 ** It does not impact deployment within the `ROOT` context like Spring-boot which do not have such context path prefix.
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,18 @@ endif::[]
 ==== 1.27.0 - YYYY/MM/DD
 
 [float]
+===== Breaking changes
+* `transaction_ignore_urls` now relies on full request URL path - {pull}2146[#2146]
+** On a typical application server like Tomcat, deploying an `app.war` application to the non-ROOT context makes it accessible with `http://localhost:8080/app/`
+** Ignoring the whole webapp through `/app/*` was not possible until now.
+** We can now ignore a whole webapp through `/app/*`.
+** Existing configuration needs to be updated to include the deployment context, thus for example `/static/*.js` used to
+exclude known static files in all applications might be changed to `/app/static/*.js`.
+** It only impacts prefix patterns due to the additional context path in pattern.
+** It does not impact deployment within the `ROOT` context like Spring-boot which do not have such context path prefix.
+
+
+[float]
 ===== Features
 * Improved capturing of logged exceptions when using Log4j2 {pull}2139[#2139]
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/ServletTransactionCreationHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/ServletTransactionCreationHelper.java
@@ -60,25 +60,14 @@ public class ServletTransactionCreationHelper {
         return transaction;
     }
 
-    private boolean isExcluded(HttpServletRequest request) {
+    boolean isExcluded(HttpServletRequest request) {
         String userAgent = request.getHeader("User-Agent");
 
-        String pathFirstPart = request.getServletPath();
-        String pathSecondPart = Objects.toString(request.getPathInfo(), "");
+        String requestUri = request.getRequestURI();
 
-        if (pathFirstPart.isEmpty()) {
-            // when servlet path is empty, reconstructing the path from the request URI
-            // this can happen when transaction is created by a filter (and thus servlet path is unknown yet)
-            String contextPath = request.getContextPath();
-            if (null != contextPath) {
-                pathFirstPart = request.getRequestURI().substring(contextPath.length());
-                pathSecondPart = "";
-            }
-        }
-
-        final WildcardMatcher excludeUrlMatcher = WildcardMatcher.anyMatch(webConfiguration.getIgnoreUrls(), pathFirstPart, pathSecondPart);
+        final WildcardMatcher excludeUrlMatcher = WildcardMatcher.anyMatch(webConfiguration.getIgnoreUrls(), requestUri);
         if (excludeUrlMatcher != null && logger.isDebugEnabled()) {
-            logger.debug("Not tracing this request as the URL {}{} is ignored by the matcher {}", pathFirstPart, pathSecondPart, excludeUrlMatcher);
+            logger.debug("Not tracing this request as the URL {} is ignored by the matcher {}", requestUri, excludeUrlMatcher);
         }
         final WildcardMatcher excludeAgentMatcher = userAgent != null ? WildcardMatcher.anyMatch(webConfiguration.getIgnoreUserAgents(), userAgent) : null;
         if (excludeAgentMatcher != null) {
@@ -86,7 +75,7 @@ public class ServletTransactionCreationHelper {
         }
         boolean isExcluded = excludeUrlMatcher != null || excludeAgentMatcher != null;
         if (!isExcluded && logger.isTraceEnabled()) {
-            logger.trace("No matcher found for excluding this request with URL: {}{}, and User-Agent: {}", pathFirstPart, pathSecondPart, userAgent);
+            logger.trace("No matcher found for excluding this request with URL: {}, and User-Agent: {}", requestUri, userAgent);
         }
         return isExcluded;
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ApmFilterTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ApmFilterTest.java
@@ -159,22 +159,16 @@ class ApmFilterTest extends AbstractInstrumentationTest {
             .hasSize(0);
     }
 
-    void testIgnoreUserAgent(String ignoreUserAgent, String userAgent) throws ServletException, IOException {
-        when(webConfiguration.getIgnoreUserAgents()).thenReturn(Collections.singletonList(WildcardMatcher.valueOf(ignoreUserAgent)));
+    @Test
+    void testIgnoreUserAGent() throws IOException, ServletException {
+        String config = "curl/*";
+        String userAgent = "curl/7.54.0";
+
+        when(webConfiguration.getIgnoreUserAgents()).thenReturn(Collections.singletonList(WildcardMatcher.valueOf(config)));
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("user-agent", userAgent);
         filterChain.doFilter(request, new MockHttpServletResponse());
         assertThat(reporter.getTransactions()).hasSize(0);
-    }
-
-    @Test
-    void testIgnoreUserAgentStartWith() throws IOException, ServletException {
-        testIgnoreUserAgent("curl/*","curl/7.54.0");
-    }
-
-    @Test
-    void testIgnoreUserAgentInfix() throws IOException, ServletException {
-        testIgnoreUserAgent("*pingdom*","Pingdom.com_bot_version_1.4_(http://www.pingdom.com)");
     }
 
     @Test

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
@@ -46,12 +46,8 @@ class ServletTransactionHelperTest extends AbstractInstrumentationTest {
 
     @BeforeEach
     void setUp() {
-        ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
         webConfig = config.getConfig(WebConfiguration.class);
-        servletTransactionHelper = new ServletTransactionHelper(new ElasticApmTracerBuilder()
-            .configurationRegistry(config)
-            .reporter(reporter)
-            .build());
+        servletTransactionHelper = new ServletTransactionHelper(tracer);
     }
 
     @Test
@@ -123,4 +119,5 @@ class ServletTransactionHelperTest extends AbstractInstrumentationTest {
         servletTransactionHelper.applyDefaultTransactionName(method, path, null, transaction);
         return transaction.getNameAsString();
     }
+
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
@@ -20,15 +20,12 @@ package co.elastic.apm.agent.servlet;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
 import co.elastic.apm.agent.MockTracer;
-import co.elastic.apm.agent.configuration.SpyConfiguration;
-import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
+import co.elastic.apm.agent.impl.context.web.WebConfiguration;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.matcher.WildcardMatcher;
-import co.elastic.apm.agent.impl.context.web.WebConfiguration;
 import co.elastic.apm.agent.util.TransactionNameUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import javax.annotation.Nonnull;
 import java.net.URL;

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/helper/ServletTransactionCreationHelperTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/helper/ServletTransactionCreationHelperTest.java
@@ -1,0 +1,109 @@
+package co.elastic.apm.agent.servlet.helper;
+
+import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.impl.context.web.WebConfiguration;
+import co.elastic.apm.agent.matcher.WildcardMatcher;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class ServletTransactionCreationHelperTest extends AbstractInstrumentationTest {
+
+    private WebConfiguration webConfig;
+    private ServletTransactionCreationHelper helper;
+
+    @BeforeEach
+    void setUp() {
+        webConfig = config.getConfig(WebConfiguration.class);
+        helper = new ServletTransactionCreationHelper(tracer);
+    }
+
+    @Test
+    void requestPathNotIgnored() {
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/not-ignored");
+
+        assertThat(helper.isExcluded(request)).isFalse();
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        delimiterString = " ", value = {
+        "/ignored/from/prefix /ignored*",
+        "/ignored/with-suffix.js *.js",
+        "/ignored/with/term *with*"})
+    void requestPathIgnored(String path, String ignoreExpr) {
+        when(webConfig.getIgnoreUrls())
+            .thenReturn(parseWildcard(ignoreExpr));
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn(path);
+
+        assertThat(helper.isExcluded(request))
+            .describedAs("request with path '%s' should be ignored", path)
+            .isTrue();
+    }
+
+    @ParameterizedTest
+    @CsvSource(delimiterString = " ", value = {
+        "anderson and*",
+        "anderson smith,anderson"
+    })
+    void requestUserAgentIgnored(String userAgent, String ignoreExpr) {
+        when(webConfig.getIgnoreUserAgents())
+            .thenReturn(parseWildcard(ignoreExpr));
+
+        HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getRequestURI()).thenReturn("/request/path");
+
+
+        ArgumentCaptor<String> headerName = ArgumentCaptor.forClass(String.class);
+        when(request.getHeader(headerName.capture())).thenReturn(userAgent);
+
+        doReturn(userAgent).when(request).getHeader(anyString());
+
+        assertThat(helper.isExcluded(request))
+            .describedAs("request with user-agent '%s' should be ignored", userAgent)
+            .isTrue();
+
+        verify(request).getHeader(headerName.capture());
+        assertThat(headerName.getValue().toLowerCase(Locale.ROOT)).isEqualTo("user-agent");
+    }
+
+    private static List<WildcardMatcher> parseWildcard(String expr){
+        return Stream.of(expr.split(","))
+            .map(WildcardMatcher::valueOf)
+            .collect(Collectors.toList());
+    }
+
+    @Test
+    void safeGetClassLoader(){
+        assertThat(helper.getClassloader(null)).isNull();
+
+        ServletContext servletContext = mock(ServletContext.class);
+        doThrow(UnsupportedOperationException.class).when(servletContext).getClassLoader();
+        assertThat(helper.getClassloader(servletContext)).isNull();
+
+        servletContext = mock(ServletContext.class);
+        ClassLoader cl = mock(ClassLoader.class);
+        when(servletContext.getClassLoader()).thenReturn(cl);
+        assertThat(helper.getClassloader(servletContext)).isSameAs(cl);
+    }
+}

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/helper/ServletTransactionCreationHelperTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/helper/ServletTransactionCreationHelperTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.servlet.helper;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -152,10 +152,18 @@ public abstract class AbstractServletContainerIntegrationTest {
         }
         this.expectedDefaultServiceName = expectedDefaultServiceName;
         this.containerName = containerName;
+
+        List<String> ignoreUrls = new ArrayList<>();
+        for (TestApp app : getTestApps()) {
+            ignoreUrls.add(String.format("/%s/status*", app.getDeploymentContext()));
+        }
+        ignoreUrls.add("/favicon.ico");
+        String ignoreUrlConfig = String.join(",", ignoreUrls);
+
         servletContainer
             .withNetwork(Network.SHARED)
             .withEnv("ELASTIC_APM_SERVER_URL", "http://apm-server:1080")
-            .withEnv("ELASTIC_APM_IGNORE_URLS", "/*/status*,/favicon.ico") // status ignore path is broad to fit all deployment context paths
+            .withEnv("ELASTIC_APM_IGNORE_URLS", ignoreUrlConfig)
             .withEnv("ELASTIC_APM_REPORT_SYNC", "true")
             .withEnv("ELASTIC_APM_LOG_LEVEL", "DEBUG")
             .withEnv("ELASTIC_APM_METRICS_INTERVAL", "1s")

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -155,7 +155,7 @@ public abstract class AbstractServletContainerIntegrationTest {
         servletContainer
             .withNetwork(Network.SHARED)
             .withEnv("ELASTIC_APM_SERVER_URL", "http://apm-server:1080")
-            .withEnv("ELASTIC_APM_IGNORE_URLS", "/status*,/favicon.ico")
+            .withEnv("ELASTIC_APM_IGNORE_URLS", "/*/status*,/favicon.ico") // status ignore path is broad to fit all deployment context paths
             .withEnv("ELASTIC_APM_REPORT_SYNC", "true")
             .withEnv("ELASTIC_APM_LOG_LEVEL", "DEBUG")
             .withEnv("ELASTIC_APM_METRICS_INTERVAL", "1s")

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/CdiApplicationServerTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/CdiApplicationServerTestApp.java
@@ -29,7 +29,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CdiApplicationServerTestApp extends TestApp {
 
     public CdiApplicationServerTestApp() {
-        super("../cdi-app/cdi-app-dependent", "cdi-app.war", "/cdi-app/status.html", "CDI App");
+        super("../cdi-app/cdi-app-dependent",
+            "cdi-app.war",
+            "cdi-app",
+            "status.html",
+            "CDI App");
     }
 
     @Override

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/CdiServletContainerTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/CdiServletContainerTestApp.java
@@ -23,7 +23,11 @@ import co.elastic.apm.servlet.AbstractServletContainerIntegrationTest;
 public class CdiServletContainerTestApp extends TestApp {
 
     public CdiServletContainerTestApp() {
-        super("../cdi-app/cdi-app-standalone", "cdi-app.war", "/cdi-app/status.html", "CDI App");
+        super("../cdi-app/cdi-app-standalone",
+            "cdi-app.war",
+            "cdi-app",
+            "status.html",
+            "CDI App");
     }
 
     @Override

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/ExternalPluginTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/ExternalPluginTestApp.java
@@ -31,10 +31,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExternalPluginTestApp extends TestApp {
     public ExternalPluginTestApp() {
-        super(
-            "../external-plugin-test/external-plugin-app",
+        super("../external-plugin-test/external-plugin-app",
             "external-plugin-webapp.war",
-            "/external-plugin-webapp/status.html",
+            "external-plugin-webapp",
+            "status.html",
             "external-plugin-webapp"
         );
     }

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/JsfApplicationServerTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/JsfApplicationServerTestApp.java
@@ -30,7 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class JsfApplicationServerTestApp extends TestApp {
 
     public JsfApplicationServerTestApp() {
-        super("../jsf-app/jsf-app-dependent", "jsf-http-get.war", "/jsf-http-get/status.html", "jsf-http-get");
+        super("../jsf-app/jsf-app-dependent",
+            "jsf-http-get.war",
+            "jsf-http-get",
+            "status.html",
+            "jsf-http-get");
     }
 
     @Override

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/JsfServletContainerTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/JsfServletContainerTestApp.java
@@ -22,7 +22,11 @@ import co.elastic.apm.servlet.AbstractServletContainerIntegrationTest;
 
 public class JsfServletContainerTestApp extends TestApp {
     public JsfServletContainerTestApp() {
-        super("../jsf-app/jsf-app-standalone", "jsf-http-get.war", "/jsf-http-get/status.html", "jsf-http-get");
+        super("../jsf-app/jsf-app-standalone",
+            "jsf-http-get.war",
+            "jsf-http-get",
+            "status.html",
+            "jsf-http-get");
     }
 
     @Override

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/ServletApiTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/ServletApiTestApp.java
@@ -39,7 +39,11 @@ import static org.awaitility.Awaitility.await;
 public class ServletApiTestApp extends TestApp {
 
     public ServletApiTestApp() {
-        super("../simple-webapp", "simple-webapp.war", "/simple-webapp/status.jsp", "Simple Web App");
+        super("../simple-webapp",
+            "simple-webapp.war",
+            "simple-webapp",
+            "status.jsp",
+            "Simple Web App");
     }
 
     @Override

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/SoapTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/SoapTestApp.java
@@ -30,7 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class SoapTestApp extends TestApp {
     public SoapTestApp() {
-        super("../soap-test", "soap-test.war", "/soap-test/status.html", "soap-test");
+        super("../soap-test",
+            "soap-test.war",
+            "soap-test",
+            "status.html",
+            "soap-test");
     }
 
     @Override

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/TestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/TestApp.java
@@ -36,7 +36,7 @@ public abstract class TestApp {
     TestApp(String modulePath, String appFileName, String deploymentContext, String statusEndpoint, @Nullable String expectedServiceName) {
         this.modulePath = modulePath;
         this.appFileName = appFileName;
-        this.statusEndpoint = String.format("%s/%s", deploymentContext, statusEndpoint);
+        this.statusEndpoint = String.format("/%s/%s", deploymentContext, statusEndpoint);
         this.deploymentContext = deploymentContext;
         this.expectedServiceName = expectedServiceName;
     }

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/TestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/TestApp.java
@@ -31,11 +31,13 @@ public abstract class TestApp {
     private final String statusEndpoint;
     @Nullable
     private final String expectedServiceName;
+    private final String deploymentContext;
 
-    TestApp(String modulePath, String appFileName, String statusEndpoint, @Nullable String expectedServiceName) {
+    TestApp(String modulePath, String appFileName, String deploymentContext, String statusEndpoint, @Nullable String expectedServiceName) {
         this.modulePath = modulePath;
         this.appFileName = appFileName;
-        this.statusEndpoint = statusEndpoint;
+        this.statusEndpoint = String.format("%s/%s", deploymentContext, statusEndpoint);
+        this.deploymentContext = deploymentContext;
         this.expectedServiceName = expectedServiceName;
     }
 
@@ -49,6 +51,10 @@ public abstract class TestApp {
 
     public String getStatusEndpoint() {
         return statusEndpoint;
+    }
+
+    public String getDeploymentContext() {
+        return deploymentContext;
     }
 
     @Nullable


### PR DESCRIPTION
## What does this PR do?

Currently we ignore request using Servlet path, which does not include the Servlet context path.
As a result, trying to ignore URLs with `/app-context/*` with a web-application deployed to the `/app-context` context path is not ignored.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
