### PR TITLE
Migrate plugins from ElasticApmInstrumentation to TracerAwareInstrumentation

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/tracemethods/TraceMethodInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/tracemethods/TraceMethodInstrumentation.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.apm.agent.tracemethods;
 
+import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import co.elastic.apm.agent.bci.bytebuddy.SimpleMethodSignatureOffsetMappingFactory;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
@@ -26,7 +27,6 @@ import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.matcher.MethodMatcher;
 import co.elastic.apm.agent.matcher.WildcardMatcher;
-import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -51,7 +51,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-public class TraceMethodInstrumentation extends ElasticApmInstrumentation {
+public class TraceMethodInstrumentation extends TracerAwareInstrumentation {
 
     private final MethodMatcher methodMatcher;
     private final CoreConfiguration config;

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -475,7 +475,7 @@ class InstrumentationTest {
         return "";
     }
 
-    public static class TestInstrumentation extends ElasticApmInstrumentation {
+    public static class TestInstrumentation extends TracerAwareInstrumentation {
         public static class AdviceClass {
             @AssignTo.Return
             @Advice.OnMethodExit(inline = false)
@@ -525,7 +525,7 @@ class InstrumentationTest {
         }
     }
 
-    public static class MathInstrumentation extends ElasticApmInstrumentation {
+    public static class MathInstrumentation extends TracerAwareInstrumentation {
         public static class AdviceClass {
             @AssignTo.Return
             @Advice.OnMethodExit(inline = false)
@@ -551,7 +551,7 @@ class InstrumentationTest {
 
     }
 
-    public static class ExceptionInstrumentation extends ElasticApmInstrumentation {
+    public static class ExceptionInstrumentation extends TracerAwareInstrumentation {
         public static class AdviceClass {
             @Advice.OnMethodExit(inline = false)
             public static void onMethodExit() {
@@ -576,7 +576,7 @@ class InstrumentationTest {
 
     }
 
-    public static class SuppressExceptionInstrumentation extends ElasticApmInstrumentation {
+    public static class SuppressExceptionInstrumentation extends TracerAwareInstrumentation {
         public static class AdviceClass {
             @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
             public static String onMethodEnter() {
@@ -607,7 +607,7 @@ class InstrumentationTest {
 
     }
 
-    public static class FieldAccessInstrumentation extends ElasticApmInstrumentation {
+    public static class FieldAccessInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @AssignTo.Field("privateString")
@@ -634,7 +634,7 @@ class InstrumentationTest {
 
     }
 
-    public static class FieldAccessArrayInstrumentation extends ElasticApmInstrumentation {
+    public static class FieldAccessArrayInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @AssignTo(fields = @AssignTo.Field(index = 0, value = "privateString"))
@@ -661,7 +661,7 @@ class InstrumentationTest {
 
     }
 
-    public static class AssignToArgumentInstrumentation extends ElasticApmInstrumentation {
+    public static class AssignToArgumentInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @AssignTo.Argument(0)
@@ -688,7 +688,7 @@ class InstrumentationTest {
 
     }
 
-    public static class AssignToArgumentsInstrumentation extends ElasticApmInstrumentation {
+    public static class AssignToArgumentsInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @AssignTo(arguments = {
@@ -718,7 +718,7 @@ class InstrumentationTest {
 
     }
 
-    public static class AssignToReturnArrayInstrumentation extends ElasticApmInstrumentation {
+    public static class AssignToReturnArrayInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @AssignTo(returns = @AssignTo.Return(index = 0))
@@ -745,7 +745,7 @@ class InstrumentationTest {
 
     }
 
-    public static class CommonsLangInstrumentation extends ElasticApmInstrumentation {
+    public static class CommonsLangInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             public static AtomicInteger enterCount = GlobalVariables.get(CommonsLangInstrumentation.class, "enterCount", new AtomicInteger());
@@ -779,7 +779,7 @@ class InstrumentationTest {
 
     }
 
-    public static class LoggerFactoryInstrumentation extends ElasticApmInstrumentation {
+    public static class LoggerFactoryInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             public static AtomicInteger enterCount = GlobalVariables.get(LoggerFactoryInstrumentation.class, "enterCount", new AtomicInteger());
@@ -813,7 +813,7 @@ class InstrumentationTest {
 
     }
 
-    public static class StatUtilsInstrumentation extends ElasticApmInstrumentation {
+    public static class StatUtilsInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             public static AtomicInteger enterCount = GlobalVariables.get(StatUtilsInstrumentation.class, "enterCount", new AtomicInteger());
@@ -847,7 +847,7 @@ class InstrumentationTest {
 
     }
 
-    public static class LogManagerInstrumentation extends ElasticApmInstrumentation {
+    public static class LogManagerInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             public static AtomicInteger enterCount = GlobalVariables.get(LogManagerInstrumentation.class, "enterCount", new AtomicInteger());
@@ -881,7 +881,7 @@ class InstrumentationTest {
 
     }
 
-    public static class CallStackUtilsInstrumentation extends ElasticApmInstrumentation {
+    public static class CallStackUtilsInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             public static AtomicInteger enterCount = GlobalVariables.get(CallStackUtilsInstrumentation.class, "enterCount", new AtomicInteger());
@@ -915,7 +915,7 @@ class InstrumentationTest {
 
     }
 
-    public static class ClassLoadingTestInstrumentation extends ElasticApmInstrumentation {
+    public static class ClassLoadingTestInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @AssignTo.Return
@@ -942,7 +942,7 @@ class InstrumentationTest {
 
     }
 
-    public static class InlinedIndyAdviceInstrumentation extends ElasticApmInstrumentation {
+    public static class InlinedIndyAdviceInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @Advice.OnMethodEnter
@@ -967,7 +967,7 @@ class InstrumentationTest {
 
     }
 
-    public static class AgentTypeReturnInstrumentation extends ElasticApmInstrumentation {
+    public static class AgentTypeReturnInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @Advice.OnMethodEnter(inline = false)
@@ -993,7 +993,7 @@ class InstrumentationTest {
 
     }
 
-    public static class AgentTypeParameterInstrumentation extends ElasticApmInstrumentation {
+    public static class AgentTypeParameterInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @Advice.OnMethodEnter(inline = false)
@@ -1023,7 +1023,7 @@ class InstrumentationTest {
 
     }
 
-    public static class GetClassLoaderInstrumentation extends ElasticApmInstrumentation {
+    public static class GetClassLoaderInstrumentation extends TracerAwareInstrumentation {
 
         public static class AdviceClass {
             @AssignTo.Return

--- a/apm-agent-plugins/apm-jdk-httpserver-plugin/src/main/java/co/elastic/apm/agent/httpserver/JdkHttpServerInstrumentation.java
+++ b/apm-agent-plugins/apm-jdk-httpserver-plugin/src/main/java/co/elastic/apm/agent/httpserver/JdkHttpServerInstrumentation.java
@@ -18,12 +18,12 @@
  */
 package co.elastic.apm.agent.httpserver;
 
-import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
+import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 
 import java.util.Arrays;
 import java.util.Collection;
 
-public abstract class JdkHttpServerInstrumentation extends ElasticApmInstrumentation {
+public abstract class JdkHttpServerInstrumentation extends TracerAwareInstrumentation {
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {

--- a/apm-agent-plugins/apm-sparkjava-plugin/src/main/java/co/elastic/apm/agent/sparkjava/RoutesInstrumentation.java
+++ b/apm-agent-plugins/apm-sparkjava-plugin/src/main/java/co/elastic/apm/agent/sparkjava/RoutesInstrumentation.java
@@ -18,7 +18,7 @@
  */
 package co.elastic.apm.agent.sparkjava;
 
-import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
+import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -32,7 +32,7 @@ import static net.bytebuddy.matcher.ElementMatchers.returns;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-public class RoutesInstrumentation extends ElasticApmInstrumentation {
+public class RoutesInstrumentation extends TracerAwareInstrumentation {
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {

--- a/apm-agent-plugins/apm-struts-plugin/src/main/java/co/elastic/apm/agent/struts/Struts2TransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-struts-plugin/src/main/java/co/elastic/apm/agent/struts/Struts2TransactionNameInstrumentation.java
@@ -18,7 +18,7 @@
  */
 package co.elastic.apm.agent.struts;
 
-import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
+import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
@@ -31,7 +31,7 @@ import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
-public class Struts2TransactionNameInstrumentation extends ElasticApmInstrumentation {
+public class Struts2TransactionNameInstrumentation extends TracerAwareInstrumentation {
 
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {


### PR DESCRIPTION
## What does this PR do?
Migrated plugins from ElasticApmInstrumentation to TracerAwareInstrumentation to be more in line with the rest of the plugins.

## Checklist
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
