### PR TITLE
Adding instrumentation warmup

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyBootstrap.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/IndyBootstrap.java
@@ -341,7 +341,7 @@ public class IndyBootstrap {
      * @param adviceMethodType A {@link java.lang.invoke.MethodType} representing the arguments and return type of the advice method.
      * @param args             Additional arguments that are provided by Byte Buddy:
      *                         <ul>
-     *                           <li>A {@link String} of the binary target class name.</li>
+     *                           <li>A {@link String} of the binary advice class name.</li>
      *                           <li>A {@link int} with value {@code 0} for an enter advice and {code 1} for an exist advice.</li>
      *                           <li>A {@link Class} representing the class implementing the instrumented method.</li>
      *                           <li>A {@link String} with the name of the instrumented method.</li>

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/InstallationListenerImpl.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/InstallationListenerImpl.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.bci.bytebuddy;
+
+import co.elastic.apm.agent.bci.ElasticApmAgent;
+import co.elastic.apm.agent.bci.IndyBootstrap;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.agent.builder.ResettableClassFileTransformer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.ConstantCallSite;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Set;
+
+public class InstallationListenerImpl extends AgentBuilder.InstallationListener.Adapter {
+    @Override
+    public void onAfterWarmUp(Set<Class<?>> types, ResettableClassFileTransformer classFileTransformer, boolean transformed) {
+        try {
+            // should be safe to get a logger by now
+            Logger logger = LoggerFactory.getLogger(InstallationListenerImpl.class);
+            if (!transformed) {
+                logger.warn("Byte Buddy warmup ended without transforming at least one class. The agent may not work as expected.");
+            } else  {
+                if (types.contains(Instrumented.class)) {
+                    Instrumented.setWarmedUp();
+                    logger.debug("Warmup of {} classes ended properly", types.size());
+                } else {
+                    logger.warn("Warmup did not include the {} class as expected", Instrumented.class.getName());
+                }
+            }
+
+            // We need to register a CL in order to invoke the bootstrap code path
+            String warmupInstrumentationAdviceClassName = "co.elastic.apm.agent.bci.bytebuddy.WarmupInstrumentation$AdviceClass";
+            ElasticApmAgent.mapInstrumentationCL2adviceClassName(warmupInstrumentationAdviceClassName, InstallationListenerImpl.class.getClassLoader());
+
+            @SuppressWarnings({"RedundantArrayCreation", "UnnecessaryBoxing"})
+            ConstantCallSite onMethodEnter = IndyBootstrap.bootstrap(
+                // The agent CL lookup is the right one here
+                MethodHandles.lookup(),
+                "onMethodEnter",
+                MethodType.methodType(Object.class, new Class[]{Object.class, String.class}),
+                new Object[]{
+                    warmupInstrumentationAdviceClassName,
+                    Integer.valueOf(0),
+                    Instrumented.class,
+                    "isInstrumented"
+                }
+            );
+        } catch (Throwable throwable) {
+            // keep quiet, most likely the problem is with getting the logger
+        }
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/Instrumented.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/Instrumented.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.bci.bytebuddy;
+
+public class Instrumented {
+
+    private static volatile boolean warmedUp = false;
+
+    public static boolean isWarmedUp() {
+        return warmedUp;
+    }
+
+    public static void setWarmedUp() {
+        warmedUp = true;
+    }
+
+    public boolean isInstrumented() {
+        return false;
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/NonInstrumented.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/NonInstrumented.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.bci.bytebuddy;
+
+public class NonInstrumented {
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/WarmupInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/WarmupInstrumentation.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.bci.bytebuddy;
+
+import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+
+import static net.bytebuddy.matcher.ElementMatchers.isStatic;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.returns;
+import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
+
+public class WarmupInstrumentation extends TracerAwareInstrumentation {
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return named("co.elastic.apm.agent.bci.bytebuddy.Instrumented");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return not(isStatic()).and(named("isInstrumented")).and(takesNoArguments()).and(returns(boolean.class));
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        return Collections.emptyList();
+    }
+
+    public static class AdviceClass {
+        @Nullable
+        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+        public static Object onMethodEnter(
+            @Advice.This Object thiz,
+            @SimpleMethodSignatureOffsetMappingFactory.SimpleMethodSignature String signature) {
+            return null;
+        }
+
+        @Advice.AssignReturned.ToReturned
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+        public static boolean onMethodExit(@Advice.Enter @Nullable Object nullFromEnter,
+                                           @Advice.Thrown @Nullable Throwable t) {
+            return true;
+        }
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -380,6 +380,14 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .description("When enabled, configures Byte Buddy to use a type pool cache.")
         .buildWithDefault(true);
 
+    private final ConfigurationOption<Boolean> warmupByteBuddy = ConfigurationOption.booleanOption()
+        .key("warmup_byte_buddy")
+        .configurationCategory(CORE_CATEGORY)
+        .tags("internal")
+        .description("When set to true, configures Byte Buddy to warmup instrumentation processes on the \n" +
+            "attaching thread just before installing the transformer on the JVM Instrumentation.")
+        .buildWithDefault(true);
+
     private final ConfigurationOption<String> bytecodeDumpPath = ConfigurationOption.stringOption()
         .key("bytecode_dump_path")
         .configurationCategory(CORE_CATEGORY)
@@ -775,6 +783,10 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
 
     public boolean isTypePoolCacheEnabled() {
         return typePoolCache.get();
+    }
+
+    public boolean shouldWarmupByteBuddy() {
+        return warmupByteBuddy.get();
     }
 
     @Nullable

--- a/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -1,0 +1,1 @@
+co.elastic.apm.agent.bci.bytebuddy.WarmupInstrumentation

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/bci/InstrumentationTest.java
@@ -19,6 +19,7 @@
 package co.elastic.apm.agent.bci;
 
 import co.elastic.apm.agent.MockTracer;
+import co.elastic.apm.agent.bci.bytebuddy.Instrumented;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
@@ -268,6 +269,17 @@ class InstrumentationTest {
             ByteBuddyAgent.install(),
             Collections.singletonList(new SuppressExceptionInstrumentation()));
         assertThatThrownBy(this::exceptionPlease).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testWarmup() {
+        doReturn(true).when(coreConfig).shouldWarmupByteBuddy();
+        assertThat(Instrumented.isWarmedUp()).isFalse();
+        Instrumented instrumented = new Instrumented();
+        assertThat(instrumented.isInstrumented()).isFalse();
+        ElasticApmAgent.initInstrumentation(tracer, ByteBuddyAgent.install());
+        assertThat(Instrumented.isWarmedUp()).isTrue();
+        assertThat(instrumented.isInstrumented()).isTrue();
     }
 
     @Test

--- a/apm-agent-core/src/test/resources/test.elasticapm.properties
+++ b/apm-agent-core/src/test/resources/test.elasticapm.properties
@@ -3,3 +3,4 @@ application_packages=co.elastic.apm
 ship_agent_logs=false
 log_level=DEBUG
 cloud_provider=NONE
+warmup_byte_buddy=false

--- a/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
+++ b/apm-agent-plugins/apm-grpc/apm-grpc-test-latest/src/test/java/co/elastic/apm/agent/grpc/latest/testapp/generated/HelloGrpc.java
@@ -23,7 +23,7 @@ import static io.grpc.MethodDescriptor.generateFullMethodName;
 /**
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.42.1)",
+    value = "by gRPC proto compiler (version 1.43.1)",
     comments = "Source: rpc.proto")
 @io.grpc.stub.annotations.GrpcGenerated
 public final class HelloGrpc {

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-log4j2-plugin/pom.xml
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-log4j2-plugin/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.10.0</version>
+            <version>2.17.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->
Tries to invoke as much as possible instrumentation-related code paths, including the instrumentation logic and the `invokedynamic` runtime linkage path, on the agent-attaching thread before registering the`ClassFileTransformer` to the JVM-global `java.lang.instrument.Instrumentation`.
This ensures that most Byte Buddy and agent types related to these processes are loaded and initialized on a single thread, thus reducing the chances for deadlock.
We will start with having warmup on by default, but with a hidden config flag that enables disabling it.
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have made corresponding changes to the documentation

