### PR TITLE
Create the Redis spans as exit spans

### DIFF
--- a/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/main/java/co/elastic/apm/agent/redis/RedisSpanUtils.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-redis-common/src/main/java/co/elastic/apm/agent/redis/RedisSpanUtils.java
@@ -28,11 +28,16 @@ public class RedisSpanUtils {
     @Nullable
     public static Span createRedisSpan(String command) {
         AbstractSpan<?> activeSpan = GlobalTracer.get().getActive();
-        if (activeSpan == null || activeSpan.isExit()) {
+        if (activeSpan == null) {
             return null;
         }
-        Span span = activeSpan.createSpan()
-            .withName(command)
+
+        Span span = activeSpan.createExitSpan();
+        if (span == null) {
+            return null;
+        }
+
+        span.withName(command)
             .withType("db")
             .withSubtype("redis")
             .withAction("query");
@@ -40,8 +45,6 @@ public class RedisSpanUtils {
             .withName("redis")
             .withResource("redis")
             .withType("db");
-        return span
-            .asExit()
-            .activate();
+        return span.activate();
     }
 }


### PR DESCRIPTION
## What does this PR do?
Instead of manually checking if the parent is an exit span, one can use `createExitSpan`.

## Checklist
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
