### PR TITLE
Fixed changelog for Jakarta JSF

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ endif::[]
 
 [float]
 ===== Features
+* Add support to Jakarta EE for JSF - {pull}2254[#2254]
 
 [float]
 ===== Bug fixes
@@ -64,7 +65,6 @@ by the agent may be different. This was done in order to improve the integration
 * Add support to Jakarta EE for JAX-RS - {pull}2248[#2248]
 * Add support for Jakarta EE EJB annotations `@Schedule`, `@Schedules` - {pull}2250[#2250]
 * Added support to Quartz 1.x - {pull}2219[#2219]
-* Add support to Jakarta EE for JSF - {pull}2254[#2254]
 
 [float]
 ===== Performance improvements


### PR DESCRIPTION
## What does this PR do?
moved changelog entry from 1.27.0 to 1.28.0

## Checklist
- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
