### PR TITLE
Upgrade ByteBuddy to version 1.12.1

### DIFF
--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
@@ -23,7 +23,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.41.0)",
+    value = "by gRPC proto compiler (version 1.42.0)",
     comments = "Source: rpc.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 public final class HelloGrpc {

--- a/integration-tests/runtime-attach/runtime-attach-app/pom.xml
+++ b/integration-tests/runtime-attach/runtime-attach-app/pom.xml
@@ -32,7 +32,7 @@
             <!-- known old version of byte-buddy added intentionally to the app classpath -->
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy-agent</artifactId>
-            <version>1.11.22</version>
+            <version>1.9.16</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <version.jetty-server>9.4.11.v20180605</version.jetty-server>
         <version.json-schema-validator>1.0.63</version.json-schema-validator>
         <!-- Byte Buddy and ASM must be kept in sync -->
-        <version.byte-buddy>1.11.22</version.byte-buddy>
+        <version.byte-buddy>1.12.1</version.byte-buddy>
         <version.asm>9.2</version.asm>
         <version.cucumber>5.4.0</version.cucumber>
 


### PR DESCRIPTION
closes #2245 

- 1.12.1 fixes an issue with 1.12.0
- I restored the deliberately older version in our attach test