### PR TITLE
Fix copyright notice in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 - 2020 Elasticsearch BV
+   Copyright 2018 Elastic and contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
The year doesn't need to be a range of years. Just the start year is relevant.
We don't require contributors to transfer the copyright to us, so the copyright is for Elastic and contributors.