### PR TITLE
ci: move the benchmark env variables

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -62,6 +62,11 @@ pipeline {
               dir("${BASE_DIR}"){
                 // Skip all the stages except docs for PR's with asciidoc and md changes only
                 env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
+                // Prepare the env variables for the benchmark results
+                env.COMMIT_ISO_8601 = sh(script: 'git log -1 -s --format=%cI', returnStdout: true).trim()
+                env.NOW_ISO_8601 = sh(script: 'date -u "+%Y-%m-%dT%H%M%SZ"', returnStdout: true).trim()
+                env.RESULT_FILE = "apm-agent-benchmark-results-${env.COMMIT_ISO_8601}.json"
+                env.BULK_UPLOAD_FILE = "apm-agent-bulk-${env.NOW_ISO_8601}.json"
               }
             }
           }
@@ -241,12 +246,6 @@ pipeline {
               deleteDir()
               unstash 'build'
               dir("${BASE_DIR}"){
-                script {
-                  env.COMMIT_ISO_8601 = sh(script: 'git log -1 -s --format=%cI', returnStdout: true).trim()
-                  env.NOW_ISO_8601 = sh(script: 'date -u "+%Y-%m-%dT%H%M%SZ"', returnStdout: true).trim()
-                  env.RESULT_FILE = "apm-agent-benchmark-results-${env.COMMIT_ISO_8601}.json"
-                  env.BULK_UPLOAD_FILE = "apm-agent-bulk-${env.NOW_ISO_8601}.json"
-                }
                 withOtelEnv() {
                   sh './scripts/jenkins/run-benchmarks.sh'
                 }


### PR DESCRIPTION
## What does this PR do?

somehow the baremetal stages face some issues with  Failed to traverse parents

Initially attempted to be fixes in https://github.com/elastic/apm-agent-java/pull/1462

Guessing the error is related with the reference repo in the baremetals:

```
[2021-11-30T09:53:07.559Z] + git log -1 -s --format=%cI
[2021-11-30T09:53:07.559Z] error: object directory /var/lib/jenkins/.git-references/apm-agent-java.git/objects does not exist; check .git/objects/info/alternates
[2021-11-30T09:53:07.559Z] error: Could not read 721d892447016cbbbc9f0e1e29e27da4f98ab672
[2021-11-30T09:53:07.559Z] fatal: Failed to traverse parents of commit 1c0f1c6e7d44a7e41b9f883b2ce53e22236cadfc
[2021-11-30T09:53:09.253Z] Terminated
```
