### PR TITLE
Execute runtime attach in verify phase

### DIFF
--- a/integration-tests/runtime-attach/runtime-attach-test/src/test/java/co/elastic/apm/testapp/RuntimeAttachTestIT.java
+++ b/integration-tests/runtime-attach/runtime-attach-test/src/test/java/co/elastic/apm/testapp/RuntimeAttachTestIT.java
@@ -55,7 +55,7 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
-class RuntimeAttachTest {
+class RuntimeAttachTestIT {
 
     private static final ObjectName JMX_BEAN;
 
@@ -392,7 +392,7 @@ class RuntimeAttachTest {
             throw new IllegalStateException(e);
         }
         return found.findFirst().orElseThrow(() -> {
-            throw new IllegalStateException("Unable to find packaged test application in folder :" + folder.toAbsolutePath());
+            throw new IllegalStateException(String.format("Unable to find packaged test application in folder : %s, make sure to run 'mvn package' in folder '%s' first", folder.toAbsolutePath(), folder.toAbsolutePath().getParent()));
         });
     }
 


### PR DESCRIPTION
## What does this PR do?

Runtime attach test relies on a packaged agent jar, thus running it in the `test` phase of the build makes it always fail unless we run the build with `mvn package test` which is not what people are used to. Renaming the test file with `IT` suffix ensures it's executed in the `verify` phase which runs after the `package` one. 

Closes #2222 

