### PR TITLE
Delaying reporter start

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerReporter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerReporter.java
@@ -113,8 +113,8 @@ public class ApmServerReporter implements Reporter {
 
     @Override
     public void start() {
-        disruptor.start();
         reportingEventHandler.init(this);
+        disruptor.start();
     }
 
     @Override


### PR DESCRIPTION
Currently, this is just a test to POC the approach of reporting events before starting the disruptor without losing events.

@felixbarny this is what we discussed - it can be used in `ApmServerReporter#start` that would asynchronously invoke a blocking `ReportingEventHandler#init` and start the disruptor only after it returns. It can then block on metadata discovery as well as APM Server client and health check, so that we can start accumulating events in the ring buffer before we are ready to send them.

One drawback of this approach is that it won't cover for intermittent connection failures with APM server, so maybe the best approach is to simply resubmit events to the buffer when send fails.

I currently open this as draft so that we can further look into it later on. 
Applying better coverage to these scenarios may also resolve the inconsistent integration tests failures reported in #2176 