### PR TITLE
[release] fetch tags before checking out

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -157,6 +157,7 @@ pipeline {
                 if (isMajor) {
                   // major release, create '.x' branch
                   sh(script: """
+                    git fetch origin ${RELEASE_TAG} # ensure remote tag is fetched for local checkout
                     git checkout ${RELEASE_TAG}
                     git checkout -b ${BRANCH_DOT_X}
                   """)
@@ -167,6 +168,7 @@ pipeline {
                   // fix doc or release notes should also have been applied to master/stable branch we are releasing from
                   sh(script: """
                     git fetch origin ${BRANCH_DOT_X} # ensure remote branch is fetched for local checkout
+                    git fetch origin ${RELEASE_TAG} # ensure remote tag is fetched for local checkout
                     git checkout --track origin/${BRANCH_DOT_X}
                     git reset --hard ${RELEASE_TAG}
                     """)


### PR DESCRIPTION
## What does this PR do?

Fetch the tags before the checking out.

## Why

Otherwise, those tags won't be in the workspace.

See 

![image](https://user-images.githubusercontent.com/2871786/141822504-d6852eb2-ea9d-42d8-9d9e-d9cc3f9ce185.png)


```bash
$ git fetch upstream v1.27.0
From github.com:elastic/apm-agent-java
 * tag                   v1.27.0    -> FETCH_HEAD
```