### PR TITLE
jjbb: enable tags for the opbeans automation

### DIFF
--- a/.ci/jobs/apm-agent-java-mbp.yml
+++ b/.ci/jobs/apm-agent-java-mbp.yml
@@ -13,7 +13,7 @@
             discover-pr-forks-trust: permission
             discover-pr-origin: merge-current
             discover-tags: true
-            head-filter-regex: '(master|PR-.*)'
+            head-filter-regex: '(master|PR-.*|v\d+\.\d+\.\d+.*)'
             notification-context: 'apm-ci'
             repo: apm-agent-java
             repo-owner: elastic


### PR DESCRIPTION
## What does this PR do?

https://github.com/elastic/apm-agent-java/pull/2389 removed the tags, but they are required to let the automation for the opbeans to work similar what it has been done in the past and in the other APM agents.

See https://github.com/elastic/apm-agent-java/blob/9448cc7185747c4e2b25895936a162ae4beaa87e/Jenkinsfile#L412-L438