### PR TITLE
Fix concurrency issues with ensureInstrumented

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,14 +36,15 @@ exclude known static files in all applications might be changed to `/app/static/
 
 [float]
 ===== Features
-* Improved capturing of logged exceptions when using Log4j2 {pull}2139[#2139]
+* Improved capturing of logged exceptions when using Log4j2 - {pull}2139[#2139]
 
 [float]
 ===== Bug fixes
+* Fixing/reducing startup delays related to `ensureInstrumented` - {pull}2150[#2150]
 
 [float]
 ===== Refactorings
-* Loading the agent from an isolated class loader {pull}2109[#2109]
+* Loading the agent from an isolated class loader - {pull}2109[#2109]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -719,6 +719,7 @@ public class ElasticApmAgent {
                     throw new IllegalStateException("Agent is not initialized");
                 }
 
+                appliedInstrumentations = dynamicallyInstrumentedClasses.get(classToInstrument);
                 if (!appliedInstrumentations.contains(instrumentationClasses)) {
                     appliedInstrumentations = new HashSet<>(appliedInstrumentations);
                     appliedInstrumentations.add(instrumentationClasses);
@@ -754,7 +755,7 @@ public class ElasticApmAgent {
         Set<Collection<Class<? extends ElasticApmInstrumentation>>> instrumentedClasses = dynamicallyInstrumentedClasses.get(classToInstrument);
         if (instrumentedClasses == null) {
             instrumentedClasses = new HashSet<Collection<Class<? extends ElasticApmInstrumentation>>>();
-            Set<Collection<Class<? extends ElasticApmInstrumentation>>> racy = dynamicallyInstrumentedClasses.put(classToInstrument, instrumentedClasses);
+            Set<Collection<Class<? extends ElasticApmInstrumentation>>> racy = dynamicallyInstrumentedClasses.putIfAbsent(classToInstrument, instrumentedClasses);
             if (racy != null) {
                 instrumentedClasses = racy;
             }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -28,6 +28,7 @@ import co.elastic.apm.agent.sdk.DynamicTransformer;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.sdk.advice.AssignTo;
 import co.elastic.apm.agent.sdk.state.GlobalVariables;
+import co.elastic.apm.agent.util.ExecutorUtils;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
@@ -56,7 +57,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static net.bytebuddy.matcher.ElementMatchers.any;
@@ -167,8 +167,7 @@ class InstrumentationTest {
         for (int i = 0; i < nThreads; i++) {
             executorService.submit(() -> ElasticApmAgent.ensureInstrumented(getClass(), List.of(TestCounterInstrumentation.class)));
         }
-        executorService.shutdown();
-        executorService.awaitTermination(1000, TimeUnit.MILLISECONDS);
+        ExecutorUtils.shutdownAndWaitTermination(executorService);
         assertThat(TestCounterInstrumentation.getCounter()).isEqualTo(1);
         assertThat(interceptMe()).isEqualTo("intercepted");
     }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -513,7 +513,6 @@ class InstrumentationTest {
         @Override
         public ElementMatcher<? super TypeDescription> getTypeMatcher() {
             counter.incrementAndGet();
-            new Throwable().printStackTrace();
             return super.getTypeMatcher();
         }
 


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
We got several reports that there are cases where the agent gets blocked for a while on startup and thread dumps show multiple threads being blocked during the execution of `ensureInstrumented` (e.g. #2091, #1839).
This PR adds a test for concurrently invoking `ensureInstrumented` in many threads. The test indeed assisted with identifying two concurrency issues (not affecting functionality, only introducing an unnecessary delay).
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
