### PR TITLE
ci: three meta-stages (checkout, build, release)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,8 +61,35 @@ pipeline {
     booleanParam(name: 'jdk_compatibility_ci', defaultValue: false, description: 'Enable JDK compatibility tests')
   }
   stages {
-    stage('Initializing'){
+    stage('Checkout') {
       options { skipDefaultCheckout() }
+      steps {
+        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
+        deleteDir()
+        gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, shallow: false,
+                    reference: '/var/lib/jenkins/.git-references/apm-agent-java.git')
+        stash allowEmpty: true, name: 'source', useDefaultExcludes: false
+        script {
+          dir("${BASE_DIR}"){
+            // Skip all the stages except docs for PR's with asciidoc and md changes only
+            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
+            // Prepare the env variables for the benchmark results
+            env.COMMIT_ISO_8601 = sh(script: 'git log -1 -s --format=%cI', returnStdout: true).trim()
+            env.NOW_ISO_8601 = sh(script: 'date -u "+%Y-%m-%dT%H%M%SZ"', returnStdout: true).trim()
+            env.RESULT_FILE = "apm-agent-benchmark-results-${env.COMMIT_ISO_8601}.json"
+            env.BULK_UPLOAD_FILE = "apm-agent-bulk-${env.NOW_ISO_8601}.json"
+          }
+        }
+      }
+    }
+    stage('Builds'){
+      options { skipDefaultCheckout() }
+      when {
+        // Tags are not required to be built/tested.
+        not {
+          tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+        }
+      }
       environment {
         HOME = "${env.WORKSPACE}"
         JAVA_HOME = "${env.HUDSON_HOME}/.java/java11"
@@ -70,29 +97,6 @@ pipeline {
         MAVEN_CONFIG = "${params.MAVEN_CONFIG} ${env.MAVEN_CONFIG}"
       }
       stages {
-        /**
-         Checkout the code and stash it, to use it on other stages.
-        */
-        stage('Checkout') {
-          steps {
-            pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
-            deleteDir()
-            gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, shallow: false,
-                        reference: '/var/lib/jenkins/.git-references/apm-agent-java.git')
-            stash allowEmpty: true, name: 'source', useDefaultExcludes: false
-            script {
-              dir("${BASE_DIR}"){
-                // Skip all the stages except docs for PR's with asciidoc and md changes only
-                env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
-                // Prepare the env variables for the benchmark results
-                env.COMMIT_ISO_8601 = sh(script: 'git log -1 -s --format=%cI', returnStdout: true).trim()
-                env.NOW_ISO_8601 = sh(script: 'date -u "+%Y-%m-%dT%H%M%SZ"', returnStdout: true).trim()
-                env.RESULT_FILE = "apm-agent-benchmark-results-${env.COMMIT_ISO_8601}.json"
-                env.BULK_UPLOAD_FILE = "apm-agent-bulk-${env.NOW_ISO_8601}.json"
-              }
-            }
-          }
-        }
         /**
         Build on a linux environment.
         */
@@ -127,310 +131,288 @@ pipeline {
             }
           }
         }
-      }
-    }
-    stage('Tests') {
-      when {
-        beforeAgent true
-        expression { return env.ONLY_DOCS == "false" }
-      }
-      environment {
-        MAVEN_CONFIG = "${params.MAVEN_CONFIG} ${env.MAVEN_CONFIG}"
-      }
-      failFast true
-      parallel {
-        /**
-          Run only unit test.
-        */
-        stage('Unit Tests') {
-          options { skipDefaultCheckout() }
-          environment {
-            HOME = "${env.WORKSPACE}"
-            JAVA_HOME = "${env.HUDSON_HOME}/.java/java11"
-            PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
-          }
-          when {
-            beforeAgent true
-            expression { return params.test_ci }
-          }
-          steps {
-            withGithubNotify(context: 'Unit Tests', tab: 'tests') {
-              deleteDir()
-              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
-              dir("${BASE_DIR}"){
-                withOtelEnv() {
-                  sh """#!/bin/bash
-                  set -euxo pipefail
-                  ./mvnw test
-                  """
-                }
-              }
-            }
-          }
-          post {
-            always {
-              reportTestResults()
-            }
-          }
-        }
-        stage('Non-Application Server integration tests') {
-          agent { label 'linux && immutable' }
-          options { skipDefaultCheckout() }
-          environment {
-            HOME = "${env.WORKSPACE}"
-            JAVA_HOME = "${env.HUDSON_HOME}/.java/java11"
-            PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
-          }
-          when {
-            beforeAgent true
-            anyOf {
-              expression { return params.agent_integration_tests_ci }
-              expression { return env.GITHUB_COMMENT?.contains('integration tests') }
-              expression { matchesPrLabel(label: 'ci:agent-integration') }
-              expression { return env.CHANGE_ID != null && !pullRequest.draft }
-            }
-          }
-          steps {
-            withGithubNotify(context: 'Non-Application Server integration tests', tab: 'tests') {
-              deleteDir()
-              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
-              dir("${BASE_DIR}"){
-                withOtelEnv() {
-                  sh './mvnw -q -P ci-non-application-server-integration-tests verify'
-                }
-              }
-            }
-          }
-          post {
-            always {
-              reportTestResults()
-            }
-          }
-        }
-        stage('Application Server integration tests') {
-          agent { label 'linux && immutable' }
-          options { skipDefaultCheckout() }
-          environment {
-            HOME = "${env.WORKSPACE}"
-            JAVA_HOME = "${env.HUDSON_HOME}/.java/java11"
-            PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
-          }
-          when {
-            beforeAgent true
-            anyOf {
-              expression { return params.agent_integration_tests_ci }
-              expression { return env.GITHUB_COMMENT?.contains('integration tests') }
-              expression { matchesPrLabel(label: 'ci:agent-integration') }
-              expression { return env.CHANGE_ID != null && !pullRequest.draft }
-            }
-          }
-          steps {
-            withGithubNotify(context: 'Application Server integration tests', tab: 'tests') {
-              deleteDir()
-              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
-              dir("${BASE_DIR}"){
-                withOtelEnv() {
-                  sh './mvnw -q -P ci-application-server-integration-tests verify'
-                }
-              }
-            }
-          }
-          post {
-            always {
-              reportTestResults()
-            }
-          }
-        }
-        /**
-          Run the benchmarks and store the results on ES.
-          The result JSON files are also archive into Jenkins.
-        */
-        stage('Benchmarks') {
-          agent { label 'metal' }
-          options { skipDefaultCheckout() }
-          environment {
-            HOME = "${env.WORKSPACE}"
-            JAVA_HOME = "${env.HUDSON_HOME}/.java/java11"
-            PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
-            NO_BUILD = "true"
-          }
-          when {
-            beforeAgent true
-            allOf {
-              anyOf {
-                branch 'main'
-                expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
-              }
-              expression { return params.bench_ci }
-            }
-          }
-          steps {
-            withGithubNotify(context: 'Benchmarks', tab: 'artifacts') {
-              deleteDir()
-              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
-              dir("${BASE_DIR}"){
-                withOtelEnv() {
-                  sh './scripts/jenkins/run-benchmarks.sh'
-                }
-              }
-            }
-          }
-          post {
-            always {
-              archiveArtifacts(allowEmptyArchive: true,
-                artifacts: "${BASE_DIR}/${RESULT_FILE}",
-                onlyIfSuccessful: false)
-              sendBenchmarks(file: "${BASE_DIR}/${BULK_UPLOAD_FILE}", index: "benchmark-java")
-            }
-          }
-        }
-        /**
-          Build javadoc files.
-        */
-        stage('Javadoc') {
-          agent { label 'linux && immutable' }
-          options { skipDefaultCheckout() }
-          environment {
-            HOME = "${env.WORKSPACE}"
-            JAVA_HOME = "${env.HUDSON_HOME}/.java/java11"
-            PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
-          }
+        stage('Tests') {
           when {
             beforeAgent true
             expression { return env.ONLY_DOCS == "false" }
           }
-          steps {
-            withGithubNotify(context: 'Javadoc') {
-              deleteDir()
-              unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
-              dir("${BASE_DIR}"){
-                withOtelEnv() {
-                  sh """#!/bin/bash
-                  set -euxo pipefail
-                  ./mvnw compile javadoc:javadoc
-                  """
+          failFast true
+          parallel {
+            /**
+              Run only unit test.
+            */
+            stage('Unit Tests') {
+              options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                expression { return params.test_ci }
+              }
+              steps {
+                withGithubNotify(context: 'Unit Tests', tab: 'tests') {
+                  deleteDir()
+                  unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
+                  dir("${BASE_DIR}"){
+                    withOtelEnv() {
+                      sh """#!/bin/bash
+                      set -euxo pipefail
+                      ./mvnw test
+                      """
+                    }
+                  }
+                }
+              }
+              post {
+                always {
+                  reportTestResults()
                 }
               }
             }
-          }
-        }
-      }
-    }
-    stage('End-To-End Integration Tests') {
-      agent none
-      when {
-        allOf {
-          expression { return env.ONLY_DOCS == "false" }
-          anyOf {
-            expression { return params.end_to_end_tests_ci }
-            expression { return env.GITHUB_COMMENT?.contains('end-to-end tests') }
-            expression { matchesPrLabel(label: 'ci:end-to-end') }
-            expression { return env.CHANGE_ID != null && !pullRequest.draft }
-          }
-        }
-      }
-      steps {
-        build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-              parameters: [string(name: 'INTEGRATION_TEST', value: 'Java'),
-                           string(name: 'BUILD_OPTS', value: "--java-agent-version ${env.GIT_BASE_COMMIT} --opbeans-java-agent-branch ${env.GIT_BASE_COMMIT}"),
-                           string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
-                           string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                           string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
-        githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
-      }
-    }
-    stage('JDK Compatibility Tests') {
-      options { skipDefaultCheckout() }
-      when {
-        beforeAgent true
-        allOf {
-          expression { return env.ONLY_DOCS == "false" }
-          anyOf {
-            expression { return params.jdk_compatibility_ci }
-            expression { return env.GITHUB_COMMENT?.contains('jdk compatibility tests') }
-            expression { matchesPrLabel(label: 'ci:jdk-compatibility') }
-          }
-        }
-      }
-      matrix {
-        agent { label 'linux && immutable' }
-        axes {
-          axis {
-            // the list of support java versions can be found in the infra repo (ansible/roles/java/defaults/main.yml)
-            name 'JAVA_VERSION'
-            // 'openjdk18'  disabled for now see https://github.com/elastic/apm-agent-java/issues/2328
-            values 'openjdk17'
-
-          }
-        }
-        stages {
-          stage('Test') {
-            environment {
-              HOME = "${env.WORKSPACE}"
-              JAVA_HOME = "${env.HUDSON_HOME}/.java/${JAVA_VERSION}"
-              PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
+            stage('Non-Application Server integration tests') {
+              agent { label 'linux && immutable' }
+              options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                anyOf {
+                  expression { return params.agent_integration_tests_ci }
+                  expression { return env.GITHUB_COMMENT?.contains('integration tests') }
+                  expression { matchesPrLabel(label: 'ci:agent-integration') }
+                  expression { return env.CHANGE_ID != null && !pullRequest.draft }
+                }
+              }
+              steps {
+                withGithubNotify(context: 'Non-Application Server integration tests', tab: 'tests') {
+                  deleteDir()
+                  unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
+                  dir("${BASE_DIR}"){
+                    withOtelEnv() {
+                      sh './mvnw -q -P ci-non-application-server-integration-tests verify'
+                    }
+                  }
+                }
+              }
+              post {
+                always {
+                  reportTestResults()
+                }
+              }
             }
-            steps {
-              withGithubNotify(context: "Unit Tests ${JAVA_VERSION}", tab: 'tests') {
-                deleteDir()
-                unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
-                dir("${BASE_DIR}"){
-                  withOtelEnv() {
-                    sh(label: "./mvnw test for ${JAVA_VERSION}", script: './mvnw test')
+            stage('Application Server integration tests') {
+              agent { label 'linux && immutable' }
+              options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                anyOf {
+                  expression { return params.agent_integration_tests_ci }
+                  expression { return env.GITHUB_COMMENT?.contains('integration tests') }
+                  expression { matchesPrLabel(label: 'ci:agent-integration') }
+                  expression { return env.CHANGE_ID != null && !pullRequest.draft }
+                }
+              }
+              steps {
+                withGithubNotify(context: 'Application Server integration tests', tab: 'tests') {
+                  deleteDir()
+                  unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
+                  dir("${BASE_DIR}"){
+                    withOtelEnv() {
+                      sh './mvnw -q -P ci-application-server-integration-tests verify'
+                    }
+                  }
+                }
+              }
+              post {
+                always {
+                  reportTestResults()
+                }
+              }
+            }
+            /**
+              Run the benchmarks and store the results on ES.
+              The result JSON files are also archive into Jenkins.
+            */
+            stage('Benchmarks') {
+              agent { label 'metal' }
+              options { skipDefaultCheckout() }
+              environment {
+                NO_BUILD = "true"
+              }
+              when {
+                beforeAgent true
+                allOf {
+                  anyOf {
+                    branch 'main'
+                    expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
+                  }
+                  expression { return params.bench_ci }
+                }
+              }
+              steps {
+                withGithubNotify(context: 'Benchmarks', tab: 'artifacts') {
+                  deleteDir()
+                  unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
+                  dir("${BASE_DIR}"){
+                    withOtelEnv() {
+                      sh './scripts/jenkins/run-benchmarks.sh'
+                    }
+                  }
+                }
+              }
+              post {
+                always {
+                  archiveArtifacts(allowEmptyArchive: true,
+                    artifacts: "${BASE_DIR}/${RESULT_FILE}",
+                    onlyIfSuccessful: false)
+                  sendBenchmarks(file: "${BASE_DIR}/${BULK_UPLOAD_FILE}", index: "benchmark-java")
+                }
+              }
+            }
+            /**
+              Build javadoc files.
+            */
+            stage('Javadoc') {
+              agent { label 'linux && immutable' }
+              options { skipDefaultCheckout() }
+              when {
+                beforeAgent true
+                expression { return env.ONLY_DOCS == "false" }
+              }
+              steps {
+                withGithubNotify(context: 'Javadoc') {
+                  deleteDir()
+                  unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}")
+                  dir("${BASE_DIR}"){
+                    withOtelEnv() {
+                      sh """#!/bin/bash
+                      set -euxo pipefail
+                      ./mvnw compile javadoc:javadoc
+                      """
+                    }
                   }
                 }
               }
             }
-            post {
-              always {
-                reportTestResults()
+          }
+        }
+        stage('End-To-End Integration Tests') {
+          agent none
+          when {
+            allOf {
+              expression { return env.ONLY_DOCS == "false" }
+              anyOf {
+                expression { return params.end_to_end_tests_ci }
+                expression { return env.GITHUB_COMMENT?.contains('end-to-end tests') }
+                expression { matchesPrLabel(label: 'ci:end-to-end') }
+                expression { return env.CHANGE_ID != null && !pullRequest.draft }
+              }
+            }
+          }
+          steps {
+            build(job: env.ITS_PIPELINE, propagate: false, wait: false,
+                  parameters: [string(name: 'INTEGRATION_TEST', value: 'Java'),
+                               string(name: 'BUILD_OPTS', value: "--java-agent-version ${env.GIT_BASE_COMMIT} --opbeans-java-agent-branch ${env.GIT_BASE_COMMIT}"),
+                               string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
+                               string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
+                               string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
+            githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
+          }
+        }
+        stage('JDK Compatibility Tests') {
+          options { skipDefaultCheckout() }
+          when {
+            beforeAgent true
+            allOf {
+              expression { return env.ONLY_DOCS == "false" }
+              anyOf {
+                expression { return params.jdk_compatibility_ci }
+                expression { return env.GITHUB_COMMENT?.contains('jdk compatibility tests') }
+                expression { matchesPrLabel(label: 'ci:jdk-compatibility') }
+              }
+            }
+          }
+          matrix {
+            agent { label 'linux && immutable' }
+            axes {
+              axis {
+                // the list of support java versions can be found in the infra repo (ansible/roles/java/defaults/main.yml)
+                name 'JAVA_VERSION'
+                // 'openjdk18'  disabled for now see https://github.com/elastic/apm-agent-java/issues/2328
+                values 'openjdk17'
+              }
+            }
+            stages {
+              stage('Test') {
+                steps {
+                  withGithubNotify(context: "Unit Tests ${JAVA_VERSION}", tab: 'tests') {
+                    deleteDir()
+                    unstashV2(name: 'build', bucket: "${JOB_GCS_BUCKET_STASH}", credentialsId: "${JOB_GCS_CREDENTIALS}") 
+                    dir("${BASE_DIR}"){
+                      withOtelEnv() {
+                        sh(label: "./mvnw test for ${JAVA_VERSION}", script: './mvnw test')
+                      }
+                    }
+                  }
+                }
+                post {
+                  always {
+                    reportTestResults()
+                  }
+                }
               }
             }
           }
         }
       }
     }
-    stage('Stable') {
-      options { skipDefaultCheckout() }
+    stage('Releases'){
       when {
-        branch 'main'
-      }
-      steps {
-        deleteDir()
-        unstash 'source'
-        dir("${BASE_DIR}"){
-          setupAPMGitEmail(global: false)
-          sh(label: "checkout ${BRANCH_NAME} branch", script: "git checkout -f '${BRANCH_NAME}'")
-          sh(label: 'rebase stable', script: """
-            git rev-parse --quiet --verify stable && git checkout stable || git checkout -b stable
-            git rebase '${BRANCH_NAME}'
-          """)
-          gitPush()
+        anyOf {
+          branch 'main'
+          tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
         }
       }
-    }
-    stage('AfterRelease') {
-      options { skipDefaultCheckout() }
-      when {
-        tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
-      }
       stages {
-        stage('Opbeans') {
-          environment {
-            REPO_NAME = "${OPBEANS_REPO}"
+        stage('Stable') {
+          options { skipDefaultCheckout() }
+          when {
+            branch 'main'
           }
           steps {
             deleteDir()
-            dir("${OPBEANS_REPO}"){
-              git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-                  url: "git@github.com:elastic/${OPBEANS_REPO}.git",
-                  branch: 'main')
-              // It's required to transform the tag value to the artifact version
-              sh script: ".ci/bump-version.sh ${env.BRANCH_NAME.replaceAll('^v', '')}", label: 'Bump version'
-              // The opbeans-java pipeline will trigger a release for the main branch
+            unstash 'source'
+            dir("${BASE_DIR}"){
+              setupAPMGitEmail(global: false)
+              sh(label: "checkout ${BRANCH_NAME} branch", script: "git checkout -f '${BRANCH_NAME}'")
+              sh(label: 'rebase stable', script: """
+                git rev-parse --quiet --verify stable && git checkout stable || git checkout -b stable
+                git rebase '${BRANCH_NAME}'
+              """)
               gitPush()
-              // The opbeans-java pipeline will trigger a release for the release tag
-              gitCreateTag(tag: "${env.BRANCH_NAME}")
+            }
+          }
+        }
+        stage('AfterRelease') {
+          options { skipDefaultCheckout() }
+          when {
+            tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
+          }
+          stages {
+            stage('Opbeans') {
+              environment {
+                REPO_NAME = "${OPBEANS_REPO}"
+              }
+              steps {
+                deleteDir()
+                dir("${OPBEANS_REPO}"){
+                  git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                      url: "git@github.com:elastic/${OPBEANS_REPO}.git",
+                      branch: 'main')
+                  // It's required to transform the tag value to the artifact version
+                  sh script: ".ci/bump-version.sh ${env.BRANCH_NAME.replaceAll('^v', '')}", label: 'Bump version'
+                  // The opbeans-java pipeline will trigger a release for the main branch
+                  gitPush()
+                  // The opbeans-java pipeline will trigger a release for the release tag
+                  gitCreateTag(tag: "${env.BRANCH_NAME}")
+                }
+              }
             }
           }
         }


### PR DESCRIPTION
## What does this PR do?

Refactor the main pipeline in three meta-stages:

1) `Checkout` (it runs by default)
2) `Build` (it runs on branches and PRs) It's composed by all the stages but the opbeans or stable ones
3) `Release` (it runs for the `main` branch or tags). It's composed by the `opbeans` and `stable` stages.

I also removed the duplicated entries in the environment sections, when running for Windows then we might need to revisit this!

## Why

See https://github.com/elastic/apm-agent-java/pull/2414#issuecomment-1020952186

## Test

Default behaviour with a draft PR

![image](https://user-images.githubusercontent.com/2871786/150996010-54e40780-6bfe-4199-a0e1-40c6eb002706.png)
