### PR TITLE
Always include detected hostname

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ endif::[]
 * Fixing missing Micrometer metrics in Spring boot due to premature initialization - {pull}2255[#2255]
 * Fixing hostname trimming of FQDN too aggressive - {pull}2286[#2286]
 * Fixing agent `unknown` version - {pull}2289[#2289]
+* Always capture agent hostname - {pull}2295[#2295]
 
 
 [[release-notes-1.x]]

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
@@ -84,7 +84,7 @@ public class SystemInfo {
         this(architecture, configuredHostname, detectedHostname, platform, null, null);
     }
 
-    SystemInfo(String architecture, @Nullable String configuredHostname, @Nullable String detectedHostname,
+    private SystemInfo(String architecture, @Nullable String configuredHostname, @Nullable String detectedHostname,
                String platform, @Nullable Container container, @Nullable Kubernetes kubernetes) {
         this.architecture = architecture;
         this.configuredHostname = configuredHostname;
@@ -105,14 +105,11 @@ public class SystemInfo {
         final String osName = System.getProperty("os.name");
         final String osArch = System.getProperty("os.arch");
 
-        SystemInfo systemInfo;
-        if (configuredHostname != null && !configuredHostname.isEmpty()) {
-            systemInfo = new SystemInfo(osArch, configuredHostname, null, osName);
-        } else {
-            // this call is invoking external commands
-            String detectedHostname = discoverHostname(isWindows(osName), timeoutMillis);
-            systemInfo = new SystemInfo(osArch, configuredHostname, detectedHostname, osName);
-        }
+        // this call is invoking external commands
+        String detectedHostname = discoverHostname(isWindows(osName), timeoutMillis);
+
+        SystemInfo systemInfo = new SystemInfo(osArch, configuredHostname, detectedHostname, osName);
+
         // this call reads and parses files
         systemInfo.findContainerDetails();
         return systemInfo;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -19,7 +19,6 @@
 package co.elastic.apm.agent.report.serialize;
 
 import co.elastic.apm.agent.collections.LongList;
-import co.elastic.apm.agent.impl.metadata.MetaData;
 import co.elastic.apm.agent.impl.context.AbstractContext;
 import co.elastic.apm.agent.impl.context.Db;
 import co.elastic.apm.agent.impl.context.Destination;
@@ -37,6 +36,7 @@ import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.metadata.Agent;
 import co.elastic.apm.agent.impl.metadata.CloudProviderInfo;
 import co.elastic.apm.agent.impl.metadata.Language;
+import co.elastic.apm.agent.impl.metadata.MetaData;
 import co.elastic.apm.agent.impl.metadata.Node;
 import co.elastic.apm.agent.impl.metadata.ProcessInfo;
 import co.elastic.apm.agent.impl.metadata.RuntimeInfo;
@@ -520,11 +520,10 @@ public class DslJsonSerializer implements PayloadSerializer {
             String configuredHostname = system.getConfiguredHostname();
             if (configuredHostname != null && !configuredHostname.isEmpty()) {
                 writeField("configured_hostname", configuredHostname, replaceBuilder, jw);
-            } else {
-                String detectedHostname = system.getDetectedHostname();
-                if (detectedHostname != null && !detectedHostname.isEmpty()) {
-                    writeField("detected_hostname", detectedHostname, replaceBuilder, jw);
-                }
+            }
+            String detectedHostname = system.getDetectedHostname();
+            if (detectedHostname != null && !detectedHostname.isEmpty()) {
+                writeField("detected_hostname", detectedHostname, replaceBuilder, jw);
             }
         } else {
             writeField("hostname", system.getHostname(), replaceBuilder, jw);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/metadata/SystemInfoTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/metadata/SystemInfoTest.java
@@ -32,10 +32,19 @@ public class SystemInfoTest extends CustomEnvVariables {
 
     private static final SystemInfo systemInfo;
     private static final boolean isWindows;
+    private static final int TIMEOUT_MILLIS = 300;
 
     static {
-        systemInfo = SystemInfo.create("hostname", 0);
+        systemInfo = SystemInfo.create("hostname", TIMEOUT_MILLIS);
         isWindows = SystemInfo.isWindows(systemInfo.getPlatform());
+    }
+
+    @Test
+    void testHostnameDiscovery() {
+        SystemInfo info = SystemInfo.create(null, TIMEOUT_MILLIS);
+        assertThat(info.getDetectedHostname())
+            .describedAs("detected hostname should always be available")
+            .isNotEmpty();
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -952,7 +952,7 @@ class DslJsonSerializerTest {
         assertThat(platform).isEqualTo(system.get("platform").asText());
         if (supportsConfiguredAndDetectedHostname) {
             assertThat(system.get("configured_hostname").asText()).isEqualTo("configured");
-            assertThat(system.get("detected_hostname")).isNull();
+            assertThat(system.get("detected_hostname").asText()).isEqualTo("detected");
             assertThat(system.get("hostname")).isNull();
         } else {
             assertThat(system.get("configured_hostname")).isNull();


### PR DESCRIPTION
## What does this PR do?

With `1.27.0` we do not send the `detected_hostname` field when `configured_hostname` is being sent.
That avoids running an external command, however it triggers the following [bug](https://github.com/elastic/kibana/issues/119737) in Kibana.

This PR changes the current implementation that was introduced in `1.27.0` with the following behavior for `metadata`:
- provide the `system.hostname` for APM server < 7.4
- provide `system.detected_hostname` for APM server >= 7.4
- provide `system.configured_hostname` for APM server >= 7.4 and when agent `hostname` configuration is set.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
