### PR TITLE
Setting agent CL as context CL for agent threads

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ExecutorUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ExecutorUtils.java
@@ -84,7 +84,7 @@ public final class ExecutorUtils {
             thread.setDaemon(true);
             thread.setName(threadName);
             ClassLoader originalContextCL = thread.getContextClassLoader();
-            thread.setContextClassLoader(null);
+            thread.setContextClassLoader(ExecutorUtils.class.getClassLoader());
             logThreadCreation(originalContextCL, threadName);
             return thread;
         }
@@ -116,7 +116,7 @@ public final class ExecutorUtils {
             String threadName = ThreadUtils.addElasticApmThreadPrefix(threadPurpose) + "-" + threadCounter.getAndIncrement();
             thread.setName(threadName);
             ClassLoader originalContextCL = thread.getContextClassLoader();
-            thread.setContextClassLoader(null);
+            thread.setContextClassLoader(ExecutorUtils.class.getClassLoader());
             logThreadCreation(originalContextCL, threadName);
             return thread;
         }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/ExecutorUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/ExecutorUtilsTest.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.util;
+
+import co.elastic.apm.agent.common.ThreadUtils;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ExecutorUtilsTest {
+
+    @Test
+    void testSingleThreadSchedulingDaemonPool() throws ExecutionException, InterruptedException, TimeoutException {
+        final String threadPurpose = "test-single-scheduling-pool";
+        ThreadPoolExecutor singleThreadDaemonPool = ExecutorUtils.createSingleThreadSchedulingDaemonPool(threadPurpose);
+        executeTestOnThreadPool(singleThreadDaemonPool, threadPurpose, 1);
+    }
+
+    @Test
+    void testSingleThreadDaemonPool() throws ExecutionException, InterruptedException, TimeoutException {
+        final String threadPurpose = "test-single-pool";
+        ThreadPoolExecutor singleThreadDaemonPool = ExecutorUtils.createSingleThreadDaemonPool(threadPurpose, 5);
+        executeTestOnThreadPool(singleThreadDaemonPool, threadPurpose, 1);
+    }
+
+    @Test
+    void testThreadDaemonPool() throws ExecutionException, InterruptedException, TimeoutException {
+        final String threadPurpose = "test-single-pool";
+        ThreadPoolExecutor singleThreadDaemonPool = ExecutorUtils.createThreadDaemonPool(threadPurpose, 3, 5);
+        executeTestOnThreadPool(singleThreadDaemonPool, threadPurpose, 3);
+    }
+
+    private void executeTestOnThreadPool(ThreadPoolExecutor singleThreadDaemonPool, String threadPurpose, int maxPoolSize)
+        throws InterruptedException, ExecutionException, TimeoutException {
+        assertThat(singleThreadDaemonPool.getPoolSize()).isEqualTo(0);
+        assertThat(singleThreadDaemonPool.getMaximumPoolSize()).isEqualTo(maxPoolSize);
+        final ClassLoader agentClassLoader = ExecutorUtils.class.getClassLoader();
+        try {
+            Future<Boolean> future = singleThreadDaemonPool.submit(() -> {
+                Thread currentThread = Thread.currentThread();
+                assertThat(currentThread.getName()).startsWith(ThreadUtils.addElasticApmThreadPrefix(threadPurpose));
+                assertThat(currentThread.isDaemon()).isTrue();
+                assertThat(currentThread.getContextClassLoader()).isEqualTo(agentClassLoader);
+                return true;
+            });
+            assertThat(singleThreadDaemonPool.getPoolSize()).isEqualTo(1);
+            assertThat(future.get(100, TimeUnit.MILLISECONDS)).isTrue();
+        } finally {
+            singleThreadDaemonPool.shutdown();
+        }
+    }
+}


### PR DESCRIPTION
## What does this PR do?
We never saw a need for that, but recently we got a report of a weird JULI bug in Tomcat 9, where it doesn't expect the context CL to be `null`:
```
[elastic-apm-metadata-1] WARN  co.elastic.apm.agent.impl.metadata.CloudMetadataProvider - Unexpected error during automatic discovery process for cloud provider
java.lang.NoClassDefFoundError: Could not initialize class sun.net.www.protocol.http.HttpURLConnection
        at sun.net.www.protocol.http.Handler.openConnection(Handler.java:62) ~[?:?]
        at ...
        at co.elastic.apm.agent.impl.metadata.CloudMetadataProvider.executeRequest(CloudMetadataProvider.java:418) ~
        ...
[elastic-apm-cloud-metadata-1] ERROR co.elastic.apm.agent.util.ExecutorUtils - Could not initialize class sun.net.www.protocol.http.HttpURLConnection
java.lang.NoClassDefFoundError: Could not initialize class sun.net.www.protocol.http.HttpURLConnection
        at sun.net.www.protocol.http.Handler.openConnection(Handler.java:62) ~[?:?]
        at ...
[elastic-apm-cloud-metadata-0] ERROR co.elastic.apm.agent.util.ExecutorUtils - null
java.lang.ExceptionInInitializerError: null
        at sun.net.www.protocol.http.Handler.openConnection(Handler.java:62) ~[?:?]
        at ...
Caused by: java.lang.NullPointerException
        at org.apache.juli.ClassLoaderLogManager.findProperty(ClassLoaderLogManager.java:311) ~[?:?]
        at org.apache.juli.ClassLoaderLogManager.getProperty(ClassLoaderLogManager.java:291) ~[?:?]
        at ...
        at sun.net.www.protocol.http.HttpURLConnection.<clinit>(HttpURLConnection.java:432) ~[?:?]
```

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->
- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
