### PR TITLE
opentelemetry: use io.opentelemetry.contrib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -510,9 +510,9 @@
         </pluginManagement>
         <extensions>
             <extension>
-                <groupId>co.elastic.opentelemetry.contrib</groupId>
+                <groupId>io.opentelemetry.contrib</groupId>
                 <artifactId>opentelemetry-maven-extension</artifactId>
-                <version>0.1.0-beta-5</version>
+                <version>1.7.0-alpha</version>
             </extension>
         </extensions>
     </build>


### PR DESCRIPTION
## What does this PR do?

Use https://github.com/open-telemetry/opentelemetry-java-contrib/tree/main/maven-extension since it's now the official project

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- ~~[ ] This is an enhancement of existing features, or a new feature in existing plugins~~
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- ~~[ ] This is a bugfix~~
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- ~~[ ] This is a new plugin~~
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - ~~[ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)~~


### Tests

See 

![image](https://user-images.githubusercontent.com/2871786/144437002-0b06f692-ca59-4abb-9773-bdf4007ccf67.png)
