### PR TITLE
Do not try to instrument proxy classes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,10 @@ endif::[]
 ===== Features
 * Added support for setting service name and version for a transaction via the public api - {pull}2451[#2451]
 
+[float]
+===== Performance improvements
+* Proxy classes are excluded from instrumentation in more cases - {pull}2474[#2474]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-plugins/apm-jakarta-websocket-plugin/src/main/java/co/elastic/apm/agent/websocket/BaseServerEndpointInstrumentation.java
+++ b/apm-agent-plugins/apm-jakarta-websocket-plugin/src/main/java/co/elastic/apm/agent/websocket/BaseServerEndpointInstrumentation.java
@@ -35,9 +35,11 @@ import java.util.Collection;
 
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPackage;
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isProxy;
 import static co.elastic.apm.agent.impl.transaction.AbstractSpan.PRIO_HIGH_LEVEL_FRAMEWORK;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
+import static net.bytebuddy.matcher.ElementMatchers.isInterface;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
 import static net.bytebuddy.matcher.ElementMatchers.not;
@@ -63,7 +65,7 @@ public abstract class BaseServerEndpointInstrumentation extends TracerAwareInstr
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return isAnnotatedWith(named(getServerEndpointClassName()));
+        return not(isInterface()).and(not(isProxy())).and(isAnnotatedWith(named(getServerEndpointClassName())));
     }
 
     @Override

--- a/apm-agent-plugins/apm-jaxws-plugin/src/main/java/co/elastic/apm/agent/jaxws/JaxWsTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-jaxws-plugin/src/main/java/co/elastic/apm/agent/jaxws/JaxWsTransactionNameInstrumentation.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPackage;
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isProxy;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.overridesOrImplementsMethodThat;
 import static co.elastic.apm.agent.impl.transaction.AbstractSpan.PRIO_HIGH_LEVEL_FRAMEWORK;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
@@ -76,7 +77,7 @@ public class JaxWsTransactionNameInstrumentation extends TracerAwareInstrumentat
         // the implementations have to be annotated as well
         // quote from javadoc:
         // "Marks a Java class as implementing a Web Service, or a Java interface as defining a Web Service interface."
-        return isAnnotatedWith(namedOneOf("javax.jws.WebService", "jakarta.jws.WebService")).and(not(isInterface()));
+        return not(isInterface()).and(not(isProxy())).and(isAnnotatedWith(namedOneOf("javax.jws.WebService", "jakarta.jws.WebService")));
     }
 
     @Override

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-plugin-base/src/main/java/co/elastic/apm/agent/jms/JmsMessageListenerInstrumentation.java
@@ -31,6 +31,7 @@ import javax.jms.Destination;
 import javax.jms.JMSException;
 import javax.jms.Message;
 
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isProxy;
 import static co.elastic.apm.agent.jms.JmsInstrumentationHelper.MESSAGING_TYPE;
 import static co.elastic.apm.agent.jms.JmsInstrumentationHelper.RECEIVE_NAME_PREFIX;
 import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
@@ -47,7 +48,7 @@ public class JmsMessageListenerInstrumentation extends BaseJmsInstrumentation {
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return not(isInterface()).and(hasSuperType(named("javax.jms.MessageListener")));
+        return not(isInterface()).and(not(isProxy())).and(hasSuperType(named("javax.jms.MessageListener")));
     }
 
     @Override

--- a/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/scheduled/ScheduledTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/scheduled/ScheduledTransactionNameInstrumentation.java
@@ -39,9 +39,11 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPackage;
+import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isProxy;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.namedOneOf;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 public class ScheduledTransactionNameInstrumentation extends TracerAwareInstrumentation {
 
@@ -89,6 +91,7 @@ public class ScheduledTransactionNameInstrumentation extends TracerAwareInstrume
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
         return isInAnyPackage(applicationPackages, ElementMatchers.<NamedElement>none())
+            .and(not(isProxy()))
             .and(declaresMethod(getMethodMatcher()));
     }
 


### PR DESCRIPTION
## What does this PR do?
I started the agent with debug logging enabled (on a test system) and noticed that the `JavaxServerEndpointInstrumentation`, `JmsMessageListenerInstrumentation` and `ScheduledTransactionNameInstrumentation ` instrumented proxy classes generated by the JakartaEE runtime. As these proxies mostly just call the (also instrumented) implementation, instrumenting them is a waste of time.

## Checklist
- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
