### PR TITLE
Using path for Spring MVC transactions only as fallback

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,6 +28,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
+* Preferring controller names for Spring MVC transactions, `use_path_as_transaction_name` only as a fallback - {pull}2320[#2320]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/SpringTransactionNameInstrumentation.java
@@ -145,11 +145,16 @@ public class SpringTransactionNameInstrumentation extends TracerAwareInstrumenta
                     methodName,
                     transaction.getAndOverrideName(PRIO_LOW_LEVEL_FRAMEWORK + 1)
                 );
+            } else {
+                // Class name is empty - probably an anonymous handler class
+                StringBuilder transactionName = transaction.getAndOverrideName(PRIO_LOW_LEVEL_FRAMEWORK + 1);
+                if (transactionName != null) {
+                    transactionName.append(request.getMethod()).append(" unknown route");
+                }
             }
 
             transaction.setFrameworkName(FRAMEWORK_NAME);
             transaction.setFrameworkVersion(VersionUtils.getVersion(HandlerMethod.class, "org.springframework", "spring-web"));
         }
-
     }
 }

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/SpringTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/SpringTransactionNameInstrumentationTest.java
@@ -100,9 +100,8 @@ class SpringTransactionNameInstrumentationTest extends AbstractInstrumentationTe
 
         String expectedContent = "without-servlet-invocation";
 
-        // there is no servlet invocation through ServletWrappingController, thus name should fall back to the low priority:
-        // path if use_path_as_transaction_name==true, or the Spring Servlet name otherwise
-        String expectedName = fallbackToUsePath ? "GET /testControllerWithoutServlet" : "TestDispatcherServlet#doGet";
+        // no servlet invocation through ServletWrappingController, thus name should fall back to the low priority (depending on the use_path_as_transaction_name setting)
+        String expectedName = fallbackToUsePath ? "GET /testControllerWithoutServlet" : "GET unknown route";
         String urlPath = "/testControllerWithoutServlet";
 
         testTransactionName(fallbackToUsePath, expectedContent, expectedName, urlPath);


### PR DESCRIPTION
## What does this PR do?
Closes #2291 

Aligning Spring MVC instrumentation with other frameworks: the request path is used only as a fallback when there is not enough info to provide a high-value name AND if `use_path_as_transaction_name` is set to `true`.

Specifically for Spring MVC, a high-value name is considered to be such that either relies on the Controller name AND method, or the Servlet class name and method if using a `ServletWrappingController`.

<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
