### PR TITLE
Service name auto discovery docs and polishing

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -57,6 +57,7 @@ paths. The BCI warmup is on by default and may be disabled through the internal 
 * Fix External plugins automatic setting of span outcome - {pull}2376[#2376]
 * Avoid early initialization of JMX on Weblogic - {pull}2420[#2420]
 * Ensure agent always uses JDK HTTP client - {pull}2429[#2429]
+* Avoid standalone spring applications to have two different service names, one based on the jar name, the other based on `spring.application.name`.
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -92,20 +92,67 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .description("This is used to keep all the errors and transactions of your service together\n" +
             "and is the primary filter in the Elastic APM user interface.\n" +
             "\n" +
+            "Instead of configuring the service name manually,\n" +
+            "you can also choose to rely on the service name auto-detection mechanisms of the agent.\n" +
+            "If `service_name` is set explicitly, all auto-detection mechanisms are disabled.\n" +
+            "\n" +
+            "This is how the service name auto-detection works:\n" +
+            "\n" +
+            "* For standalone applications\n" +
+            "** The agent uses `Implementation-Title` in the `META-INF/MANIFEST.MF` file if the application is started via `java -jar`.\n" +
+            "** Falls back to the name of the main class or jar file.\n" +
+            "* For applications that are deployed to a servlet container/application server, the agent auto-detects the name for each application.\n" +
+            "** For Spring-based applications, the agent uses the `spring.application.name` property, if set.\n" +
+            "** For servlet-based applications, falls back to the `Implementation-Title` in the `META-INF/MANIFEST.MF` file.\n" +
+            "** Falls back to the `display-name` of the `web.xml`, if available.\n" +
+            "** Falls back to the servlet context path the application is mapped to (unless mapped to the root context).\n" +
+            "\n" +
+            "Generally, it is recommended to rely on the service name detection based on `META-INF/MANIFEST.MF`.\n" +
+            "Spring Boot automatically adds the relevant manifest entries.\n" +
+            "For other applications that are built with Maven, this is how you add the manifest entries:\n" +
+            "\n" +
+            "<#noparse>\n" +
+            "[source,xml]\n" +
+            ".pom.xml\n" +
+            "----\n" +
+            "    <build>\n" +
+            "        <plugins>\n" +
+            "            <plugin>\n" +
+            "                <groupId>org.apache.maven.plugins</groupId>\n" +
+            "                <!-- uncomment if you're building a jar\n" +
+            "                <artifactId>maven-jar-plugin</artifactId>\n" +
+            "                <version>3.2.2</version>\n" +
+            "                -->\n" +
+            "                <!-- uncomment if you're building a war\n" +
+            "                <artifactId>maven-war-plugin</artifactId>\n" +
+            "                <version>3.3.2</version>\n" +
+            "                -->\n" +
+            "                <configuration>\n" +
+            "                    <archive>\n" +
+            "                        <!-- Adds\n" +
+            "                        Implementation-Title based on ${project.name} and\n" +
+            "                        Implementation-Version based on ${project.version}\n" +
+            "                        -->\n" +
+            "                        <manifest>\n" +
+            "                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>\n" +
+            "                        </manifest>\n" +
+            "                        <!-- To customize the Implementation-* entries, remove addDefaultImplementationEntries and add them manually\n" +
+            "                        <manifestEntries>\n" +
+            "                            <Implementation-Title>foo</Implementation-Title>\n" +
+            "                            <Implementation-Version>4.2.0</Implementation-Version>\n" +
+            "                        </manifestEntries>\n" +
+            "                        -->\n" +
+            "                    </archive>\n" +
+            "                </configuration>\n" +
+            "            </plugin>\n" +
+            "        </plugins>\n" +
+            "    </build>\n" +
+            "----\n" +
+            "</#noparse>\n" +
+            "\n" +
             "The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]+$`.\n" +
             "In less regexy terms:\n" +
             "Your service name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces.\n" +
-            "\n" +
-            "NOTE: When relying on auto-discovery of the service name in Servlet environments (including Spring Boot),\n" +
-            "there is currently a caveat related to metrics.\n" +
-            "The consequence is that the 'Metrics' tab of a service does not show process-global metrics like CPU utilization.\n" +
-            "The reason is that metrics are reported with the detected default service name for the JVM,\n" +
-            "for example `tomcat-application`.\n" +
-            "That is because there may be multiple web applications deployed to a single JVM/servlet container.\n" +
-            "However, you can view those metrics by selecting the `tomcat-application` service name, for example.\n" +
-            "Future versions of the Elastic APM stack will have better support for that scenario.\n" +
-            "A workaround is to explicitly set the `service_name` which means all applications deployed to the same servlet container will have the same name\n" +
-            "or to disable the corresponding `*-service-name` detecting instrumentations via <<config-disable-instrumentations>>.\n" +
             "\n" +
             "NOTE: Service name auto discovery mechanisms require APM Server 7.0+.")
         .addValidator(RegexValidator.of("^[a-zA-Z0-9 _-]+$", "Your service name \"{0}\" must only contain characters " +

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -118,15 +118,8 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "    <build>\n" +
             "        <plugins>\n" +
             "            <plugin>\n" +
-            "                <groupId>org.apache.maven.plugins</groupId>\n" +
-            "                <!-- uncomment if you're building a jar\n" +
+            "                <!-- replace with 'maven-war-plugin' if you're building a war -->\n" +
             "                <artifactId>maven-jar-plugin</artifactId>\n" +
-            "                <version>3.2.2</version>\n" +
-            "                -->\n" +
-            "                <!-- uncomment if you're building a war\n" +
-            "                <artifactId>maven-war-plugin</artifactId>\n" +
-            "                <version>3.3.2</version>\n" +
-            "                -->\n" +
             "                <configuration>\n" +
             "                    <archive>\n" +
             "                        <!-- Adds\n" +

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -191,7 +191,12 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .configurationCategory(CORE_CATEGORY)
         .description("A version string for the currently deployed version of the service. If you don’t version your deployments, " +
             "the recommended value for this field is the commit identifier of the deployed revision, " +
-            "e.g. the output of git rev-parse HEAD.")
+            "e.g. the output of git rev-parse HEAD.\n" +
+            "\n" +
+            "Similar to the auto-detection of <<config-service-name>>, " +
+            "the agent can auto-detect the service version based on the `Implementation-Title` attribute in `META-INF/MANIFEST.MF`.\n" +
+            "See <<config-service-name>> on how to set this attribute.\n" +
+            "\n")
         .defaultValue(ServiceInfo.autoDetected().getServiceVersion())
         .build();
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/ServiceInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/ServiceInfo.java
@@ -35,12 +35,18 @@ public class ServiceInfo {
     private final String serviceName;
     @Nullable
     private final String serviceVersion;
+    private final boolean multiServiceContainer;
 
     public ServiceInfo(@Nullable String serviceName) {
         this(serviceName, null);
     }
 
     private ServiceInfo(@Nullable String serviceName, @Nullable String serviceVersion) {
+        this(serviceName, serviceVersion, false);
+    }
+
+    private ServiceInfo(@Nullable String serviceName, @Nullable String serviceVersion, boolean multiServiceContainer) {
+        this.multiServiceContainer = multiServiceContainer;
         if (serviceName == null || serviceName.trim().isEmpty()) {
             this.serviceName = DEFAULT_SERVICE_NAME;
         } else {
@@ -55,6 +61,10 @@ public class ServiceInfo {
 
     public static ServiceInfo of(@Nullable String serviceName) {
         return of(serviceName, null);
+    }
+
+    public static ServiceInfo ofMultiServiceContainer(String serviceName) {
+        return new ServiceInfo(serviceName, null, true);
     }
 
     public static ServiceInfo of(@Nullable String serviceName, @Nullable String serviceVersion) {
@@ -94,7 +104,7 @@ public class ServiceInfo {
         command = command.trim();
         String serviceName = getContainerServiceName(command);
         if (serviceName != null) {
-            return ServiceInfo.of(serviceName);
+            return ServiceInfo.ofMultiServiceContainer(serviceName);
         }
         if (command.contains(".jar")) {
             return fromJarCommand(command);
@@ -181,6 +191,15 @@ public class ServiceInfo {
         return serviceVersion;
     }
 
+    /**
+     * Returns true if the service is a container service that can host multiple other applications.
+     * For example, an application server or servlet container.
+     * A standalone application that's built on embedded Tomcat, for example, would return {@code false}.
+     */
+    public boolean isMultiServiceContainer() {
+        return multiServiceContainer;
+    }
+
     public ServiceInfo withFallback(ServiceInfo fallback) {
         return ServiceInfo.of(
             hasServiceName() ? serviceName : fallback.serviceName,
@@ -200,19 +219,20 @@ public class ServiceInfo {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         ServiceInfo that = (ServiceInfo) o;
-        return serviceName.equals(that.serviceName) && Objects.equals(serviceVersion, that.serviceVersion);
+        return multiServiceContainer == that.multiServiceContainer && serviceName.equals(that.serviceName) && Objects.equals(serviceVersion, that.serviceVersion);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(serviceName, serviceVersion);
+        return Objects.hash(serviceName, serviceVersion, multiServiceContainer);
     }
 
     @Override
     public String toString() {
         return "ServiceInfo{" +
-            "name='" + serviceName + '\'' +
-            ", version='" + serviceVersion + '\'' +
+            "serviceName='" + serviceName + '\'' +
+            ", serviceVersion='" + serviceVersion + '\'' +
+            ", multiServiceContainer=" + multiServiceContainer +
             '}';
     }
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletServiceNameHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletServiceNameHelper.java
@@ -50,6 +50,11 @@ public class ServletServiceNameHelper {
         if (servletContextClassLoader == null || nameInitialized.putIfAbsent(servletContextClassLoader, Boolean.TRUE) != null) {
             return;
         }
+        ServiceInfo serviceInfo = detectServiceInfo(adapter, servletContext, servletContextClassLoader);
+        tracer.overrideServiceInfoForClassLoader(servletContextClassLoader, serviceInfo);
+    }
+
+    public static <ServletContext> ServiceInfo detectServiceInfo(ServletContextAdapter<ServletContext> adapter, ServletContext servletContext, ClassLoader servletContextClassLoader) {
         String servletContextName = adapter.getServletContextName(servletContext);
         String contextPath = adapter.getContextPath(servletContext);
 
@@ -75,7 +80,7 @@ public class ServletServiceNameHelper {
             // remove leading slash
             fromContextPath = ServiceInfo.of(contextPath.substring(1));
         }
-        tracer.overrideServiceInfoForClassLoader(servletContextClassLoader, fromWarManifest.withFallback(fromContextName).withFallback(fromContextPath));
+        return fromWarManifest.withFallback(fromContextName).withFallback(fromContextPath);
     }
 
     @Nullable

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/pom.xml
@@ -17,6 +17,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-servlet-plugin</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>
@@ -28,6 +34,7 @@
             <version>${version.spring}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
@@ -44,12 +51,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <version>2.0.2.RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apm-servlet-plugin</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apm-agent/src/test/resources/configuration.asciidoc.ftl
+++ b/apm-agent/src/test/resources/configuration.asciidoc.ftl
@@ -54,7 +54,10 @@ Only the external file can be used for dynamic configuration.
 In order to get started with Elastic APM,
 the most important configuration options are <<config-service-name>>,
 <<config-server-url>> and <<config-application-packages>>.
-So a minimal version of a configuration might look like this:
+Note that even these settings are optional.
+Click on their name to see how the default values are determined.
+
+An example configuration looks like this:
 
 [source,bash]
 .System properties
@@ -80,12 +83,7 @@ ELASTIC_APM_APPLICATION_PACKAGES=org.example,org.another.example
 ELASTIC_APM_SERVER_URL=http://localhost:8200
 ----
 <#assign defaultServiceName>
-For Spring-based application, uses the `spring.application.name` property, if set.
-For Servlet-based applications, uses the `display-name` of the `web.xml`, if available.
-Falls back to the servlet context path the application is mapped to (unless mapped to the root context).
-Falls back to the `Implementation-Title` in the `MANIFEST.MF` file.
-Falls back to the name of the main class or jar file.
-If the service name is set explicitly, it overrides all of the above.
+Auto-detected based on the rules described above
 </#assign>
 
 [float]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -57,7 +57,10 @@ Only the external file can be used for dynamic configuration.
 In order to get started with Elastic APM,
 the most important configuration options are <<config-service-name>>,
 <<config-server-url>> and <<config-application-packages>>.
-So a minimal version of a configuration might look like this:
+Note that even these settings are optional.
+Click on their name to see how the default values are determined.
+
+An example configuration looks like this:
 
 [source,bash]
 .System properties
@@ -471,20 +474,65 @@ NOTE: Changing this value at runtime can slow down the application temporarily.
 This is used to keep all the errors and transactions of your service together
 and is the primary filter in the Elastic APM user interface.
 
+Instead of configuring the service name manually,
+you can also choose to rely on the service name auto-detection mechanisms of the agent.
+If `service_name` is set explicitly, all auto-detection mechanisms are disabled.
+
+This is how the service name auto-detection works:
+
+* For standalone applications
+** The agent uses `Implementation-Title` in the `META-INF/MANIFEST.MF` file if the application is started via `java -jar`.
+** Falls back to the name of the main class or jar file.
+* For applications that are deployed to a servlet container/application server, the agent auto-detects the name for each application.
+** For Spring-based applications, the agent uses the `spring.application.name` property, if set.
+** For servlet-based applications, falls back to the `Implementation-Title` in the `META-INF/MANIFEST.MF` file.
+** Falls back to the `display-name` of the `web.xml`, if available.
+** Falls back to the servlet context path the application is mapped to (unless mapped to the root context).
+
+Generally, it is recommended to rely on the service name detection based on `META-INF/MANIFEST.MF`.
+Spring Boot automatically adds the relevant manifest entries.
+For other applications that are built with Maven, this is how you add the manifest entries:
+
+[source,xml]
+.pom.xml
+----
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <!-- uncomment if you're building a jar
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>3.2.2</version>
+                -->
+                <!-- uncomment if you're building a war
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.3.2</version>
+                -->
+                <configuration>
+                    <archive>
+                        <!-- Adds
+                        Implementation-Title based on ${project.name} and
+                        Implementation-Version based on ${project.version}
+                        -->
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                        <!-- To customize the Implementation-* entries, remove addDefaultImplementationEntries and add them manually
+                        <manifestEntries>
+                            <Implementation-Title>foo</Implementation-Title>
+                            <Implementation-Version>4.2.0</Implementation-Version>
+                        </manifestEntries>
+                        -->
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+----
+
 The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]+$`.
 In less regexy terms:
 Your service name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces.
-
-NOTE: When relying on auto-discovery of the service name in Servlet environments (including Spring Boot),
-there is currently a caveat related to metrics.
-The consequence is that the 'Metrics' tab of a service does not show process-global metrics like CPU utilization.
-The reason is that metrics are reported with the detected default service name for the JVM,
-for example `tomcat-application`.
-That is because there may be multiple web applications deployed to a single JVM/servlet container.
-However, you can view those metrics by selecting the `tomcat-application` service name, for example.
-Future versions of the Elastic APM stack will have better support for that scenario.
-A workaround is to explicitly set the `service_name` which means all applications deployed to the same servlet container will have the same name
-or to disable the corresponding `*-service-name` detecting instrumentations via <<config-disable-instrumentations>>.
 
 NOTE: Service name auto discovery mechanisms require APM Server 7.0+.
 
@@ -494,12 +542,7 @@ NOTE: Service name auto discovery mechanisms require APM Server 7.0+.
 [options="header"]
 |============
 | Default                          | Type                | Dynamic
-| For Spring-based application, uses the `spring.application.name` property, if set.
-For Servlet-based applications, uses the `display-name` of the `web.xml`, if available.
-Falls back to the servlet context path the application is mapped to (unless mapped to the root context).
-Falls back to the `Implementation-Title` in the `MANIFEST.MF` file.
-Falls back to the name of the main class or jar file.
-If the service name is set explicitly, it overrides all of the above.
+| Auto-detected based on the rules described above
  | String | false
 |============
 
@@ -2870,31 +2913,73 @@ The default unit for this option is `ms`.
 # This is used to keep all the errors and transactions of your service together
 # and is the primary filter in the Elastic APM user interface.
 # 
+# Instead of configuring the service name manually,
+# you can also choose to rely on the service name auto-detection mechanisms of the agent.
+# If `service_name` is set explicitly, all auto-detection mechanisms are disabled.
+# 
+# This is how the service name auto-detection works:
+# 
+# * For standalone applications
+# ** The agent uses `Implementation-Title` in the `META-INF/MANIFEST.MF` file if the application is started via `java -jar`.
+# ** Falls back to the name of the main class or jar file.
+# * For applications that are deployed to a servlet container/application server, the agent auto-detects the name for each application.
+# ** For Spring-based applications, the agent uses the `spring.application.name` property, if set.
+# ** For servlet-based applications, falls back to the `Implementation-Title` in the `META-INF/MANIFEST.MF` file.
+# ** Falls back to the `display-name` of the `web.xml`, if available.
+# ** Falls back to the servlet context path the application is mapped to (unless mapped to the root context).
+# 
+# Generally, it is recommended to rely on the service name detection based on `META-INF/MANIFEST.MF`.
+# Spring Boot automatically adds the relevant manifest entries.
+# For other applications that are built with Maven, this is how you add the manifest entries:
+# 
+# 
+# [source,xml]
+# .pom.xml
+# ----
+#     <build>
+#         <plugins>
+#             <plugin>
+#                 <groupId>org.apache.maven.plugins</groupId>
+#                 <!-- uncomment if you're building a jar
+#                 <artifactId>maven-jar-plugin</artifactId>
+#                 <version>3.2.2</version>
+#                 -->
+#                 <!-- uncomment if you're building a war
+#                 <artifactId>maven-war-plugin</artifactId>
+#                 <version>3.3.2</version>
+#                 -->
+#                 <configuration>
+#                     <archive>
+#                         <!-- Adds
+#                         Implementation-Title based on ${project.name} and
+#                         Implementation-Version based on ${project.version}
+#                         -->
+#                         <manifest>
+#                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+#                         </manifest>
+#                         <!-- To customize the Implementation-* entries, remove addDefaultImplementationEntries and add them manually
+#                         <manifestEntries>
+#                             <Implementation-Title>foo</Implementation-Title>
+#                             <Implementation-Version>4.2.0</Implementation-Version>
+#                         </manifestEntries>
+#                         -->
+#                     </archive>
+#                 </configuration>
+#             </plugin>
+#         </plugins>
+#     </build>
+# ----
+# 
+# 
 # The service name must conform to this regular expression: `^[a-zA-Z0-9 _-]+$`.
 # In less regexy terms:
 # Your service name must only contain characters from the ASCII alphabet, numbers, dashes, underscores and spaces.
-# 
-# NOTE: When relying on auto-discovery of the service name in Servlet environments (including Spring Boot),
-# there is currently a caveat related to metrics.
-# The consequence is that the 'Metrics' tab of a service does not show process-global metrics like CPU utilization.
-# The reason is that metrics are reported with the detected default service name for the JVM,
-# for example `tomcat-application`.
-# That is because there may be multiple web applications deployed to a single JVM/servlet container.
-# However, you can view those metrics by selecting the `tomcat-application` service name, for example.
-# Future versions of the Elastic APM stack will have better support for that scenario.
-# A workaround is to explicitly set the `service_name` which means all applications deployed to the same servlet container will have the same name
-# or to disable the corresponding `*-service-name` detecting instrumentations via <<config-disable-instrumentations>>.
 # 
 # NOTE: Service name auto discovery mechanisms require APM Server 7.0+.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String
-# Default value: For Spring-based application, uses the `spring.application.name` property, if set.
-# For Servlet-based applications, uses the `display-name` of the `web.xml`, if available.
-# Falls back to the servlet context path the application is mapped to (unless mapped to the root context).
-# Falls back to the `Implementation-Title` in the `MANIFEST.MF` file.
-# Falls back to the name of the main class or jar file.
-# If the service name is set explicitly, it overrides all of the above.
+# Default value: Auto-detected based on the rules described above
 # 
 #
 # service_name=

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -499,15 +499,8 @@ For other applications that are built with Maven, this is how you add the manife
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <!-- uncomment if you're building a jar
+                <!-- replace with 'maven-war-plugin' if you're building a war -->
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.2.2</version>
-                -->
-                <!-- uncomment if you're building a war
-                <artifactId>maven-war-plugin</artifactId>
-                <version>3.3.2</version>
-                -->
                 <configuration>
                     <archive>
                         <!-- Adds
@@ -2944,15 +2937,8 @@ The default unit for this option is `ms`.
 #     <build>
 #         <plugins>
 #             <plugin>
-#                 <groupId>org.apache.maven.plugins</groupId>
-#                 <!-- uncomment if you're building a jar
+#                 <!-- replace with 'maven-war-plugin' if you're building a war -->
 #                 <artifactId>maven-jar-plugin</artifactId>
-#                 <version>3.2.2</version>
-#                 -->
-#                 <!-- uncomment if you're building a war
-#                 <artifactId>maven-war-plugin</artifactId>
-#                 <version>3.3.2</version>
-#                 -->
 #                 <configuration>
 #                     <archive>
 #                         <!-- Adds

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -592,6 +592,11 @@ NOTE: Metrics views can utilize this configuration since APM Server 7.5
 
 A version string for the currently deployed version of the service. If you don’t version your deployments, the recommended value for this field is the commit identifier of the deployed revision, e.g. the output of git rev-parse HEAD.
 
+Similar to the auto-detection of <<config-service-name>>, the agent can auto-detect the service version based on the `Implementation-Title` attribute in `META-INF/MANIFEST.MF`.
+See <<config-service-name>> on how to set this attribute.
+
+
+
 
 
 
@@ -3004,6 +3009,11 @@ The default unit for this option is `ms`.
 # service_node_name=
 
 # A version string for the currently deployed version of the service. If you don’t version your deployments, the recommended value for this field is the commit identifier of the deployed revision, e.g. the output of git rev-parse HEAD.
+# 
+# Similar to the auto-detection of <<config-service-name>>, the agent can auto-detect the service version based on the `Implementation-Title` attribute in `META-INF/MANIFEST.MF`.
+# See <<config-service-name>> on how to set this attribute.
+# 
+# 
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: String

--- a/integration-tests/spring-boot-2/spring-boot-2-base/src/test/java/co/elastic/apm/spring/boot/AbstractSpringBootTest.java
+++ b/integration-tests/spring-boot-2/spring-boot-2-base/src/test/java/co/elastic/apm/spring/boot/AbstractSpringBootTest.java
@@ -102,7 +102,9 @@ public abstract class AbstractSpringBootTest {
         assertThat(transaction.getContext().getUser().getId()).isEqualTo("id");
         assertThat(transaction.getContext().getUser().getEmail()).isEqualTo("email");
         assertThat(transaction.getContext().getUser().getUsername()).isEqualTo("username");
-        assertThat(transaction.getTraceContext().getServiceName()).isEqualTo("spring-boot-test");
+        // as this test runs in a standalone application and not in a servlet container,
+        // the service.name will not be overwritten for the webapp class loader based on spring.application.name
+        assertThat(transaction.getTraceContext().getServiceName()).isNull();
         assertThat(transaction.getFrameworkName()).isEqualTo("Spring Web MVC");
         assertThat(transaction.getFrameworkVersion()).isEqualTo("5.1.9.RELEASE");
     }


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

- Documents service name auto discovery mechanisms
- Documents how to set `Implementation-Title` and `Implementation-Version` manifest entries with maven
- Avoid standalone spring applications to have two different service names, one based on the jar name, the other based on `spring.application.name`.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - ~[ ] Added an API method or config option? Document in which version this will be introduced~
  - [x] I have made corresponding changes to the documentation
