### PR TITLE
ci: use Google Storage to speed up stash/unstash

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ pipeline {
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/master'
     MAVEN_CONFIG = '-Dmaven.repo.local=.m2'
     OPBEANS_REPO = 'opbeans-java'
+    JOB_GCS_BUCKET_STASH = 'apm-ci-temp'
+    JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
   }
   options {
     timeout(time: 90, unit: 'MINUTES')
@@ -96,7 +98,7 @@ pipeline {
                   sh label: 'mvn license', script: "./mvnw org.codehaus.mojo:license-maven-plugin:aggregate-third-party-report -Dlicense.excludedGroups=^co\\.elastic\\."
                 }
               }
-              stash allowEmpty: true, name: 'build', useDefaultExcludes: false
+              stashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
               archiveArtifacts allowEmptyArchive: true,
                 artifacts: "${BASE_DIR}/elastic-apm-agent/target/elastic-apm-agent-*.jar,${BASE_DIR}/apm-agent-attach/target/apm-agent-attach-*.jar,\
                       ${BASE_DIR}/apm-agent-attach-cli/target/apm-agent-attach-cli-*.jar,${BASE_DIR}/apm-agent-api/target/apm-agent-api-*.jar,\
@@ -134,7 +136,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Unit Tests', tab: 'tests') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
               dir("${BASE_DIR}"){
                 withOtelEnv() {
                   sh """#!/bin/bash
@@ -169,7 +171,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Smoke Tests 01', tab: 'tests') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
               dir("${BASE_DIR}"){
                 withOtelEnv() {
                   sh './scripts/jenkins/smoketests-01.sh'
@@ -201,7 +203,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Smoke Tests 02', tab: 'tests') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
               dir("${BASE_DIR}"){
                 withOtelEnv() {
                   sh './scripts/jenkins/smoketests-02.sh'
@@ -244,7 +246,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Benchmarks', tab: 'artifacts') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
               dir("${BASE_DIR}"){
                 withOtelEnv() {
                   sh './scripts/jenkins/run-benchmarks.sh'
@@ -279,7 +281,7 @@ pipeline {
           steps {
             withGithubNotify(context: 'Javadoc') {
               deleteDir()
-              unstash 'build'
+              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
               dir("${BASE_DIR}"){
                 withOtelEnv() {
                   sh """#!/bin/bash
@@ -346,7 +348,7 @@ pipeline {
             steps {
               withGithubNotify(context: "Unit Tests ${JAVA_VERSION}", tab: 'tests') {
                 deleteDir()
-                unstash 'build'
+                unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
                 dir("${BASE_DIR}"){
                   withOtelEnv() {
                     sh(label: "./mvnw test for ${JAVA_VERSION}", script: './mvnw test')


### PR DESCRIPTION

## What does this PR do?

Use the customised stash/unstash that uses Google Storage to upload the temporary files to be consumed in parallel in some of the stages among the CI execution.

New steps:
- https://github.com/elastic/apm-pipeline-library/blob/master/vars/stashV2.txt
- https://github.com/elastic/apm-pipeline-library/blob/master/vars/unstashV2.txt

## Why

The main reason is the stash/unstash for the compiled workspace takes 2 minutes each

Reduce the waiting time from:
- `2.36` minutes to `2.20` minutes for the stashing
- `2.10` minutes to `30 seconds` for the unstashing

Therefore the improvement is about 2 minutes faster and less overhead in the `apm-ci` controller

### before

![image](https://user-images.githubusercontent.com/2871786/144755515-e9dbb7dc-cf8f-4324-a5bb-712a9b06153d.png)

![image](https://user-images.githubusercontent.com/2871786/144755530-32b0c324-d25a-4875-98f7-95b3ca97b310.png)

### After

![image](https://user-images.githubusercontent.com/2871786/144756083-19816a44-f06e-4968-b58d-202984918059.png)


![image](https://user-images.githubusercontent.com/2871786/144756102-79787b91-6c80-4cf7-b122-588b6121d103.png)


## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- ~~[ ] This is an enhancement of existing features, or a new feature in existing plugins~~
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- ~~[ ] This is a bugfix~~
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- ~~[ ] This is a new plugin~~
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - ~~[ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)~~
