### PR TITLE
Javalin: Add span around template rendering

### DIFF
--- a/apm-agent-plugins/apm-javalin-plugin/pom.xml
+++ b/apm-agent-plugins/apm-javalin-plugin/pom.xml
@@ -19,9 +19,9 @@
         <maven.compiler.source>${maven.compiler.target}</maven.compiler.source>
         <animal.sniffer.skip>true</animal.sniffer.skip>
 
-        <javalin.version>3.13.9</javalin.version>
+        <javalin.version>4.2.0</javalin.version>
         <!-- this has to override the global jetty dependency, and needs to match the javalin version -->
-        <jetty.version>9.4.42.v20210604</jetty.version>
+        <jetty.version>9.4.44.v20210927</jetty.version>
     </properties>
 
     <dependencies>

--- a/apm-agent-plugins/apm-javalin-plugin/src/main/java/co/elastic/apm/agent/javalin/JavalinRenderInstrumentation.java
+++ b/apm-agent-plugins/apm-javalin-plugin/src/main/java/co/elastic/apm/agent/javalin/JavalinRenderInstrumentation.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.javalin;
+
+import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Span;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.method.MethodDescription;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Collections;
+
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
+
+public class JavalinRenderInstrumentation extends TracerAwareInstrumentation {
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return hasSuperType(named("io.javalin.plugin.rendering.FileRenderer")).and(not(isInterface()));
+    }
+
+    @Override
+    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
+        return classLoaderCanLoadClass("io.javalin.plugin.rendering.FileRenderer");
+    }
+
+    @Override
+    public ElementMatcher<? super MethodDescription> getMethodMatcher() {
+        return  named("render")
+            .and(takesArgument(0, named("java.lang.String")))
+            .and(takesArgument(1, named("java.util.Map")))
+            .and(takesArgument(2, named("io.javalin.http.Context")));
+    }
+
+    @Override
+    public Collection<String> getInstrumentationGroupNames() {
+        return Collections.singleton("javalin");
+    }
+
+    @Override
+    public String getAdviceClassName() {
+        return "co.elastic.apm.agent.javalin.JavalinRenderInstrumentation$RenderAdapterAdvice";
+    }
+
+    public static class RenderAdapterAdvice {
+
+        @Nullable
+        @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+        public static Object setSpanName(@Advice.Argument(0) String template) {
+            final AbstractSpan<?> parent = tracer.getActive();
+            if (parent == null) {
+                return null;
+            }
+
+            Span span = parent.createSpan().activate();
+            span.withType("app").withSubtype("handler");
+            span.appendToName("render ").appendToName(template);
+            return span;
+        }
+
+
+        @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)
+        public static void onAfterExecute(@Advice.Enter @Nullable Object spanObj,
+                                          @Advice.Thrown @Nullable Throwable t) {
+            if (spanObj != null) {
+                final Span span = (Span) spanObj;
+                span.deactivate();
+                span.captureException(t);
+                span.end();
+            }
+        }
+    }
+}

--- a/apm-agent-plugins/apm-javalin-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-javalin-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -1,2 +1,3 @@
 co.elastic.apm.agent.javalin.JavalinInstrumentation
 co.elastic.apm.agent.javalin.JavalinHandlerLambdaInstrumentation
+co.elastic.apm.agent.javalin.JavalinRenderInstrumentation

--- a/apm-agent-plugins/apm-javalin-plugin/src/test/java/co/elastic/apm/agent/javalin/JavalinInstrumentationTest.java
+++ b/apm-agent-plugins/apm-javalin-plugin/src/test/java/co/elastic/apm/agent/javalin/JavalinInstrumentationTest.java
@@ -67,13 +67,13 @@ public class JavalinInstrumentationTest extends AbstractInstrumentationTest {
 
     @Test
     public void testJavalinParametrizedInput() throws Exception {
-        app.post("/hello/:id", ctx -> ctx.status(200).result("hello " + ctx.pathParam("id")));
+        app.post("/hello/{id}", ctx -> ctx.status(200).result("hello " + ctx.pathParam("id")));
 
         HttpRequest request = HttpRequest.newBuilder().POST(BodyPublishers.noBody()).uri(URI.create("http://localhost:" + app.port() + "/hello/foo")).build();
         final HttpResponse<String> mainUrlResponse = client.send(request, HttpResponse.BodyHandlers.ofString());
         assertThat(mainUrlResponse.statusCode()).isEqualTo(200);
-        assertThat(reporter.getFirstTransaction().getNameAsString()).isEqualTo("POST /hello/:id");
-        assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("POST /hello/:id");
+        assertThat(reporter.getFirstTransaction().getNameAsString()).isEqualTo("POST /hello/{id}");
+        assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("POST /hello/{id}");
     }
 
     @Test
@@ -146,7 +146,7 @@ public class JavalinInstrumentationTest extends AbstractInstrumentationTest {
     @Test
     public void testFuturesGetInstrumented() throws Exception {
         final String endpoint = "/test-future-instrumentation";
-        app.get(endpoint, ctx -> ctx.result(CompletableFuture.runAsync(() -> ctx.status(404))));
+        app.get(endpoint, ctx -> ctx.future(CompletableFuture.runAsync(() -> ctx.status(404))));
 
         HttpRequest request = HttpRequest.newBuilder().uri(URI.create(baseUrl + endpoint)).build();
         final HttpResponse<String> mainUrlResponse = client.send(request, HttpResponse.BodyHandlers.ofString());


### PR DESCRIPTION
## What does this PR do?

This PR adds a span, when a template is rendered by wrapping an advice around the `FileRenderer` interface.


## Checklist

- [X] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [X] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/master/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
