### PR TITLE
Use emulated attach as fallback

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
+* Fix runtime attach with some docker images - {pull}2385[#2385]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x


### PR DESCRIPTION
## What does this PR do?

Fixes #2383


It appears that some openjdk images do not behave as expected when using runtime attach.
- `openjdk:8-jdk-alpine` does not work and produce the stack trace below, the "native attach" is available as its a JDK, but there is no fallback to the emulated attach in this case
- `openjdk:8-jre-alpine` works, as a JRE is used only the "emulated attach" is available

One possible work-around is to add the `--init` argument to the `docker run` command, but that's not really convenient.
The agent already has a permanent work-around in the form of the "emulated attach" that already allows to use a JRE.

<details><summary>Stack trace</summary>
<p>

```
Exception in thread "main" java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:49)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:108)
        at org.springframework.boot.loader.Launcher.launch(Launcher.java:58)
        at org.springframework.boot.loader.JarLauncher.main(JarLauncher.java:88)
Caused by: java.lang.IllegalStateException: Error during attachment using: co.elastic.apm.attach.bytebuddy.agent.ByteBuddyAgent$AttachmentProvider$Compound@5e91993f
        at co.elastic.apm.attach.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:639)
        at co.elastic.apm.attach.bytebuddy.agent.ByteBuddyAgent.attach(ByteBuddyAgent.java:299)
        at co.elastic.apm.attach.ElasticApmAttacher.attach(ElasticApmAttacher.java:154)
        at co.elastic.apm.attach.ElasticApmAttacher.attach(ElasticApmAttacher.java:140)
        at co.elastic.apm.attach.ElasticApmAttacher.attach(ElasticApmAttacher.java:105)
        at co.elastic.apm.attach.ElasticApmAttacher.attach(ElasticApmAttacher.java:58)
        at com.example.springboot.Application.main(Application.java:16)
        ... 8 more
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at co.elastic.apm.attach.bytebuddy.agent.Attacher.install(Attacher.java:102)
        at co.elastic.apm.attach.bytebuddy.agent.ByteBuddyAgent.install(ByteBuddyAgent.java:634)
        ... 14 more
Caused by: com.sun.tools.attach.AttachNotSupportedException: Unable to get pid of LinuxThreads manager thread
        at sun.tools.attach.LinuxVirtualMachine.<init>(LinuxVirtualMachine.java:86)
        at sun.tools.attach.LinuxAttachProvider.attachVirtualMachine(LinuxAttachProvider.java:63)
        at com.sun.tools.attach.VirtualMachine.attach(VirtualMachine.java:208)
        ... 20 more
```

</p>
</details>

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/master/CHANGELOG.asciidoc)
  - [x] ~~I have added tests that would fail without this fix~~
  - [x] manually testing (and reproducing) the issue with a local application
