### PR TITLE
Capture exceptions that are logged using the fatal log level.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,10 @@ endif::[]
 ==== 1.28.4 - YYYY/MM/DD
 
 [float]
+===== Features
+* Exceptions that are logged using the fatal log level are now captured (log4j2 only) - {pull}2377[#2377]
+
+[float]
 ===== Bug fixes
 * Fix `@Traced` annotation to return proper outcome instead of `failed` - {pull}2370[#2370]
 

--- a/apm-agent-plugins/apm-error-logging-plugin/src/main/java/co/elastic/apm/agent/errorlogging/Log4j2LoggerErrorCapturingInstrumentation.java
+++ b/apm-agent-plugins/apm-error-logging-plugin/src/main/java/co/elastic/apm/agent/errorlogging/Log4j2LoggerErrorCapturingInstrumentation.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.apm.agent.errorlogging;
 
+import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
@@ -27,6 +28,7 @@ import static co.elastic.apm.agent.errorlogging.Slf4jLoggerErrorCapturingInstrum
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 public class Log4j2LoggerErrorCapturingInstrumentation extends AbstractLoggerErrorCapturingInstrumentation {
 
@@ -35,6 +37,11 @@ public class Log4j2LoggerErrorCapturingInstrumentation extends AbstractLoggerErr
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
         return hasSuperType(named(LOG4J2_LOGGER)).and(not(hasSuperType(named(SLF4J_LOGGER))));
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return named("fatal").and(takesArgument(1, named("java.lang.Throwable"))).or(super.getMethodMatcher());
     }
 
     @Override

--- a/apm-agent-plugins/apm-error-logging-plugin/src/test/java/co/elastic/apm/agent/errorlogging/Log4j2LoggerErrorCapturingInstrumentationTest.java
+++ b/apm-agent-plugins/apm-error-logging-plugin/src/test/java/co/elastic/apm/agent/errorlogging/Log4j2LoggerErrorCapturingInstrumentationTest.java
@@ -20,6 +20,7 @@ package co.elastic.apm.agent.errorlogging;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.message.ParameterizedMessageFactory;
 import org.junit.jupiter.api.Test;
 
@@ -28,15 +29,20 @@ class Log4j2LoggerErrorCapturingInstrumentationTest extends AbstractErrorLogging
     private static final Logger logger = LogManager.getLogger(Log4j2LoggerErrorCapturingInstrumentationTest.class);
 
     @Test
-    void captureExceptionWithStringMessage() {
+    void captureErrorExceptionWithStringMessage() {
         logger.error("exception captured", new RuntimeException("some business exception"));
         verifyThatExceptionCaptured(1, "some business exception", RuntimeException.class);
     }
 
+    @Test
+    void captureErrorExceptionWithMessageMessage() {
+        logger.error(ParameterizedMessageFactory.INSTANCE.newMessage("exception captured with parameter {}", "foo"), new RuntimeException("some business exception"));
+        verifyThatExceptionCaptured(1, "some business exception", RuntimeException.class);
+    }
 
     @Test
-    void captureExceptionWithMessageMessage() {
-        logger.error(ParameterizedMessageFactory.INSTANCE.newMessage("exception captured with parameter {}", "foo"), new RuntimeException("some business exception"));
+    void captureFatalException() {
+        logger.fatal("exception captured", new RuntimeException("some business exception"));
         verifyThatExceptionCaptured(1, "some business exception", RuntimeException.class);
     }
 }


### PR DESCRIPTION
## Checklist
- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
