### PR TITLE
Fix reading agent version

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ endif::[]
 [float]
 ===== Bug fixes
 * Fixing missing Micrometer metrics in Spring boot due to premature initialization - {pull}2255[#2255]
+* Fixing agent `unknown` version - {pull}2289[#2289]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
@@ -64,7 +64,16 @@ public class StartupInfo extends AbstractLifecycleListener {
     void logConfiguration(ConfigurationRegistry configurationRegistry, Logger logger) {
         final String serviceName = configurationRegistry.getConfig(CoreConfiguration.class).getServiceName();
         final String serviceVersion = configurationRegistry.getConfig(CoreConfiguration.class).getServiceVersion();
-        logger.info("Starting Elastic APM {} as {} ({}) on {}", elasticApmVersion, serviceName, serviceVersion, getJvmAndOsVersionString());
+
+        StringBuilder serviceNameAndVersion = new StringBuilder(serviceName);
+        if (serviceVersion != null) {
+            serviceNameAndVersion.append(" (").append(serviceVersion).append(")");
+        }
+
+        logger.info("Starting Elastic APM {} as {} on {}",
+            elasticApmVersion,
+            serviceNameAndVersion,
+            getJvmAndOsVersionString());
         logger.debug("VM Arguments: {}", ManagementFactory.getRuntimeMXBean().getInputArguments());
         for (List<ConfigurationOption<?>> options : configurationRegistry.getConfigurationOptionsByCategory().values()) {
             for (ConfigurationOption<?> option : options) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/VersionUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/VersionUtils.java
@@ -38,9 +38,10 @@ public final class VersionUtils {
     private static final String AGENT_VERSION;
 
     static {
-        String version = getVersion(VersionUtils.class, "co.elastic.apm", "elastic-apm-agent");
+        File agentJar = ElasticApmAgent.getAgentJarFile();
+        String version = getManifestEntry(agentJar, "Implementation-Version");
         if (version != null && version.endsWith("SNAPSHOT")) {
-            String gitRev = getManifestEntry(ElasticApmAgent.getAgentJarFile(), "SCM-Revision");
+            String gitRev = getManifestEntry(agentJar, "SCM-Revision");
             if (gitRev != null) {
                 version = version + "." + gitRev;
             }

--- a/apm-agent/pom.xml
+++ b/apm-agent/pom.xml
@@ -21,8 +21,6 @@
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
 
-        <!-- default value that will be overloaded through commit-id plugin -->
-        <git.commit.id.abbrev>UNKNOWN</git.commit.id.abbrev>
     </properties>
 
     <dependencies>
@@ -445,7 +443,6 @@
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
                                     <manifestEntries>
                                         <Automatic-Module-Name>${project.groupId}.agent</Automatic-Module-Name>
-                                        <SCM-Revision>${git.commit.id.abbrev}</SCM-Revision>
                                     </manifestEntries>
                                 </transformer>
                                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer" />
@@ -474,19 +471,6 @@
                                 <dependencySourceInclude>${project.groupId}:apm-agent-core</dependencySourceInclude>
                             </dependencySourceIncludes>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.2</version>
-                <executions>
-                    <execution>
-                        <id>get-the-git-infos</id>
-                        <goals>
-                            <goal>revision</goal>
-                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -13,6 +13,9 @@
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
+
+        <!-- default value that will be overloaded through commit-id plugin -->
+        <git.commit.id.abbrev>UNKNOWN</git.commit.id.abbrev>
     </properties>
 
     <dependencies>
@@ -102,7 +105,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
                 <version>3.0.0</version>
                 <executions>
@@ -168,6 +170,19 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>pl.project13.maven</groupId>
+                <artifactId>git-commit-id-plugin</artifactId>
+                <version>4.0.2</version>
+                <executions>
+                    <execution>
+                        <id>get-the-git-infos</id>
+                        <goals>
+                            <goal>revision</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-shade-plugin</artifactId>
                 <executions>
                     <execution>
@@ -190,6 +205,7 @@
                                     <manifestEntries>
                                         <Premain-Class>co.elastic.apm.agent.premain.AgentMain</Premain-Class>
                                         <Agent-Class>co.elastic.apm.agent.premain.AgentMain</Agent-Class>
+                                        <SCM-Revision>${git.commit.id.abbrev}</SCM-Revision>
                                         <Can-Redefine-Classes>true</Can-Redefine-Classes>
                                         <Can-Retransform-Classes>true</Can-Retransform-Classes>
                                         <Can-Set-Native-Method-Prefix>true</Can-Set-Native-Method-Prefix>

--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/AgentPackagingIT.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/AgentPackagingIT.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.premain;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.jar.Attributes;
+import java.util.jar.JarFile;
+import java.util.jar.Manifest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AgentPackagingIT {
+
+    private static Path agentJar;
+    private static String agentVersion;
+
+    @BeforeAll
+    static void before() throws URISyntaxException, IOException {
+        // find packaged jar location
+
+        String classResource = AgentPackagingIT.class.getCanonicalName().replace(".", "/") + ".class";
+        URL url = AgentPackagingIT.class.getClassLoader().getResource(classResource);
+        assertThat(url).isNotNull();
+
+        Path path = Paths.get(url.toURI());
+        Path targetFolder = null;
+        while (path != null && targetFolder == null) {
+            if (path.endsWith("target")) {
+                targetFolder = path;
+            }
+            path = path.getParent();
+        }
+        assertThat(targetFolder).isNotNull();
+
+        Path mavenPropertiesFile = targetFolder.resolve("maven-archiver").resolve("pom.properties");
+        assertThat(mavenPropertiesFile).isRegularFile();
+
+        Properties mavenProperties = new Properties();
+        try (BufferedReader reader = Files.newBufferedReader(mavenPropertiesFile)) {
+            mavenProperties.load(reader);
+        }
+
+        String artifactId = mavenProperties.getProperty("artifactId");
+        assertThat(artifactId).isEqualTo("elastic-apm-agent");
+
+        agentVersion = mavenProperties.getProperty("version");
+        assertThat(agentVersion).isNotNull();
+
+        agentJar = targetFolder.resolve(String.format("%s-%s.jar", artifactId, agentVersion));
+        assertThat(agentJar).isRegularFile();
+    }
+
+    @Test
+    void agentManifest() throws IOException {
+
+        JarFile jarFile = new JarFile(agentJar.toFile());
+
+        Manifest manifest = jarFile.getManifest();
+
+        Attributes attributes = manifest.getMainAttributes();
+        assertThat(attributes.getValue("Implementation-Version")).isEqualTo(agentVersion);
+        String agentClass = attributes.getValue("Agent-Class");
+        assertThat(agentClass).isNotEmpty();
+        assertThat(attributes.getValue("Premain-Class")).isEqualTo(agentClass);
+        assertThat(attributes.getValue("SCM-Revision")).isNotEmpty();
+    }
+
+}


### PR DESCRIPTION
## What does this PR do?
- For agent version `1.27.0`, the agent is unable to read its own version
- This is a small regression introduced with https://github.com/elastic/apm-agent-java/pull/2109
- (minor) when `service_version` is not set, the agent will produce a `(null)` in the logs, which could be confusing.

Has been reported in the forum [here](https://discuss.elastic.co/t/java-apm-agent-version-unknown-and-host-n-a-due-to-missing-host-hostname/290076).

For a not-yet-known reason, reading maven descriptor as resources does not seem to work as expected
with the new agent architecture where classes and resources are moved to a separate `/agent` folder to exclude them from classpath.

However, reading the `META-INF/MANIFEST.MF` works as expected as this file remains in the same location in the agent jar itself, so this PR just implements this minor change.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
