### PR TITLE
Remove JndiLookup from attach-cli

### DIFF
--- a/apm-agent-attach-cli/pom.xml
+++ b/apm-agent-attach-cli/pom.xml
@@ -159,6 +159,10 @@
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
+                                    <!--Keep in sync with
+                                    - apm-agent-attach-cli/pom.xml
+                                    - cli-slim execution in this file
+                                    -->
                                     <excludes>
                                         <!--
                                         Excluding the Bouncy Castle implementation for PGP signature verification, which
@@ -170,6 +174,12 @@
                                         https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle
                                         -->
                                         <exclude>org/apache/logging/log4j/core/appender/SmtpAppender.class</exclude>
+                                        <!--
+                                        Strip out JndiLookup class to avoid any possibility of exploitation of CVE-2021-44228
+                                        See: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
+                                        See: https://issues.apache.org/jira/browse/LOG4J2-3201
+                                        -->
+                                        <exclude>org/apache/logging/log4j/core/lookup/JndiLookup.class</exclude>
                                     </excludes>
                                 </filter>
                             </filters>
@@ -202,6 +212,10 @@
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
+                                    <!--Keep in sync with
+                                    - apm-agent-attach-cli/pom.xml
+                                    - cli execution in this file
+                                    -->
                                     <excludes>
                                         <exclude>elastic-apm-agent.jar</exclude>
                                         <!--
@@ -214,6 +228,12 @@
                                         https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle
                                         -->
                                         <exclude>org/apache/logging/log4j/core/appender/SmtpAppender.class</exclude>
+                                        <!--
+                                        Strip out JndiLookup class to avoid any possibility of exploitation of CVE-2021-44228
+                                        See: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
+                                        See: https://issues.apache.org/jira/browse/LOG4J2-3201
+                                        -->
+                                        <exclude>org/apache/logging/log4j/core/lookup/JndiLookup.class</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/apm-agent/pom.xml
+++ b/apm-agent/pom.xml
@@ -421,12 +421,18 @@
                                 </filter>
                                 <filter>
                                     <artifact>org.apache.logging.log4j:log4j-core</artifact>
+                                    <!--Keep in sync with apm-agent-attach-cli/pom.xml-->
                                     <excludes>
                                         <!--
                                         Eliminating exposure to the log4j2 vulnerability related to the SMTP appender -
                                         https://nvd.nist.gov/vuln/detail/CVE-2020-9488#vulnCurrentDescriptionTitle
                                         -->
                                         <exclude>org/apache/logging/log4j/core/appender/SmtpAppender.class</exclude>
+                                        <!--
+                                        Strip out JndiLookup class to avoid any possibility of exploitation of CVE-2021-44228
+                                        See: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228
+                                        See: https://issues.apache.org/jira/browse/LOG4J2-3201
+                                        -->
                                         <exclude>org/apache/logging/log4j/core/lookup/JndiLookup.class</exclude>
                                     </excludes>
                                 </filter>


### PR DESCRIPTION
This is just a precautionary measure.
As the attacher is always using JSON logging via ecs-logging-java where lookups on the message don't work,
it is not vulnerable to Log4Shell (CVE-2021-44228)