### PR TITLE
docs: Link to APM Guide

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -595,7 +595,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .key("use_elastic_traceparent_header")
         .tags("added[1.14.0]")
         .configurationCategory(CORE_CATEGORY)
-        .description("To enable {apm-overview-ref-v}/distributed-tracing.html[distributed tracing], the agent\n" +
+        .description("To enable {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing], the agent\n" +
             "adds trace context headers to outgoing requests (like HTTP requests, Kafka records, gRPC requests etc.).\n" +
             "These headers (`traceparent` and `tracestate`) are defined in the\n" +
             "https://www.w3.org/TR/trace-context-1/[W3C Trace Context] specification.\n" +

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -192,12 +192,12 @@ Click on a key to get more information.
 
 NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
 
-A boolean specifying whether the circuit breaker should be enabled or not.
-When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state.
-If ANY of the monitors detects a stress indication, the agent will become inactive, as if the
-<<config-recording,`recording`>> configuration option has been set to `false`, thus reducing resource consumption to a minimum.
-When inactive, the agent continues polling the same monitors in order to detect whether the stress state
-has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the
+A boolean specifying whether the circuit breaker should be enabled or not. 
+When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state. 
+If ANY of the monitors detects a stress indication, the agent will become inactive, as if the 
+<<config-recording,`recording`>> configuration option has been set to `false`, thus reducing resource consumption to a minimum. 
+When inactive, the agent continues polling the same monitors in order to detect whether the stress state 
+has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the 
 agent will resume and become fully functional.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -248,8 +248,8 @@ The default unit for this option is `s`.
 ==== `stress_monitor_gc_stress_threshold` (performance)
 
 The threshold used by the GC monitor to rely on for identifying heap stress.
-The same threshold will be used for all heap pools, so that if ANY has a usage percentage that crosses it,
-the agent will consider it as a heap stress. The GC monitor relies only on memory consumption measured
+The same threshold will be used for all heap pools, so that if ANY has a usage percentage that crosses it, 
+the agent will consider it as a heap stress. The GC monitor relies only on memory consumption measured 
 after a recent GC.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -274,8 +274,8 @@ after a recent GC.
 ==== `stress_monitor_gc_relief_threshold` (performance)
 
 The threshold used by the GC monitor to rely on for identifying when the heap is not under stress .
-If `stress_monitor_gc_stress_threshold` has been crossed, the agent will consider it a heap-stress state.
-In order to determine that the stress state is over, percentage of occupied memory in ALL heap pools should
+If `stress_monitor_gc_stress_threshold` has been crossed, the agent will consider it a heap-stress state. 
+In order to determine that the stress state is over, percentage of occupied memory in ALL heap pools should 
 be lower than this threshold. The GC monitor relies only on memory consumption measured after a recent GC.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -299,9 +299,9 @@ be lower than this threshold. The GC monitor relies only on memory consumption m
 [[config-stress-monitor-cpu-duration-threshold]]
 ==== `stress_monitor_cpu_duration_threshold` (performance)
 
-The minimal time required in order to determine whether the system is
-either currently under stress, or that the stress detected previously has been relieved.
-All measurements during this time must be consistent in comparison to the relevant threshold in
+The minimal time required in order to determine whether the system is 
+either currently under stress, or that the stress detected previously has been relieved. 
+All measurements during this time must be consistent in comparison to the relevant threshold in 
 order to detect a change of stress state. Must be at least `1m`.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -328,8 +328,8 @@ The default unit for this option is `m`.
 [[config-stress-monitor-system-cpu-stress-threshold]]
 ==== `stress_monitor_system_cpu_stress_threshold` (performance)
 
-The threshold used by the system CPU monitor to detect system CPU stress.
-If the system CPU crosses this threshold for a duration of at least `stress_monitor_cpu_duration_threshold`,
+The threshold used by the system CPU monitor to detect system CPU stress. 
+If the system CPU crosses this threshold for a duration of at least `stress_monitor_cpu_duration_threshold`, 
 the monitor considers this as a stress state.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -353,9 +353,9 @@ the monitor considers this as a stress state.
 [[config-stress-monitor-system-cpu-relief-threshold]]
 ==== `stress_monitor_system_cpu_relief_threshold` (performance)
 
-The threshold used by the system CPU monitor to determine that the system is
-not under CPU stress. If the monitor detected a CPU stress, the measured system CPU needs to be below
-this threshold for a duration of at least `stress_monitor_cpu_duration_threshold` in order for the
+The threshold used by the system CPU monitor to determine that the system is 
+not under CPU stress. If the monitor detected a CPU stress, the measured system CPU needs to be below 
+this threshold for a duration of at least `stress_monitor_cpu_duration_threshold` in order for the 
 monitor to decide that the CPU stress has been relieved.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -381,14 +381,14 @@ monitor to decide that the CPU stress has been relieved.
 [[config-recording]]
 ==== `recording` (added[1.15.0])
 
-NOTE: This option was available in older versions through the `active` key. The old key is still
+NOTE: This option was available in older versions through the `active` key. The old key is still 
 supported in newer versions, but it is now deprecated.
 
 A boolean specifying if the agent should be recording or not.
 When recording, the agent instruments incoming HTTP requests, tracks errors and collects and sends metrics.
 When not recording, the agent works as a noop, not collecting data and not communicating with the APM sever,
 except for polling the central configuration endpoint.
-As this is a reversible switch, agent threads are not being killed when inactivated, but they will be
+As this is a reversible switch, agent threads are not being killed when inactivated, but they will be 
 mostly idle in this state, so the overhead should be negligible.
 
 You can use this setting to dynamically disable Elastic APM at runtime.
@@ -439,8 +439,8 @@ If you want to dynamically change the status of the agent, use <<config-recordin
 ==== `instrument` (added[1.0.0,Changing this value at runtime is possible since version 1.15.0])
 
 A boolean specifying if the agent should instrument the application to collect traces for the app.
- When set to `false`, most built-in instrumentation plugins are disabled, which would minimize the effect on
-your application. However, the agent would still apply instrumentation related to manual tracing options and it
+ When set to `false`, most built-in instrumentation plugins are disabled, which would minimize the effect on 
+your application. However, the agent would still apply instrumentation related to manual tracing options and it 
 would still collect and send metrics to APM Server.
 
 NOTE: Both active and instrument needs to be true for instrumentation to be running.
@@ -514,13 +514,13 @@ If the service name is set explicitly, it overrides all of the above.
 [[config-service-node-name]]
 ==== `service_node_name` (added[1.11.0])
 
-If set, this name is used to distinguish between different nodes of a service,
-therefore it should be unique for each JVM within a service.
-If not set, data aggregations will be done based on a container ID (where valid) or on the reported
-hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>).
+If set, this name is used to distinguish between different nodes of a service, 
+therefore it should be unique for each JVM within a service. 
+If not set, data aggregations will be done based on a container ID (where valid) or on the reported 
+hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>). 
 
-NOTE: JVM metrics views rely on aggregations that are based on the service node name.
-If you have multiple JVMs installed on the same host reporting data for the same service name,
+NOTE: JVM metrics views rely on aggregations that are based on the service node name. 
+If you have multiple JVMs installed on the same host reporting data for the same service name, 
 you must set a unique node name for each in order to view metrics at the JVM level.
 
 NOTE: Metrics views can utilize this configuration since APM Server 7.5
@@ -865,16 +865,16 @@ NOTE: Exception inheritance is not supported, thus you have to explicitly list a
 [[config-capture-body]]
 ==== `capture_body` (performance)
 
-For transactions that are HTTP requests, the Java agent can optionally capture the request body (e.g. POST
-variables). For transactions that are initiated by receiving a message from a message broker, the agent can
+For transactions that are HTTP requests, the Java agent can optionally capture the request body (e.g. POST 
+variables). For transactions that are initiated by receiving a message from a message broker, the agent can 
 capture the textual message body.
 
 If the HTTP request or the message has a body and this setting is disabled, the body will be shown as [REDACTED].
 
 This option is case-insensitive.
 
-NOTE: Currently, the body length is limited to 10000 characters and it is not configurable.
-If the body size exceeds the limit, it will be truncated.
+NOTE: Currently, the body length is limited to 10000 characters and it is not configurable. 
+If the body size exceeds the limit, it will be truncated. 
 
 NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.
 The option <<config-capture-body-content-types>> determines which content types are captured.
@@ -906,7 +906,7 @@ Valid options: `off`, `errors`, `transactions`, `all`
 [[config-capture-headers]]
 ==== `capture_headers` (performance)
 
-If set to `true`, the agent will capture HTTP request and response headers (including cookies),
+If set to `true`, the agent will capture HTTP request and response headers (including cookies), 
 as well as messages' headers/properties when using messaging frameworks like Kafka or JMS.
 
 NOTE: Setting this to `false` reduces network bandwidth, disk space and object allocations.
@@ -958,7 +958,7 @@ NOTE: This feature requires APM Server 7.2+
 [[config-classes-excluded-from-instrumentation]]
 ==== `classes_excluded_from_instrumentation`
 
-Use to exclude specific classes from being instrumented. In order to exclude entire packages,
+Use to exclude specific classes from being instrumented. In order to exclude entire packages, 
 use wildcards, as in: `com.project.exclude.*`
 This option supports the wildcard `*`, which matches zero or more characters.
 Examples: `/foo/*/bar/*/baz*`, `*foo*`.
@@ -1071,7 +1071,7 @@ NOTE: Changing this value at runtime can slow down the application temporarily.
 [[config-trace-methods-duration-threshold]]
 ==== `trace_methods_duration_threshold` (added[1.7.0])
 
-If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on
+If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on 
 duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded by default.
 Such methods will be traced and reported if one of the following applies:
 
@@ -1284,8 +1284,8 @@ The default unit for this option is `ms`.
 [[config-cloud-provider]]
 ==== `cloud_provider` (added[1.21.0])
 
-This config value allows you to specify which cloud provider should be assumed
-for metadata collection. By default, the agent will attempt to detect the cloud
+This config value allows you to specify which cloud provider should be assumed 
+for metadata collection. By default, the agent will attempt to detect the cloud 
 provider or, if that fails, will use trial and error to collect the metadata.
 
 
