### PR TITLE
[jjbb] reduce the branch indexing schedule

### DIFF
--- a/.ci/jobs/apm-agent-java-mbp.yml
+++ b/.ci/jobs/apm-agent-java-mbp.yml
@@ -42,4 +42,4 @@
             reference-repo: /var/lib/jenkins/.git-references/apm-agent-java.git
             use-author: true
             wipe-workspace: true
-    periodic-folder-trigger: 1h
+    periodic-folder-trigger: 4h


### PR DESCRIPTION
## What does this PR do?

Reduce the branch indexing from one hour to 4 hours.

## Why

Otherwise, PRs from contributors might not be built correctly, since every hour if their target branches are not updated a new build will kick off and kill the on-going builds.


The aim of the periodic configuration was to have always all the PRs ready to be merged, and a way to do so was by evaluating if their target branches changed every hour.


We can move away from this approach if needed, but for the time being less put some fix in place

@jackshirazi , you are the one suffering this issue.
