### PR TITLE
ci: support AWS ARN automation on release tag basis

### DIFF
--- a/.ci/Makefile
+++ b/.ci/Makefile
@@ -1,0 +1,90 @@
+SHELL = /bin/bash -eo pipefail
+
+AWS_FOLDER = .aws
+AWS_LAMBDA_ZIP_LOCATION = elastic-apm-agent/target
+
+export AWS_FOLDER
+
+dist: validate-branch-name
+	@cp $(AWS_LAMBDA_ZIP_LOCATION)/elastic-apm-java-aws-lambda-layer-*.zip $(AWS_LAMBDA_ZIP_LOCATION)/$(ELASTIC_LAYER_NAME).zip
+
+# List all the AWS regions
+get-all-aws-regions:
+	@aws \
+		ec2 \
+		describe-regions \
+		--region us-east-1 \
+		--output json \
+		--no-cli-pager \
+		| jq -r '.Regions[].RegionName' > .regions
+
+# Publish the given LAYER in all the AWS regions
+publish-in-all-aws-regions: validate-layer-name get-all-aws-regions dist
+	@mkdir -p $(AWS_FOLDER)
+	@while read AWS_DEFAULT_REGION; do \
+		echo "publish '$(ELASTIC_LAYER_NAME)' in $${AWS_DEFAULT_REGION}"; \
+		AWS_DEFAULT_REGION="$${AWS_DEFAULT_REGION}" ELASTIC_LAYER_NAME=$(ELASTIC_LAYER_NAME) $(MAKE) publish > $(AWS_FOLDER)/$${AWS_DEFAULT_REGION}; \
+		AWS_DEFAULT_REGION="$${AWS_DEFAULT_REGION}" ELASTIC_LAYER_NAME=$(ELASTIC_LAYER_NAME) $(MAKE) grant-public-layer-access; \
+	done <.regions
+
+# Publish the given LAYER in the given AWS region
+publish: validate-layer-name validate-aws-default-region
+	@aws lambda \
+		--output json \
+		publish-layer-version \
+		--layer-name "$(ELASTIC_LAYER_NAME)" \
+		--description "AWS Lambda Extension Layer for Elastic APM Java" \
+		--license "Apache-2.0" \
+		--zip-file "fileb://./$(AWS_LAMBDA_ZIP_LOCATION)/$(ELASTIC_LAYER_NAME).zip"
+
+# Grant public access to the given LAYER in the given AWS region
+grant-public-layer-access: validate-layer-name validate-aws-default-region
+	@echo "[debug] $(ELASTIC_LAYER_NAME) with version: $$($(MAKE) -s --no-print-directory get-version)"
+	@aws lambda \
+		--output json \
+		add-layer-version-permission \
+		--layer-name "$(ELASTIC_LAYER_NAME)" \
+		--action lambda:GetLayerVersion \
+		--principal '*' \
+		--statement-id "$(ELASTIC_LAYER_NAME)" \
+		--version-number $$($(MAKE) -s --no-print-directory get-version) > $(AWS_FOLDER)/.$(AWS_DEFAULT_REGION)-public
+
+# Generate the file with the ARN entries
+create-arn-file: validate-suffix-arn-file
+	@./create-arn-table.sh
+
+release-notes: validate-branch-name validate-suffix-arn-file
+	@gh release list
+	@gh \
+		release \
+		create $(BRANCH_NAME) \
+        --draft \
+		--title '$(BRANCH_NAME)' \
+		--notes-file $(SUFFIX_ARN_FILE) \
+		./$(AWS_LAMBDA_ZIP_LOCATION)/$(ELASTIC_LAYER_NAME).zip
+
+# Get the ARN Version for the AWS_REGIONS
+# NOTE: jq -r .Version "$(AWS_FOLDER)/$(AWS_DEFAULT_REGION)" fails in the CI
+#       with 'parse error: Invalid numeric literal at line 1, column 5'
+get-version: validate-aws-default-region
+	@grep '"Version"' "$(AWS_FOLDER)/$(AWS_DEFAULT_REGION)" | cut -d":" -f2 | sed 's/ //g' | cut -d"," -f1
+
+validate-branch-name:
+ifndef BRANCH_NAME
+	$(error BRANCH_NAME is undefined)
+endif
+
+validate-suffix-arn-file:
+ifndef SUFFIX_ARN_FILE
+	$(error SUFFIX_ARN_FILE is undefined)
+endif
+
+validate-layer-name:
+ifndef ELASTIC_LAYER_NAME
+	$(error ELASTIC_LAYER_NAME is undefined)
+endif
+
+validate-aws-default-region:
+ifndef AWS_DEFAULT_REGION
+	$(error AWS_DEFAULT_REGION is undefined)
+endif

--- a/.ci/create-arn-table.sh
+++ b/.ci/create-arn-table.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -o pipefail
+
+#
+# Create the AWS ARN table given the below environment variables:
+#
+#   - AWS_FOLDER      - that's the location of the publish-layer-version output for each region
+#	- SUFFIX_ARN_FILE - that's the output file.
+#	- RELEASE_VERSION - that's the release version to be published in GitHub.
+#
+
+ARN_FILE=${SUFFIX_ARN_FILE}
+
+{
+    echo "[Release Notes for ${RELEASE_VERSION}](https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-1.x.html#release-notes-${RELEASE_VERSION})"
+	echo ''
+	echo "### ARN"
+	echo ''
+	echo '|Region|ARN|'
+	echo '|------|---|'
+} > "${ARN_FILE}"
+
+for f in $(ls "${AWS_FOLDER}"); do
+	LAYER_VERSION_ARN=$(grep '"LayerVersionArn"' "$AWS_FOLDER/${f}" | cut -d":" -f2- | sed 's/ //g' | sed 's/"//g' | cut -d"," -f1)
+	echo "INFO: create-arn-table ARN(${LAYER_VERSION_ARN}):region(${f}))"
+	echo "|${f}|${LAYER_VERSION_ARN}|" >> "${ARN_FILE}"
+done
+
+echo '' >> "${ARN_FILE}"


### PR DESCRIPTION
## What does this PR do?

- Update release with the aws-lambda file
- Enable automation for the AWS lambda publishing
- Create ARN table with the details in each region.

## Question

- Do we want to use `.ci/release/Jenkinsfile` or the main pipeline?
  - Main pipeline simplifies the integration as we can test as many times as we want before making this change available. 
  - Release in another CI controller makes hard to go through the release iteration 

## Tasks

- Since there are no builds for `tag` releases, see https://github.com/elastic/apm-agent-java/pull/2414#issuecomment-1020952186, we need to figure out where to copy the aws-lambda.zip file from.