### PR TITLE
Instrumenting Logback only if both core AND classic classes available

### DIFF
--- a/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/LogbackLogShadingInstrumentation.java
+++ b/apm-agent-plugins/apm-log-shader-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/LogbackLogShadingInstrumentation.java
@@ -43,7 +43,9 @@ public abstract class LogbackLogShadingInstrumentation extends AbstractLogShadin
 
     @Override
     public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
-        return not(isBootstrapClassLoader()).and(classLoaderCanLoadClass("ch.qos.logback.core.OutputStreamAppender"));
+        return not(isBootstrapClassLoader())
+            .and(classLoaderCanLoadClass("ch.qos.logback.core.OutputStreamAppender"))
+            .and(classLoaderCanLoadClass("ch.qos.logback.classic.LoggerContext"));
     }
 
     @Override


### PR DESCRIPTION
In some OSGi systems, it is possible that `logback-classic` is not available from the context of `logback-core`.
We instrument a class from the latter and expect a class from the former to be available to the plugin class loader in order for ECS reformatting to work.
This PR doesn't fix the issue, meaning - Logback ECS-reformatting will not work in such cases, but it won't cause the huge amount of `NoClassDefFoundError`s that are caused by this.