### PR TITLE
Fix APM Server version parsing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
+* Fix error with parsing APM Server version for 7.16+ - {pull}2313[#2313]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/Version.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/Version.java
@@ -72,4 +72,14 @@ public class Version implements Comparable<Version> {
         }
         return 0;
     }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < numbers.length - 1; i++) {
+            sb.append(numbers[i]).append('.');
+        }
+        sb.append(numbers[numbers.length - 1]);
+        return sb.toString();
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/Version.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/Version.java
@@ -76,10 +76,12 @@ public class Version implements Comparable<Version> {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < numbers.length - 1; i++) {
-            sb.append(numbers[i]).append('.');
+        for (int i = 0; i < numbers.length; i++) {
+            sb.append(numbers[i]);
+            if (i < numbers.length - 1) {
+                sb.append('.');
+            }
         }
-        sb.append(numbers[numbers.length - 1]);
         return sb.toString();
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerHealthCheckerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerHealthCheckerTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.report;
+
+import co.elastic.apm.agent.util.Version;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ApmServerHealthCheckerTest {
+
+    @Test
+    void testParseVersion() throws IOException {
+        // 7.16+
+        String body = "{  \"build_date\": \"2021-11-04T12:50:39Z\",  \"build_sha\": \"74a2ccb4be966ebab82b9727caef355fe9097340\",  \"publish_ready\": true,  \"version\": \"8.0.0\"}";
+        assertThat(ApmServerHealthChecker.parseVersion(body).compareTo(Version.of("8.0.0"))).isEqualTo(0);
+        // 7.0 -> 7.15
+        body = "{  \"build_date\": \"2021-03-06T04:41:35Z\",  \"build_sha\": \"b706a93fac838d7ca44622d8d9686d2c3b3c8bde\",  \"version\": \"7.11.2\"}";
+        assertThat(ApmServerHealthChecker.parseVersion(body).compareTo(Version.of("7.11.2"))).isEqualTo(0);
+        // 6.x
+        body = "{\"ok\":{\"build_date\":\"2021-10-13T17:29:41Z\",\"build_sha\":\"04a84d8d3d0358af5e73b3581c4ba37fbdbc979e\",\"version\":\"6.8.20\"}}";
+        assertThat(ApmServerHealthChecker.parseVersion(body).compareTo(Version.of("6.8.20"))).isEqualTo(0);
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/VersionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/VersionTest.java
@@ -36,4 +36,14 @@ class VersionTest {
         assertThat(Version.of("httpclient.4.5.13.redhat")).isEqualByComparingTo(Version.of("4.5.13"));
         assertThat(Version.of("httpclient.4.5.13-redhat")).isEqualByComparingTo(Version.of("4.5.13"));
     }
+
+    @Test
+    void testToString() {
+        System.out.println(Version.of(""));
+        System.out.println(Version.of("1"));
+        System.out.println(Version.of("1.2"));
+        System.out.println(Version.of("1.2.3"));
+        System.out.println(Version.of("1.2.3.4"));
+        System.out.println(Version.of("1.2.3.ignore"));
+    }
 }


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Adjusting APM Server version parsing to match 7.16+
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Tested manually with
    - [x] 6.8.20
    - [x] 7.0.0
    - [x] 7.11.2
    - [x] 7.16.0
    - [x] 8.0.0-beta1
