### PR TITLE
Print the service version when starting the agent

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
@@ -68,7 +68,8 @@ public class StartupInfo extends AbstractLifecycleListener {
 
     void logConfiguration(ConfigurationRegistry configurationRegistry, Logger logger) {
         final String serviceName = configurationRegistry.getConfig(CoreConfiguration.class).getServiceName();
-        logger.info("Starting Elastic APM {} as {} on {}", elasticApmVersion, serviceName, getJvmAndOsVersionString());
+        final String serviceVersion = configurationRegistry.getConfig(CoreConfiguration.class).getServiceVersion();
+        logger.info("Starting Elastic APM {} as {} ({}) on {}", elasticApmVersion, serviceName, serviceVersion, getJvmAndOsVersionString());
         logger.debug("VM Arguments: {}", ManagementFactory.getRuntimeMXBean().getInputArguments());
         for (List<ConfigurationOption<?>> options : configurationRegistry.getConfigurationOptionsByCategory().values()) {
             for (ConfigurationOption<?> option : options) {


### PR DESCRIPTION
## What does this PR do?
When the agent starts the (configured) service version is printed in the logs.

## Checklist
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