@@ -1621,7 +1621,7 @@ The resulting documents in Elasticsearch look similar to these (metadata omitted
 The agent also supports composite values for the attribute value.
 In this example, `HeapMemoryUsage` is a composite value, consisting of `committed`, `init`, `used` and `max`.
 ----
-object_name[java.lang:type=Memory] attribute[HeapMemoryUsage:metric_name=heap]
+object_name[java.lang:type=Memory] attribute[HeapMemoryUsage:metric_name=heap] 
 ----
 
 The resulting documents in Elasticsearch look similar to this:
@@ -1673,7 +1673,7 @@ The resulting documents in Elasticsearch look similar to this:
 Sets the logging level for the agent.
 This option is case-insensitive.
 
-NOTE: `CRITICAL` is a valid option, but it is mapped to `ERROR`; `WARN` and `WARNING` are equivalent;
+NOTE: `CRITICAL` is a valid option, but it is mapped to `ERROR`; `WARN` and `WARNING` are equivalent; 
 `OFF` is only available since version 1.16.0
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -1760,27 +1760,27 @@ NOTE: While it's allowed to enable this setting at runtime, you can't disable it
 
 NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
 
-Specifying whether and how the agent should automatically reformat application logs
-into {ecs-logging-ref}/index.html[ECS-compatible JSON], suitable for ingestion into Elasticsearch for
-further Log analysis. This functionality is available for log4j1, log4j2 and Logback.
-Once this option is enabled with any valid option, log correlation will be activated as well, regardless of the <<config-enable-log-correlation,`enable_log_correlation`>> configuration.
+Specifying whether and how the agent should automatically reformat application logs 
+into {ecs-logging-ref}/index.html[ECS-compatible JSON], suitable for ingestion into Elasticsearch for 
+further Log analysis. This functionality is available for log4j1, log4j2 and Logback. 
+Once this option is enabled with any valid option, log correlation will be activated as well, regardless of the <<config-enable-log-correlation,`enable_log_correlation`>> configuration. 
 
 Available options:
 
- - OFF - application logs are not reformatted.
- - SHADE - agent logs are reformatted and "shade" ECS-JSON-formatted logs are automatically created in
-   addition to the original application logs. Shade logs will have the same name as the original logs,
-   but with the ".ecs.json" extension instead of the original extension. Destination directory for the
-   shade logs can be configured through the <<config-log-ecs-reformatting-dir,`log_ecs_reformatting_dir`>>
-   configuration. Shade logs do not inherit file-rollover strategy from the original logs. Instead, they
-   use their own size-based rollover strategy according to the <<config-log-file-size, `log_file_size`>>
+ - OFF - application logs are not reformatted. 
+ - SHADE - agent logs are reformatted and "shade" ECS-JSON-formatted logs are automatically created in 
+   addition to the original application logs. Shade logs will have the same name as the original logs, 
+   but with the ".ecs.json" extension instead of the original extension. Destination directory for the 
+   shade logs can be configured through the <<config-log-ecs-reformatting-dir,`log_ecs_reformatting_dir`>> 
+   configuration. Shade logs do not inherit file-rollover strategy from the original logs. Instead, they 
+   use their own size-based rollover strategy according to the <<config-log-file-size, `log_file_size`>> 
    configuration and while allowing maximum of two shade log files.
- - REPLACE - similar to `SHADE`, but the original logs will not be written. This option is useful if
-   you wish to maintain similar logging-related overhead, but write logs to a different location and/or
+ - REPLACE - similar to `SHADE`, but the original logs will not be written. This option is useful if 
+   you wish to maintain similar logging-related overhead, but write logs to a different location and/or 
    with a different file extension.
- - OVERRIDE - same log output is used, but in ECS-compatible JSON format instead of the original format.
+ - OVERRIDE - same log output is used, but in ECS-compatible JSON format instead of the original format. 
 
-NOTE: while `SHADE` and `REPLACE` options are only relevant to file log appenders, the `OVERRIDE` option
+NOTE: while `SHADE` and `REPLACE` options are only relevant to file log appenders, the `OVERRIDE` option 
 is also valid for other appenders, like System out and console
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -1831,11 +1831,11 @@ A comma-separated list of key-value pairs that will be added as additional field
 [[config-log-ecs-formatter-allow-list]]
 ==== `log_ecs_formatter_allow_list`
 
-Only formatters that match an item on this list will be automatically reformatted to ECS when
-<<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.
-A formatter is the logging-framework-specific entity that is responsible for the formatting
-of log events. For example, in log4j it would be a `Layout` implementation, whereas in Logback it would
-be an `Encoder` implementation.
+Only formatters that match an item on this list will be automatically reformatted to ECS when 
+<<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`. 
+A formatter is the logging-framework-specific entity that is responsible for the formatting 
+of log events. For example, in log4j it would be a `Layout` implementation, whereas in Logback it would 
+be an `Encoder` implementation. 
 
 This option supports the wildcard `*`, which matches zero or more characters.
 Examples: `/foo/*/bar/*/baz*`, `*foo*`.
@@ -1863,10 +1863,10 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 [[config-log-ecs-reformatting-dir]]
 ==== `log_ecs_reformatting_dir`
 
-If <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to `SHADE` or `REPLACE`,
-the shade log files will be written alongside the original logs in the same directory by default.
-Use this configuration in order to write the shade logs into an alternative destination. Omitting this
-config or setting it to an empty string will restore the default behavior. If relative path is used,
+If <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to `SHADE` or `REPLACE`, 
+the shade log files will be written alongside the original logs in the same directory by default. 
+Use this configuration in order to write the shade logs into an alternative destination. Omitting this 
+config or setting it to an empty string will restore the default behavior. If relative path is used, 
 this path will be used relative to the original logs directory.
 
 
@@ -1973,7 +1973,7 @@ Valid options: `PLAIN_TEXT`, `JSON`
 [[config-ignore-message-queues]]
 ==== `ignore_message_queues`
 
-Used to filter out specific messaging queues/topics from being traced.
+Used to filter out specific messaging queues/topics from being traced. 
 
 This property should be set to an array containing one or more strings.
 When set, sends-to and receives-from the specified queues/topic will be ignored.
@@ -2268,12 +2268,12 @@ Use if APM Server requires an API key.
 
 The URL must be fully qualified, including protocol (http or https) and port.
 
-If SSL is enabled on the APM Server, use the `https` protocol. For more information, see
+If SSL is enabled on the APM Server, use the `https` protocol. For more information, see 
 <<ssl-configuration>>.
 
 If outgoing HTTP traffic has to go through a proxy,
 you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
-See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation]
+See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation] 
 for more information.
 
 NOTE: This configuration can only be reloaded dynamically as of 1.8.0
@@ -2305,16 +2305,16 @@ Fails over to the next APM Server URL in the event of connection errors.
 Achieves load-balancing by shuffling the list of configured URLs.
 When multiple agents are active, they'll tend towards spreading evenly across the set of servers due to randomization.
 
-If SSL is enabled on the APM Server, use the `https` protocol. For more information, see
+If SSL is enabled on the APM Server, use the `https` protocol. For more information, see 
 <<ssl-configuration>>.
 
 If outgoing HTTP traffic has to go through a proxy,
 you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
-See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation]
+See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation] 
 for more information.
 
-NOTE: This configuration is specific to the Java agent and does not align with any other APM agent. In order
-to use a cross-agent config, use <<config-server-url>> instead, which is the recommended option regardless if you
+NOTE: This configuration is specific to the Java agent and does not align with any other APM agent. In order 
+to use a cross-agent config, use <<config-server-url>> instead, which is the recommended option regardless if you 
 are only setting a single URL.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -2338,10 +2338,10 @@ are only setting a single URL.
 [[config-disable-send]]
 ==== `disable_send`
 
-If set to `true`, the agent will work as usual, except from any task requiring communication with
-the APM server. Events will be dropped and the agent won't be able to receive central configuration, which
-means that any other configuration cannot be changed in this state without restarting the service.
-An example use case for this would be maintaining the ability to create traces and log
+If set to `true`, the agent will work as usual, except from any task requiring communication with 
+the APM server. Events will be dropped and the agent won't be able to receive central configuration, which 
+means that any other configuration cannot be changed in this state without restarting the service. 
+An example use case for this would be maintaining the ability to create traces and log 
 trace/transaction/span IDs through the log correlation feature, without setting up an APM Server.
 
 
@@ -2589,8 +2589,8 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 [[config-aws-lambda-handler]]
 ==== `aws_lambda_handler` (added[1.28.0])
 
-This config option must be used when running the agent in an AWS Lambda context.
-This config value allows to specify the fully qualified name of the class handling the lambda function.
+This config option must be used when running the agent in an AWS Lambda context. 
+This config value allows to specify the fully qualified name of the class handling the lambda function. 
 An empty value (default value) indicates that the agent is not running within an AWS lambda function.
 
 
@@ -2614,7 +2614,7 @@ An empty value (default value) indicates that the agent is not running within an
 [[config-data-flush-timeout]]
 ==== `data_flush_timeout` (added[1.28.0])
 
-This config value allows to specify the timeout in milliseconds for flushing APM data at the end of a serverless function.
+This config value allows to specify the timeout in milliseconds for flushing APM data at the end of a serverless function. 
 For serverless functions, APM data is written in a synchronous way, thus, blocking the termination of the function util data is written or the specified timeout is reached.
 
 
@@ -2702,7 +2702,7 @@ Setting it to 0 will disable stack trace collection. Any positive integer value 
 [[config-span-stack-trace-min-duration]]
 ==== `span_stack_trace_min_duration` (performance)
 
-While this is very helpful to find the exact place in your code that causes the span, collecting this stack trace does have some overhead.
+While this is very helpful to find the exact place in your code that causes the span, collecting this stack trace does have some overhead. 
 When setting this option to value `0ms`, stack traces will be collected for all spans. Setting it to a positive value, e.g. `5ms`, will limit stack trace collection to spans with durations equal to or longer than the given value, e.g. 5 milliseconds.
 
 To disable stack trace collection for spans completely, set the value to `-1ms`.
@@ -2738,12 +2738,12 @@ The default unit for this option is `ms`.
 # Circuit-Breaker                          #
 ############################################
 
-# A boolean specifying whether the circuit breaker should be enabled or not.
-# When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state.
-# If ANY of the monitors detects a stress indication, the agent will become inactive, as if the
-# <<config-recording,`recording`>> configuration option has been set to `false`, thus reducing resource consumption to a minimum.
-# When inactive, the agent continues polling the same monitors in order to detect whether the stress state
-# has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the
+# A boolean specifying whether the circuit breaker should be enabled or not. 
+# When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state. 
+# If ANY of the monitors detects a stress indication, the agent will become inactive, as if the 
+# <<config-recording,`recording`>> configuration option has been set to `false`, thus reducing resource consumption to a minimum. 
+# When inactive, the agent continues polling the same monitors in order to detect whether the stress state 
+# has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the 
 # agent will resume and become fully functional.
 #
 # This setting can be changed at runtime
@@ -2763,8 +2763,8 @@ The default unit for this option is `ms`.
 # stress_monitoring_interval=5s
 
 # The threshold used by the GC monitor to rely on for identifying heap stress.
-# The same threshold will be used for all heap pools, so that if ANY has a usage percentage that crosses it,
-# the agent will consider it as a heap stress. The GC monitor relies only on memory consumption measured
+# The same threshold will be used for all heap pools, so that if ANY has a usage percentage that crosses it, 
+# the agent will consider it as a heap stress. The GC monitor relies only on memory consumption measured 
 # after a recent GC.
 #
 # This setting can be changed at runtime
@@ -2774,8 +2774,8 @@ The default unit for this option is `ms`.
 # stress_monitor_gc_stress_threshold=0.95
 
 # The threshold used by the GC monitor to rely on for identifying when the heap is not under stress .
-# If `stress_monitor_gc_stress_threshold` has been crossed, the agent will consider it a heap-stress state.
-# In order to determine that the stress state is over, percentage of occupied memory in ALL heap pools should
+# If `stress_monitor_gc_stress_threshold` has been crossed, the agent will consider it a heap-stress state. 
+# In order to determine that the stress state is over, percentage of occupied memory in ALL heap pools should 
 # be lower than this threshold. The GC monitor relies only on memory consumption measured after a recent GC.
 #
 # This setting can be changed at runtime
@@ -2784,9 +2784,9 @@ The default unit for this option is `ms`.
 #
 # stress_monitor_gc_relief_threshold=0.75
 
-# The minimal time required in order to determine whether the system is
-# either currently under stress, or that the stress detected previously has been relieved.
-# All measurements during this time must be consistent in comparison to the relevant threshold in
+# The minimal time required in order to determine whether the system is 
+# either currently under stress, or that the stress detected previously has been relieved. 
+# All measurements during this time must be consistent in comparison to the relevant threshold in 
 # order to detect a change of stress state. Must be at least `1m`.
 #
 # This setting can be changed at runtime
@@ -2797,8 +2797,8 @@ The default unit for this option is `ms`.
 #
 # stress_monitor_cpu_duration_threshold=1m
 
-# The threshold used by the system CPU monitor to detect system CPU stress.
-# If the system CPU crosses this threshold for a duration of at least `stress_monitor_cpu_duration_threshold`,
+# The threshold used by the system CPU monitor to detect system CPU stress. 
+# If the system CPU crosses this threshold for a duration of at least `stress_monitor_cpu_duration_threshold`, 
 # the monitor considers this as a stress state.
 #
 # This setting can be changed at runtime
@@ -2807,9 +2807,9 @@ The default unit for this option is `ms`.
 #
 # stress_monitor_system_cpu_stress_threshold=0.95
 
-# The threshold used by the system CPU monitor to determine that the system is
-# not under CPU stress. If the monitor detected a CPU stress, the measured system CPU needs to be below
-# this threshold for a duration of at least `stress_monitor_cpu_duration_threshold` in order for the
+# The threshold used by the system CPU monitor to determine that the system is 
+# not under CPU stress. If the monitor detected a CPU stress, the measured system CPU needs to be below 
+# this threshold for a duration of at least `stress_monitor_cpu_duration_threshold` in order for the 
 # monitor to decide that the CPU stress has been relieved.
 #
 # This setting can be changed at runtime
@@ -2822,16 +2822,16 @@ The default unit for this option is `ms`.
 # Core                                     #
 ############################################
 
-# NOTE: This option was available in older versions through the `active` key. The old key is still
+# NOTE: This option was available in older versions through the `active` key. The old key is still 
 # supported in newer versions, but it is now deprecated.
-#
+# 
 # A boolean specifying if the agent should be recording or not.
 # When recording, the agent instruments incoming HTTP requests, tracks errors and collects and sends metrics.
 # When not recording, the agent works as a noop, not collecting data and not communicating with the APM sever,
 # except for polling the central configuration endpoint.
-# As this is a reversible switch, agent threads are not being killed when inactivated, but they will be
+# As this is a reversible switch, agent threads are not being killed when inactivated, but they will be 
 # mostly idle in this state, so the overhead should be negligible.
-#
+# 
 # You can use this setting to dynamically disable Elastic APM at runtime.
 #
 # This setting can be changed at runtime
@@ -2850,12 +2850,12 @@ The default unit for this option is `ms`.
 # enabled=true
 
 # A boolean specifying if the agent should instrument the application to collect traces for the app.
-#  When set to `false`, most built-in instrumentation plugins are disabled, which would minimize the effect on
-# your application. However, the agent would still apply instrumentation related to manual tracing options and it
+#  When set to `false`, most built-in instrumentation plugins are disabled, which would minimize the effect on 
+# your application. However, the agent would still apply instrumentation related to manual tracing options and it 
 # would still collect and send metrics to APM Server.
-#
+# 
 # NOTE: Both active and instrument needs to be true for instrumentation to be running.
-#
+# 
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 #
 # This setting can be changed at runtime
@@ -2868,11 +2868,11 @@ The default unit for this option is `ms`.
 #
 # This is used to keep all the errors and transactions of your service together
 # and is the primary filter in the Elastic APM user interface.
-#
+# 
 # The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]+$`.
 # In less regexy terms:
 # Your service name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces.
-#
+# 
 # NOTE: When relying on auto-discovery of the service name in Servlet environments (including Spring Boot),
 # there is currently a caveat related to metrics.
 # The consequence is that the 'Metrics' tab of a service does not show process-global metrics like CPU utilization.
@@ -2883,7 +2883,7 @@ The default unit for this option is `ms`.
 # Future versions of the Elastic APM stack will have better support for that scenario.
 # A workaround is to explicitly set the `service_name` which means all applications deployed to the same servlet container will have the same name
 # or to disable the corresponding `*-service-name` detecting instrumentations via <<config-disable-instrumentations>>.
-#
+# 
 # NOTE: Service name auto discovery mechanisms require APM Server 7.0+.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -2893,26 +2893,26 @@ The default unit for this option is `ms`.
 # Falls back to the servlet context path the application is mapped to (unless mapped to the root context).
 # Falls back to the name of the main class or jar file.
 # If the service name is set explicitly, it overrides all of the above.
-#
+# 
 #
 # service_name=
 
 # A unique name for the service node
 #
-# If set, this name is used to distinguish between different nodes of a service,
-# therefore it should be unique for each JVM within a service.
-# If not set, data aggregations will be done based on a container ID (where valid) or on the reported
-# hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>).
-#
-# NOTE: JVM metrics views rely on aggregations that are based on the service node name.
-# If you have multiple JVMs installed on the same host reporting data for the same service name,
+# If set, this name is used to distinguish between different nodes of a service, 
+# therefore it should be unique for each JVM within a service. 
+# If not set, data aggregations will be done based on a container ID (where valid) or on the reported 
+# hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>). 
+# 
+# NOTE: JVM metrics views rely on aggregations that are based on the service node name. 
+# If you have multiple JVMs installed on the same host reporting data for the same service name, 
 # you must set a unique node name for each in order to view metrics at the JVM level.
-#
+# 
 # NOTE: Metrics views can utilize this configuration since APM Server 7.5
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # service_node_name=
 
@@ -2920,7 +2920,7 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # service_version=
 
@@ -2928,27 +2928,27 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # hostname=
 
 # The name of the environment this service is deployed in, e.g. "production" or "staging".
-#
+# 
 # Environments allow you to easily filter data on a global level in the APM app.
 # It's important to be consistent when naming environments across agents.
 # See {apm-app-ref}/filters.html#environment-selector[environment selector] in the APM app for more information.
-#
+# 
 # NOTE: This feature is fully supported in the APM app in Kibana versions >= 7.2.
 # You must use the query bar to filter for a specific environment in versions prior to 7.2.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # environment=
 
 # By default, the agent will sample every transaction (e.g. request to your service). To reduce overhead and storage requirements, you can set the sample rate to a value between 0.0 and 1.0. We still record overall time and the result for unsampled transactions, but no context information, labels, or spans.
-#
+# 
 # Value will be rounded with 4 significant digits, as an example, value '0.55555' will be rounded to `0.5556`
 #
 # This setting can be changed at runtime
@@ -2958,11 +2958,11 @@ The default unit for this option is `ms`.
 # transaction_sample_rate=1
 
 # Limits the amount of spans that are recorded per transaction.
-#
+# 
 # This is helpful in cases where a transaction creates a very high amount of spans (e.g. thousands of SQL queries).
-#
+# 
 # Setting an upper limit will prevent overloading the agent and the APM server with too much work for such edge cases.
-#
+# 
 # A message will be logged when the max number of spans has been exceeded but only at a rate of once every 5 minutes to ensure performance is not impacted.
 #
 # This setting can be changed at runtime
@@ -2973,19 +2973,19 @@ The default unit for this option is `ms`.
 
 # Sometimes it is necessary to sanitize the data sent to Elastic APM,
 # e.g. remove sensitive data.
-#
+# 
 # Configure a list of wildcard patterns of field names which should be sanitized.
 # These apply for example to HTTP headers and `application/x-www-form-urlencoded` data.
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
 # Prepending an element with `(?-i)` makes the matching case sensitive.
-#
+# 
 # NOTE: Data in the query string is considered non-sensitive,
 # as sensitive information should not be sent in the query string.
 # See https://www.owasp.org/index.php/Information_exposure_through_query_strings_in_url for more information
-#
+# 
 # NOTE: Review the data captured by Elastic APM carefully to make sure it does not capture sensitive information.
 # If you do find sensitive data in the Elasticsearch index,
 # you should add an additional entry to this list (make sure to also include the default entries).
@@ -3000,29 +3000,29 @@ The default unit for this option is `ms`.
 # Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `aws-lambda`, `cassandra`, `concurrent`, `dubbo`, `elasticsearch-restclient`, `exception-handler`, `executor`, `executor-collection`, `experimental`, `fork-join`, `grails`, `grpc`, `hibernate-search`, `http-client`, `javalin`, `jax-rs`, `jax-ws`, `jdbc`, `jdk-httpclient`, `jdk-httpserver`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j1-ecs`, `log4j2-ecs`, `log4j2-error`, `logback-ecs`, `logging`, `micrometer`, `mongodb-client`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `rabbitmq`, `reactor`, `redis`, `redisson`, `render`, `scala-future`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-api-dispatch`, `servlet-input-stream`, `slf4j-error`, `sparkjava`, `spring-amqp`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `spring-webflux`, `ssl-context`, `struts`, `timer-task`, `urlconnection`, `vertx`, `vertx-web`, `vertx-webclient`.
 # When set to non-empty value, only listed instrumentations will be enabled if they are not disabled through <<config-disable-instrumentations>> or <<config-enable-experimental-instrumentations>>.
 # When not set or empty (default), all instrumentations enabled by default will be enabled unless they are disabled through <<config-disable-instrumentations>> or <<config-enable-experimental-instrumentations>>.
-#
+# 
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # enable_instrumentations=
 
 # A list of instrumentations which should be disabled.
 # Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `aws-lambda`, `cassandra`, `concurrent`, `dubbo`, `elasticsearch-restclient`, `exception-handler`, `executor`, `executor-collection`, `experimental`, `fork-join`, `grails`, `grpc`, `hibernate-search`, `http-client`, `javalin`, `jax-rs`, `jax-ws`, `jdbc`, `jdk-httpclient`, `jdk-httpserver`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j1-ecs`, `log4j2-ecs`, `log4j2-error`, `logback-ecs`, `logging`, `micrometer`, `mongodb-client`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `rabbitmq`, `reactor`, `redis`, `redisson`, `render`, `scala-future`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-api-dispatch`, `servlet-input-stream`, `slf4j-error`, `sparkjava`, `spring-amqp`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `spring-webflux`, `ssl-context`, `struts`, `timer-task`, `urlconnection`, `vertx`, `vertx-web`, `vertx-webclient`.
 # For version `1.25.0` and later, use <<config-enable-experimental-instrumentations>> to enable experimental instrumentations.
-#
+# 
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # disable_instrumentations=
 
 # Whether to apply experimental instrumentations.
-#
+# 
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 # Setting to `true` will enable instrumentations in the `experimental` group.
 #
@@ -3036,7 +3036,7 @@ The default unit for this option is `ms`.
 # un-nests the exceptions matching the wildcard pattern.
 # This can come in handy for Spring's `org.springframework.web.util.NestedServletException`,
 # for example.
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3050,40 +3050,40 @@ The default unit for this option is `ms`.
 
 # A list of exceptions that should be ignored and not reported as errors.
 # This allows to ignore exceptions thrown in regular control flow that are not actual errors
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
 # Prepending an element with `(?-i)` makes the matching case sensitive.
-#
+# 
 # Examples:
-#
+# 
 #  - `com.mycompany.ExceptionToIgnore`: using fully qualified name
 #  - `*ExceptionToIgnore`: using wildcard to avoid package name
 #  - `*exceptiontoignore`: case-insensitive by default
-#
+# 
 # NOTE: Exception inheritance is not supported, thus you have to explicitly list all the thrown exception types
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # ignore_exceptions=
 
-# For transactions that are HTTP requests, the Java agent can optionally capture the request body (e.g. POST
-# variables). For transactions that are initiated by receiving a message from a message broker, the agent can
+# For transactions that are HTTP requests, the Java agent can optionally capture the request body (e.g. POST 
+# variables). For transactions that are initiated by receiving a message from a message broker, the agent can 
 # capture the textual message body.
-#
+# 
 # If the HTTP request or the message has a body and this setting is disabled, the body will be shown as [REDACTED].
-#
+# 
 # This option is case-insensitive.
-#
-# NOTE: Currently, the body length is limited to 10000 characters and it is not configurable.
-# If the body size exceeds the limit, it will be truncated.
-#
+# 
+# NOTE: Currently, the body length is limited to 10000 characters and it is not configurable. 
+# If the body size exceeds the limit, it will be truncated. 
+# 
 # NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.
 # The option <<config-capture-body-content-types>> determines which content types are captured.
-#
+# 
 # WARNING: Request bodies often contain sensitive values like passwords, credit card numbers etc.
 # If your service handles data like this, we advise to only enable this feature with care.
 # Turning on body capturing can also significantly increase the overhead in terms of heap usage,
@@ -3096,9 +3096,9 @@ The default unit for this option is `ms`.
 #
 # capture_body=OFF
 
-# If set to `true`, the agent will capture HTTP request and response headers (including cookies),
+# If set to `true`, the agent will capture HTTP request and response headers (including cookies), 
 # as well as messages' headers/properties when using messaging frameworks like Kafka or JMS.
-#
+# 
 # NOTE: Setting this to `false` reduces network bandwidth, disk space and object allocations.
 #
 # This setting can be changed at runtime
@@ -3109,16 +3109,16 @@ The default unit for this option is `ms`.
 
 # Labels added to all events, with the format `key=value[,key=value[,...]]`.
 # Any labels set by application via the API will override global labels with the same keys.
-#
+# 
 # NOTE: This feature requires APM Server 7.2+
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: Map
-# Default value:
+# Default value: 
 #
 # global_labels=
 
-# Use to exclude specific classes from being instrumented. In order to exclude entire packages,
+# Use to exclude specific classes from being instrumented. In order to exclude entire packages, 
 # use wildcards, as in: `com.project.exclude.*`
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
@@ -3127,21 +3127,21 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # classes_excluded_from_instrumentation=
 
 # A list of methods for which to create a transaction or span.
-#
+# 
 # If you want to monitor a large number of methods,
 # use  <<config-profiling-inferred-spans-enabled, `profiling_inferred_spans_enabled`>> instead.
-#
+# 
 # This works by instrumenting each matching method to include code that creates a span for the method.
 # While creating a span is quite cheap in terms of performance,
 # instrumenting a whole code base or a method which is executed in a tight loop leads to significant overhead.
-#
+# 
 # Using a pointcut-like syntax, you can match based on
-#
+# 
 #  - Method modifier (optional) +
 #    Example: `public`, `protected`, `private` or `*`
 #  - Package and class name (wildcards include sub-packages) +
@@ -3154,11 +3154,11 @@ The default unit for this option is `ms`.
 #    Example: `@*ApplicationScoped`
 #  - Classes with a specific annotation that is itself annotated with the given meta-annotation (optional) +
 #    Example: `@@javax.enterpr*se.context.NormalScope`
-#
+# 
 # The syntax is `modifier @fully.qualified.AnnotationName fully.qualified.ClassName#methodName(fully.qualified.ParameterType)`.
-#
+# 
 # A few examples:
-#
+# 
 #  - `org.example.*` added[1.4.0,Omitting the method is possible since 1.4.0]
 #  - `org.example.*#*` (before 1.4.0, you need to specify a method matcher)
 #  - `org.example.MyClass#myMethod`
@@ -3171,53 +3171,53 @@ The default unit for this option is `ms`.
 #  - `public @java.inject.ApplicationScoped org.example.*`
 #  - `public @java.inject.* org.example.*`
 #  - `public @@javax.enterprise.context.NormalScope org.example.*, public @@jakarta.enterprise.context.NormalScope org.example.*`
-#
+# 
 # NOTE: Only use wildcards if necessary.
 # The more methods you match the more overhead will be caused by the agent.
 # Also note that there is a maximum amount of spans per transaction (see <<config-transaction-max-spans, `transaction_max_spans`>>).
-#
+# 
 # NOTE: The agent will create stack traces for spans which took longer than
 # <<config-span-stack-trace-min-duration, `span_stack_trace_min_duration`>>.
 # When tracing a large number of methods (for example by using wildcards),
 # this may lead to high overhead.
 # Consider increasing the threshold or disabling stack trace collection altogether.
-#
+# 
 # Common configurations:
-#
+# 
 # Trace all public methods in CDI-Annotated beans:
-#
+# 
 # ----
 # public @@javax.enterprise.context.NormalScope your.application.package.*
 # public @@jakarta.enterprise.context.NormalScope your.application.package.*
 # public @@javax.inject.Scope your.application.package.*
 # ----
 # NOTE: This method is only available in the Elastic APM Java Agent.
-#
+# 
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # trace_methods=
 
-# If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on
+# If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on 
 # duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded by default.
 # Such methods will be traced and reported if one of the following applies:
-#
+# 
 #  - This method's duration crossed the configured threshold.
 #  - This method ended with Exception.
 #  - A method executed as part of the execution of this method crossed the threshold or ended with Exception.
 #  - A "forcibly-traced method" (e.g. DB queries, HTTP exits, custom) was executed during the execution of this method.
-#
+# 
 # Set to 0 to disable.
-#
+# 
 # NOTE: Transactions are never discarded, regardless of their duration.
 # This configuration affects only spans.
 # In order not to break span references,
 # all spans leading to an async operation or an exit span (such as a HTTP request or a DB query) are never discarded,
 # regardless of their duration.
-#
+# 
 # NOTE: If this option and <<config-span-min-duration,`span_min_duration`>> are both configured,
 # the higher of both thresholds will determine which spans will be discarded.
 #
@@ -3249,7 +3249,7 @@ The default unit for this option is `ms`.
 # The special value `_AGENT_HOME_` is a placeholder for the folder the `elastic-apm-agent.jar` is in.
 # The file has to be on the file system.
 # You can not refer to classpath locations.
-#
+# 
 # NOTE: this option can only be set via system properties, environment variables or the attacher options.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -3259,7 +3259,7 @@ The default unit for this option is `ms`.
 # config_file=_AGENT_HOME_/elasticapm.properties
 
 # A folder that contains external agent plugins.
-#
+# 
 # Use the `apm-agent-plugin-sdk` and the `apm-agent-api` artifacts to create a jar and place it into the plugins folder.
 # The agent will load all instrumentations that are declared in the
 # `META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation` service descriptor.
@@ -3267,7 +3267,7 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # plugins_dir=
 
@@ -3275,7 +3275,7 @@ The default unit for this option is `ms`.
 # adds trace context headers to outgoing requests (like HTTP requests, Kafka records, gRPC requests etc.).
 # These headers (`traceparent` and `tracestate`) are defined in the
 # https://www.w3.org/TR/trace-context-1/[W3C Trace Context] specification.
-#
+# 
 # When this setting is `true`, the agent will also add the header `elastic-apm-traceparent`
 # for backwards compatibility with older versions of Elastic APM agents.
 #
@@ -3287,13 +3287,13 @@ The default unit for this option is `ms`.
 
 # Sets the minimum duration of spans.
 # Spans that execute faster than this threshold are attempted to be discarded.
-#
+# 
 # The attempt fails if they lead up to a span that can't be discarded.
 # Spans that propagate the trace context to downstream services,
 # such as outgoing HTTP requests,
 # can't be discarded.
 # Additionally, spans that lead to an error or that may be a parent of an async operation can't be discarded.
-#
+# 
 # However, external calls that don't propagate context,
 # such as calls to a database, can be discarded using this threshold.
 #
@@ -3305,8 +3305,8 @@ The default unit for this option is `ms`.
 #
 # span_min_duration=0ms
 
-# This config value allows you to specify which cloud provider should be assumed
-# for metadata collection. By default, the agent will attempt to detect the cloud
+# This config value allows you to specify which cloud provider should be assumed 
+# for metadata collection. By default, the agent will attempt to detect the cloud 
 # provider or, if that fails, will use trial and error to collect the metadata.
 #
 # Valid options: AUTO, AWS, GCP, AZURE, NONE
@@ -3332,9 +3332,9 @@ The default unit for this option is `ms`.
 ############################################
 
 # Configures which content types should be recorded.
-#
+# 
 # The defaults end with a wildcard so that content types like `text/plain; charset=utf-8` are captured as well.
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3347,10 +3347,10 @@ The default unit for this option is `ms`.
 # capture_body_content_types=application/x-www-form-urlencoded*,text/*,application/json*,application/xml*
 
 # Used to restrict requests to certain URLs from being instrumented.
-#
+# 
 # This property should be set to an array containing one or more strings.
 # When an incoming HTTP request is detected, its URL will be tested against each element in this list.
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3363,11 +3363,11 @@ The default unit for this option is `ms`.
 # transaction_ignore_urls=/VAADIN/*,/heartbeat*,/favicon.ico,*.js,*.css,*.jpg,*.jpeg,*.png,*.gif,*.webp,*.svg,*.woff,*.woff2
 
 # Used to restrict requests from certain User-Agents from being instrumented.
-#
+# 
 # When an incoming HTTP request is detected,
 # the User-Agent from the request headers will be tested against each element in this list.
 # Example: `curl/*`, `*pingdom*`
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3375,13 +3375,13 @@ The default unit for this option is `ms`.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # transaction_ignore_user_agents=
 
 # If set to `true`,
 # transaction names of unsupported or partially-supported frameworks will be in the form of `$method $path` instead of just `$method unknown route`.
-#
+# 
 # WARNING: If your URLs contain path parameters like `/user/$userId`,
 # you should be very careful when enabling this flag,
 # as it can lead to an explosion of transaction groups.
@@ -3394,9 +3394,9 @@ The default unit for this option is `ms`.
 # use_path_as_transaction_name=false
 
 # This option is only considered, when `use_path_as_transaction_name` is active.
-#
+# 
 # With this option, you can group several URL paths together by using a wildcard expression like `/user/*`.
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3404,7 +3404,7 @@ The default unit for this option is `ms`.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # url_groups=
 
@@ -3414,7 +3414,7 @@ The default unit for this option is `ms`.
 
 # By default, the agent will scan for @Path annotations on the whole class hierarchy, recognizing a class as a JAX-RS resource if the class or any of its superclasses/interfaces has a class level @Path annotation.
 # If your application does not use @Path annotation inheritance, set this property to 'false' to only scan for direct @Path annotations. This can improve the startup time of the agent.
-#
+# 
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: Boolean
@@ -3436,13 +3436,13 @@ The default unit for this option is `ms`.
 ############################################
 
 # Report metrics from JMX to the APM Server
-#
+# 
 # Can contain multiple comma separated JMX metric definitions:
-#
+# 
 # ----
 # object_name[<JMX object name pattern>] attribute[<JMX attribute>:metric_name=<optional metric name>]
 # ----
-#
+# 
 # * `object_name`:
 # +
 # For more information about the JMX object name pattern syntax,
@@ -3461,18 +3461,18 @@ The default unit for this option is `ms`.
 # This is the name under which the metric will be stored.
 # Setting this is optional and will be the same as the `attribute` if not set.
 # Note that all JMX metric names will be prefixed with `jvm.jmx.` by the agent.
-#
+# 
 # The agent creates `labels` for each link:https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html#getKeyPropertyList()[JMX key property] such as `type` and `name`.
-#
+# 
 # The link:https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html[JMX object name pattern] supports wildcards.
 # In this example, the agent will create a metricset for each memory pool `name` (such as `G1 Old Generation` and `G1 Young Generation`)
-#
+# 
 # ----
 # object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionCount:metric_name=collection_count] attribute[CollectionTime]
 # ----
-#
+# 
 # The resulting documents in Elasticsearch look similar to these (metadata omitted for brevity):
-#
+# 
 # [source,json]
 # ----
 # {
@@ -3489,7 +3489,7 @@ The default unit for this option is `ms`.
 #   }
 # }
 # ----
-#
+# 
 # [source,json]
 # ----
 # {
@@ -3506,16 +3506,16 @@ The default unit for this option is `ms`.
 #   }
 # }
 # ----
-#
-#
+# 
+# 
 # The agent also supports composite values for the attribute value.
 # In this example, `HeapMemoryUsage` is a composite value, consisting of `committed`, `init`, `used` and `max`.
 # ----
-# object_name[java.lang:type=Memory] attribute[HeapMemoryUsage:metric_name=heap]
+# object_name[java.lang:type=Memory] attribute[HeapMemoryUsage:metric_name=heap] 
 # ----
-#
+# 
 # The resulting documents in Elasticsearch look similar to this:
-#
+# 
 # [source,json]
 # ----
 # {
@@ -3535,11 +3535,11 @@ The default unit for this option is `ms`.
 #   }
 # }
 # ----
-#
+# 
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # capture_jmx_metrics=
 
@@ -3549,8 +3549,8 @@ The default unit for this option is `ms`.
 
 # Sets the logging level for the agent.
 # This option is case-insensitive.
-#
-# NOTE: `CRITICAL` is a valid option, but it is mapped to `ERROR`; `WARN` and `WARNING` are equivalent;
+# 
+# NOTE: `CRITICAL` is a valid option, but it is mapped to `ERROR`; `WARN` and `WARNING` are equivalent; 
 # `OFF` is only available since version 1.16.0
 #
 # Valid options: OFF, ERROR, CRITICAL, WARN, WARNING, INFO, DEBUG, TRACE
@@ -3563,10 +3563,10 @@ The default unit for this option is `ms`.
 # Sets the path of the agent logs.
 # The special value `_AGENT_HOME_` is a placeholder for the folder the elastic-apm-agent.jar is in.
 # Example: `_AGENT_HOME_/logs/elastic-apm.log`
-#
+# 
 # When set to the special value 'System.out',
 # the logs are sent to standard out.
-#
+# 
 # NOTE: When logging to a file,
 # the log will be formatted in new-line-delimited JSON.
 # When logging to std out, the log will be formatted as plain-text.
@@ -3581,7 +3581,7 @@ The default unit for this option is `ms`.
 # If set to `true`, the agent will set the `trace.id` and `transaction.id` for the currently active spans and transactions to the MDC.
 # Since version 1.16.0, the agent also adds `error.id` of captured error to the MDC just before the error message is logged.
 # See <<log-correlation>> for more details.
-#
+# 
 # NOTE: While it's allowed to enable this setting at runtime, you can't disable it without a restart.
 #
 # This setting can be changed at runtime
@@ -3590,27 +3590,27 @@ The default unit for this option is `ms`.
 #
 # enable_log_correlation=false
 
-# Specifying whether and how the agent should automatically reformat application logs
-# into {ecs-logging-ref}/index.html[ECS-compatible JSON], suitable for ingestion into Elasticsearch for
-# further Log analysis. This functionality is available for log4j1, log4j2 and Logback.
-# Once this option is enabled with any valid option, log correlation will be activated as well, regardless of the <<config-enable-log-correlation,`enable_log_correlation`>> configuration.
-#
+# Specifying whether and how the agent should automatically reformat application logs 
+# into {ecs-logging-ref}/index.html[ECS-compatible JSON], suitable for ingestion into Elasticsearch for 
+# further Log analysis. This functionality is available for log4j1, log4j2 and Logback. 
+# Once this option is enabled with any valid option, log correlation will be activated as well, regardless of the <<config-enable-log-correlation,`enable_log_correlation`>> configuration. 
+# 
 # Available options:
-#
-#  - OFF - application logs are not reformatted.
-#  - SHADE - agent logs are reformatted and "shade" ECS-JSON-formatted logs are automatically created in
-#    addition to the original application logs. Shade logs will have the same name as the original logs,
-#    but with the ".ecs.json" extension instead of the original extension. Destination directory for the
-#    shade logs can be configured through the <<config-log-ecs-reformatting-dir,`log_ecs_reformatting_dir`>>
-#    configuration. Shade logs do not inherit file-rollover strategy from the original logs. Instead, they
-#    use their own size-based rollover strategy according to the <<config-log-file-size, `log_file_size`>>
+# 
+#  - OFF - application logs are not reformatted. 
+#  - SHADE - agent logs are reformatted and "shade" ECS-JSON-formatted logs are automatically created in 
+#    addition to the original application logs. Shade logs will have the same name as the original logs, 
+#    but with the ".ecs.json" extension instead of the original extension. Destination directory for the 
+#    shade logs can be configured through the <<config-log-ecs-reformatting-dir,`log_ecs_reformatting_dir`>> 
+#    configuration. Shade logs do not inherit file-rollover strategy from the original logs. Instead, they 
+#    use their own size-based rollover strategy according to the <<config-log-file-size, `log_file_size`>> 
 #    configuration and while allowing maximum of two shade log files.
-#  - REPLACE - similar to `SHADE`, but the original logs will not be written. This option is useful if
-#    you wish to maintain similar logging-related overhead, but write logs to a different location and/or
+#  - REPLACE - similar to `SHADE`, but the original logs will not be written. This option is useful if 
+#    you wish to maintain similar logging-related overhead, but write logs to a different location and/or 
 #    with a different file extension.
-#  - OVERRIDE - same log output is used, but in ECS-compatible JSON format instead of the original format.
-#
-# NOTE: while `SHADE` and `REPLACE` options are only relevant to file log appenders, the `OVERRIDE` option
+#  - OVERRIDE - same log output is used, but in ECS-compatible JSON format instead of the original format. 
+# 
+# NOTE: while `SHADE` and `REPLACE` options are only relevant to file log appenders, the `OVERRIDE` option 
 # is also valid for other appenders, like System out and console
 #
 # Valid options: OFF, SHADE, REPLACE, OVERRIDE
@@ -3623,20 +3623,20 @@ The default unit for this option is `ms`.
 # A comma-separated list of key-value pairs that will be added as additional fields to all log events.
 #  Takes the format `key=value[,key=value[,...]]`, for example: `key1=value1,key2=value2`.
 #  Only relevant if <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.
-#
+# 
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: Map
-# Default value:
+# Default value: 
 #
 # log_ecs_reformatting_additional_fields=
 
-# Only formatters that match an item on this list will be automatically reformatted to ECS when
-# <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.
-# A formatter is the logging-framework-specific entity that is responsible for the formatting
-# of log events. For example, in log4j it would be a `Layout` implementation, whereas in Logback it would
-# be an `Encoder` implementation.
-#
+# Only formatters that match an item on this list will be automatically reformatted to ECS when 
+# <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`. 
+# A formatter is the logging-framework-specific entity that is responsible for the formatting 
+# of log events. For example, in log4j it would be a `Layout` implementation, whereas in Logback it would 
+# be an `Encoder` implementation. 
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3648,22 +3648,22 @@ The default unit for this option is `ms`.
 #
 # log_ecs_formatter_allow_list=*PatternLayout*,org.apache.log4j.SimpleLayout,ch.qos.logback.core.encoder.EchoEncoder
 
-# If <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to `SHADE` or `REPLACE`,
-# the shade log files will be written alongside the original logs in the same directory by default.
-# Use this configuration in order to write the shade logs into an alternative destination. Omitting this
-# config or setting it to an empty string will restore the default behavior. If relative path is used,
+# If <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to `SHADE` or `REPLACE`, 
+# the shade log files will be written alongside the original logs in the same directory by default. 
+# Use this configuration in order to write the shade logs into an alternative destination. Omitting this 
+# config or setting it to an empty string will restore the default behavior. If relative path is used, 
 # this path will be used relative to the original logs directory.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # log_ecs_reformatting_dir=
 
 # The size of the log file.
-#
+# 
 # The agent always keeps one history file so that the max total log file size is twice the value of this setting.
-#
+# 
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: ByteValue
@@ -3672,7 +3672,7 @@ The default unit for this option is `ms`.
 # log_file_size=50mb
 
 # Defines the log format when logging to `System.out`.
-#
+# 
 # When set to `JSON`, the agent will format the logs in an https://github.com/elastic/ecs-logging-java[ECS-compliant JSON format]
 # where each log event is serialized as a single line.
 #
@@ -3684,10 +3684,10 @@ The default unit for this option is `ms`.
 # log_format_sout=PLAIN_TEXT
 
 # Defines the log format when logging to a file.
-#
+# 
 # When set to `JSON`, the agent will format the logs in an https://github.com/elastic/ecs-logging-java[ECS-compliant JSON format]
 # where each log event is serialized as a single line.
-#
+# 
 #
 # Valid options: PLAIN_TEXT, JSON
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -3700,11 +3700,11 @@ The default unit for this option is `ms`.
 # Messaging                                #
 ############################################
 
-# Used to filter out specific messaging queues/topics from being traced.
-#
+# Used to filter out specific messaging queues/topics from being traced. 
+# 
 # This property should be set to an array containing one or more strings.
 # When set, sends-to and receives-from the specified queues/topic will be ignored.
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3712,7 +3712,7 @@ The default unit for this option is `ms`.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # ignore_message_queues=
 
@@ -3721,7 +3721,7 @@ The default unit for this option is `ms`.
 ############################################
 
 # Replaces dots with underscores in the metric names for custom metrics, such as Micrometer metrics.
-#
+# 
 # WARNING: Setting this to `false` can lead to mapping conflicts as dots indicate nesting in Elasticsearch.
 # An example of when a conflict happens is two metrics with the name `foo` and `foo.bar`.
 # The first metric maps `foo` to a number and the second metric maps `foo` as an object.
@@ -3738,14 +3738,14 @@ The default unit for this option is `ms`.
 
 # Set to `true` to make the agent create spans for method executions based on
 # https://github.com/jvm-profiling-tools/async-profiler[async-profiler], a sampling aka statistical profiler.
-#
+# 
 # Due to the nature of how sampling profilers work,
 # the duration of the inferred spans are not exact, but only estimations.
 # The <<config-profiling-inferred-spans-sampling-interval, `profiling_inferred_spans_sampling_interval`>> lets you fine tune the trade-off between accuracy and overhead.
-#
+# 
 # The inferred spans are created after a profiling session has ended.
 # This means there is a delay between the regular and the inferred spans being visible in the UI.
-#
+# 
 # NOTE: This feature is not available on Windows and on OpenJ9
 #
 # This setting can be changed at runtime
@@ -3782,7 +3782,7 @@ The default unit for this option is `ms`.
 # If set, the agent will only create inferred spans for methods which match this list.
 # Setting a value may slightly reduce overhead and can reduce clutter by only creating spans for the classes you are interested in.
 # Example: `org.example.myapp.*`
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3795,7 +3795,7 @@ The default unit for this option is `ms`.
 # profiling_inferred_spans_included_classes=*
 
 # Excludes classes for which no profiler-inferred spans should be created.
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3814,7 +3814,7 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # profiling_inferred_spans_lib_directory=
 
@@ -3823,40 +3823,40 @@ The default unit for this option is `ms`.
 ############################################
 
 # This string is used to ensure that only your agents can send data to your APM server.
-#
+# 
 # Both the agents and the APM server have to be configured with the same secret token.
 # Use if APM Server requires a token.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # secret_token=
 
 # This string is used to ensure that only your agents can send data to your APM server.
-#
+# 
 # Agents can use API keys as a replacement of secret token, APM server can have multiple API keys.
 # When both secret token and API key are used, API key has priority and secret token is ignored.
 # Use if APM Server requires an API key.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # api_key=
 
 # The URL for your APM Server
 #
 # The URL must be fully qualified, including protocol (http or https) and port.
-#
-# If SSL is enabled on the APM Server, use the `https` protocol. For more information, see
+# 
+# If SSL is enabled on the APM Server, use the `https` protocol. For more information, see 
 # <<ssl-configuration>>.
-#
+# 
 # If outgoing HTTP traffic has to go through a proxy,
 # you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
-# See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation]
+# See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation] 
 # for more information.
-#
+# 
 # NOTE: This configuration can only be reloaded dynamically as of 1.8.0
 #
 # This setting can be changed at runtime
@@ -3868,33 +3868,33 @@ The default unit for this option is `ms`.
 # The URLs for your APM Servers
 #
 # The URLs must be fully qualified, including protocol (http or https) and port.
-#
+# 
 # Fails over to the next APM Server URL in the event of connection errors.
 # Achieves load-balancing by shuffling the list of configured URLs.
 # When multiple agents are active, they'll tend towards spreading evenly across the set of servers due to randomization.
-#
-# If SSL is enabled on the APM Server, use the `https` protocol. For more information, see
+# 
+# If SSL is enabled on the APM Server, use the `https` protocol. For more information, see 
 # <<ssl-configuration>>.
-#
+# 
 # If outgoing HTTP traffic has to go through a proxy,
 # you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
-# See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation]
+# See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation] 
 # for more information.
-#
-# NOTE: This configuration is specific to the Java agent and does not align with any other APM agent. In order
-# to use a cross-agent config, use <<config-server-url>> instead, which is the recommended option regardless if you
+# 
+# NOTE: This configuration is specific to the Java agent and does not align with any other APM agent. In order 
+# to use a cross-agent config, use <<config-server-url>> instead, which is the recommended option regardless if you 
 # are only setting a single URL.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # server_urls=
 
-# If set to `true`, the agent will work as usual, except from any task requiring communication with
-# the APM server. Events will be dropped and the agent won't be able to receive central configuration, which
-# means that any other configuration cannot be changed in this state without restarting the service.
-# An example use case for this would be maintaining the ability to create traces and log
+# If set to `true`, the agent will work as usual, except from any task requiring communication with 
+# the APM server. Events will be dropped and the agent won't be able to receive central configuration, which 
+# means that any other configuration cannot be changed in this state without restarting the service. 
+# An example use case for this would be maintaining the ability to create traces and log 
 # trace/transaction/span IDs through the log correlation feature, without setting up an APM Server.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -3908,7 +3908,7 @@ The default unit for this option is `ms`.
 # If a request to the APM server takes longer than the configured timeout,
 # the request is cancelled and the event (exception or transaction) is discarded.
 # Set to 0 to disable timeouts.
-#
+# 
 # WARNING: If timeouts are disabled or set to a high value, your app could experience memory issues if the APM server times out.
 #
 # This setting can be changed at runtime
@@ -3920,7 +3920,7 @@ The default unit for this option is `ms`.
 # server_timeout=5s
 
 # By default, the agent verifies the SSL certificate if you use an HTTPS connection to the APM server.
-#
+# 
 # Verification can be disabled by changing this setting to false.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -3930,12 +3930,12 @@ The default unit for this option is `ms`.
 # verify_server_cert=true
 
 # The maximum size of buffered events.
-#
+# 
 # Events like transactions and spans are buffered when the agent can't keep up with sending them to the APM Server or if the APM server is down.
-#
+# 
 # If the queue is full, events are rejected which means you will lose transactions and spans in that case.
 # This guards the application from crashing in case the APM server is unavailable for a longer period of time.
-#
+# 
 # A lower value will decrease the heap overhead of the agent,
 # while a higher value makes it less likely to lose events in case of a temporary spike in throughput.
 #
@@ -3955,7 +3955,7 @@ The default unit for this option is `ms`.
 # include_process_args=false
 
 # Maximum time to keep an HTTP request to the APM Server open for.
-#
+# 
 # NOTE: This value has to be lower than the APM Server's `read_timeout` setting.
 #
 # This setting can be changed at runtime
@@ -3968,7 +3968,7 @@ The default unit for this option is `ms`.
 
 # The maximum total compressed size of the request body which is sent to the APM server intake api via a chunked encoding (HTTP streaming).
 # Note that a small overshoot is possible.
-#
+# 
 # Allowed byte units are `b`, `kb` and `mb`. `1kb` is equal to `1024b`.
 #
 # This setting can be changed at runtime
@@ -3992,7 +3992,7 @@ The default unit for this option is `ms`.
 # Disables the collection of certain metrics.
 # If the name of a metric matches any of the wildcard expressions, it will not be collected.
 # Example: `foo.*,bar.*`
-#
+# 
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -4000,7 +4000,7 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # disable_metrics=
 
@@ -4008,17 +4008,17 @@ The default unit for this option is `ms`.
 # Serverless                               #
 ############################################
 
-# This config option must be used when running the agent in an AWS Lambda context.
-# This config value allows to specify the fully qualified name of the class handling the lambda function.
+# This config option must be used when running the agent in an AWS Lambda context. 
+# This config value allows to specify the fully qualified name of the class handling the lambda function. 
 # An empty value (default value) indicates that the agent is not running within an AWS lambda function.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value:
+# Default value: 
 #
 # aws_lambda_handler=
 
-# This config value allows to specify the timeout in milliseconds for flushing APM data at the end of a serverless function.
+# This config value allows to specify the timeout in milliseconds for flushing APM data at the end of a serverless function. 
 # For serverless functions, APM data is written in a synchronous way, thus, blocking the termination of the function util data is written or the specified timeout is reached.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -4038,20 +4038,20 @@ The default unit for this option is `ms`.
 # there's no need to configure sub-packages.
 # Because this setting helps determine which classes to scan on startup,
 # setting this option can also improve startup time.
-#
+# 
 # You must set this option in order to use the API annotations `@CaptureTransaction` and `@CaptureSpan`.
-#
+# 
 # **Example**
-#
+# 
 # Most Java projects have a root package, e.g. `com.myproject`. You can set the application package using Java system properties:
 # `-Delastic.apm.application_packages=com.myproject`
-#
+# 
 # If you are only interested in specific subpackages, you can separate them with commas:
 # `-Delastic.apm.application_packages=com.myproject.api,com.myproject.impl`
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value:
+# Default value: 
 #
 # application_packages=
 
@@ -4063,9 +4063,9 @@ The default unit for this option is `ms`.
 #
 # stack_trace_limit=50
 
-# While this is very helpful to find the exact place in your code that causes the span, collecting this stack trace does have some overhead.
+# While this is very helpful to find the exact place in your code that causes the span, collecting this stack trace does have some overhead. 
 # When setting this option to value `0ms`, stack traces will be collected for all spans. Setting it to a positive value, e.g. `5ms`, will limit stack trace collection to spans with durations equal to or longer than the given value, e.g. 5 milliseconds.
-#
+# 
 # To disable stack trace collection for spans completely, set the value to `-1ms`.
 #
 # This setting can be changed at runtime

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -192,12 +192,12 @@ Click on a key to get more information.
 
 NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
 
-A boolean specifying whether the circuit breaker should be enabled or not. 
-When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state. 
-If ANY of the monitors detects a stress indication, the agent will become inactive, as if the 
-<<config-recording,`recording`>> configuration option has been set to `false`, thus reducing resource consumption to a minimum. 
-When inactive, the agent continues polling the same monitors in order to detect whether the stress state 
-has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the 
+A boolean specifying whether the circuit breaker should be enabled or not.
+When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state.
+If ANY of the monitors detects a stress indication, the agent will become inactive, as if the
+<<config-recording,`recording`>> configuration option has been set to `false`, thus reducing resource consumption to a minimum.
+When inactive, the agent continues polling the same monitors in order to detect whether the stress state
+has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the
 agent will resume and become fully functional.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -248,8 +248,8 @@ The default unit for this option is `s`.
 ==== `stress_monitor_gc_stress_threshold` (performance)
 
 The threshold used by the GC monitor to rely on for identifying heap stress.
-The same threshold will be used for all heap pools, so that if ANY has a usage percentage that crosses it, 
-the agent will consider it as a heap stress. The GC monitor relies only on memory consumption measured 
+The same threshold will be used for all heap pools, so that if ANY has a usage percentage that crosses it,
+the agent will consider it as a heap stress. The GC monitor relies only on memory consumption measured
 after a recent GC.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -274,8 +274,8 @@ after a recent GC.
 ==== `stress_monitor_gc_relief_threshold` (performance)
 
 The threshold used by the GC monitor to rely on for identifying when the heap is not under stress .
-If `stress_monitor_gc_stress_threshold` has been crossed, the agent will consider it a heap-stress state. 
-In order to determine that the stress state is over, percentage of occupied memory in ALL heap pools should 
+If `stress_monitor_gc_stress_threshold` has been crossed, the agent will consider it a heap-stress state.
+In order to determine that the stress state is over, percentage of occupied memory in ALL heap pools should
 be lower than this threshold. The GC monitor relies only on memory consumption measured after a recent GC.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -299,9 +299,9 @@ be lower than this threshold. The GC monitor relies only on memory consumption m
 [[config-stress-monitor-cpu-duration-threshold]]
 ==== `stress_monitor_cpu_duration_threshold` (performance)
 
-The minimal time required in order to determine whether the system is 
-either currently under stress, or that the stress detected previously has been relieved. 
-All measurements during this time must be consistent in comparison to the relevant threshold in 
+The minimal time required in order to determine whether the system is
+either currently under stress, or that the stress detected previously has been relieved.
+All measurements during this time must be consistent in comparison to the relevant threshold in
 order to detect a change of stress state. Must be at least `1m`.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -328,8 +328,8 @@ The default unit for this option is `m`.
 [[config-stress-monitor-system-cpu-stress-threshold]]
 ==== `stress_monitor_system_cpu_stress_threshold` (performance)
 
-The threshold used by the system CPU monitor to detect system CPU stress. 
-If the system CPU crosses this threshold for a duration of at least `stress_monitor_cpu_duration_threshold`, 
+The threshold used by the system CPU monitor to detect system CPU stress.
+If the system CPU crosses this threshold for a duration of at least `stress_monitor_cpu_duration_threshold`,
 the monitor considers this as a stress state.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -353,9 +353,9 @@ the monitor considers this as a stress state.
 [[config-stress-monitor-system-cpu-relief-threshold]]
 ==== `stress_monitor_system_cpu_relief_threshold` (performance)
 
-The threshold used by the system CPU monitor to determine that the system is 
-not under CPU stress. If the monitor detected a CPU stress, the measured system CPU needs to be below 
-this threshold for a duration of at least `stress_monitor_cpu_duration_threshold` in order for the 
+The threshold used by the system CPU monitor to determine that the system is
+not under CPU stress. If the monitor detected a CPU stress, the measured system CPU needs to be below
+this threshold for a duration of at least `stress_monitor_cpu_duration_threshold` in order for the
 monitor to decide that the CPU stress has been relieved.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -381,14 +381,14 @@ monitor to decide that the CPU stress has been relieved.
 [[config-recording]]
 ==== `recording` (added[1.15.0])
 
-NOTE: This option was available in older versions through the `active` key. The old key is still 
+NOTE: This option was available in older versions through the `active` key. The old key is still
 supported in newer versions, but it is now deprecated.
 
 A boolean specifying if the agent should be recording or not.
 When recording, the agent instruments incoming HTTP requests, tracks errors and collects and sends metrics.
 When not recording, the agent works as a noop, not collecting data and not communicating with the APM sever,
 except for polling the central configuration endpoint.
-As this is a reversible switch, agent threads are not being killed when inactivated, but they will be 
+As this is a reversible switch, agent threads are not being killed when inactivated, but they will be
 mostly idle in this state, so the overhead should be negligible.
 
 You can use this setting to dynamically disable Elastic APM at runtime.
@@ -439,8 +439,8 @@ If you want to dynamically change the status of the agent, use <<config-recordin
 ==== `instrument` (added[1.0.0,Changing this value at runtime is possible since version 1.15.0])
 
 A boolean specifying if the agent should instrument the application to collect traces for the app.
- When set to `false`, most built-in instrumentation plugins are disabled, which would minimize the effect on 
-your application. However, the agent would still apply instrumentation related to manual tracing options and it 
+ When set to `false`, most built-in instrumentation plugins are disabled, which would minimize the effect on
+your application. However, the agent would still apply instrumentation related to manual tracing options and it
 would still collect and send metrics to APM Server.
 
 NOTE: Both active and instrument needs to be true for instrumentation to be running.
@@ -514,13 +514,13 @@ If the service name is set explicitly, it overrides all of the above.
 [[config-service-node-name]]
 ==== `service_node_name` (added[1.11.0])
 
-If set, this name is used to distinguish between different nodes of a service, 
-therefore it should be unique for each JVM within a service. 
-If not set, data aggregations will be done based on a container ID (where valid) or on the reported 
-hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>). 
+If set, this name is used to distinguish between different nodes of a service,
+therefore it should be unique for each JVM within a service.
+If not set, data aggregations will be done based on a container ID (where valid) or on the reported
+hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>).
 
