### PR TITLE
Only time type/method matching if the debug logging is enabled

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,10 @@ endif::[]
 [float]
 ===== Features
 
+[float]
+===== Performance improvements
+* Only time type/method matching if the debug logging is enabled as the results are only used when debug logging is enabled - {pull}2471[#2471]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -258,10 +258,8 @@ public class ElasticApmAgent {
             @Override
             public void run() {
                 tracer.stop();
-                instrumentationStats.reset();
             }
         });
-        instrumentationStats.reset();
         Logger logger = getLogger();
         if (ElasticApmAgent.instrumentation != null) {
             logger.warn("Instrumentation has already been initialized");
@@ -397,7 +395,7 @@ public class ElasticApmAgent {
             }
         };
         return agentBuilder
-            .type(logger.isDebugEnabled() ? new AgentBuilder.RawMatcher() {
+            .type(instrumentationStats.shouldMeasureMatching() ? new AgentBuilder.RawMatcher() {
                 @Override
                 public boolean matches(TypeDescription typeDescription, ClassLoader classLoader, JavaModule module, Class<?> classBeingRedefined, ProtectionDomain protectionDomain) {
                     long start = System.nanoTime();
@@ -469,7 +467,7 @@ public class ElasticApmAgent {
             }
         };
         return new AgentBuilder.Transformer.ForAdvice(withCustomMapping)
-            .advice(logger.isDebugEnabled() ? new ElementMatcher<MethodDescription>() {
+            .advice(instrumentationStats.shouldMeasureMatching() ? new ElementMatcher<MethodDescription>() {
                 @Override
                 public boolean matches(MethodDescription target) {
                     long start = System.nanoTime();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/InstrumentationStats.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/InstrumentationStats.java
@@ -36,10 +36,13 @@ public final class InstrumentationStats {
 
     private final ConcurrentMap<String, MatcherTimer> matcherTimers = new ConcurrentHashMap<>();
 
+    private boolean measureMatching = false;
+
     void reset() {
         allInstrumentations.clear();
         usedInstrumentations.clear();
         matcherTimers.clear();
+        measureMatching = false;
     }
 
     void addInstrumentation(ElasticApmInstrumentation instrumentation) {
@@ -92,4 +95,11 @@ public final class InstrumentationStats {
         return matcherTimers.values();
     }
 
+    public void setMeasureMatching(boolean measureMatching) {
+        this.measureMatching = measureMatching;
+    }
+
+    public boolean shouldMeasureMatching() {
+        return measureMatching;
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/InstrumentationStatsLifecycleListener.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/InstrumentationStatsLifecycleListener.java
@@ -20,6 +20,7 @@ package co.elastic.apm.agent.bci;
 
 import co.elastic.apm.agent.bci.bytebuddy.MatcherTimer;
 import co.elastic.apm.agent.context.AbstractLifecycleListener;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 
@@ -30,10 +31,17 @@ public class InstrumentationStatsLifecycleListener extends AbstractLifecycleList
     private static final Logger logger = LoggerFactory.getLogger(InstrumentationStatsLifecycleListener.class);
 
     @Override
+    public void init(ElasticApmTracer tracer) {
+        InstrumentationStats instrumentationStats = ElasticApmAgent.getInstrumentationStats();
+        instrumentationStats.reset();
+        instrumentationStats.setMeasureMatching(logger.isDebugEnabled());
+    }
+
+    @Override
     public void stop() {
         InstrumentationStats instrumentationStats = ElasticApmAgent.getInstrumentationStats();
         logger.info("Used instrumentation groups: {}", instrumentationStats.getUsedInstrumentationGroups());
-        if (logger.isDebugEnabled()) {
+        if (instrumentationStats.shouldMeasureMatching()) {
             final ArrayList<MatcherTimer> matcherTimers = new ArrayList<>(instrumentationStats.getMatcherTimers());
             Collections.sort(matcherTimers);
             StringBuilder sb = new StringBuilder()


### PR DESCRIPTION
## What does this PR do?
Increase matching performance when debug logging is not enabled.

## Checklist
- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
