### PR TITLE
Add the (current) transaction name to the error object

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ by the agent may be different. This was done in order to improve the integration
 * Added support to capture `context.message.routing-key` in rabbitmq, spring amqp instrumentations - {pull}1767[#1767]
 * Breakdown metrics are now tracked per service (when using APM Server 8.0) - {pull}2208[#2208]
 * Add support for Spring AMQP batch API - {pull}1716[#1716]
+* Add the (current) transaction name to the error (when using APM Server 8.0) - {pull}2235[#2235]
 
 [float]
 ===== Performance improvements

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -330,7 +330,7 @@ public class ElasticApmTracer implements Tracer {
             Transaction currentTransaction = currentTransaction();
             if (currentTransaction != null) {
                 if (currentTransaction.getNameForSerialization().length() > 0) {
-                    error.setTransactionName(currentTransaction.getNameAsString());
+                    error.setTransactionName(currentTransaction.getNameForSerialization());
                 }
                 error.setTransactionType(currentTransaction.getType());
                 error.setTransactionSampled(currentTransaction.isSampled());

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -329,6 +329,9 @@ public class ElasticApmTracer implements Tracer {
             error.setException(e);
             Transaction currentTransaction = currentTransaction();
             if (currentTransaction != null) {
+                if (currentTransaction.getNameForSerialization().length() > 0) {
+                    error.setTransactionName(currentTransaction.getNameAsString());
+                }
                 error.setTransactionType(currentTransaction.getType());
                 error.setTransactionSampled(currentTransaction.isSampled());
             }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorCapture.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorCapture.java
@@ -239,6 +239,11 @@ public class ErrorCapture implements Recyclable {
          */
         private boolean isSampled;
         /**
+         * The related TransactionInfo name
+         */
+        @Nullable
+        private String name;
+        /**
          * The related TransactionInfo type
          */
         @Nullable
@@ -247,11 +252,17 @@ public class ErrorCapture implements Recyclable {
         @Override
         public void resetState() {
             isSampled = false;
+            name = null;
             type = null;
         }
 
         public boolean isSampled() {
             return isSampled;
+        }
+
+        @Nullable
+        public String getName() {
+            return name;
         }
 
         @Nullable
@@ -266,6 +277,10 @@ public class ErrorCapture implements Recyclable {
 
     public void setTransactionSampled(boolean transactionSampled) {
         transactionInfo.isSampled = transactionSampled;
+    }
+
+    public void setTransactionName(@Nullable String name) {
+        transactionInfo.name = name;
     }
 
     public void setTransactionType(@Nullable String type) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorCapture.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorCapture.java
@@ -241,8 +241,7 @@ public class ErrorCapture implements Recyclable {
         /**
          * The related TransactionInfo name
          */
-        @Nullable
-        private String name;
+        private StringBuilder name = new StringBuilder();
         /**
          * The related TransactionInfo type
          */
@@ -252,7 +251,7 @@ public class ErrorCapture implements Recyclable {
         @Override
         public void resetState() {
             isSampled = false;
-            name = null;
+            name.setLength(0);
             type = null;
         }
 
@@ -260,8 +259,7 @@ public class ErrorCapture implements Recyclable {
             return isSampled;
         }
 
-        @Nullable
-        public String getName() {
+        public StringBuilder getName() {
             return name;
         }
 
@@ -279,8 +277,9 @@ public class ErrorCapture implements Recyclable {
         transactionInfo.isSampled = transactionSampled;
     }
 
-    public void setTransactionName(@Nullable String name) {
-        transactionInfo.name = name;
+    public void setTransactionName(@Nullable StringBuilder name) {
+        transactionInfo.name.setLength(0);
+        transactionInfo.name.append(name);
     }
 
     public void setTransactionType(@Nullable String type) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -338,6 +338,9 @@ public class DslJsonSerializer implements PayloadSerializer {
     private void serializeErrorTransactionInfo(ErrorCapture.TransactionInfo errorTransactionInfo) {
         writeFieldName("transaction");
         jw.writeByte(JsonWriter.OBJECT_START);
+        if (errorTransactionInfo.getName() != null) {
+            writeField("name", errorTransactionInfo.getName());
+        }
         if (errorTransactionInfo.getType() != null) {
             writeField("type", errorTransactionInfo.getType());
         }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -497,7 +497,7 @@ class ElasticApmTracerTest {
 
         assertThat(reporter.getErrors()).hasSize(1);
         ErrorCapture error = reporter.getFirstError();
-        assertThat(error.getTransactionInfo().getName()).isEqualTo("My Transaction");
+        assertThat(error.getTransactionInfo().getName().toString()).isEqualTo("My Transaction");
     }
 
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -267,6 +267,9 @@ class ElasticApmTracerTest {
             .describedAs("error trace context [%s] should be a child of span trace context [%s]", error.getTraceContext(), span.getTraceContext())
             .isTrue();
         assertThat(error.getTransactionInfo().isSampled()).isEqualTo(sampled);
+        if (!transaction.getNameAsString().isEmpty()) {
+            assertThat(error.getTransactionInfo().getName()).isEqualTo(transaction.getNameAsString());
+        }
         assertThat(error.getTransactionInfo().getType()).isEqualTo(transaction.getType());
         return error;
     }
@@ -482,6 +485,19 @@ class ElasticApmTracerTest {
         assertThat(errorId).isNotNull();
         ErrorCapture error = reporter.getFirstError();
         assertThat(error.getTraceContext().getId().toString()).isEqualTo(errorId);
+    }
+
+    @Test
+    void testCaptureExceptionWithTransactionName() {
+        Transaction transaction = startTestRootTransaction().withName("My Transaction");
+        try (Scope scope = transaction.activateInScope()) {
+            transaction.captureException(new Exception("test"));
+            transaction.end();
+        }
+
+        assertThat(reporter.getErrors()).hasSize(1);
+        ErrorCapture error = reporter.getFirstError();
+        assertThat(error.getTransactionInfo().getName()).isEqualTo("My Transaction");
     }
 
 }


### PR DESCRIPTION
## What does this PR do?
Since elastic/apm-server#6539 it is possible to add the transaction name to an error object. I added support for it to the java agent.

## Checklist
- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