-NOTE: JVM metrics views rely on aggregations that are based on the service node name. 
-If you have multiple JVMs installed on the same host reporting data for the same service name, 
+NOTE: JVM metrics views rely on aggregations that are based on the service node name.
+If you have multiple JVMs installed on the same host reporting data for the same service name,
 you must set a unique node name for each in order to view metrics at the JVM level.
 
 NOTE: Metrics views can utilize this configuration since APM Server 7.5
@@ -865,16 +865,16 @@ NOTE: Exception inheritance is not supported, thus you have to explicitly list a
 [[config-capture-body]]
 ==== `capture_body` (performance)
 
-For transactions that are HTTP requests, the Java agent can optionally capture the request body (e.g. POST 
-variables). For transactions that are initiated by receiving a message from a message broker, the agent can 
+For transactions that are HTTP requests, the Java agent can optionally capture the request body (e.g. POST
+variables). For transactions that are initiated by receiving a message from a message broker, the agent can
 capture the textual message body.
 
 If the HTTP request or the message has a body and this setting is disabled, the body will be shown as [REDACTED].
 
 This option is case-insensitive.
 
-NOTE: Currently, the body length is limited to 10000 characters and it is not configurable. 
-If the body size exceeds the limit, it will be truncated. 
+NOTE: Currently, the body length is limited to 10000 characters and it is not configurable.
+If the body size exceeds the limit, it will be truncated.
 
 NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.
 The option <<config-capture-body-content-types>> determines which content types are captured.
