### PR TITLE
fix windows hostname test

### DIFF
--- a/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/AgentDownloadUtils.java
+++ b/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/AgentDownloadUtils.java
@@ -48,7 +48,13 @@ public class AgentDownloadUtils {
         }
 
         URL jarLocation = AgentDownloadUtils.class.getProtectionDomain().getCodeSource().getLocation();
-        Path attacherCliDir = Paths.get(jarLocation.getPath()).getParent();
+        String jarLocationPath = jarLocation.getPath();
+        if (jarLocationPath.matches("/\\w\\:.*")){
+            // looks something like /C:/path... - Paths.get() doesn't like that
+            // so strip the leading /
+            jarLocationPath = jarLocationPath.substring(1);
+        }
+        Path attacherCliDir = Paths.get(jarLocationPath).getParent();
 
         Path agentBaseDir;
         if (Files.isWritable(attacherCliDir)) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
@@ -212,10 +212,22 @@ public class SystemInfo {
         return hostname;
     }
 
+    /**
+     * Returns the hostname from environment variables.
+     * <br/>
+     * Note for Windows: the Windows implementation relies on the COMPUTERNAME environment variable that does not
+     * 100% matches the computer name: the returned value is the "netbios name" in upper-case and limited to the first
+     * 15 characters of the complete computer name returned by {@code hostname} command.
+     *
+     * @param isWindows {@literal true} for Windows
+     * @return computer/host name from environment variables.
+     */
     @Nullable
     static String discoverHostnameThroughEnv(boolean isWindows) {
         String hostname;
         if (isWindows) {
+            // Windows implementation will always return an upper-case name
+            // limited to the 15 first characters of the actual computer name
             hostname = System.getenv("COMPUTERNAME");
         } else {
             hostname = System.getenv("HOSTNAME");

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/metadata/SystemInfoTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/metadata/SystemInfoTest.java
@@ -78,11 +78,21 @@ public class SystemInfoTest extends CustomEnvVariables {
         customEnvVariables.put("HOSTNAME", null);
         customEnvVariables.put("COMPUTERNAME", null);
 
-        if (isWindows) {
-            runWithCustomEnvVariables(customEnvVariables, () -> assertThat(SystemInfo.fallbackHostnameDiscovery(true)).isEqualTo(expectedHostname));
-        } else {
-            runWithCustomEnvVariables(customEnvVariables, () -> assertThat(SystemInfo.fallbackHostnameDiscovery(false)).isEqualTo(expectedHostname));
-            runWithCustomEnvVariables(customEnvVariables, () -> assertThat(SystemInfo.fallbackHostnameDiscovery(false)).isEqualTo(expectedHostname));
+        runWithCustomEnvVariables(customEnvVariables, () -> {
+
+            // sanity check for test instrumentation to ensure those are not set
+            checkSystemPropertiesNotSet("HOST","HOSTNAME","COMPUTERNAME");
+
+            assertThat(SystemInfo.fallbackHostnameDiscovery(isWindows))
+                .isEqualTo(expectedHostname);
+        });
+    }
+
+    private static void checkSystemPropertiesNotSet(String... keys){
+        Map<String, String> map = System.getenv();
+        for (String key : keys) {
+            assertThat(System.getenv(key)).isNull();
+            assertThat(map.get(key)).isNull();
         }
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemAllEnvVariablesInstrumentation.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemAllEnvVariablesInstrumentation.java
@@ -22,7 +22,6 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
@@ -39,13 +38,8 @@ public class SystemAllEnvVariablesInstrumentation extends SystemEnvVariableInstr
     public static class AdviceClass {
         @Advice.AssignReturned.ToReturned
         @Advice.OnMethodExit(onThrowable = Throwable.class, inline = false)
-        public static Map<String, String> appendToEnvVariables(@Advice.Return Map<String, String> ret) {
-            Map<String, String> customEnvVariables = customEnvVariablesTL.get();
-            if (customEnvVariables != null && !customEnvVariables.isEmpty()) {
-                ret = new HashMap<>(ret);
-                ret.putAll(customEnvVariables);
-            }
-            return ret;
+        public static Map<String, String> alterEnvVariables(@Advice.Return Map<String, String> ret) {
+            return getCustomEnvironmentMap(ret);
         }
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemEnvVariableInstrumentation.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemEnvVariableInstrumentation.java
@@ -26,6 +26,7 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,18 +36,67 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 
 public abstract class SystemEnvVariableInstrumentation extends TracerAwareInstrumentation {
 
-    protected static final DetachedThreadLocal<Map<String, String>> customEnvVariablesTL =
+    private static final DetachedThreadLocal<Map<String, String>> customEnvVariablesTL =
         GlobalVariables.get(SystemEnvVariableInstrumentation.class, "customEnvVariables", WeakConcurrent.<Map<String, String>>buildThreadLocal());
+
+    private static final String NULL_ENTRY = "null";
 
     /**
      * Sets custom env variables that will be added to the actual env variables returned by {@link System#getenv()} or
-     * {@link System#getenv(String)} on the current thread.
+     * {@link System#getenv(String)} on the current thread. Entries with {@literal null} values will allow to emulate
+     * when those environment variables are not set.
+     * <p>
      * NOTE: caller must clear the custom variables when they are not required anymore through {@link #clearCustomEnvVariables()}.
+     *
      * @param customEnvVariables a map of key-value pairs that will be appended to the actual environment variables
      *                           returned by {@link System#getenv()} on the current thread
      */
     public static void setCustomEnvVariables(Map<String, String> customEnvVariables) {
-        customEnvVariablesTL.set(customEnvVariables);
+        Map<String,String> map = new HashMap<>();
+        for (Map.Entry<String, String> entry : customEnvVariables.entrySet()) {
+            String value = entry.getValue();
+            if (value == null) {
+                value = NULL_ENTRY;
+            }
+            map.put(entry.getKey(), value);
+        }
+        customEnvVariablesTL.set(map);
+    }
+
+    protected static Map<String,String> getCustomEnvironmentMap(Map<String,String> originalValues){
+        Map<String,String> customMap = customEnvVariablesTL.get();
+        if(customMap == null){
+            return originalValues;
+        }
+        Map<String,String> map = new HashMap<>(originalValues);
+        for (Map.Entry<String, String> entry: customMap.entrySet()) {
+            String value = entry.getValue();
+
+            //noinspection StringEquality
+            if(value == null || value == NULL_ENTRY){
+                map.remove(entry.getKey());
+            } else {
+                map.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        return map;
+    }
+
+    protected static String getCustomEnvironmentEntry(String key, @Nullable String originalValue) {
+        Map<String,String> customMap = customEnvVariablesTL.get();
+        if (customMap == null) {
+            return originalValue;
+        }
+        String customValue = customMap.get(key);
+
+        //noinspection StringEquality
+        if(customValue == NULL_ENTRY){
+            return null;
+        } else if (customValue != null){
+            return customValue;
+        }
+        return originalValue;
     }
 
     public static void clearCustomEnvVariables() {
@@ -66,13 +116,8 @@ public abstract class SystemEnvVariableInstrumentation extends TracerAwareInstru
     public static class AdviceClass {
         @Advice.AssignReturned.ToReturned
         @Advice.OnMethodExit(onThrowable = Throwable.class, inline = false)
-        public static Map<String, String> appendToEnvVariables(@Advice.Return Map<String, String> ret) {
-            Map<String, String> customEnvVariables = customEnvVariablesTL.get();
-            if (customEnvVariables != null && !customEnvVariables.isEmpty()) {
-                ret = new HashMap<>(ret);
-                ret.putAll(customEnvVariables);
-            }
-            return ret;
+        public static Map<String, String> alterEnvVariables(@Advice.Return Map<String, String> ret) {
+            return getCustomEnvironmentMap(ret);
         }
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemEnvVariableInstrumentation.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemEnvVariableInstrumentation.java
@@ -36,8 +36,8 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 
 public abstract class SystemEnvVariableInstrumentation extends TracerAwareInstrumentation {
 
-    private static final DetachedThreadLocal<Map<String, String>> customEnvVariablesTL =
-        GlobalVariables.get(SystemEnvVariableInstrumentation.class, "customEnvVariables", WeakConcurrent.<Map<String, String>>buildThreadLocal());
+    private static final DetachedThreadLocal<Map<String, String>> customEnvVariablesTL = GlobalVariables
+        .get(SystemEnvVariableInstrumentation.class, "customEnvVariables", WeakConcurrent.<Map<String, String>>buildThreadLocal());
 
     private static final String NULL_ENTRY = "null";
 
@@ -52,7 +52,7 @@ public abstract class SystemEnvVariableInstrumentation extends TracerAwareInstru
      *                           returned by {@link System#getenv()} on the current thread
      */
     public static void setCustomEnvVariables(Map<String, String> customEnvVariables) {
-        Map<String,String> map = new HashMap<>();
+        Map<String, String> map = new HashMap<>();
         for (Map.Entry<String, String> entry : customEnvVariables.entrySet()) {
             String value = entry.getValue();
             if (value == null) {
@@ -63,17 +63,17 @@ public abstract class SystemEnvVariableInstrumentation extends TracerAwareInstru
         customEnvVariablesTL.set(map);
     }
 
-    protected static Map<String,String> getCustomEnvironmentMap(Map<String,String> originalValues){
-        Map<String,String> customMap = customEnvVariablesTL.get();
-        if(customMap == null){
+    protected static Map<String, String> getCustomEnvironmentMap(Map<String, String> originalValues) {
+        Map<String, String> customMap = customEnvVariablesTL.get();
+        if (customMap == null) {
             return originalValues;
         }
-        Map<String,String> map = new HashMap<>(originalValues);
-        for (Map.Entry<String, String> entry: customMap.entrySet()) {
+        Map<String, String> map = new HashMap<>(originalValues);
+        for (Map.Entry<String, String> entry : customMap.entrySet()) {
             String value = entry.getValue();
 
             //noinspection StringEquality
-            if(value == null || value == NULL_ENTRY){
+            if (value == null || value == NULL_ENTRY) {
                 map.remove(entry.getKey());
             } else {
                 map.put(entry.getKey(), entry.getValue());
@@ -84,16 +84,16 @@ public abstract class SystemEnvVariableInstrumentation extends TracerAwareInstru
     }
 
     protected static String getCustomEnvironmentEntry(String key, @Nullable String originalValue) {
-        Map<String,String> customMap = customEnvVariablesTL.get();
+        Map<String, String> customMap = customEnvVariablesTL.get();
         if (customMap == null) {
             return originalValue;
         }
         String customValue = customMap.get(key);
 
         //noinspection StringEquality
-        if(customValue == NULL_ENTRY){
+        if (customValue == NULL_ENTRY) {
             return null;
-        } else if (customValue != null){
+        } else if (customValue != null) {
             return customValue;
         }
         return originalValue;

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemSingleEnvVariablesInstrumentation.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemSingleEnvVariablesInstrumentation.java
@@ -22,6 +22,7 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
@@ -38,15 +39,8 @@ public class SystemSingleEnvVariablesInstrumentation extends SystemEnvVariableIn
     public static class AdviceClass {
         @Advice.AssignReturned.ToReturned
         @Advice.OnMethodExit(onThrowable = Throwable.class, inline = false)
-        public static String appendToEnvVariables(@Advice.Argument(0) String varName, @Advice.Return String ret) {
-            Map<String, String> customEnvVariables = customEnvVariablesTL.get();
-            if (customEnvVariables != null) {
-                String customValue = customEnvVariables.get(varName);
-                if (customValue != null) {
-                    ret = customValue;
-                }
-            }
-            return ret;
+        public static String alterEnvVariables(@Advice.Argument(0) String varName, @Advice.Return @Nullable String ret) {
+            return getCustomEnvironmentEntry(varName, ret);
         }
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemSingleEnvVariablesInstrumentation.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testinstr/SystemSingleEnvVariablesInstrumentation.java
@@ -23,8 +23,8 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
 import javax.annotation.Nullable;
-import java.util.Map;
 
+import static net.bytebuddy.implementation.bytecode.assign.Assigner.Typing.DYNAMIC;
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
@@ -37,10 +37,11 @@ public class SystemSingleEnvVariablesInstrumentation extends SystemEnvVariableIn
     }
 
     public static class AdviceClass {
-        @Advice.AssignReturned.ToReturned
+        // note: requires to use the array return form in order to be able to set return value to 'null'
+        @Advice.AssignReturned.ToReturned(index = 0, typing = DYNAMIC)
         @Advice.OnMethodExit(onThrowable = Throwable.class, inline = false)
-        public static String alterEnvVariables(@Advice.Argument(0) String varName, @Advice.Return @Nullable String ret) {
-            return getCustomEnvironmentEntry(varName, ret);
+        public static Object[] alterEnvVariables(@Advice.Argument(0) String varName, @Advice.Return @Nullable String ret) {
+            return new Object[]{getCustomEnvironmentEntry(varName, ret)};
         }
     }
 }

--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/ShadedClassLoaderTest.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/ShadedClassLoaderTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URLClassLoader;
 import java.util.List;
 import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
@@ -42,6 +43,7 @@ class ShadedClassLoaderTest {
         Class<?> clazz = cl.loadClass(ShadedClassLoaderTest.class.getName());
         assertThat(clazz).isNotNull();
         assertThat(clazz).isNotSameAs(ShadedClassLoaderTest.class);
+        ((URLClassLoader) cl).close();
     }
 
     @Test
@@ -59,6 +61,7 @@ class ShadedClassLoaderTest {
         ClassLoader cl = new ShadedClassLoader(jar, null, "agent/");
         assertThatThrownBy(() -> cl.loadClass(ShadedClassLoaderTest.class.getName()))
             .isInstanceOf(ClassNotFoundException.class);
+        ((URLClassLoader) cl).close();
     }
 
     @Test
@@ -73,6 +76,7 @@ class ShadedClassLoaderTest {
         assertThat(cl.getResource(resourceName).openStream().readAllBytes()).isEqualTo(expected);
         assertThat(cl.getResources(resourceName).hasMoreElements()).isTrue();
         assertThat(cl.getResources(resourceName).nextElement().openStream().readAllBytes()).isEqualTo(expected);
+        ((URLClassLoader) cl).close();
     }
 
     @Test
@@ -82,6 +86,7 @@ class ShadedClassLoaderTest {
         String resourceName = ShadedClassLoaderTest.class.getName().replace('.', '/') + ".resource";
 
         assertThat(cl.getResourceAsStream(resourceName)).isNull();
+        ((URLClassLoader) cl).close();
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

Fixes #2436 

The test failed on Windows, but not on *nix because of the combination of a few things:
- our test instrumentation did not allowed to emulate a non-existing env variable
- by default the tested env variables `HOST` and `HOSTNAME` are not set on *nix, which is the case also on CI, so the test that tried to cover this case behaved as expected by accident.
- on Windows the `COMPUTERNAME` env variable seems to always be present (including in CI), thus not being able to emulate a missing value did not worked as expected and as a result the test failed.

Morale of the story: testing on Windows helped us to find a bug in or test instrumentation, but it was not due to an underlying bug in the agent, only in testing code.

## Checklist

- [x] This is a bugfix
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~ not required here
  - [x] I have added tests that would fail without this fix
  
  
## Other failing tests

There are other tests that are currently failing on Windows and will need further investigation, fixing them could be done either in this PR or separately. Fixing them is expected to trigger new failing tests that weren't previously known to fail

- [ ] co.elastic.apm.agent.log4j2.Log4j2ShadingTest#testLazyShadeFileCreation
- [ ] co.elastic.apm.agent.log4j2.Log4j2ShadingTest#testLogOverride
