### PR TITLE
Fix @Traced annotation outcome

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
+* Fix `@Traced` annotation to return proper outcome instead of `failed` - {pull}2370[#2370]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TracedInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TracedInstrumentation.java
@@ -108,7 +108,7 @@ public class TracedInstrumentation extends TracerAwareInstrumentation {
             if (abstractSpan instanceof AbstractSpan<?>) {
                 ((AbstractSpan<?>) abstractSpan)
                     .captureException(t)
-                    .withOutcome(t != null ? Outcome.FAILURE : Outcome.FAILURE)
+                    .withOutcome(t != null ? Outcome.FAILURE : Outcome.SUCCESS)
                     .deactivate()
                     .end();
             }

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationApiTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationApiTest.java
@@ -124,6 +124,7 @@ class AnnotationApiTest extends AbstractApiTest {
         assertThat(reporter.getFirstSpan().getType()).isEqualTo("app");
         assertThat(reporter.getFirstSpan().getSubtype()).isEqualTo("subtype");
         assertThat(reporter.getFirstSpan().getAction()).isEqualTo("action");
+        assertThat(reporter.getFirstSpan().getOutcome().toString()).isEqualTo("success");
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

In the current implementation a method annotated with `@Traced` **never** returns a successful outcome. This commit fixes this to properly check for the existence of an exception. Currently any transaction involving a `@Traced` method is marked as failed:

![image](https://user-images.githubusercontent.com/667544/147255885-a298db53-649c-4066-9325-f1f2274b9f96.png)


## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [X] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [X] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
