### PR TITLE
Make integration tests run on Testcontainers Cloud

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/UrlTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/context/UrlTest.java
@@ -130,7 +130,7 @@ class UrlTest {
         // only the 'full' property is always computed
         // other attributes are not parsed unless sanitization is applied (which is an implementation detail)
         if(input.contains("@")){
-            assertThat(url.getHostname()).isEqualTo("localhost");
+            assertThat(url.getHostname()).isIn("localhost", "127.0.0.1");
             assertThat(url.getPort()).isEqualTo(80);
         } else {
             assertThat(url.getHostname()).isNull();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientProxySupportIT.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerClientProxySupportIT.java
@@ -20,18 +20,18 @@ package co.elastic.apm.agent.report;
 
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.configuration.SpyConfiguration;
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import io.undertow.Undertow;
 import io.undertow.io.Sender;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import co.elastic.apm.agent.sdk.logging.Logger;
-import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 import org.testcontainers.Testcontainers;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.MountableFile;
 
 import javax.annotation.Nullable;
 import java.io.IOException;
@@ -123,8 +123,8 @@ public class ApmServerClientProxySupportIT {
         String squidConfig = String.format("squid/squid_%s.conf", useAuth ? "basic-auth" : "no-auth");
 
         proxy = new GenericContainer<>(DOCKER_IMAGE_NAME)
-            .withClasspathResourceMapping(squidConfig, "/etc/squid/squid.conf", BindMode.READ_ONLY)
-            .withClasspathResourceMapping("squid/squid_passwd", "/etc/squid/passwd", BindMode.READ_ONLY);
+            .withCopyFileToContainer(MountableFile.forClasspathResource(squidConfig), "/etc/squid/squid.conf")
+            .withCopyFileToContainer(MountableFile.forClasspathResource("squid/squid_passwd"), "/etc/squid/passwd");
 
         proxy.addExposedPorts(3128);
         proxy.start();

--- a/apm-agent-plugins/apm-dubbo-plugin/src/test/java/co/elastic/apm/agent/dubbo/AbstractDubboInstrumentationTest.java
+++ b/apm-agent-plugins/apm-dubbo-plugin/src/test/java/co/elastic/apm/agent/dubbo/AbstractDubboInstrumentationTest.java
@@ -167,7 +167,7 @@ public abstract class AbstractDubboInstrumentationTest extends AbstractInstrumen
         assertThat(span.getType()).isEqualTo("external");
         assertThat(span.getSubtype()).isEqualTo("dubbo");
         Destination destination = span.getContext().getDestination();
-        assertThat(destination.getAddress().toString()).isEqualTo("localhost");
+        assertThat(destination.getAddress().toString()).isIn("localhost", "127.0.0.1");
         assertThat(destination.getPort()).isEqualTo(getPort());
 
         Destination.Service service = destination.getService();

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/AbstractJdbcInstrumentationTest.java
@@ -436,7 +436,7 @@ public abstract class AbstractJdbcInstrumentationTest extends AbstractInstrument
             .isEqualTo(expectedAffectedRows);
 
         Destination destination = span.getContext().getDestination();
-        assertThat(destination.getAddress().toString()).isEqualTo("localhost");
+        assertThat(destination.getAddress().toString()).isIn("localhost", "127.0.0.1");
         if (expectedDbVendor.equals("h2")) {
             assertThat(destination.getPort()).isEqualTo(-1);
         } else {

--- a/apm-agent-plugins/apm-mongoclient-plugin/src/test/java/co/elastic/apm/agent/mongoclient/AbstractMongoClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-mongoclient-plugin/src/test/java/co/elastic/apm/agent/mongoclient/AbstractMongoClientInstrumentationTest.java
@@ -202,7 +202,7 @@ public abstract class AbstractMongoClientInstrumentationTest extends AbstractIns
 
         // verify destination
         Destination destination = span.getContext().getDestination();
-        assertThat(destination.getAddress().toString()).isEqualTo("localhost");
+        assertThat(destination.getAddress().toString()).isIn("localhost", "127.0.0.1");
         assertThat(destination.getPort()).isEqualTo(container.getMappedPort(PORT));
 
         Destination.Service service = destination.getService();

--- a/integration-tests/application-server-integration-tests/pom.xml
+++ b/integration-tests/application-server-integration-tests/pom.xml
@@ -124,6 +124,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.terma</groupId>
+            <artifactId>javaniotcpproxy</artifactId>
+            <version>1.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
             <version>5.4.1</version>

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractJettyIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractJettyIT.java
@@ -28,7 +28,7 @@ public abstract class AbstractJettyIT extends AbstractServletContainerIntegratio
     private String version;
 
     public AbstractJettyIT(final String version) {
-        super(new GenericContainer<>("jetty:" + version)
+        super(new GenericContainerWithTcpProxy<>("jetty:" + version)
                 .withExposedPorts(8080),
             "jetty-application",
             "/var/lib/jetty/webapps",

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -40,7 +40,6 @@ import org.mockserver.model.HttpResponse;
 import org.testcontainers.containers.Container;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
-import org.testcontainers.containers.SocatContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.MountableFile;
 
@@ -130,8 +129,6 @@ public abstract class AbstractServletContainerIntegrationTest {
     private final int webPort;
     private final String expectedDefaultServiceName;
     private final String containerName;
-    @Nullable
-    private GenericContainer<?> debugProxy;
     private TestApp currentTestApp;
 
     protected AbstractServletContainerIntegrationTest(GenericContainer<?> servletContainer, String expectedDefaultServiceName, String deploymentPath, String containerName) {
@@ -144,7 +141,6 @@ public abstract class AbstractServletContainerIntegrationTest {
         this.webPort = webPort;
         if (ENABLE_DEBUGGING) {
             enableDebugging(servletContainer);
-            this.debugProxy = createDebugProxy(servletContainer, debugPort);
         }
         if (runtimeAttachSupported() && !ENABLE_RUNTIME_ATTACH) {
             // If runtime attach is off for Servlet containers that support that, we need to add the javaagent here
@@ -181,28 +177,30 @@ public abstract class AbstractServletContainerIntegrationTest {
             .withEnv("ELASTIC_APM_PROFILING_SPANS_ENABLED", "true")
             .withEnv("ELASTIC_APM_APPLICATION_PACKAGES", "co.elastic") // allows to use API annotations, we have to use a broad package due to multiple apps
             .withLogConsumer(new StandardOutLogConsumer().withPrefix(containerName))
-            .withExposedPorts(webPort)
-            .withFileSystemBind(pathToJavaagent, "/elastic-apm-agent.jar")
-            .withFileSystemBind(pathToAttach, "/apm-agent-attach-cli.jar")
-            .withFileSystemBind(pathToSlimAttach, "/apm-agent-attach-cli-slim.jar")
+            .withCopyFileToContainer(MountableFile.forHostPath(pathToJavaagent), "/elastic-apm-agent.jar")
+            .withCopyFileToContainer(MountableFile.forHostPath(pathToAttach), "/apm-agent-attach-cli.jar")
+            .withCopyFileToContainer(MountableFile.forHostPath(pathToSlimAttach), "/apm-agent-attach-cli-slim.jar")
             .withStartupTimeout(Duration.ofMinutes(5));
+        if (ENABLE_DEBUGGING) {
+            servletContainer.withExposedPorts(webPort, debugPort);
+        } else {
+            servletContainer.withExposedPorts(webPort);
+        }
         for (TestApp testApp : getTestApps()) {
             testApp.getAdditionalEnvVariables().forEach(servletContainer::withEnv);
             try {
                 testApp.getAdditionalFilesToBind().forEach((pathToFile, containerPath) -> {
                     checkFilePresent(pathToFile);
-                    servletContainer.withFileSystemBind(pathToFile, containerPath);
+                    servletContainer.withCopyFileToContainer(MountableFile.forHostPath(pathToFile), containerPath);
                 });
             } catch (Exception e) {
                 e.printStackTrace();
             }
         }
-        if (isDeployViaFileSystemBind()) {
-            for (TestApp testApp : getTestApps()) {
-                String pathToAppFile = testApp.getAppFilePath();
-                checkFilePresent(pathToAppFile);
-                servletContainer.withFileSystemBind(pathToAppFile, deploymentPath + "/" + testApp.getAppFileName());
-            }
+        for (TestApp testApp : getTestApps()) {
+            String pathToAppFile = testApp.getAppFilePath();
+            checkFilePresent(pathToAppFile);
+            servletContainer.withCopyFileToContainer(MountableFile.forHostPath(pathToAppFile), deploymentPath + "/" + testApp.getAppFileName());
         }
         this.servletContainer.withCreateContainerCmdModifier(TestContainersUtils.withMemoryLimit(4096));
         this.servletContainer.start();
@@ -219,13 +217,6 @@ public abstract class AbstractServletContainerIntegrationTest {
                 System.out.println(result.getStderr());
             } catch (Exception e) {
                 throw new RuntimeException(e);
-            }
-        }
-        if (!isDeployViaFileSystemBind()) {
-            for (TestApp testApp : getTestApps()) {
-                String pathToAppFile = testApp.getAppFilePath();
-                checkFilePresent(pathToAppFile);
-                servletContainer.copyFileToContainer(MountableFile.forHostPath(pathToAppFile), deploymentPath + "/" + testApp.getAppFileName());
             }
         }
     }
@@ -246,13 +237,6 @@ public abstract class AbstractServletContainerIntegrationTest {
 
     public String getImageName() {
         return servletContainer.getDockerImageName();
-    }
-
-    /**
-     * If set to true, the war files are {@code --mount}ed into the container instead of copied, which is faster.
-     */
-    protected boolean isDeployViaFileSystemBind() {
-        return true;
     }
 
     /**
@@ -287,33 +271,12 @@ public abstract class AbstractServletContainerIntegrationTest {
     protected void enableDebugging(GenericContainer<?> servletContainer) {
     }
 
-    // makes sure the debugging port is always 5005
-    // if the port is not available, the test can still run
-    @Nullable
-    private GenericContainer<?> createDebugProxy(GenericContainer<?> servletContainer, final int debugPort) {
-        try {
-            final SocatContainer socatContainer = new SocatContainer() {{
-                addFixedExposedPort(debugPort, debugPort);
-            }}
-                .withNetwork(Network.SHARED)
-                .withTarget(debugPort, servletContainer.getNetworkAliases().get(0));
-            socatContainer.start();
-            return socatContainer;
-        } catch (Exception e) {
-            logger.warn("Starting debug proxy failed");
-            return null;
-        }
-    }
-
     @After
     public final void stopServer() {
         servletContainer.getDockerClient()
             .stopContainerCmd(servletContainer.getContainerId())
             .exec();
         servletContainer.stop();
-        if (debugProxy != null) {
-            debugProxy.stop();
-        }
     }
 
     protected Iterable<TestApp> getTestApps() {

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/GenericContainerWithTcpProxy.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/GenericContainerWithTcpProxy.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package co.elastic.apm.servlet;
+
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
+import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.terma.javaniotcpproxy.StaticTcpProxyConfig;
+import com.github.terma.javaniotcpproxy.TcpProxy;
+import org.testcontainers.containers.GenericContainer;
+
+import javax.annotation.Nullable;
+import java.util.concurrent.Future;
+
+public class GenericContainerWithTcpProxy<SELF extends GenericContainerWithTcpProxy<SELF>> extends GenericContainer<SELF> {
+
+    private static final Logger logger = LoggerFactory.getLogger(GenericContainerWithTcpProxy.class);
+    private static final int DEFAULT_DEBUG_PORT = 5005;
+
+    @Nullable
+    private TcpProxy tcpProxy;
+    private final int localPort;
+
+    public GenericContainerWithTcpProxy(String dockerImageName) {
+        this(dockerImageName, DEFAULT_DEBUG_PORT);
+    }
+
+    public GenericContainerWithTcpProxy(Future<String> image) {
+        this(image, DEFAULT_DEBUG_PORT);
+    }
+
+    public GenericContainerWithTcpProxy(Future<String> image, int localPort) {
+        super(image);
+        this.localPort = localPort;
+    }
+
+    public GenericContainerWithTcpProxy(String dockerImageName, int localPort) {
+        super(dockerImageName);
+        this.localPort = localPort;
+    }
+
+    @Override
+    protected void containerIsStarting(InspectContainerResponse containerInfo) {
+        if (!AbstractServletContainerIntegrationTest.ENABLE_DEBUGGING) {
+            return;
+        }
+        try {
+            var config = new StaticTcpProxyConfig(
+                localPort,
+                getContainerIpAddress(),
+                getMappedPort(localPort)
+            );
+            config.setWorkerCount(1);
+            tcpProxy = new TcpProxy(config);
+            tcpProxy.start();
+        } catch (Exception e) {
+            logger.warn("Exception while trying to start tcp debugger proxy", e);
+        }
+    }
+
+    @Override
+    protected void containerIsStopping(InspectContainerResponse containerInfo) {
+        if (tcpProxy != null) {
+            tcpProxy.shutdown();
+        }
+    }
+}

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JBossIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JBossIT.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
 public class JBossIT extends AbstractServletContainerIntegrationTest {
 
     public JBossIT(final String jbossVersion) {
-        super(new GenericContainer<>("registry.access.redhat.com/" + jbossVersion)
+        super(new GenericContainerWithTcpProxy<>("registry.access.redhat.com/" + jbossVersion)
                 // this overrides the defaults, so we have to manually re-add preferIPv4Stack
                 // the other defaults don't seem to be important
                 .withEnv("JAVA_OPTS", "-javaagent:/elastic-apm-agent.jar -Djava.net.preferIPv4Stack=true " +

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/PayaraIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/PayaraIT.java
@@ -25,7 +25,6 @@ import co.elastic.apm.servlet.tests.ServletApiTestApp;
 import co.elastic.apm.servlet.tests.TestApp;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
 import java.util.Arrays;
@@ -34,7 +33,7 @@ import java.util.Arrays;
 public class PayaraIT extends AbstractServletContainerIntegrationTest {
 
     public PayaraIT(final String serverVersion, final String deploymentsFolder) {
-        super(new GenericContainer<>(
+        super(new GenericContainerWithTcpProxy<>(
                 new ImageFromDockerfile()
                     .withDockerfileFromBuilder(builder -> {
                             builder

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebLogicIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebLogicIT.java
@@ -27,8 +27,8 @@ import co.elastic.apm.servlet.tests.TestApp;
 import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.MountableFile;
 
 import java.util.Arrays;
 import java.util.List;
@@ -38,8 +38,8 @@ import java.util.List;
 public class WebLogicIT extends AbstractServletContainerIntegrationTest {
 
     public WebLogicIT(final String webLogicVersion) {
-        super(new GenericContainer<>("store/oracle/weblogic:" + webLogicVersion)
-                .withClasspathResourceMapping("domain.properties", "/u01/oracle/properties/domain.properties", BindMode.READ_WRITE),
+        super(new GenericContainerWithTcpProxy<>("store/oracle/weblogic:" + webLogicVersion)
+                .withCopyFileToContainer(MountableFile.forClasspathResource("domain.properties"), "/u01/oracle/properties/domain.properties"),
             7001,
             5005,
             "weblogic-application",
@@ -75,13 +75,6 @@ public class WebLogicIT extends AbstractServletContainerIntegrationTest {
         // WebLogic can't handle the case when a exception is thrown in the runnable submitted to AsyncContext#start(Runnable)
         // it requires AsyncContext#complete() to be called, otherwise it throws a timeout
         return List.of("/index.jsp", "/servlet", "/async-dispatch-servlet");
-    }
-
-    @Override
-    protected boolean isDeployViaFileSystemBind() {
-        // WebLogic requires the files to be writable
-        // Even binding with BindMode.READ_WRITE does not work for some reason
-        return false;
     }
 
     @Override

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebSphereIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebSphereIT.java
@@ -35,12 +35,13 @@ public class WebSphereIT extends AbstractServletContainerIntegrationTest {
 
     public WebSphereIT(final String version) {
         super((ENABLE_DEBUGGING
-                ? new GenericContainer<>(new ImageFromDockerfile()
+                ? new GenericContainerWithTcpProxy<>(new ImageFromDockerfile()
                 .withDockerfileFromBuilder(builder -> builder
-                    .from("websphere-liberty:" + version).cmd("/opt/ibm/wlp/bin/server", "debug", "defaultServer")))
+                    .from("websphere-liberty:" + version)
+                    .cmd("/opt/ibm/wlp/bin/server", "debug", "defaultServer")),
+                7777)
                 : new GenericContainer<>("websphere-liberty:" + version)
-            )
-                .withEnv("JVM_ARGS", "-javaagent:/elastic-apm-agent.jar"),
+            ).withEnv("JVM_ARGS", "-javaagent:/elastic-apm-agent.jar"),
             9080,
             7777,
             "websphere-application",

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WildFlyIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WildFlyIT.java
@@ -34,7 +34,7 @@ import java.util.Arrays;
 public class WildFlyIT extends AbstractServletContainerIntegrationTest {
 
     public WildFlyIT(final String wildFlyVersion) {
-        super(new GenericContainer<>("jboss/wildfly:" + wildFlyVersion)
+        super(new GenericContainerWithTcpProxy<>("jboss/wildfly:" + wildFlyVersion)
                 // this overrides the defaults, so we have to manually re-add preferIPv4Stack
                 // the other defaults don't seem to be important
                 .withEnv("JAVA_OPTS", "-javaagent:/elastic-apm-agent.jar -Djava.net.preferIPv4Stack=true"),

--- a/integration-tests/main-app-test/src/test/java/co/elastic/apm/test/ServiceIT.java
+++ b/integration-tests/main-app-test/src/test/java/co/elastic/apm/test/ServiceIT.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.utility.MountableFile;
 
 import java.io.File;
 import java.io.FileFilter;
@@ -37,8 +38,8 @@ class ServiceIT {
     void testServiceNameAndVersionFromManifest(String image) {
         assertThat(new File("target/main-app-test.jar")).exists();
         GenericContainer<?> app = new GenericContainer<>(DockerImageName.parse(image))
-            .withFileSystemBind(getAgentJar(), "/tmp/elastic-apm-agent.jar")
-            .withFileSystemBind("target/main-app-test.jar", "/tmp/main-app.jar")
+            .withCopyFileToContainer(MountableFile.forHostPath(getAgentJar()), "/tmp/elastic-apm-agent.jar")
+            .withCopyFileToContainer(MountableFile.forHostPath("target/main-app-test.jar"), "/tmp/main-app.jar")
             .withCommand("java -javaagent:/tmp/elastic-apm-agent.jar -jar /tmp/main-app.jar")
             .waitingFor(Wait.forLogMessage(".* Starting Elastic APM .*", 1));
         app.start();

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <!-- used both for plugin & annotations dependency -->
         <version.animal-sniffer>1.17</version.animal-sniffer>
 
-        <version.testcontainers>1.16.2</version.testcontainers>
+        <version.testcontainers>1.16.3</version.testcontainers>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
## What does this PR do?
Makes the test suite fit for Testcontainers Cloud (TCC)
- Enables running all tests on M1 processors
- Biggest change is that `withFileSystemBind` has to be replaced with `withCopyFileToContainer`
- I've tested remote debugging to a Tomcat that runs on TCC. The performance seems to be good enough.

## What's not yet working
- When running the full test suite, the TCC workers run out of disk space (TCC is working on increasing disk space)

## Follow ups
- Currently, this is mainly for local development. But we may want to consider TCC for CI, too.
  - As Docker-based tests are run on TCC, we could switch to faster and cheaper ARM-based workers for the rest of the build.
  - Instead of splitting up the integration tests into several parallel steps, we could just execute them in one and increase the JUnit fork count. This will create one TCC worker per fork. Note that this is not implemented yet on TCC.
  - Rely on TCC's image cache. Currently we don't cache any Docker images on our CI(!)