@@ -906,7 +906,7 @@ Valid options: `off`, `errors`, `transactions`, `all`
 [[config-capture-headers]]
 ==== `capture_headers` (performance)
 
-If set to `true`, the agent will capture HTTP request and response headers (including cookies), 
+If set to `true`, the agent will capture HTTP request and response headers (including cookies),
 as well as messages' headers/properties when using messaging frameworks like Kafka or JMS.
 
 NOTE: Setting this to `false` reduces network bandwidth, disk space and object allocations.
@@ -958,7 +958,7 @@ NOTE: This feature requires APM Server 7.2+
 [[config-classes-excluded-from-instrumentation]]
 ==== `classes_excluded_from_instrumentation`
 
-Use to exclude specific classes from being instrumented. In order to exclude entire packages, 
+Use to exclude specific classes from being instrumented. In order to exclude entire packages,
 use wildcards, as in: `com.project.exclude.*`
 This option supports the wildcard `*`, which matches zero or more characters.
 Examples: `/foo/*/bar/*/baz*`, `*foo*`.
@@ -1071,7 +1071,7 @@ NOTE: Changing this value at runtime can slow down the application temporarily.
 [[config-trace-methods-duration-threshold]]
 ==== `trace_methods_duration_threshold` (added[1.7.0])
 
