### PR TITLE
Restricting Logback ECS-reformatting instrumentation to version 1.0.0

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchers.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/CustomElementMatchers.java
@@ -219,6 +219,9 @@ public class CustomElementMatchers {
                         Manifest manifest = jarFile.getManifest();
                         if (manifest != null) {
                             String implementationVersion = manifest.getMainAttributes().getValue("Implementation-Version");
+                            if (implementationVersion == null) {
+                                implementationVersion = manifest.getMainAttributes().getValue("Bundle-Version");
+                            }
                             if (implementationVersion != null) {
                                 version = Version.of(implementationVersion);
                             }

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/LogbackLogShadingInstrumentation.java
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/LogbackLogShadingInstrumentation.java
@@ -18,11 +18,13 @@
  */
 package co.elastic.apm.agent.logback;
 
+import co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers;
 import co.elastic.apm.agent.log.shader.AbstractLogShadingInstrumentation;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
+import java.security.ProtectionDomain;
 import java.util.Collection;
 
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
@@ -49,6 +51,11 @@ public abstract class LogbackLogShadingInstrumentation extends AbstractLogShadin
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
         return named("ch.qos.logback.core.OutputStreamAppender");
+    }
+
+    @Override
+    public ElementMatcher.Junction<ProtectionDomain> getProtectionDomainPostFilter() {
+        return CustomElementMatchers.implementationVersionGte("1.0.0");
     }
 
     public static class ShadingInstrumentation extends LogbackLogShadingInstrumentation {

--- a/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-legacy-tests/pom.xml
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-legacy-tests/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.1.0</version>
+            <version>1.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
In order to implement that, I added a fallback to look at the jar manifest's `Bundle-Version` if the `Implementation-Version` is unavailable