### PR TITLE
[release] unstash current checkout

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -136,6 +136,8 @@ pipeline {
                     gitPush()
                 }
 
+                stash(allowEmpty: true, name: 'source-with-changes', useDefaultExcludes: false)
+
                 env.RELEASE_TAG = "v" + user_release_version
                 env.RELEASE_VERSION = user_release_version
                 env.BRANCH_DOT_X = user_release_version.substring(0, user_release_version.indexOf('.'))+'.x'
@@ -153,6 +155,7 @@ pipeline {
                     defaultValue: "",
                     description: "Input release version without '-SNAPSHOT' suffix"
                   ]])
+                stash(allowEmpty: true, name: 'source-with-changes', useDefaultExcludes: false)
 
                 env.RELEASE_TAG = "v" + user_release_version
                 env.RELEASE_VERSION = user_release_version
@@ -217,7 +220,7 @@ pipeline {
               // the version when the tag was created, which might not match the release branch state
               deleteDir()
               dir("${BASE_DIR}") {
-                unstash 'source'
+                unstash 'source-with-changes'
                 sh(label: "remote branch is fetched for local checkout", script: "git fetch origin ${BRANCH_SPECIFIER}")
               }
             }
@@ -263,7 +266,7 @@ pipeline {
             // ensure that we don't rely on side effect of another step
             deleteDir()
             dir("${BASE_DIR}") {
-              unstash 'source'
+              unstash 'source-with-changes'
               sh(label: "remote branch is fetched for local checkout", script: "git fetch origin ${BRANCH_SPECIFIER}")
               sh(script: "./scripts/jenkins/update_cloudfoundry.sh ${RELEASE_VERSION}")
               gitPush()

--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -213,11 +213,12 @@ pipeline {
           }
           post {
             cleanup {
+              // restore git state before updating .x branch, otherwise later external scripts will use
+              // the version when the tag was created, which might not match the release branch state
+              deleteDir()
               dir("${BASE_DIR}") {
-                // restore git state before updating .x branch, otherwise later external scripts will use
-                // the version when the tag was created, which might not match the release branch state
+                unstash 'source'
                 sh(label: "remote branch is fetched for local checkout", script: "git fetch origin ${BRANCH_SPECIFIER}")
-                sh(label: "restore to previous updating version", script: "git branch -f ${BRANCH_SPECIFIER} origin/${BRANCH_SPECIFIER} && git checkout ${BRANCH_SPECIFIER}")
               }
             }
           }
@@ -259,10 +260,11 @@ pipeline {
         }
         stage('Update Cloudfoundry') {
           steps {
-            dir("${BASE_DIR}"){
-              // ensure that we don't rely on side effect of another step
+            // ensure that we don't rely on side effect of another step
+            deleteDir()
+            dir("${BASE_DIR}") {
+              unstash 'source'
               sh(label: "remote branch is fetched for local checkout", script: "git fetch origin ${BRANCH_SPECIFIER}")
-              sh(label: "restore to previous updating version", script: "git branch -f ${BRANCH_SPECIFIER} origin/${BRANCH_SPECIFIER} && git checkout ${BRANCH_SPECIFIER}")
               sh(script: "./scripts/jenkins/update_cloudfoundry.sh ${RELEASE_VERSION}")
               gitPush()
             }


### PR DESCRIPTION
## What does this PR do?


IIUC, the git checkout --track commands intend to keep the previous untouched version where the checkout started from.

Therefore, we can use the unstash 'source` since it contains the workspace with the checkout version.

It might not contains all the tags/commits that were pushed, but I don't think they are needed 