### PR TITLE
Fix LinkageError in apm-ecs-logging-plugin

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
@@ -68,7 +68,7 @@ public class IndyPluginClassLoader extends ByteArrayClassLoader.ChildFirst {
             // The list of packages not to load should correspond with matching dependency exclusions from the apm-agent-core in apm-agent-plugins/pom.xml
             // As we're using a custom logging facade, plugins don't need to refer to the agent-bundled log4j2 or slf4j.
             return new DiscriminatingMultiParentClassLoader(
-                agentClassLoader, not(startsWith("org.apache.logging.log4j").and(not(startsWith("org.slf4j")))),
+                agentClassLoader, not(startsWith("org.apache.logging.log4j").and(not(startsWith("org.slf4j")))).and(not(startsWith("co.elastic.logging.log4j2"))),
                 targetClassLoader, ElementMatchers.<String>any());
         }
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/classloading/IndyPluginClassLoader.java
@@ -68,7 +68,7 @@ public class IndyPluginClassLoader extends ByteArrayClassLoader.ChildFirst {
             // The list of packages not to load should correspond with matching dependency exclusions from the apm-agent-core in apm-agent-plugins/pom.xml
             // As we're using a custom logging facade, plugins don't need to refer to the agent-bundled log4j2 or slf4j.
             return new DiscriminatingMultiParentClassLoader(
-                agentClassLoader, not(startsWith("org.apache.logging.log4j").and(not(startsWith("org.slf4j")))).and(not(startsWith("co.elastic.logging.log4j2"))),
+                agentClassLoader, not(startsWith("org.apache.logging.log4j")).and(not(startsWith("org.slf4j"))).and(not(startsWith("co.elastic.logging.log4j2"))),
                 targetClassLoader, ElementMatchers.<String>any());
         }
     }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/Log4j2ServiceNameInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/Log4j2ServiceNameInstrumentation.java
@@ -19,6 +19,7 @@
 package co.elastic.apm.agent.ecs_logging;
 
 import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
+import co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.configuration.ServiceInfo;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
@@ -33,8 +34,14 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 public class Log4j2ServiceNameInstrumentation extends TracerAwareInstrumentation {
+
+    @Override
+    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
+        return not(CustomElementMatchers.isAgentClassLoader());
+    }
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {


### PR DESCRIPTION
## What does this PR do?
Fixes:
```
java.lang.IllegalAccessException: no such method: co.elastic.apm.agent.ecs_logging.Log4j2ServiceNameInstrumentation$AdviceClass.onEnter(Builder)void/invokeStatic
	at java.lang.invoke.MemberName.makeAccessException(MemberName.java:867) ~[?:1.8.0_322]
	at java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1003) ~[?:1.8.0_322]
	at java.lang.invoke.MethodHandles$Lookup.resolveOrFail(MethodHandles.java:1386) ~[?:1.8.0_322]
	at java.lang.invoke.MethodHandles$Lookup.findStatic(MethodHandles.java:780) ~[?:1.8.0_322]
	at co.elastic.apm.agent.bci.IndyBootstrap.bootstrap(IndyBootstrap.java:408) [elastic-apm-agent-1.28.5-SNAPSHOT.jar:?]
	at sun.reflect.GeneratedMethodAccessor7.invoke(Unknown Source) ~[?:?]
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_322]
	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_322]
	at java.lang.IndyBootstrapDispatcher.bootstrap(IndyBootstrapDispatcher.java:60) [?:1.8.0_322]
	at java.lang.invoke.CallSite.makeSite(CallSite.java:310) [?:1.8.0_322]
	at java.lang.invoke.MethodHandleNatives.linkCallSiteImpl(MethodHandleNatives.java:307) [?:1.8.0_322]
	at java.lang.invoke.MethodHandleNatives.linkCallSite(MethodHandleNatives.java:297) [?:1.8.0_322]
	at co.elastic.logging.log4j2.EcsLayout$Builder.build(EcsLayout.java:425) [log4j2-ecs-layout-1.3.2.jar:?]
	at co.elastic.logging.log4j2.EcsLayout$Builder.build(EcsLayout.java:328) [log4j2-ecs-layout-1.3.2.jar:?]
	at org.apache.logging.log4j.core.config.plugins.util.PluginBuilder.build(PluginBuilder.java:122) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.config.AbstractConfiguration.createPluginObject(AbstractConfiguration.java:1120) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.config.AbstractConfiguration.createConfiguration(AbstractConfiguration.java:1045) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.config.AbstractConfiguration.createConfiguration(AbstractConfiguration.java:1037) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.config.AbstractConfiguration.createConfiguration(AbstractConfiguration.java:1037) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.config.AbstractConfiguration.doConfigure(AbstractConfiguration.java:651) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.config.AbstractConfiguration.initialize(AbstractConfiguration.java:247) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.config.AbstractConfiguration.start(AbstractConfiguration.java:293) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.LoggerContext.setConfiguration(LoggerContext.java:626) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:699) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.LoggerContext.reconfigure(LoggerContext.java:716) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.LoggerContext.start(LoggerContext.java:270) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:155) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.core.impl.Log4jContextFactory.getContext(Log4jContextFactory.java:47) [log4j-core-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.LogManager.getContext(LogManager.java:196) [log4j-api-2.17.1.jar:2.17.1]
	at org.apache.logging.log4j.LogManager.getLogger(LogManager.java:599) [log4j-api-2.17.1.jar:2.17.1]
    ...
	at java.lang.Thread.run(Thread.java:750) [?:1.8.0_322]
Caused by: java.lang.LinkageError: bad method type alias: (Builder)void not visible from class co.elastic.apm.agent.ecs_logging.Log4j2ServiceNameInstrumentation$AdviceClass
	at java.lang.invoke.MemberName.checkForTypeAlias(MemberName.java:793) ~[?:1.8.0_322]
	at java.lang.invoke.MemberName$Factory.resolve(MemberName.java:976) ~[?:1.8.0_322]
	at java.lang.invoke.MemberName$Factory.resolveOrFail(MemberName.java:1000) ~[?:1.8.0_322]
	... 47 more
```

## Checklist
- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix