### PR TITLE
Fix ECS log reformatting

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyBootstrap.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyBootstrap.java
@@ -43,6 +43,7 @@ import java.lang.invoke.MethodType;
 import java.lang.reflect.Method;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,7 +53,6 @@ import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.is;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**
@@ -66,8 +66,9 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  * This will also create the plugin class loader.
  * </p>
  * <pre>
- *   Bootstrap CL ←──────────────────────────── Agent CL
- *       ↑ └java.lang.IndyBootstrapDispatcher ─ ↑ ─→ └ {@link IndyBootstrap#bootstrap}
+ *                      {@link co.elastic.apm.agent.premain.ShadedClassLoader}
+ *   Bootstrap CL ←─────Cached Lookup Key────── Agent CL {@link co.elastic.apm.agent.premain.ShadedClassLoader}
+ *       ↑ └java.lang.IndyBootstrapDispatcher ─ ↑ ───→ └ {@link IndyBootstrap#bootstrap}
  *     Ext/Platform CL               ↑          │                        ╷
  *       ↑                           ╷          │                        ↓
  *     System CL                     ╷          │        {@link IndyPluginClassLoaderFactory#getOrCreatePluginClassLoader}
@@ -77,8 +78,10 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
  * WebApp1  WebApp2                  ╷          │ ├ AdviceHelper      creates
  *          ↑ - InstrumentedClass    ╷          │ ├ GlobalState          ╷
  *          │                ╷       ╷          │ └ LookupExposer        ╷
- *          │                INVOKEDYNAMIC      │                        ↓
- *          └────────────────┼──────────────────{@link IndyPluginClassLoader}
+ *          │                INVOKEDYNAMIC      │                        ╷
+ *          └────────────────┼──────────────────{@link net.bytebuddy.dynamic.loading.MultipleParentClassLoader}
+ *                           │                  ↑                        ↓
+ *                           │                  {@link IndyPluginClassLoader}
  *                           └╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶╶→ ├ AdviceClass
  *                                              ├ AdviceHelper
  *                                              └ LookupExposer
@@ -348,9 +351,6 @@ public class IndyBootstrap {
                 instrumentationClassLoader,
                 classFileLocator,
                 isAnnotatedWith(named(GlobalState.class.getName()))
-                    // no plugin CL necessary as all types are available form bootstrap CL
-                    // also, this plugin is used as a dependency in other plugins
-                    .or(nameStartsWith("co.elastic.apm.agent.concurrent"))
                     // if config classes would be loaded from the plugin CL,
                     // tracer.getConfig(Config.class) would return null when called from an advice as the classes are not the same
                     .or(nameContains("Config").and(hasSuperType(is(ConfigurationOptionProvider.class)))));
@@ -375,7 +375,12 @@ public class IndyBootstrap {
         String pluginPackage = adviceClassName.substring(0, adviceClassName.indexOf('.', EMBEDDED_PLUGINS_PACKAGE_PREFIX.length()));
         List<String> pluginClasses = classesByPackage.get(pluginPackage);
         if (pluginClasses == null) {
-            classesByPackage.putIfAbsent(pluginPackage, PackageScanner.getClassNames(pluginPackage, adviceClassLoader));
+            pluginClasses = new ArrayList<>();
+            Collection<String> pluginClassLoaderRootPackages = ElasticApmAgent.getPluginClassLoaderRootPackages(pluginPackage);
+            for (String pkg : pluginClassLoaderRootPackages) {
+                pluginClasses.addAll(PackageScanner.getClassNames(pkg, adviceClassLoader));
+            }
+            classesByPackage.putIfAbsent(pluginPackage, pluginClasses);
             pluginClasses = classesByPackage.get(pluginPackage);
         }
         return pluginClasses;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/TracerAwareInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/TracerAwareInstrumentation.java
@@ -23,11 +23,42 @@ import co.elastic.apm.agent.impl.GlobalTracer;
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * The constructor can optionally have a {@link ElasticApmTracer} parameter.
  */
 public abstract class TracerAwareInstrumentation extends ElasticApmInstrumentation {
 
+    /**
+     * The root package name prefix that all embedded plugins classes must start with
+     */
+    private static final String EMBEDDED_PLUGINS_PACKAGE_PREFIX = "co.elastic.apm.agent.";
+
     public static final Tracer tracer = GlobalTracer.get();
+    private final String pluginPackage;
+
+    public TracerAwareInstrumentation() {
+        String className = getClass().getName();
+        if (!className.startsWith(EMBEDDED_PLUGINS_PACKAGE_PREFIX)) {
+            throw new IllegalArgumentException("invalid instrumentation class location : " + className);
+        }
+        this.pluginPackage = className.substring(0, className.indexOf('.', EMBEDDED_PLUGINS_PACKAGE_PREFIX.length()));
+    }
+
+    public final String getPluginPackage() {
+        return pluginPackage;
+    }
+
+    /**
+     * All classes in the provided packages except for the ones annotated with {@link co.elastic.apm.agent.sdk.state.GlobalState}
+     * and classes extending {@link org.stagemonitor.configuration.ConfigurationOptionProvider}
+     * will be loaded from a dedicated plugin class loader that has access to both the instrumented classes and the agent classes.
+     * Note that the all root packages of each distinct {@link #pluginPackage} will be combined.
+     */
+    public Collection<String> pluginClassLoaderRootPackages() {
+        return Collections.singletonList(pluginPackage);
+    }
 
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
@@ -37,7 +37,11 @@ public class IndyPluginClassLoader extends ByteArrayClassLoader.ChildFirst {
     private static final ClassLoader SYSTEM_CLASS_LOADER = ClassLoader.getSystemClassLoader();
 
     public IndyPluginClassLoader(@Nullable ClassLoader targetClassLoader, ClassLoader agentClassLoader, Map<String, byte[]> typeDefinitions) {
-        super(getParent(targetClassLoader, agentClassLoader), true, typeDefinitions, PersistenceHandler.MANIFEST);
+        // PersistenceHandler.LATENT reduces the memory footprint of the class loader
+        // after a class has been loaded, the class file byte[] is removed from the map
+        // the tradeoff that looking up the class as a resource isn't possible
+        // that shouldn't be an issue as it can be looked up from the parent class loader (agent class loader)
+        super(getParent(targetClassLoader, agentClassLoader), true, typeDefinitions, PersistenceHandler.LATENT);
     }
 
     private static ClassLoader getParent(@Nullable ClassLoader targetClassLoader, ClassLoader agentClassLoader) {

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/ElasticApmInstrumentation.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/ElasticApmInstrumentation.java
@@ -39,10 +39,12 @@ import static net.bytebuddy.matcher.ElementMatchers.any;
  * The actual instrumentation of the matched methods is performed by static methods within this class,
  * which are annotated by {@link net.bytebuddy.asm.Advice.OnMethodEnter} or {@link net.bytebuddy.asm.Advice.OnMethodExit}.
  * </p>
- * For internal plugins, the whole package (starting at {@code co.elastic.apm.agent.<plugin-root>})
+ * For internal plugins, by default, the whole package (starting at {@code co.elastic.apm.agent.<plugin-root>})
  * will be loaded from a plugin class loader that has both the agent class loader and the class loader of the
  * instrumented class as parents.
  * This class loader is also known as the {@code IndyPluginClassLoader}.
+ * To include more packages (for example, to add 3rd party dependencies),
+ * internal plugins can override {@code co.elastic.apm.agent.bci.TracerAwareInstrumentation#pluginClassLoaderRootPackages()}.
  * For external plugins, the whole jar will be loaded from the indy plugin class loader.
  * <p>
  * The advice methods will be dispatched via an {@code INVOKEDYNAMIC} instruction.

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/AbstractJavaConcurrentInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/AbstractJavaConcurrentInstrumentation.java
@@ -16,28 +16,19 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.log.shader;
-
+package co.elastic.apm.agent.concurrent;
 
 import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.Collections;
 
-public abstract class AbstractLogShadingInstrumentation extends TracerAwareInstrumentation {
-
-    @Override
-    public Collection<String> getInstrumentationGroupNames() {
-        Collection<String> ret = new ArrayList<>();
-        ret.add("logging");
-        return ret;
-    }
+public abstract class AbstractJavaConcurrentInstrumentation extends TracerAwareInstrumentation {
 
     @Override
     public Collection<String> pluginClassLoaderRootPackages() {
-        List<String> pluginPackages = new ArrayList<>(super.pluginClassLoaderRootPackages());
-        pluginPackages.add("co.elastic.logging");
-        return pluginPackages;
+        // the classes of this plugin don't need to be injected into a no plugin CL
+        // as all types referenced in this plugin are available form the bootstrap CL, thus also the agent CL
+        return Collections.emptyList();
     }
 }

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
@@ -18,7 +18,6 @@
  */
 package co.elastic.apm.agent.concurrent;
 
-import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import co.elastic.apm.agent.sdk.advice.AssignTo;
 import co.elastic.apm.agent.sdk.state.GlobalVariables;
 import net.bytebuddy.asm.Advice;
@@ -56,7 +55,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-public abstract class ExecutorInstrumentation extends TracerAwareInstrumentation {
+public abstract class ExecutorInstrumentation extends AbstractJavaConcurrentInstrumentation {
 
     static final Set<String> excludedClasses = GlobalVariables.get(ExecutorInstrumentation.class, "excludedClasses", new HashSet<String>());
 

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ForkJoinTaskInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ForkJoinTaskInstrumentation.java
@@ -18,7 +18,6 @@
  */
 package co.elastic.apm.agent.concurrent;
 
-import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -36,7 +35,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 /**
  * Instruments {@link ForkJoinTask#fork()} to support parallel streams.
  */
-public class ForkJoinTaskInstrumentation extends TracerAwareInstrumentation {
+public class ForkJoinTaskInstrumentation extends AbstractJavaConcurrentInstrumentation {
 
     static {
         if (Boolean.parseBoolean(System.getProperty("intellij.debug.agent"))) {

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/JavaConcurrent.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/JavaConcurrent.java
@@ -22,6 +22,7 @@ import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.sdk.DynamicTransformer;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
+import co.elastic.apm.agent.sdk.state.GlobalState;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakConcurrent;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakMap;
 
@@ -35,6 +36,9 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinTask;
 
+// Not strictly necessary as AbstractJavaConcurrentInstrumentation returns an empty collection for pluginClassLoaderRootPackages
+// but this signals the intent that this class must not be loaded from the IndyBootstrapClassLoader so that the state in this class applies globally
+@GlobalState
 public class JavaConcurrent {
 
     private static final WeakMap<Object, AbstractSpan<?>> contextMap = WeakConcurrent.buildMap();

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/RunnableCallableForkJoinTaskInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/RunnableCallableForkJoinTaskInstrumentation.java
@@ -18,7 +18,6 @@
  */
 package co.elastic.apm.agent.concurrent;
 
-import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.sdk.DynamicTransformer;
 import net.bytebuddy.asm.Advice;
@@ -43,7 +42,7 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
  * {@linkplain DynamicTransformer#ensureInstrumented(Class, Collection) ensure}
  * that particular {@link Callable}, {@link Runnable} and {@link ForkJoinTask} classes are instrumented.
  */
-public class RunnableCallableForkJoinTaskInstrumentation extends TracerAwareInstrumentation {
+public class RunnableCallableForkJoinTaskInstrumentation extends AbstractJavaConcurrentInstrumentation {
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {

--- a/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/ShadedClassLoader.java
+++ b/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/ShadedClassLoader.java
@@ -81,13 +81,16 @@ public class ShadedClassLoader extends URLClassLoader {
     private Class<?> defineClass(String name, byte[] classBytes) {
         String packageName = getPackageName(name);
         if (packageName != null && getPackage(packageName) == null) {
-            synchronized (this) {
+            try {
+                if (manifest != null) {
+                    definePackage(name, manifest, jarUrl);
+                } else {
+                    definePackage(packageName, null, null, null, null, null, null, null);
+                }
+            } catch (IllegalArgumentException e) {
+                // The package may have been defined by a parent class loader in the meantime
                 if (getPackage(packageName) == null) {
-                    if (manifest != null) {
-                        definePackage(name, manifest, jarUrl);
-                    } else {
-                        definePackage(packageName, null, null, null, null, null, null, null);
-                    }
+                    throw e;
                 }
             }
         }


### PR DESCRIPTION
Fixes #2163

Adds a mechanism for plugins to include additional packages to the IndyPluginClassLoader

I've manually tested the fix by setting `log_ecs_reformatting=shade` on a test app.