-If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on 
+If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on
 duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded by default.
 Such methods will be traced and reported if one of the following applies:
 
@@ -1219,7 +1219,7 @@ See `integration-tests/external-plugin-test` for an example plugin.
 [[config-use-elastic-traceparent-header]]
 ==== `use_elastic_traceparent_header` (added[1.14.0])
 
-To enable {apm-overview-ref-v}/distributed-tracing.html[distributed tracing], the agent
+To enable {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing], the agent
 adds trace context headers to outgoing requests (like HTTP requests, Kafka records, gRPC requests etc.).
 These headers (`traceparent` and `tracestate`) are defined in the
 https://www.w3.org/TR/trace-context-1/[W3C Trace Context] specification.
@@ -1284,8 +1284,8 @@ The default unit for this option is `ms`.
 [[config-cloud-provider]]
 ==== `cloud_provider` (added[1.21.0])
 
-This config value allows you to specify which cloud provider should be assumed 
-for metadata collection. By default, the agent will attempt to detect the cloud 
+This config value allows you to specify which cloud provider should be assumed
+for metadata collection. By default, the agent will attempt to detect the cloud
 provider or, if that fails, will use trial and error to collect the metadata.
 
 
@@ -1621,7 +1621,7 @@ The resulting documents in Elasticsearch look similar to these (metadata omitted
 The agent also supports composite values for the attribute value.
 In this example, `HeapMemoryUsage` is a composite value, consisting of `committed`, `init`, `used` and `max`.
 ----
-object_name[java.lang:type=Memory] attribute[HeapMemoryUsage:metric_name=heap] 
+object_name[java.lang:type=Memory] attribute[HeapMemoryUsage:metric_name=heap]
 ----
 
 The resulting documents in Elasticsearch look similar to this:
@@ -1673,7 +1673,7 @@ The resulting documents in Elasticsearch look similar to this:
 Sets the logging level for the agent.
 This option is case-insensitive.
 
-NOTE: `CRITICAL` is a valid option, but it is mapped to `ERROR`; `WARN` and `WARNING` are equivalent; 
+NOTE: `CRITICAL` is a valid option, but it is mapped to `ERROR`; `WARN` and `WARNING` are equivalent;
 `OFF` is only available since version 1.16.0
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -1760,27 +1760,27 @@ NOTE: While it's allowed to enable this setting at runtime, you can't disable it
 
 NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
 
-Specifying whether and how the agent should automatically reformat application logs 
-into {ecs-logging-ref}/index.html[ECS-compatible JSON], suitable for ingestion into Elasticsearch for 
-further Log analysis. This functionality is available for log4j1, log4j2 and Logback. 
-Once this option is enabled with any valid option, log correlation will be activated as well, regardless of the <<config-enable-log-correlation,`enable_log_correlation`>> configuration. 
+Specifying whether and how the agent should automatically reformat application logs
+into {ecs-logging-ref}/index.html[ECS-compatible JSON], suitable for ingestion into Elasticsearch for
+further Log analysis. This functionality is available for log4j1, log4j2 and Logback.
+Once this option is enabled with any valid option, log correlation will be activated as well, regardless of the <<config-enable-log-correlation,`enable_log_correlation`>> configuration.
 
 Available options:
 
- - OFF - application logs are not reformatted. 
- - SHADE - agent logs are reformatted and "shade" ECS-JSON-formatted logs are automatically created in 
-   addition to the original application logs. Shade logs will have the same name as the original logs, 
-   but with the ".ecs.json" extension instead of the original extension. Destination directory for the 
-   shade logs can be configured through the <<config-log-ecs-reformatting-dir,`log_ecs_reformatting_dir`>> 
-   configuration. Shade logs do not inherit file-rollover strategy from the original logs. Instead, they 
-   use their own size-based rollover strategy according to the <<config-log-file-size, `log_file_size`>> 
+ - OFF - application logs are not reformatted.
+ - SHADE - agent logs are reformatted and "shade" ECS-JSON-formatted logs are automatically created in
+   addition to the original application logs. Shade logs will have the same name as the original logs,
+   but with the ".ecs.json" extension instead of the original extension. Destination directory for the
+   shade logs can be configured through the <<config-log-ecs-reformatting-dir,`log_ecs_reformatting_dir`>>
+   configuration. Shade logs do not inherit file-rollover strategy from the original logs. Instead, they
+   use their own size-based rollover strategy according to the <<config-log-file-size, `log_file_size`>>
    configuration and while allowing maximum of two shade log files.
- - REPLACE - similar to `SHADE`, but the original logs will not be written. This option is useful if 
-   you wish to maintain similar logging-related overhead, but write logs to a different location and/or 
+ - REPLACE - similar to `SHADE`, but the original logs will not be written. This option is useful if
+   you wish to maintain similar logging-related overhead, but write logs to a different location and/or
    with a different file extension.
- - OVERRIDE - same log output is used, but in ECS-compatible JSON format instead of the original format. 
+ - OVERRIDE - same log output is used, but in ECS-compatible JSON format instead of the original format.
 
-NOTE: while `SHADE` and `REPLACE` options are only relevant to file log appenders, the `OVERRIDE` option 
+NOTE: while `SHADE` and `REPLACE` options are only relevant to file log appenders, the `OVERRIDE` option
 is also valid for other appenders, like System out and console
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -1831,11 +1831,11 @@ A comma-separated list of key-value pairs that will be added as additional field
 [[config-log-ecs-formatter-allow-list]]
 ==== `log_ecs_formatter_allow_list`
 
-Only formatters that match an item on this list will be automatically reformatted to ECS when 
-<<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`. 
-A formatter is the logging-framework-specific entity that is responsible for the formatting 
-of log events. For example, in log4j it would be a `Layout` implementation, whereas in Logback it would 
-be an `Encoder` implementation. 
+Only formatters that match an item on this list will be automatically reformatted to ECS when
+<<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.
+A formatter is the logging-framework-specific entity that is responsible for the formatting
+of log events. For example, in log4j it would be a `Layout` implementation, whereas in Logback it would
+be an `Encoder` implementation.
 
 This option supports the wildcard `*`, which matches zero or more characters.
 Examples: `/foo/*/bar/*/baz*`, `*foo*`.
@@ -1863,10 +1863,10 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 [[config-log-ecs-reformatting-dir]]
 ==== `log_ecs_reformatting_dir`
 
-If <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to `SHADE` or `REPLACE`, 
-the shade log files will be written alongside the original logs in the same directory by default. 
-Use this configuration in order to write the shade logs into an alternative destination. Omitting this 
-config or setting it to an empty string will restore the default behavior. If relative path is used, 
+If <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to `SHADE` or `REPLACE`,
+the shade log files will be written alongside the original logs in the same directory by default.
+Use this configuration in order to write the shade logs into an alternative destination. Omitting this
+config or setting it to an empty string will restore the default behavior. If relative path is used,
 this path will be used relative to the original logs directory.
 
 
@@ -1973,7 +1973,7 @@ Valid options: `PLAIN_TEXT`, `JSON`
 [[config-ignore-message-queues]]
 ==== `ignore_message_queues`
 
-Used to filter out specific messaging queues/topics from being traced. 
+Used to filter out specific messaging queues/topics from being traced.
 
 This property should be set to an array containing one or more strings.
 When set, sends-to and receives-from the specified queues/topic will be ignored.
@@ -2268,12 +2268,12 @@ Use if APM Server requires an API key.
 
 The URL must be fully qualified, including protocol (http or https) and port.
 
-If SSL is enabled on the APM Server, use the `https` protocol. For more information, see 
+If SSL is enabled on the APM Server, use the `https` protocol. For more information, see
 <<ssl-configuration>>.
 
 If outgoing HTTP traffic has to go through a proxy,
 you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
-See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation] 
+See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation]
 for more information.
 
 NOTE: This configuration can only be reloaded dynamically as of 1.8.0
@@ -2305,16 +2305,16 @@ Fails over to the next APM Server URL in the event of connection errors.
 Achieves load-balancing by shuffling the list of configured URLs.
 When multiple agents are active, they'll tend towards spreading evenly across the set of servers due to randomization.
 
-If SSL is enabled on the APM Server, use the `https` protocol. For more information, see 
+If SSL is enabled on the APM Server, use the `https` protocol. For more information, see
 <<ssl-configuration>>.
 
 If outgoing HTTP traffic has to go through a proxy,
 you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
-See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation] 
+See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation]
 for more information.
 
-NOTE: This configuration is specific to the Java agent and does not align with any other APM agent. In order 
-to use a cross-agent config, use <<config-server-url>> instead, which is the recommended option regardless if you 
+NOTE: This configuration is specific to the Java agent and does not align with any other APM agent. In order
+to use a cross-agent config, use <<config-server-url>> instead, which is the recommended option regardless if you
 are only setting a single URL.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -2338,10 +2338,10 @@ are only setting a single URL.
 [[config-disable-send]]
 ==== `disable_send`
 
-If set to `true`, the agent will work as usual, except from any task requiring communication with 
-the APM server. Events will be dropped and the agent won't be able to receive central configuration, which 
-means that any other configuration cannot be changed in this state without restarting the service. 
-An example use case for this would be maintaining the ability to create traces and log 
+If set to `true`, the agent will work as usual, except from any task requiring communication with
+the APM server. Events will be dropped and the agent won't be able to receive central configuration, which
+means that any other configuration cannot be changed in this state without restarting the service.
+An example use case for this would be maintaining the ability to create traces and log
 trace/transaction/span IDs through the log correlation feature, without setting up an APM Server.
 
 
@@ -2589,8 +2589,8 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 [[config-aws-lambda-handler]]
 ==== `aws_lambda_handler` (added[1.28.0])
 
-This config option must be used when running the agent in an AWS Lambda context. 
-This config value allows to specify the fully qualified name of the class handling the lambda function. 
+This config option must be used when running the agent in an AWS Lambda context.
+This config value allows to specify the fully qualified name of the class handling the lambda function.
 An empty value (default value) indicates that the agent is not running within an AWS lambda function.
 
 
@@ -2614,7 +2614,7 @@ An empty value (default value) indicates that the agent is not running within an
 [[config-data-flush-timeout]]
 ==== `data_flush_timeout` (added[1.28.0])
 
-This config value allows to specify the timeout in milliseconds for flushing APM data at the end of a serverless function. 
+This config value allows to specify the timeout in milliseconds for flushing APM data at the end of a serverless function.
 For serverless functions, APM data is written in a synchronous way, thus, blocking the termination of the function util data is written or the specified timeout is reached.
 
 
@@ -2702,7 +2702,7 @@ Setting it to 0 will disable stack trace collection. Any positive integer value 
 [[config-span-stack-trace-min-duration]]
 ==== `span_stack_trace_min_duration` (performance)
 
-While this is very helpful to find the exact place in your code that causes the span, collecting this stack trace does have some overhead. 
+While this is very helpful to find the exact place in your code that causes the span, collecting this stack trace does have some overhead.
 When setting this option to value `0ms`, stack traces will be collected for all spans. Setting it to a positive value, e.g. `5ms`, will limit stack trace collection to spans with durations equal to or longer than the given value, e.g. 5 milliseconds.
 
 To disable stack trace collection for spans completely, set the value to `-1ms`.
@@ -2738,12 +2738,12 @@ The default unit for this option is `ms`.
 # Circuit-Breaker                          #
 ############################################
 
-# A boolean specifying whether the circuit breaker should be enabled or not. 
-# When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state. 
-# If ANY of the monitors detects a stress indication, the agent will become inactive, as if the 
-# <<config-recording,`recording`>> configuration option has been set to `false`, thus reducing resource consumption to a minimum. 
-# When inactive, the agent continues polling the same monitors in order to detect whether the stress state 
-# has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the 
+# A boolean specifying whether the circuit breaker should be enabled or not.
+# When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state.
+# If ANY of the monitors detects a stress indication, the agent will become inactive, as if the
+# <<config-recording,`recording`>> configuration option has been set to `false`, thus reducing resource consumption to a minimum.
+# When inactive, the agent continues polling the same monitors in order to detect whether the stress state
+# has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the
 # agent will resume and become fully functional.
 #
 # This setting can be changed at runtime
@@ -2763,8 +2763,8 @@ The default unit for this option is `ms`.
 # stress_monitoring_interval=5s
 
 # The threshold used by the GC monitor to rely on for identifying heap stress.
-# The same threshold will be used for all heap pools, so that if ANY has a usage percentage that crosses it, 
-# the agent will consider it as a heap stress. The GC monitor relies only on memory consumption measured 
+# The same threshold will be used for all heap pools, so that if ANY has a usage percentage that crosses it,
+# the agent will consider it as a heap stress. The GC monitor relies only on memory consumption measured
 # after a recent GC.
 #
 # This setting can be changed at runtime
@@ -2774,8 +2774,8 @@ The default unit for this option is `ms`.
 # stress_monitor_gc_stress_threshold=0.95
 
 # The threshold used by the GC monitor to rely on for identifying when the heap is not under stress .
-# If `stress_monitor_gc_stress_threshold` has been crossed, the agent will consider it a heap-stress state. 
-# In order to determine that the stress state is over, percentage of occupied memory in ALL heap pools should 
+# If `stress_monitor_gc_stress_threshold` has been crossed, the agent will consider it a heap-stress state.
+# In order to determine that the stress state is over, percentage of occupied memory in ALL heap pools should
 # be lower than this threshold. The GC monitor relies only on memory consumption measured after a recent GC.
 #
 # This setting can be changed at runtime
@@ -2784,9 +2784,9 @@ The default unit for this option is `ms`.
 #
 # stress_monitor_gc_relief_threshold=0.75
 
-# The minimal time required in order to determine whether the system is 
-# either currently under stress, or that the stress detected previously has been relieved. 
-# All measurements during this time must be consistent in comparison to the relevant threshold in 
+# The minimal time required in order to determine whether the system is
+# either currently under stress, or that the stress detected previously has been relieved.
+# All measurements during this time must be consistent in comparison to the relevant threshold in
 # order to detect a change of stress state. Must be at least `1m`.
 #
 # This setting can be changed at runtime
@@ -2797,8 +2797,8 @@ The default unit for this option is `ms`.
 #
 # stress_monitor_cpu_duration_threshold=1m
 
-# The threshold used by the system CPU monitor to detect system CPU stress. 
-# If the system CPU crosses this threshold for a duration of at least `stress_monitor_cpu_duration_threshold`, 
+# The threshold used by the system CPU monitor to detect system CPU stress.
+# If the system CPU crosses this threshold for a duration of at least `stress_monitor_cpu_duration_threshold`,
 # the monitor considers this as a stress state.
 #
 # This setting can be changed at runtime
@@ -2807,9 +2807,9 @@ The default unit for this option is `ms`.
 #
 # stress_monitor_system_cpu_stress_threshold=0.95
 
-# The threshold used by the system CPU monitor to determine that the system is 
-# not under CPU stress. If the monitor detected a CPU stress, the measured system CPU needs to be below 
-# this threshold for a duration of at least `stress_monitor_cpu_duration_threshold` in order for the 
+# The threshold used by the system CPU monitor to determine that the system is
+# not under CPU stress. If the monitor detected a CPU stress, the measured system CPU needs to be below
+# this threshold for a duration of at least `stress_monitor_cpu_duration_threshold` in order for the
 # monitor to decide that the CPU stress has been relieved.
 #
 # This setting can be changed at runtime
@@ -2822,16 +2822,16 @@ The default unit for this option is `ms`.
 # Core                                     #
 ############################################
 
-# NOTE: This option was available in older versions through the `active` key. The old key is still 
+# NOTE: This option was available in older versions through the `active` key. The old key is still
 # supported in newer versions, but it is now deprecated.
-# 
+#
 # A boolean specifying if the agent should be recording or not.
 # When recording, the agent instruments incoming HTTP requests, tracks errors and collects and sends metrics.
 # When not recording, the agent works as a noop, not collecting data and not communicating with the APM sever,
 # except for polling the central configuration endpoint.
-# As this is a reversible switch, agent threads are not being killed when inactivated, but they will be 
+# As this is a reversible switch, agent threads are not being killed when inactivated, but they will be
 # mostly idle in this state, so the overhead should be negligible.
-# 
+#
 # You can use this setting to dynamically disable Elastic APM at runtime.
 #
 # This setting can be changed at runtime
@@ -2850,12 +2850,12 @@ The default unit for this option is `ms`.
 # enabled=true
 
 # A boolean specifying if the agent should instrument the application to collect traces for the app.
-#  When set to `false`, most built-in instrumentation plugins are disabled, which would minimize the effect on 
-# your application. However, the agent would still apply instrumentation related to manual tracing options and it 
+#  When set to `false`, most built-in instrumentation plugins are disabled, which would minimize the effect on
+# your application. However, the agent would still apply instrumentation related to manual tracing options and it
 # would still collect and send metrics to APM Server.
-# 
+#
 # NOTE: Both active and instrument needs to be true for instrumentation to be running.
-# 
+#
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 #
 # This setting can be changed at runtime
@@ -2868,11 +2868,11 @@ The default unit for this option is `ms`.
 #
 # This is used to keep all the errors and transactions of your service together
 # and is the primary filter in the Elastic APM user interface.
-# 
+#
 # The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]+$`.
 # In less regexy terms:
 # Your service name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces.
-# 
+#
 # NOTE: When relying on auto-discovery of the service name in Servlet environments (including Spring Boot),
 # there is currently a caveat related to metrics.
 # The consequence is that the 'Metrics' tab of a service does not show process-global metrics like CPU utilization.
@@ -2883,7 +2883,7 @@ The default unit for this option is `ms`.
 # Future versions of the Elastic APM stack will have better support for that scenario.
 # A workaround is to explicitly set the `service_name` which means all applications deployed to the same servlet container will have the same name
 # or to disable the corresponding `*-service-name` detecting instrumentations via <<config-disable-instrumentations>>.
-# 
+#
 # NOTE: Service name auto discovery mechanisms require APM Server 7.0+.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -2893,26 +2893,26 @@ The default unit for this option is `ms`.
 # Falls back to the servlet context path the application is mapped to (unless mapped to the root context).
 # Falls back to the name of the main class or jar file.
 # If the service name is set explicitly, it overrides all of the above.
-# 
+#
 #
 # service_name=
 
 # A unique name for the service node
 #
-# If set, this name is used to distinguish between different nodes of a service, 
-# therefore it should be unique for each JVM within a service. 
-# If not set, data aggregations will be done based on a container ID (where valid) or on the reported 
-# hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>). 
-# 
-# NOTE: JVM metrics views rely on aggregations that are based on the service node name. 
-# If you have multiple JVMs installed on the same host reporting data for the same service name, 
+# If set, this name is used to distinguish between different nodes of a service,
+# therefore it should be unique for each JVM within a service.
+# If not set, data aggregations will be done based on a container ID (where valid) or on the reported
+# hostname (automatically discovered or manually configured through <<config-hostname, `hostname`>>).
+#
+# NOTE: JVM metrics views rely on aggregations that are based on the service node name.
+# If you have multiple JVMs installed on the same host reporting data for the same service name,
 # you must set a unique node name for each in order to view metrics at the JVM level.
-# 
+#
 # NOTE: Metrics views can utilize this configuration since APM Server 7.5
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # service_node_name=
 
@@ -2920,7 +2920,7 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # service_version=
 
@@ -2928,27 +2928,27 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # hostname=
 
 # The name of the environment this service is deployed in, e.g. "production" or "staging".
-# 
+#
 # Environments allow you to easily filter data on a global level in the APM app.
 # It's important to be consistent when naming environments across agents.
 # See {apm-app-ref}/filters.html#environment-selector[environment selector] in the APM app for more information.
-# 
+#
 # NOTE: This feature is fully supported in the APM app in Kibana versions >= 7.2.
 # You must use the query bar to filter for a specific environment in versions prior to 7.2.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # environment=
 
 # By default, the agent will sample every transaction (e.g. request to your service). To reduce overhead and storage requirements, you can set the sample rate to a value between 0.0 and 1.0. We still record overall time and the result for unsampled transactions, but no context information, labels, or spans.
-# 
+#
 # Value will be rounded with 4 significant digits, as an example, value '0.55555' will be rounded to `0.5556`
 #
 # This setting can be changed at runtime
@@ -2958,11 +2958,11 @@ The default unit for this option is `ms`.
 # transaction_sample_rate=1
 
 # Limits the amount of spans that are recorded per transaction.
-# 
+#
 # This is helpful in cases where a transaction creates a very high amount of spans (e.g. thousands of SQL queries).
-# 
+#
 # Setting an upper limit will prevent overloading the agent and the APM server with too much work for such edge cases.
-# 
+#
 # A message will be logged when the max number of spans has been exceeded but only at a rate of once every 5 minutes to ensure performance is not impacted.
 #
 # This setting can be changed at runtime
@@ -2973,19 +2973,19 @@ The default unit for this option is `ms`.
 
 # Sometimes it is necessary to sanitize the data sent to Elastic APM,
 # e.g. remove sensitive data.
-# 
+#
 # Configure a list of wildcard patterns of field names which should be sanitized.
 # These apply for example to HTTP headers and `application/x-www-form-urlencoded` data.
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
 # Prepending an element with `(?-i)` makes the matching case sensitive.
-# 
+#
 # NOTE: Data in the query string is considered non-sensitive,
 # as sensitive information should not be sent in the query string.
 # See https://www.owasp.org/index.php/Information_exposure_through_query_strings_in_url for more information
-# 
+#
 # NOTE: Review the data captured by Elastic APM carefully to make sure it does not capture sensitive information.
 # If you do find sensitive data in the Elasticsearch index,
 # you should add an additional entry to this list (make sure to also include the default entries).
@@ -3000,29 +3000,29 @@ The default unit for this option is `ms`.
 # Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `aws-lambda`, `cassandra`, `concurrent`, `dubbo`, `elasticsearch-restclient`, `exception-handler`, `executor`, `executor-collection`, `experimental`, `fork-join`, `grails`, `grpc`, `hibernate-search`, `http-client`, `javalin`, `jax-rs`, `jax-ws`, `jdbc`, `jdk-httpclient`, `jdk-httpserver`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j1-ecs`, `log4j2-ecs`, `log4j2-error`, `logback-ecs`, `logging`, `micrometer`, `mongodb-client`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `rabbitmq`, `reactor`, `redis`, `redisson`, `render`, `scala-future`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-api-dispatch`, `servlet-input-stream`, `slf4j-error`, `sparkjava`, `spring-amqp`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `spring-webflux`, `ssl-context`, `struts`, `timer-task`, `urlconnection`, `vertx`, `vertx-web`, `vertx-webclient`.
 # When set to non-empty value, only listed instrumentations will be enabled if they are not disabled through <<config-disable-instrumentations>> or <<config-enable-experimental-instrumentations>>.
 # When not set or empty (default), all instrumentations enabled by default will be enabled unless they are disabled through <<config-disable-instrumentations>> or <<config-enable-experimental-instrumentations>>.
-# 
+#
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # enable_instrumentations=
 
 # A list of instrumentations which should be disabled.
 # Valid options are `annotations`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `aws-lambda`, `cassandra`, `concurrent`, `dubbo`, `elasticsearch-restclient`, `exception-handler`, `executor`, `executor-collection`, `experimental`, `fork-join`, `grails`, `grpc`, `hibernate-search`, `http-client`, `javalin`, `jax-rs`, `jax-ws`, `jdbc`, `jdk-httpclient`, `jdk-httpserver`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log4j1-ecs`, `log4j2-ecs`, `log4j2-error`, `logback-ecs`, `logging`, `micrometer`, `mongodb-client`, `okhttp`, `opentracing`, `process`, `public-api`, `quartz`, `rabbitmq`, `reactor`, `redis`, `redisson`, `render`, `scala-future`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-api-dispatch`, `servlet-input-stream`, `slf4j-error`, `sparkjava`, `spring-amqp`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `spring-webflux`, `ssl-context`, `struts`, `timer-task`, `urlconnection`, `vertx`, `vertx-web`, `vertx-webclient`.
 # For version `1.25.0` and later, use <<config-enable-experimental-instrumentations>> to enable experimental instrumentations.
-# 
+#
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # disable_instrumentations=
 
 # Whether to apply experimental instrumentations.
-# 
+#
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 # Setting to `true` will enable instrumentations in the `experimental` group.
 #
@@ -3036,7 +3036,7 @@ The default unit for this option is `ms`.
 # un-nests the exceptions matching the wildcard pattern.
 # This can come in handy for Spring's `org.springframework.web.util.NestedServletException`,
 # for example.
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3050,40 +3050,40 @@ The default unit for this option is `ms`.
 
 # A list of exceptions that should be ignored and not reported as errors.
 # This allows to ignore exceptions thrown in regular control flow that are not actual errors
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
 # Prepending an element with `(?-i)` makes the matching case sensitive.
-# 
+#
 # Examples:
-# 
+#
 #  - `com.mycompany.ExceptionToIgnore`: using fully qualified name
 #  - `*ExceptionToIgnore`: using wildcard to avoid package name
 #  - `*exceptiontoignore`: case-insensitive by default
-# 
+#
 # NOTE: Exception inheritance is not supported, thus you have to explicitly list all the thrown exception types
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # ignore_exceptions=
 
-# For transactions that are HTTP requests, the Java agent can optionally capture the request body (e.g. POST 
-# variables). For transactions that are initiated by receiving a message from a message broker, the agent can 
+# For transactions that are HTTP requests, the Java agent can optionally capture the request body (e.g. POST
+# variables). For transactions that are initiated by receiving a message from a message broker, the agent can
 # capture the textual message body.
-# 
+#
 # If the HTTP request or the message has a body and this setting is disabled, the body will be shown as [REDACTED].
-# 
+#
 # This option is case-insensitive.
-# 
-# NOTE: Currently, the body length is limited to 10000 characters and it is not configurable. 
-# If the body size exceeds the limit, it will be truncated. 
-# 
+#
+# NOTE: Currently, the body length is limited to 10000 characters and it is not configurable.
+# If the body size exceeds the limit, it will be truncated.
+#
 # NOTE: Currently, only UTF-8 encoded plain text HTTP content types are supported.
 # The option <<config-capture-body-content-types>> determines which content types are captured.
-# 
+#
 # WARNING: Request bodies often contain sensitive values like passwords, credit card numbers etc.
 # If your service handles data like this, we advise to only enable this feature with care.
 # Turning on body capturing can also significantly increase the overhead in terms of heap usage,
@@ -3096,9 +3096,9 @@ The default unit for this option is `ms`.
 #
 # capture_body=OFF
 
-# If set to `true`, the agent will capture HTTP request and response headers (including cookies), 
+# If set to `true`, the agent will capture HTTP request and response headers (including cookies),
 # as well as messages' headers/properties when using messaging frameworks like Kafka or JMS.
-# 
+#
 # NOTE: Setting this to `false` reduces network bandwidth, disk space and object allocations.
 #
 # This setting can be changed at runtime
@@ -3109,16 +3109,16 @@ The default unit for this option is `ms`.
 
 # Labels added to all events, with the format `key=value[,key=value[,...]]`.
 # Any labels set by application via the API will override global labels with the same keys.
-# 
+#
 # NOTE: This feature requires APM Server 7.2+
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: Map
-# Default value: 
+# Default value:
 #
 # global_labels=
 
-# Use to exclude specific classes from being instrumented. In order to exclude entire packages, 
+# Use to exclude specific classes from being instrumented. In order to exclude entire packages,
 # use wildcards, as in: `com.project.exclude.*`
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
@@ -3127,21 +3127,21 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # classes_excluded_from_instrumentation=
 
 # A list of methods for which to create a transaction or span.
-# 
+#
 # If you want to monitor a large number of methods,
 # use  <<config-profiling-inferred-spans-enabled, `profiling_inferred_spans_enabled`>> instead.
-# 
+#
 # This works by instrumenting each matching method to include code that creates a span for the method.
 # While creating a span is quite cheap in terms of performance,
 # instrumenting a whole code base or a method which is executed in a tight loop leads to significant overhead.
-# 
+#
 # Using a pointcut-like syntax, you can match based on
-# 
+#
 #  - Method modifier (optional) +
 #    Example: `public`, `protected`, `private` or `*`
 #  - Package and class name (wildcards include sub-packages) +
@@ -3154,11 +3154,11 @@ The default unit for this option is `ms`.
 #    Example: `@*ApplicationScoped`
 #  - Classes with a specific annotation that is itself annotated with the given meta-annotation (optional) +
 #    Example: `@@javax.enterpr*se.context.NormalScope`
-# 
+#
 # The syntax is `modifier @fully.qualified.AnnotationName fully.qualified.ClassName#methodName(fully.qualified.ParameterType)`.
-# 
+#
 # A few examples:
-# 
+#
 #  - `org.example.*` added[1.4.0,Omitting the method is possible since 1.4.0]
 #  - `org.example.*#*` (before 1.4.0, you need to specify a method matcher)
 #  - `org.example.MyClass#myMethod`
@@ -3171,53 +3171,53 @@ The default unit for this option is `ms`.
 #  - `public @java.inject.ApplicationScoped org.example.*`
 #  - `public @java.inject.* org.example.*`
 #  - `public @@javax.enterprise.context.NormalScope org.example.*, public @@jakarta.enterprise.context.NormalScope org.example.*`
-# 
+#
 # NOTE: Only use wildcards if necessary.
 # The more methods you match the more overhead will be caused by the agent.
 # Also note that there is a maximum amount of spans per transaction (see <<config-transaction-max-spans, `transaction_max_spans`>>).
-# 
+#
 # NOTE: The agent will create stack traces for spans which took longer than
 # <<config-span-stack-trace-min-duration, `span_stack_trace_min_duration`>>.
 # When tracing a large number of methods (for example by using wildcards),
 # this may lead to high overhead.
 # Consider increasing the threshold or disabling stack trace collection altogether.
-# 
+#
 # Common configurations:
-# 
+#
 # Trace all public methods in CDI-Annotated beans:
-# 
+#
 # ----
 # public @@javax.enterprise.context.NormalScope your.application.package.*
 # public @@jakarta.enterprise.context.NormalScope your.application.package.*
 # public @@javax.inject.Scope your.application.package.*
 # ----
 # NOTE: This method is only available in the Elastic APM Java Agent.
-# 
+#
 # NOTE: Changing this value at runtime can slow down the application temporarily.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # trace_methods=
 
-# If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on 
+# If <<config-trace-methods, `trace_methods`>> config option is set, provides a threshold to limit spans based on
 # duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded by default.
 # Such methods will be traced and reported if one of the following applies:
-# 
+#
 #  - This method's duration crossed the configured threshold.
 #  - This method ended with Exception.
 #  - A method executed as part of the execution of this method crossed the threshold or ended with Exception.
 #  - A "forcibly-traced method" (e.g. DB queries, HTTP exits, custom) was executed during the execution of this method.
-# 
+#
 # Set to 0 to disable.
-# 
+#
 # NOTE: Transactions are never discarded, regardless of their duration.
 # This configuration affects only spans.
 # In order not to break span references,
 # all spans leading to an async operation or an exit span (such as a HTTP request or a DB query) are never discarded,
 # regardless of their duration.
-# 
+#
 # NOTE: If this option and <<config-span-min-duration,`span_min_duration`>> are both configured,
 # the higher of both thresholds will determine which spans will be discarded.
 #
@@ -3249,7 +3249,7 @@ The default unit for this option is `ms`.
 # The special value `_AGENT_HOME_` is a placeholder for the folder the `elastic-apm-agent.jar` is in.
 # The file has to be on the file system.
 # You can not refer to classpath locations.
-# 
+#
 # NOTE: this option can only be set via system properties, environment variables or the attacher options.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -3259,7 +3259,7 @@ The default unit for this option is `ms`.
 # config_file=_AGENT_HOME_/elasticapm.properties
 
 # A folder that contains external agent plugins.
-# 
+#
 # Use the `apm-agent-plugin-sdk` and the `apm-agent-api` artifacts to create a jar and place it into the plugins folder.
 # The agent will load all instrumentations that are declared in the
 # `META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation` service descriptor.
@@ -3267,15 +3267,15 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # plugins_dir=
 
-# To enable {apm-overview-ref-v}/distributed-tracing.html[distributed tracing], the agent
+# To enable {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing], the agent
 # adds trace context headers to outgoing requests (like HTTP requests, Kafka records, gRPC requests etc.).
 # These headers (`traceparent` and `tracestate`) are defined in the
 # https://www.w3.org/TR/trace-context-1/[W3C Trace Context] specification.
-# 
+#
 # When this setting is `true`, the agent will also add the header `elastic-apm-traceparent`
 # for backwards compatibility with older versions of Elastic APM agents.
 #
@@ -3287,13 +3287,13 @@ The default unit for this option is `ms`.
 
 # Sets the minimum duration of spans.
 # Spans that execute faster than this threshold are attempted to be discarded.
-# 
+#
 # The attempt fails if they lead up to a span that can't be discarded.
 # Spans that propagate the trace context to downstream services,
 # such as outgoing HTTP requests,
 # can't be discarded.
 # Additionally, spans that lead to an error or that may be a parent of an async operation can't be discarded.
-# 
+#
 # However, external calls that don't propagate context,
 # such as calls to a database, can be discarded using this threshold.
 #
@@ -3305,8 +3305,8 @@ The default unit for this option is `ms`.
 #
 # span_min_duration=0ms
 
-# This config value allows you to specify which cloud provider should be assumed 
-# for metadata collection. By default, the agent will attempt to detect the cloud 
+# This config value allows you to specify which cloud provider should be assumed
+# for metadata collection. By default, the agent will attempt to detect the cloud
 # provider or, if that fails, will use trial and error to collect the metadata.
 #
 # Valid options: AUTO, AWS, GCP, AZURE, NONE
@@ -3332,9 +3332,9 @@ The default unit for this option is `ms`.
 ############################################
 
 # Configures which content types should be recorded.
-# 
+#
 # The defaults end with a wildcard so that content types like `text/plain; charset=utf-8` are captured as well.
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3347,10 +3347,10 @@ The default unit for this option is `ms`.
 # capture_body_content_types=application/x-www-form-urlencoded*,text/*,application/json*,application/xml*
 
 # Used to restrict requests to certain URLs from being instrumented.
-# 
+#
 # This property should be set to an array containing one or more strings.
 # When an incoming HTTP request is detected, its URL will be tested against each element in this list.
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3363,11 +3363,11 @@ The default unit for this option is `ms`.
 # transaction_ignore_urls=/VAADIN/*,/heartbeat*,/favicon.ico,*.js,*.css,*.jpg,*.jpeg,*.png,*.gif,*.webp,*.svg,*.woff,*.woff2
 
 # Used to restrict requests from certain User-Agents from being instrumented.
-# 
+#
 # When an incoming HTTP request is detected,
 # the User-Agent from the request headers will be tested against each element in this list.
 # Example: `curl/*`, `*pingdom*`
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3375,13 +3375,13 @@ The default unit for this option is `ms`.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # transaction_ignore_user_agents=
 
 # If set to `true`,
 # transaction names of unsupported or partially-supported frameworks will be in the form of `$method $path` instead of just `$method unknown route`.
-# 
+#
 # WARNING: If your URLs contain path parameters like `/user/$userId`,
 # you should be very careful when enabling this flag,
 # as it can lead to an explosion of transaction groups.
@@ -3394,9 +3394,9 @@ The default unit for this option is `ms`.
 # use_path_as_transaction_name=false
 
 # This option is only considered, when `use_path_as_transaction_name` is active.
-# 
+#
 # With this option, you can group several URL paths together by using a wildcard expression like `/user/*`.
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3404,7 +3404,7 @@ The default unit for this option is `ms`.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # url_groups=
 
@@ -3414,7 +3414,7 @@ The default unit for this option is `ms`.
 
 # By default, the agent will scan for @Path annotations on the whole class hierarchy, recognizing a class as a JAX-RS resource if the class or any of its superclasses/interfaces has a class level @Path annotation.
 # If your application does not use @Path annotation inheritance, set this property to 'false' to only scan for direct @Path annotations. This can improve the startup time of the agent.
-# 
+#
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: Boolean
@@ -3436,13 +3436,13 @@ The default unit for this option is `ms`.
 ############################################
 
 # Report metrics from JMX to the APM Server
-# 
+#
 # Can contain multiple comma separated JMX metric definitions:
-# 
+#
 # ----
 # object_name[<JMX object name pattern>] attribute[<JMX attribute>:metric_name=<optional metric name>]
 # ----
-# 
+#
 # * `object_name`:
 # +
 # For more information about the JMX object name pattern syntax,
@@ -3461,18 +3461,18 @@ The default unit for this option is `ms`.
 # This is the name under which the metric will be stored.
 # Setting this is optional and will be the same as the `attribute` if not set.
 # Note that all JMX metric names will be prefixed with `jvm.jmx.` by the agent.
-# 
+#
 # The agent creates `labels` for each link:https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html#getKeyPropertyList()[JMX key property] such as `type` and `name`.
-# 
+#
 # The link:https://docs.oracle.com/javase/7/docs/api/javax/management/ObjectName.html[JMX object name pattern] supports wildcards.
 # In this example, the agent will create a metricset for each memory pool `name` (such as `G1 Old Generation` and `G1 Young Generation`)
-# 
+#
 # ----
 # object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionCount:metric_name=collection_count] attribute[CollectionTime]
 # ----
-# 
+#
 # The resulting documents in Elasticsearch look similar to these (metadata omitted for brevity):
-# 
+#
 # [source,json]
 # ----
 # {
@@ -3489,7 +3489,7 @@ The default unit for this option is `ms`.
 #   }
 # }
 # ----
-# 
+#
 # [source,json]
 # ----
 # {
@@ -3506,16 +3506,16 @@ The default unit for this option is `ms`.
 #   }
 # }
 # ----
-# 
-# 
+#
+#
 # The agent also supports composite values for the attribute value.
 # In this example, `HeapMemoryUsage` is a composite value, consisting of `committed`, `init`, `used` and `max`.
 # ----
-# object_name[java.lang:type=Memory] attribute[HeapMemoryUsage:metric_name=heap] 
+# object_name[java.lang:type=Memory] attribute[HeapMemoryUsage:metric_name=heap]
 # ----
-# 
+#
 # The resulting documents in Elasticsearch look similar to this:
-# 
+#
 # [source,json]
 # ----
 # {
@@ -3535,11 +3535,11 @@ The default unit for this option is `ms`.
 #   }
 # }
 # ----
-# 
+#
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # capture_jmx_metrics=
 
@@ -3549,8 +3549,8 @@ The default unit for this option is `ms`.
 
 # Sets the logging level for the agent.
 # This option is case-insensitive.
-# 
-# NOTE: `CRITICAL` is a valid option, but it is mapped to `ERROR`; `WARN` and `WARNING` are equivalent; 
+#
+# NOTE: `CRITICAL` is a valid option, but it is mapped to `ERROR`; `WARN` and `WARNING` are equivalent;
 # `OFF` is only available since version 1.16.0
 #
 # Valid options: OFF, ERROR, CRITICAL, WARN, WARNING, INFO, DEBUG, TRACE
@@ -3563,10 +3563,10 @@ The default unit for this option is `ms`.
 # Sets the path of the agent logs.
 # The special value `_AGENT_HOME_` is a placeholder for the folder the elastic-apm-agent.jar is in.
 # Example: `_AGENT_HOME_/logs/elastic-apm.log`
-# 
+#
 # When set to the special value 'System.out',
 # the logs are sent to standard out.
-# 
+#
 # NOTE: When logging to a file,
 # the log will be formatted in new-line-delimited JSON.
 # When logging to std out, the log will be formatted as plain-text.
@@ -3581,7 +3581,7 @@ The default unit for this option is `ms`.
 # If set to `true`, the agent will set the `trace.id` and `transaction.id` for the currently active spans and transactions to the MDC.
 # Since version 1.16.0, the agent also adds `error.id` of captured error to the MDC just before the error message is logged.
 # See <<log-correlation>> for more details.
-# 
+#
 # NOTE: While it's allowed to enable this setting at runtime, you can't disable it without a restart.
 #
 # This setting can be changed at runtime
@@ -3590,27 +3590,27 @@ The default unit for this option is `ms`.
 #
 # enable_log_correlation=false
 
-# Specifying whether and how the agent should automatically reformat application logs 
-# into {ecs-logging-ref}/index.html[ECS-compatible JSON], suitable for ingestion into Elasticsearch for 
-# further Log analysis. This functionality is available for log4j1, log4j2 and Logback. 
-# Once this option is enabled with any valid option, log correlation will be activated as well, regardless of the <<config-enable-log-correlation,`enable_log_correlation`>> configuration. 
-# 
+# Specifying whether and how the agent should automatically reformat application logs
+# into {ecs-logging-ref}/index.html[ECS-compatible JSON], suitable for ingestion into Elasticsearch for
+# further Log analysis. This functionality is available for log4j1, log4j2 and Logback.
+# Once this option is enabled with any valid option, log correlation will be activated as well, regardless of the <<config-enable-log-correlation,`enable_log_correlation`>> configuration.
+#
 # Available options:
-# 
-#  - OFF - application logs are not reformatted. 
-#  - SHADE - agent logs are reformatted and "shade" ECS-JSON-formatted logs are automatically created in 
-#    addition to the original application logs. Shade logs will have the same name as the original logs, 
-#    but with the ".ecs.json" extension instead of the original extension. Destination directory for the 
-#    shade logs can be configured through the <<config-log-ecs-reformatting-dir,`log_ecs_reformatting_dir`>> 
-#    configuration. Shade logs do not inherit file-rollover strategy from the original logs. Instead, they 
-#    use their own size-based rollover strategy according to the <<config-log-file-size, `log_file_size`>> 
+#
+#  - OFF - application logs are not reformatted.
+#  - SHADE - agent logs are reformatted and "shade" ECS-JSON-formatted logs are automatically created in
+#    addition to the original application logs. Shade logs will have the same name as the original logs,
+#    but with the ".ecs.json" extension instead of the original extension. Destination directory for the
+#    shade logs can be configured through the <<config-log-ecs-reformatting-dir,`log_ecs_reformatting_dir`>>
+#    configuration. Shade logs do not inherit file-rollover strategy from the original logs. Instead, they
+#    use their own size-based rollover strategy according to the <<config-log-file-size, `log_file_size`>>
 #    configuration and while allowing maximum of two shade log files.
-#  - REPLACE - similar to `SHADE`, but the original logs will not be written. This option is useful if 
-#    you wish to maintain similar logging-related overhead, but write logs to a different location and/or 
+#  - REPLACE - similar to `SHADE`, but the original logs will not be written. This option is useful if
+#    you wish to maintain similar logging-related overhead, but write logs to a different location and/or
 #    with a different file extension.
-#  - OVERRIDE - same log output is used, but in ECS-compatible JSON format instead of the original format. 
-# 
-# NOTE: while `SHADE` and `REPLACE` options are only relevant to file log appenders, the `OVERRIDE` option 
+#  - OVERRIDE - same log output is used, but in ECS-compatible JSON format instead of the original format.
+#
+# NOTE: while `SHADE` and `REPLACE` options are only relevant to file log appenders, the `OVERRIDE` option
 # is also valid for other appenders, like System out and console
 #
 # Valid options: OFF, SHADE, REPLACE, OVERRIDE
@@ -3623,20 +3623,20 @@ The default unit for this option is `ms`.
 # A comma-separated list of key-value pairs that will be added as additional fields to all log events.
 #  Takes the format `key=value[,key=value[,...]]`, for example: `key1=value1,key2=value2`.
 #  Only relevant if <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.
-# 
+#
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: Map
-# Default value: 
+# Default value:
 #
 # log_ecs_reformatting_additional_fields=
 
-# Only formatters that match an item on this list will be automatically reformatted to ECS when 
-# <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`. 
-# A formatter is the logging-framework-specific entity that is responsible for the formatting 
-# of log events. For example, in log4j it would be a `Layout` implementation, whereas in Logback it would 
-# be an `Encoder` implementation. 
-# 
+# Only formatters that match an item on this list will be automatically reformatted to ECS when
+# <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.
+# A formatter is the logging-framework-specific entity that is responsible for the formatting
+# of log events. For example, in log4j it would be a `Layout` implementation, whereas in Logback it would
+# be an `Encoder` implementation.
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3648,22 +3648,22 @@ The default unit for this option is `ms`.
 #
 # log_ecs_formatter_allow_list=*PatternLayout*,org.apache.log4j.SimpleLayout,ch.qos.logback.core.encoder.EchoEncoder
 
-# If <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to `SHADE` or `REPLACE`, 
-# the shade log files will be written alongside the original logs in the same directory by default. 
-# Use this configuration in order to write the shade logs into an alternative destination. Omitting this 
-# config or setting it to an empty string will restore the default behavior. If relative path is used, 
+# If <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to `SHADE` or `REPLACE`,
+# the shade log files will be written alongside the original logs in the same directory by default.
+# Use this configuration in order to write the shade logs into an alternative destination. Omitting this
+# config or setting it to an empty string will restore the default behavior. If relative path is used,
 # this path will be used relative to the original logs directory.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # log_ecs_reformatting_dir=
 
 # The size of the log file.
-# 
+#
 # The agent always keeps one history file so that the max total log file size is twice the value of this setting.
-# 
+#
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: ByteValue
@@ -3672,7 +3672,7 @@ The default unit for this option is `ms`.
 # log_file_size=50mb
 
 # Defines the log format when logging to `System.out`.
-# 
+#
 # When set to `JSON`, the agent will format the logs in an https://github.com/elastic/ecs-logging-java[ECS-compliant JSON format]
 # where each log event is serialized as a single line.
 #
@@ -3684,10 +3684,10 @@ The default unit for this option is `ms`.
 # log_format_sout=PLAIN_TEXT
 
 # Defines the log format when logging to a file.
-# 
+#
 # When set to `JSON`, the agent will format the logs in an https://github.com/elastic/ecs-logging-java[ECS-compliant JSON format]
 # where each log event is serialized as a single line.
-# 
+#
 #
 # Valid options: PLAIN_TEXT, JSON
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -3700,11 +3700,11 @@ The default unit for this option is `ms`.
 # Messaging                                #
 ############################################
 
-# Used to filter out specific messaging queues/topics from being traced. 
-# 
+# Used to filter out specific messaging queues/topics from being traced.
+#
 # This property should be set to an array containing one or more strings.
 # When set, sends-to and receives-from the specified queues/topic will be ignored.
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3712,7 +3712,7 @@ The default unit for this option is `ms`.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # ignore_message_queues=
 
@@ -3721,7 +3721,7 @@ The default unit for this option is `ms`.
 ############################################
 
 # Replaces dots with underscores in the metric names for custom metrics, such as Micrometer metrics.
-# 
+#
 # WARNING: Setting this to `false` can lead to mapping conflicts as dots indicate nesting in Elasticsearch.
 # An example of when a conflict happens is two metrics with the name `foo` and `foo.bar`.
 # The first metric maps `foo` to a number and the second metric maps `foo` as an object.
@@ -3738,14 +3738,14 @@ The default unit for this option is `ms`.
 
 # Set to `true` to make the agent create spans for method executions based on
 # https://github.com/jvm-profiling-tools/async-profiler[async-profiler], a sampling aka statistical profiler.
-# 
+#
 # Due to the nature of how sampling profilers work,
 # the duration of the inferred spans are not exact, but only estimations.
 # The <<config-profiling-inferred-spans-sampling-interval, `profiling_inferred_spans_sampling_interval`>> lets you fine tune the trade-off between accuracy and overhead.
-# 
+#
 # The inferred spans are created after a profiling session has ended.
 # This means there is a delay between the regular and the inferred spans being visible in the UI.
-# 
+#
 # NOTE: This feature is not available on Windows and on OpenJ9
 #
 # This setting can be changed at runtime
@@ -3782,7 +3782,7 @@ The default unit for this option is `ms`.
 # If set, the agent will only create inferred spans for methods which match this list.
 # Setting a value may slightly reduce overhead and can reduce clutter by only creating spans for the classes you are interested in.
 # Example: `org.example.myapp.*`
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3795,7 +3795,7 @@ The default unit for this option is `ms`.
 # profiling_inferred_spans_included_classes=*
 
 # Excludes classes for which no profiler-inferred spans should be created.
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -3814,7 +3814,7 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # profiling_inferred_spans_lib_directory=
 
@@ -3823,40 +3823,40 @@ The default unit for this option is `ms`.
 ############################################
 
 # This string is used to ensure that only your agents can send data to your APM server.
-# 
+#
 # Both the agents and the APM server have to be configured with the same secret token.
 # Use if APM Server requires a token.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # secret_token=
 
 # This string is used to ensure that only your agents can send data to your APM server.
-# 
+#
 # Agents can use API keys as a replacement of secret token, APM server can have multiple API keys.
 # When both secret token and API key are used, API key has priority and secret token is ignored.
 # Use if APM Server requires an API key.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # api_key=
 
 # The URL for your APM Server
 #
 # The URL must be fully qualified, including protocol (http or https) and port.
-# 
-# If SSL is enabled on the APM Server, use the `https` protocol. For more information, see 
+#
+# If SSL is enabled on the APM Server, use the `https` protocol. For more information, see
 # <<ssl-configuration>>.
-# 
+#
 # If outgoing HTTP traffic has to go through a proxy,
 # you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
-# See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation] 
+# See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation]
 # for more information.
-# 
+#
 # NOTE: This configuration can only be reloaded dynamically as of 1.8.0
 #
 # This setting can be changed at runtime
@@ -3868,33 +3868,33 @@ The default unit for this option is `ms`.
 # The URLs for your APM Servers
 #
 # The URLs must be fully qualified, including protocol (http or https) and port.
-# 
+#
 # Fails over to the next APM Server URL in the event of connection errors.
 # Achieves load-balancing by shuffling the list of configured URLs.
 # When multiple agents are active, they'll tend towards spreading evenly across the set of servers due to randomization.
-# 
-# If SSL is enabled on the APM Server, use the `https` protocol. For more information, see 
+#
+# If SSL is enabled on the APM Server, use the `https` protocol. For more information, see
 # <<ssl-configuration>>.
-# 
+#
 # If outgoing HTTP traffic has to go through a proxy,
 # you can use the Java system properties `http.proxyHost` and `http.proxyPort` to set that up.
-# See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation] 
+# See also https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html[Java's proxy documentation]
 # for more information.
-# 
-# NOTE: This configuration is specific to the Java agent and does not align with any other APM agent. In order 
-# to use a cross-agent config, use <<config-server-url>> instead, which is the recommended option regardless if you 
+#
+# NOTE: This configuration is specific to the Java agent and does not align with any other APM agent. In order
+# to use a cross-agent config, use <<config-server-url>> instead, which is the recommended option regardless if you
 # are only setting a single URL.
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # server_urls=
 
-# If set to `true`, the agent will work as usual, except from any task requiring communication with 
-# the APM server. Events will be dropped and the agent won't be able to receive central configuration, which 
-# means that any other configuration cannot be changed in this state without restarting the service. 
-# An example use case for this would be maintaining the ability to create traces and log 
+# If set to `true`, the agent will work as usual, except from any task requiring communication with
+# the APM server. Events will be dropped and the agent won't be able to receive central configuration, which
+# means that any other configuration cannot be changed in this state without restarting the service.
+# An example use case for this would be maintaining the ability to create traces and log
 # trace/transaction/span IDs through the log correlation feature, without setting up an APM Server.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -3908,7 +3908,7 @@ The default unit for this option is `ms`.
 # If a request to the APM server takes longer than the configured timeout,
 # the request is cancelled and the event (exception or transaction) is discarded.
 # Set to 0 to disable timeouts.
-# 
+#
 # WARNING: If timeouts are disabled or set to a high value, your app could experience memory issues if the APM server times out.
 #
 # This setting can be changed at runtime
@@ -3920,7 +3920,7 @@ The default unit for this option is `ms`.
 # server_timeout=5s
 
 # By default, the agent verifies the SSL certificate if you use an HTTPS connection to the APM server.
-# 
+#
 # Verification can be disabled by changing this setting to false.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -3930,12 +3930,12 @@ The default unit for this option is `ms`.
 # verify_server_cert=true
 
 # The maximum size of buffered events.
-# 
+#
 # Events like transactions and spans are buffered when the agent can't keep up with sending them to the APM Server or if the APM server is down.
-# 
+#
 # If the queue is full, events are rejected which means you will lose transactions and spans in that case.
 # This guards the application from crashing in case the APM server is unavailable for a longer period of time.
-# 
+#
 # A lower value will decrease the heap overhead of the agent,
 # while a higher value makes it less likely to lose events in case of a temporary spike in throughput.
 #
@@ -3955,7 +3955,7 @@ The default unit for this option is `ms`.
 # include_process_args=false
 
 # Maximum time to keep an HTTP request to the APM Server open for.
-# 
+#
 # NOTE: This value has to be lower than the APM Server's `read_timeout` setting.
 #
 # This setting can be changed at runtime
@@ -3968,7 +3968,7 @@ The default unit for this option is `ms`.
 
 # The maximum total compressed size of the request body which is sent to the APM server intake api via a chunked encoding (HTTP streaming).
 # Note that a small overshoot is possible.
-# 
+#
 # Allowed byte units are `b`, `kb` and `mb`. `1kb` is equal to `1024b`.
 #
 # This setting can be changed at runtime
@@ -3992,7 +3992,7 @@ The default unit for this option is `ms`.
 # Disables the collection of certain metrics.
 # If the name of a metric matches any of the wildcard expressions, it will not be collected.
 # Example: `foo.*,bar.*`
-# 
+#
 # This option supports the wildcard `*`, which matches zero or more characters.
 # Examples: `/foo/*/bar/*/baz*`, `*foo*`.
 # Matching is case insensitive by default.
@@ -4000,7 +4000,7 @@ The default unit for this option is `ms`.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # disable_metrics=
 
@@ -4008,17 +4008,17 @@ The default unit for this option is `ms`.
 # Serverless                               #
 ############################################
 
-# This config option must be used when running the agent in an AWS Lambda context. 
-# This config value allows to specify the fully qualified name of the class handling the lambda function. 
+# This config option must be used when running the agent in an AWS Lambda context.
+# This config value allows to specify the fully qualified name of the class handling the lambda function.
 # An empty value (default value) indicates that the agent is not running within an AWS lambda function.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: 
+# Default value:
 #
 # aws_lambda_handler=
 
-# This config value allows to specify the timeout in milliseconds for flushing APM data at the end of a serverless function. 
+# This config value allows to specify the timeout in milliseconds for flushing APM data at the end of a serverless function.
 # For serverless functions, APM data is written in a synchronous way, thus, blocking the termination of the function util data is written or the specified timeout is reached.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
@@ -4038,20 +4038,20 @@ The default unit for this option is `ms`.
 # there's no need to configure sub-packages.
 # Because this setting helps determine which classes to scan on startup,
 # setting this option can also improve startup time.
-# 
+#
 # You must set this option in order to use the API annotations `@CaptureTransaction` and `@CaptureSpan`.
-# 
+#
 # **Example**
-# 
+#
 # Most Java projects have a root package, e.g. `com.myproject`. You can set the application package using Java system properties:
 # `-Delastic.apm.application_packages=com.myproject`
-# 
+#
 # If you are only interested in specific subpackages, you can separate them with commas:
 # `-Delastic.apm.application_packages=com.myproject.api,com.myproject.impl`
 #
 # This setting can be changed at runtime
 # Type: comma separated list
-# Default value: 
+# Default value:
 #
 # application_packages=
 
@@ -4063,9 +4063,9 @@ The default unit for this option is `ms`.
 #
 # stack_trace_limit=50
 
-# While this is very helpful to find the exact place in your code that causes the span, collecting this stack trace does have some overhead. 
+# While this is very helpful to find the exact place in your code that causes the span, collecting this stack trace does have some overhead.
 # When setting this option to value `0ms`, stack traces will be collected for all spans. Setting it to a positive value, e.g. `5ms`, will limit stack trace collection to spans with durations equal to or longer than the given value, e.g. 5 milliseconds.
-# 
+#
 # To disable stack trace collection for spans completely, set the value to `-1ms`.
 #
 # This setting can be changed at runtime

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -32,6 +32,6 @@ More detailed information on how the Agent works can be found in the <<faq-how-d
 [[additional-components]]
 === Additional components
 
-APM Agents work in conjunction with the {apm-server-ref-v}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
-The {apm-overview-ref-v}/index.html[APM Overview] provides details on how these components work together,
-and provides a matrix outlining {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility].
+APM Agents work in conjunction with the {apm-guide-ref}/index.html[APM Server], {ref}/index.html[Elasticsearch], and {kibana-ref}/index.html[Kibana].
+The {apm-guide-ref}/index.html[APM Guide] provides details on how these components work together,
+and provides a matrix outlining {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility].

--- a/docs/opentracing.asciidoc
+++ b/docs/opentracing.asciidoc
@@ -14,9 +14,9 @@ In other words,
 it translates the calls to the OpenTracing API to Elastic APM and thus allows for reusing existing instrumentation.
 
 The first span of a service will be converted to an Elastic APM
-{apm-overview-ref-v}/transactions.html[`Transaction`],
+{apm-guide-ref}/data-model-transactions.html[`Transaction`],
 subsequent spans are mapped to Elastic APM
-{apm-overview-ref-v}/transaction-spans.html[`Span`].
+{apm-guide-ref}/data-model-spans.html[`Span`].
 
 [float]
 [[operation-modes]]
@@ -144,7 +144,7 @@ Baggage items are silently dropped.
 ==== Logs
 Only exception logging is supported.
 Logging an Exception on the OpenTracing span will create an Elastic APM
-{apm-overview-ref-v}/errors.html[`Error`].
+{apm-guide-ref}/data-model-errors.html[`Error`].
 Example:
 
 [source,java]

--- a/docs/setup-ssl.asciidoc
+++ b/docs/setup-ssl.asciidoc
@@ -1,7 +1,7 @@
 [[ssl-configuration]]
 === SSL/TLS communication with APM Server
 
-If {apm-server-ref-v}/ssl-setup.html[SSL/TLS communication] is enabled on the APM Server, use the `https` protocol when configuring <<config-server-url,`server_url`>>.
+If {apm-guide-ref}/agent-tls.html[SSL/TLS communication] is enabled on the APM Server, use the `https` protocol when configuring <<config-server-url,`server_url`>>.
 
 [float]
 [[ssl-server-authentication]]
@@ -21,7 +21,7 @@ For example, you can use `keytool` to import a certificate into the truststore:
 [[ssl-client-authentication]]
 ==== Agent certificate authentication
 
-If {apm-server-ref-v}/ssl-setup.html#ssl-client-authentication[SSL client authentication]
+If {apm-guide-ref}/agent-tls.html#ssl-client-authentication[SSL client authentication]
 is enabled on the APM server, the agent will be required to send a proper certificate as part of the HTTPS handshake.
 There is currently no configuration on the Java agent that supports that and no one straightforward option to do that that is suitable for all cases.
 Generally speaking, the agent will send a certificate from the JVM keystore.

--- a/docs/setup-ssl.asciidoc
+++ b/docs/setup-ssl.asciidoc
@@ -21,7 +21,7 @@ For example, you can use `keytool` to import a certificate into the truststore:
 [[ssl-client-authentication]]
 ==== Agent certificate authentication
 
-If {apm-guide-ref}/agent-tls.html#ssl-client-authentication[SSL client authentication]
+If {apm-guide-ref}/agent-tls.html#agent-client-cert[SSL client authentication]
 is enabled on the APM server, the agent will be required to send a proper certificate as part of the HTTPS handshake.
 There is currently no configuration on the Java agent that supports that and no one straightforward option to do that that is suitable for all cases.
 Generally speaking, the agent will send a certificate from the JVM keystore.

--- a/docs/setup.asciidoc
+++ b/docs/setup.asciidoc
@@ -25,7 +25,7 @@ Once you've set up the Agent, see the <<configuration,configuration guide>> on h
 [[ssl-setup]]
 === SSL/TLS communication with APM Server
 
-If {apm-server-ref-v}/ssl-setup.html[SSL/TLS communication] is enabled on the APM Server, make sure to check out the <<ssl-configuration, SSL setup guide>>.
+If {apm-guide-ref}/agent-tls.html[SSL/TLS communication] is enabled on the APM Server, make sure to check out the <<ssl-configuration, SSL setup guide>>.
 
 [float]
 [[aws-lambda-setup]]

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -7,7 +7,7 @@ Upgrades that involve a major version bump often come with some backwards incomp
 Before upgrading the agent, be sure to review the:
 
 * <<release-notes,Agent release notes>>
-* {apm-overview-ref-v}/agent-server-compatibility.html[Agent and Server compatibility chart]
+* {apm-guide-ref}/agent-server-compatibility.html[Agent and Server compatibility chart]
 
 [float]
 [[upgrade-steps]]


### PR DESCRIPTION
## What does this PR do?

The APM Overview and APM Server have been combined into one APM Guide. When version 7.17 of the stack releases, a lot of APM agent to Stack links will break. This PR fixes those links in the Java Agent documentation.

## Backports

- [ ] 1.x: https://github.com/elastic/apm-agent-java/pull/2411

## Related

For https://github.com/elastic/observability-docs/issues/1385.
