### PR TITLE
Ignoring a deliberately old version of Byte Buddy in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,7 @@ updates:
       - dependency-name: "com.squareup.okhttp3:okhttp"
       - dependency-name: "com.datastax.cassandra:cassandra-driver-core"
       - dependency-name: "com.datastax.oss:java-driver-core"
+    ignore:
+      - dependency-name: "net.bytebuddy:byte-buddy-agent"
+        # We deliberately want to keep this older version of Byte Buddy for our runtime attach test
+        versions: ["1.9.16"]


### PR DESCRIPTION
## What does this PR do?
Context: #2251 
We do want automatic PRs for Byte Buddy version upgrades, but we have a specific place where we want to keep an older version that can remain constant.
Based on docs, the [`ignore`](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#ignore) option with specified `versions` should work.
