### PR TITLE
Multi-thread intensive test for NoRandomAccessMap

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/NoRandomAccessMapTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/NoRandomAccessMapTest.java
@@ -18,10 +18,22 @@
  */
 package co.elastic.apm.agent.util;
 
+import co.elastic.apm.agent.objectpool.impl.BookkeeperObjectPool;
+import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
+import org.jctools.queues.atomic.AtomicQueueFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.Iterator;
+import java.util.Random;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.jctools.queues.spec.ConcurrentQueueSpec.createBoundedMpmc;
 
 class NoRandomAccessMapTest {
     private NoRandomAccessMap<String, String> map = new NoRandomAccessMap<>();
@@ -100,5 +112,89 @@ class NoRandomAccessMapTest {
             numElements++;
         }
         assertThat(numElements).isEqualTo(3);
+    }
+
+    @Test
+    void testMultiThreadReadWrite() throws InterruptedException {
+        final int NUM_THREADS = 100;
+        final int NUM_CYCLES = 1000;
+        QueueBasedObjectPool<NoRandomAccessMap<String, String>> rawMapPool = QueueBasedObjectPool.ofRecyclable(
+            AtomicQueueFactory.newQueue(createBoundedMpmc(NUM_THREADS)),
+            true,
+            NoRandomAccessMap::new
+        );
+        BookkeeperObjectPool<NoRandomAccessMap<String, String>> mapPool = new BookkeeperObjectPool<>(rawMapPool);
+        Random random = new Random();
+        ExecutorService writersExecutor = Executors.newFixedThreadPool(NUM_THREADS);
+        ExecutorService readersExecutor = Executors.newFixedThreadPool(NUM_THREADS);
+        final BlockingQueue<MapWrapper> mapQueue = new ArrayBlockingQueue<>(NUM_THREADS * 2);
+
+        for (int i = 0; i < NUM_THREADS; i++) {
+            writersExecutor.submit(() -> {
+                for (int j = 0; j < NUM_CYCLES; j++) {
+                    NoRandomAccessMap<String, String> localMap = mapPool.createInstance();
+                    // this checks through size
+                    assertThat(localMap.isEmpty()).isTrue();
+                    // this checks through iterator.hasNext()
+                    assertThat(localMap).isEmpty();
+                    String wrapperId = String.valueOf(random.nextInt());
+                    int numHeaders = random.nextInt(10);
+                    for (int k = 0; k < numHeaders; k++) {
+                        localMap.add(wrapperId, wrapperId);
+                    }
+                    mapQueue.offer(new MapWrapper(wrapperId, numHeaders, localMap));
+                }
+            });
+        }
+        for (int i = 0; i < NUM_THREADS; i++) {
+            readersExecutor.submit(() -> {
+                for (int j = 0; j < NUM_CYCLES; j++) {
+                    MapWrapper mapWrapper = mapQueue.take();
+                    String wrapperId = mapWrapper.getId();
+                    int numHeaders = mapWrapper.getNumHeaders();
+                    NoRandomAccessMap<String, String> localMap = mapWrapper.getMap();
+                    assertThat(localMap.size()).isEqualTo(numHeaders);
+                    Iterator<NoRandomAccessMap.Entry<String, String>> iterator = localMap.iterator();
+                    for (int k = 0; k < numHeaders; k++) {
+                        NoRandomAccessMap.Entry<String, String> entry = iterator.next();
+                        assertThat(entry.getKey()).isEqualTo(wrapperId);
+                        assertThat(entry.getValue()).isEqualTo(wrapperId);
+                    }
+                    mapPool.recycle(localMap);
+                }
+                return null;
+            });
+        }
+        writersExecutor.shutdown();
+        writersExecutor.awaitTermination(1000, TimeUnit.MILLISECONDS);
+        readersExecutor.shutdown();
+        readersExecutor.awaitTermination(1000, TimeUnit.MILLISECONDS);
+        assertThat(mapPool.getRequestedObjectCount()).isEqualTo(NUM_THREADS * NUM_CYCLES);
+        assertThat(mapPool.getObjectsInPool()).isGreaterThan(NUM_THREADS);
+        assertThat(mapPool.getObjectsInPool()).isLessThan(NUM_THREADS * 2);
+    }
+
+    private static class MapWrapper {
+        private final String id;
+        private final int numHeaders;
+        private final NoRandomAccessMap<String, String> map;
+
+        private MapWrapper(String id, int numHeaders, NoRandomAccessMap<String, String> map) {
+            this.id = id;
+            this.numHeaders = numHeaders;
+            this.map = map;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public int getNumHeaders() {
+            return numHeaders;
+        }
+
+        public NoRandomAccessMap<String, String> getMap() {
+            return map;
+        }
     }
 }


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Closes #2217 

First attempting to reproduce the issue under the assumption it's a visibility issue related to `co.elastic.apm.agent.util.NoRandomAccessMap`. I wasn't able to reproduce it this way. 
I didn't apply the same multi-thread testing for `co.elastic.apm.agent.impl.context.Headers` and `co.elastic.apm.agent.impl.context.Headers.NoGarbageIterator` because I assume the same memory barriers that serve to guard in the first will be as effective in the second.
In this test, the blocking queue may serve as an effective memory barrier between writes and reads (similarly to the disruptor in the actual agent) and the object pool as a memory barrier between reads and following writes (similarly to the agent object pooling).
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
