### PR TITLE
Avoid eager initialization of JMX on Weblogic

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ paths. The BCI warmup is on by default and may be disabled through the internal 
 ** Dubbo transaction will should be created at the provider side
 ** APM headers conversion issue within dubbo transaction
 * Fix External plugins automatic setting of span outcome - {pull}2376[#2376]
+* Avoid early initialization of JMX on Weblogic - {pull}2420[#2420]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
@@ -94,10 +94,16 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
         if (this.server != null || this.logManagerPropertyPoller != null) {
             return;
         }
-        // Avoid creating the platform MBean server, only get it if already initialized
-        // otherwise WildFly fails to start with a IllegalStateException:
+        // Do not eagerly trigger creation of the platform MBean server for known problematic cases
+        //
+        // WildFly fails to start with a IllegalStateException:
         // WFLYLOG0078: The logging subsystem requires the log manager to be org.jboss.logmanager.LogManager
-        if (setsCustomLogManager()) {
+        //
+        // JBoss sets the 'javax.management.builder.initial' system property, but uses the module classloader and
+        // current thread context class loader to initialize it
+        //
+        // Weblogic sets the 'javax.management.builder.initial' system property at runtime
+        if (setCustomPlatformMBeanServer()) {
             List<MBeanServer> servers = MBeanServerFactory.findMBeanServer(null);
             if (!servers.isEmpty()) {
                 // platform MBean server is already initialized
@@ -120,7 +126,7 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
     }
 
     private void deferInit() {
-        logger.debug("Deferring initialization of JMX metric tracking until log manager is initialized");
+        logger.debug("Deferring initialization of JMX metric tracking until platform mbean server is initialized");
         Thread thread = new Thread(new Runnable() {
 
             private final long timeout = System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5);
@@ -131,9 +137,6 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
                     List<MBeanServer> servers = MBeanServerFactory.findMBeanServer(null);
                     if (!servers.isEmpty()) {
                         // avoid actively creating a platform mbean server
-                        // because JBoss sets the javax.management.builder.initial system property
-                        // this makes Java create a JBoss specific mbean server that can only be loaded
-                        // when the module class loader is set as the current thread's context class loader
                         init(servers.get(0));
                         return;
                     }
@@ -151,8 +154,9 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
         logManagerPropertyPoller = thread;
     }
 
-    private boolean setsCustomLogManager() {
-        return ClassLoader.getSystemClassLoader().getResource("org/jboss/modules/Main.class") != null;
+    private boolean setCustomPlatformMBeanServer() {
+        return ClassLoader.getSystemClassLoader().getResource("org/jboss/modules/Main.class") != null
+            || System.getProperty("weblogic.Name") != null;
     }
 
     synchronized void init(final MBeanServer platformMBeanServer) {

--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
@@ -156,7 +156,7 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
 
     private boolean setCustomPlatformMBeanServer() {
         return ClassLoader.getSystemClassLoader().getResource("org/jboss/modules/Main.class") != null
-            || System.getProperty("weblogic.Name") != null;
+            || System.getProperty("weblogic.Name") != null || System.getProperty("weblogic.home") != null;
     }
 
     synchronized void init(final MBeanServer platformMBeanServer) {


### PR DESCRIPTION
## What does this PR do?

Fixes #2407 

Heuristic to detect Weblogic: one of `weblogic.Name` or `weblogic.home` JVM system properties is set.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [] ~~I have added tests that would fail without this fix~~
  - [x] manually testing with Weblogic 12c