### PR TITLE
Speedup instrumentation by not validating (only needed in tests)

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -427,7 +427,11 @@ public class ElasticApmAgent {
     }
 
     private static AgentBuilder.Transformer.ForAdvice getTransformer(final ElasticApmInstrumentation instrumentation, final Logger logger, final ElementMatcher<? super MethodDescription> methodMatcher) {
-        validateAdvice(instrumentation);
+        boolean validate = false;
+        assert validate = true;
+        if (validate) {
+            validateAdvice(instrumentation);
+        }
         Advice.WithCustomMapping withCustomMapping = Advice
             .withCustomMapping()
             .with(new Advice.AssignReturned.Factory().withSuppressed(ClassCastException.class))


### PR DESCRIPTION
## What does this PR do?
Sets the ElasticApmAgent.validateAdvice() call to only execute in tests. No changelog update

## Checklist
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
