### PR TITLE
Exclude log4j SMTP Appender from cli jars

### DIFF
--- a/apm-agent-attach-cli/pom.xml
+++ b/apm-agent-attach-cli/pom.xml
@@ -160,6 +160,11 @@
                                         must be loaded through a dedicated class loader
                                         -->
                                         <exclude>co/elastic/apm/attach/bouncycastle/BouncyCastleVerifier.class</exclude>
+                                        <!--
+                                        Eliminating exposure to the log4j2 vulnerability related to the SMTP appender -
+                                        https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle
+                                        -->
+                                        <exclude>org/apache/logging/log4j/core/appender/SmtpAppender.class</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -199,15 +204,10 @@
                                         must be loaded through a dedicated class loader
                                         -->
                                         <exclude>co/elastic/apm/attach/bouncycastle/BouncyCastleVerifier.class</exclude>
-                                    </excludes>
-                                </filter>
-                                <filter>
-                                    <artifact>org.apache.logging.log4j:log4j-core</artifact>
-                                    <!--
-                                    Eliminating exposure to the log4j2 vulnerability related to the SMTP appender -
-                                    https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle
-                                    -->
-                                    <excludes>
+                                        <!--
+                                        Eliminating exposure to the log4j2 vulnerability related to the SMTP appender -
+                                        https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle
+                                        -->
                                         <exclude>org/apache/logging/log4j/core/appender/SmtpAppender.class</exclude>
                                     </excludes>
                                 </filter>


### PR DESCRIPTION
Extending elastic/apm-agent-java#1878 which excluded the SMTP appender from the agent itself