### PR TITLE
Add micros time duration

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDuration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDuration.java
@@ -23,14 +23,14 @@ import java.util.regex.Pattern;
 
 public class TimeDuration implements Comparable<TimeDuration> {
 
-    public static final Pattern DURATION_PATTERN = Pattern.compile("^(-)?(\\d+)(ms|s|m)$");
+    public static final Pattern DURATION_PATTERN = Pattern.compile("^(-)?(\\d+)(us|ms|s|m)$");
     private final String durationString;
 
-    private final long durationMs;
+    private final long durationMicros;
 
-    private TimeDuration(String durationString, long durationMs) {
+    private TimeDuration(String durationString, long durationMicros) {
         this.durationString = durationString;
-        this.durationMs = durationMs;
+        this.durationMicros = durationMicros;
     }
 
     public static TimeDuration of(String durationString) {
@@ -48,23 +48,25 @@ public class TimeDuration implements Comparable<TimeDuration> {
 
     private static int getDurationMultiplier(String unit) {
         switch (unit) {
-            case "ms":
+            case "us":
                 return 1;
-            case "s":
+            case "ms":
                 return 1000;
+            case "s":
+                return 1000 *1000;
             case "m":
-                return 1000 * 60;
+                return 1000 * 1000 * 60;
             default:
                 throw new IllegalStateException("Duration unit '" + unit + "' is unknown");
         }
     }
 
     public long getMillis() {
-        return durationMs;
+        return durationMicros/1000;
     }
 
     public long getMicros() {
-        return 1000 * durationMs;
+        return durationMicros;
     }
 
     @Override
@@ -74,6 +76,6 @@ public class TimeDuration implements Comparable<TimeDuration> {
 
     @Override
     public int compareTo(TimeDuration o) {
-        return Long.compare(durationMs, o.durationMs);
+        return Long.compare(durationMicros, o.durationMicros);
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
@@ -39,7 +39,7 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
 
     @Override
     public TimeDuration convert(String s) throws IllegalArgumentException {
-        if (!s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
+        if (!s.endsWith("us") && !s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
             s += defaultDurationSuffix;
         }
         return TimeDuration.of(s);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationTest.java
@@ -30,6 +30,11 @@ class TimeDurationTest {
     @Test
     void testParseUnitSuccess() {
         assertSoftly(softly -> {
+            softly.assertThat(TimeDuration.of("1us").getMicros()).isEqualTo(1);
+            softly.assertThat(TimeDuration.of("-1us").getMicros()).isEqualTo(-1);
+            softly.assertThat(TimeDuration.of("1us").getMillis()).isEqualTo(0);
+
+            softly.assertThat(TimeDuration.of("1ms").getMicros()).isEqualTo(1000);
             softly.assertThat(TimeDuration.of("1ms").getMillis()).isEqualTo(1);
             softly.assertThat(TimeDuration.of("-1ms").getMillis()).isEqualTo(-1);
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverterTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverterTest.java
@@ -30,5 +30,8 @@ class TimeDurationValueConverterTest {
         assertThat(converter.convert("1").toString()).isEqualTo("1s");
         assertThat(converter.convert("1m").toString()).isEqualTo("1m");
         assertThat(converter.convert("1ms").toString()).isEqualTo("1ms");
+        assertThat(converter.convert("1us").toString()).isEqualTo("1us");
+        assertThat(converter.convert("1us").getMicros()).isEqualTo(1);
+        assertThat(converter.convert("1ms").getMicros()).isEqualTo(1000);
     }
 }


### PR DESCRIPTION
## What does this PR do?
https://github.com/elastic/apm/blob/main/specs/agents/handling-huge-traces/tracing-spans-drop-fast-exit.md requires us to support microsecond time durations with `us` as the unit, so that's added here

## Checklist
- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
