### PR TITLE
Switch to using Span concurrent weak map in Vert.x 3

### DIFF
--- a/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/main/java/co/elastic/apm/agent/vertx/v3/web/WebHelper.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/main/java/co/elastic/apm/agent/vertx/v3/web/WebHelper.java
@@ -18,10 +18,10 @@
  */
 package co.elastic.apm.agent.vertx.v3.web;
 
+import co.elastic.apm.agent.collections.WeakConcurrentProviderImpl;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.GlobalTracer;
 import co.elastic.apm.agent.impl.transaction.Transaction;
-import co.elastic.apm.agent.sdk.weakconcurrent.WeakConcurrent;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakMap;
 import co.elastic.apm.agent.vertx.AbstractVertxWebHelper;
 import io.vertx.core.Handler;
@@ -34,7 +34,7 @@ public class WebHelper extends AbstractVertxWebHelper {
 
     private static final WebHelper INSTANCE = new WebHelper(GlobalTracer.requireTracerImpl());
 
-    static final WeakMap<HttpServerRequest, Transaction> requestTransactionMap = WeakConcurrent.buildMap();
+    static final WeakMap<HttpServerRequest, Transaction> requestTransactionMap = WeakConcurrentProviderImpl.createWeakSpanMap();
 
     public static WebHelper getInstance() {
         return INSTANCE;

--- a/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/main/java/co/elastic/apm/agent/vertx/v3/web/http1/HttpServerRequestImplEndInstrumentation.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/main/java/co/elastic/apm/agent/vertx/v3/web/http1/HttpServerRequestImplEndInstrumentation.java
@@ -42,7 +42,7 @@ public class HttpServerRequestImplEndInstrumentation extends WebInstrumentation 
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        return named("doEnd").and(takesNoArguments());
+        return named("doEnd").or(named("onEnd")).and(takesNoArguments());
     }
 
     @Override


### PR DESCRIPTION
Implementing #2092 for Vert.x 3

Switching to the dedicated span concurrent map helped to discover a small transaction leak (not causing memory leak because GC still cleans) due to a change in internal API.