### PR TITLE
Fix dubbo flaky tests

### DIFF
--- a/apm-agent-plugins/apm-dubbo-plugin/src/test/java/co/elastic/apm/agent/dubbo/AbstractDubboInstrumentationTest.java
+++ b/apm-agent-plugins/apm-dubbo-plugin/src/test/java/co/elastic/apm/agent/dubbo/AbstractDubboInstrumentationTest.java
@@ -29,6 +29,7 @@ import co.elastic.apm.agent.impl.transaction.Outcome;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.testutils.TestPort;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,19 +39,19 @@ import javax.annotation.Nullable;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
 public abstract class AbstractDubboInstrumentationTest extends AbstractInstrumentationTest {
 
-    private final int port = TestPort.getAvailableRandomPort();
-    private final int anotherPort = TestPort.getAvailableRandomPort();
+    private static CoreConfiguration coreConfig;
 
     @Nullable
-    private DubboTestApi dubboTestApi;
+    private static DubboTestApi dubboTestApi;
 
-    static CoreConfiguration coreConfig;
+    private static int port = -1;
 
     @BeforeAll
     static void initInstrumentation() {
@@ -58,34 +59,62 @@ public abstract class AbstractDubboInstrumentationTest extends AbstractInstrumen
     }
 
     @BeforeEach
-    void startRootTransaction() {
+    void beforeEach() {
+
+        if (null == dubboTestApi) {
+            // only start test dubbo once, but with delegation to subclass for creating it
+            // thus we can't do that in @BeforeAll
+
+            port = TestPort.getAvailableRandomPort();
+            int backendPort = TestPort.getAvailableRandomPort();
+
+            assertThat(port).isNotEqualTo(backendPort);
+            dubboTestApi = buildDubboTestApi(port, backendPort);
+        }
+
         when(coreConfig.getCaptureBody()).thenReturn(CoreConfiguration.EventType.OFF);
 
-        // using context classloader is required here
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
-
-        Transaction transaction = tracer.startRootTransaction(cl);
-        assertThat(transaction).isNotNull();
-        transaction
-            .withName("dubbo test")
-            .withType("test")
-            .withResult("success")
-            .withOutcome(Outcome.SUCCESS)
-            .activate();
-
+        startTestRootTransaction("dubbo test");
     }
 
     @AfterEach
-    void clearReporter() {
-        tracer.currentTransaction().deactivate().end();
+    void afterEach() {
+        Transaction transaction = tracer.currentTransaction();
+        if (transaction != null) {
+            transaction.deactivate().end();
+        }
     }
 
-    protected abstract DubboTestApi buildDubboTestApi();
+    @AfterAll
+    static void doAfterAll(){
+        dubboTestApi = null;
+    }
 
-    public DubboTestApi getDubboTestApi() {
-        if (dubboTestApi == null) {
-            dubboTestApi = buildDubboTestApi();
+    protected static <T> T withRetry(Callable<T> task){
+        int count = 10;
+        while (count > 0) {
+            try {
+                return  task.call();
+            } catch (Exception e) {
+                count--;
+                if (count == 0) {
+                    throw new IllegalStateException("unable to start dubbo service", e);
+                } else {
+                    try {
+                        Thread.sleep(50);
+                    } catch (InterruptedException ex) {
+                        // silently ignored
+                    }
+                }
+            }
         }
+        throw new IllegalStateException("should not happen");
+    }
+
+    protected abstract DubboTestApi buildDubboTestApi(int port1, int port2);
+
+    protected DubboTestApi getDubboTestApi() {
+        assertThat(dubboTestApi).isNotNull();
         return dubboTestApi;
     }
 
@@ -94,13 +123,14 @@ public abstract class AbstractDubboInstrumentationTest extends AbstractInstrumen
         DubboTestApi dubboTestApi = getDubboTestApi();
         String normalReturn = dubboTestApi.normalReturn("arg1", 2);
         assertThat(normalReturn).isEqualTo("arg12");
-        List<Transaction> transactions = reporter.getTransactions();
-        assertThat(transactions.size()).isEqualTo(1);
-        validateDubboTransaction(transactions.get(0), DubboTestApi.class, "normalReturn");
 
-        List<Span> spans = reporter.getSpans();
-        assertThat(spans.size()).isEqualTo(1);
-        validateDubboSpan(spans.get(0), DubboTestApi.class, "normalReturn");
+        // transaction on the receiving side
+        reporter.awaitTransactionCount(1);
+        validateDubboTransaction(reporter.getFirstTransaction(), DubboTestApi.class, "normalReturn");
+
+        // span on the emitting side (outgoing from this method)
+        reporter.awaitSpanCount(1);
+        validateDubboSpan(reporter.getFirstSpan(), DubboTestApi.class, "normalReturn", port);
 
         List<ErrorCapture> errors = reporter.getErrors();
         assertThat(errors.size()).isEqualTo(0);
@@ -158,17 +188,17 @@ public abstract class AbstractDubboInstrumentationTest extends AbstractInstrumen
         assertThat(transaction.getType()).isEqualTo("request");
     }
 
-    protected String getDubboName(Class<?> apiClass, String methodName) {
+    protected static String getDubboName(Class<?> apiClass, String methodName) {
         return apiClass.getSimpleName() + "#" + methodName;
     }
 
-    public void validateDubboSpan(Span span, Class<?> apiClass, String methodName) {
+    public static void validateDubboSpan(Span span, Class<?> apiClass, String methodName, int port) {
         assertThat(span.getNameAsString()).isEqualTo(getDubboName(apiClass, methodName));
         assertThat(span.getType()).isEqualTo("external");
         assertThat(span.getSubtype()).isEqualTo("dubbo");
         Destination destination = span.getContext().getDestination();
         assertThat(destination.getAddress().toString()).isEqualTo("localhost");
-        assertThat(destination.getPort()).isEqualTo(getPort());
+        assertThat(destination.getPort()).isEqualTo(port);
 
         Destination.Service service = destination.getService();
         assertThat(service.getResource().toString()).matches("localhost:\\d+");
@@ -176,14 +206,6 @@ public abstract class AbstractDubboInstrumentationTest extends AbstractInstrumen
         assertThat(span.getOutcome())
             .describedAs("span outcome should be known")
             .isNotEqualTo(Outcome.UNKNOWN);
-    }
-
-    protected int getPort() {
-        return port;
-    }
-
-    protected int getAnotherApiPort() {
-        return anotherPort;
     }
 
     @Test


### PR DESCRIPTION
Dubbo tests randomly fail on CI and locally complaining about a network port being already busy.

- add retry logic when registering client & server as it seems to be randomly taking some time (given there are 2 clients and 2 servers, their startup ordering isn't guaranteed)
- only start the whole test setup once per JVM as it seems that otherwise a global registry is used and the test still randomly fails after a few iterations.

Tested locally: goes from ~20 tests until a failure happens to ~500+ without a single failure.