### PR TITLE
add granular/fine duration support (micros are only granular)

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDuration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDuration.java
@@ -34,13 +34,25 @@ public class TimeDuration implements Comparable<TimeDuration> {
     }
 
     public static TimeDuration of(String durationString) {
+        return with(durationString, false);
+    }
+
+    public static TimeDuration ofFine(String durationString) {
+        return with(durationString, true);
+    }
+
+    private static TimeDuration with(String durationString, boolean allowMicros) {
         Matcher matcher = DURATION_PATTERN.matcher(durationString);
         if (matcher.matches()) {
             long duration = Long.parseLong(matcher.group(2));
             if (matcher.group(1) != null) {
                 duration = duration * -1;
             }
-            return new TimeDuration(durationString, duration * getDurationMultiplier(matcher.group(3)));
+            String unit = matcher.group(3);
+            if (!allowMicros && "us".equals(unit)) {
+                throw new IllegalArgumentException("Invalid duration '" + durationString + "', 'us' are only supported for fine granular durations");
+            }
+            return new TimeDuration(durationString, duration * getDurationMultiplier(unit));
         } else {
             throw new IllegalArgumentException("Invalid duration '" + durationString + "'");
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
@@ -24,22 +24,38 @@ import org.stagemonitor.configuration.converter.AbstractValueConverter;
 public class TimeDurationValueConverter extends AbstractValueConverter<TimeDuration> {
 
     private final String defaultDurationSuffix;
+    private final boolean canUseMicros;
 
-    private TimeDurationValueConverter(String defaultDurationSuffix) {
+    private TimeDurationValueConverter(String defaultDurationSuffix, boolean canUseMicros) {
         this.defaultDurationSuffix = defaultDurationSuffix;
+        this.canUseMicros = canUseMicros;
     }
 
     public static TimeDurationValueConverter withDefaultDuration(String defaultDurationSuffix) {
-        return new TimeDurationValueConverter(defaultDurationSuffix);
+        return new TimeDurationValueConverter(defaultDurationSuffix, false);
+    }
+
+    public static TimeDurationValueConverter withDefaultFineDuration(String defaultDurationSuffix) {
+        return new TimeDurationValueConverter(defaultDurationSuffix, true);
     }
 
     public static ConfigurationOption.ConfigurationOptionBuilder<TimeDuration> durationOption(String defaultDuration) {
-        return ConfigurationOption.<TimeDuration>builder(new TimeDurationValueConverter(defaultDuration), TimeDuration.class);
+        return ConfigurationOption.<TimeDuration>builder(new TimeDurationValueConverter(defaultDuration, false), TimeDuration.class);
+    }
+
+    public static ConfigurationOption.ConfigurationOptionBuilder<TimeDuration> fineDurationOption(String defaultDuration) {
+        return ConfigurationOption.<TimeDuration>builder(new TimeDurationValueConverter(defaultDuration, true), TimeDuration.class);
     }
 
     @Override
     public TimeDuration convert(String s) throws IllegalArgumentException {
-        if (!s.endsWith("us") && !s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
+        if (this.canUseMicros) {
+            if (!s.endsWith("us") && !s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
+                s += defaultDurationSuffix;
+            }
+            return TimeDuration.ofFine(s);
+        }
+        if (!s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
             s += defaultDurationSuffix;
         }
         return TimeDuration.of(s);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
@@ -49,16 +49,10 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
 
     @Override
     public TimeDuration convert(String s) throws IllegalArgumentException {
-        if (this.canUseMicros) {
-            if (!s.endsWith("us") && !s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
-                s += defaultDurationSuffix;
-            }
-            return TimeDuration.ofFine(s);
-        }
-        if (!s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
+        if (!s.endsWith("us") && !s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
             s += defaultDurationSuffix;
         }
-        return TimeDuration.of(s);
+        return canUseMicros ? TimeDuration.ofFine(s) : TimeDuration.of(s);
     }
 
     @Override

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationTest.java
@@ -30,10 +30,6 @@ class TimeDurationTest {
     @Test
     void testParseUnitSuccess() {
         assertSoftly(softly -> {
-            softly.assertThat(TimeDuration.of("1us").getMicros()).isEqualTo(1);
-            softly.assertThat(TimeDuration.of("-1us").getMicros()).isEqualTo(-1);
-            softly.assertThat(TimeDuration.of("1us").getMillis()).isEqualTo(0);
-
             softly.assertThat(TimeDuration.of("1ms").getMicros()).isEqualTo(1000);
             softly.assertThat(TimeDuration.of("1ms").getMillis()).isEqualTo(1);
             softly.assertThat(TimeDuration.of("-1ms").getMillis()).isEqualTo(-1);
@@ -45,13 +41,32 @@ class TimeDurationTest {
 
             softly.assertThat(TimeDuration.of("3m").getMillis()).isEqualTo(180_000);
             softly.assertThat(TimeDuration.of("-3m").getMillis()).isEqualTo(-180_000);
+
+            softly.assertThat(TimeDuration.ofFine("1us").getMicros()).isEqualTo(1);
+            softly.assertThat(TimeDuration.ofFine("-1us").getMicros()).isEqualTo(-1);
+            softly.assertThat(TimeDuration.ofFine("1us").getMillis()).isEqualTo(0);
+
+            softly.assertThat(TimeDuration.ofFine("1ms").getMicros()).isEqualTo(1000);
+            softly.assertThat(TimeDuration.ofFine("1ms").getMillis()).isEqualTo(1);
+            softly.assertThat(TimeDuration.ofFine("-1ms").getMillis()).isEqualTo(-1);
+
+            softly.assertThat(TimeDuration.ofFine("2s").getMillis()).isEqualTo(2000);
+            softly.assertThat(TimeDuration.ofFine("-2s").getMillis()).isEqualTo(-2000);
+            softly.assertThat(TimeDuration.ofFine("2s").getMillis()).isEqualTo(2000);
+            softly.assertThat(TimeDuration.ofFine("60s").getMillis()).isEqualTo(60_000);
+
+            softly.assertThat(TimeDuration.ofFine("3m").getMillis()).isEqualTo(180_000);
+            softly.assertThat(TimeDuration.ofFine("-3m").getMillis()).isEqualTo(-180_000);
         });
     }
 
     @Test
     void testParseUnitInvalid() {
-        for (String invalid : List.of(" 1s", "1 s", "1s ", "1h")) {
+        for (String invalid : List.of("1us", " 1s", "1 s", "1s ", "1h")) {
             assertThatCode(() -> TimeDuration.of(invalid)).isInstanceOf(IllegalArgumentException.class);
+        }
+        for (String invalid : List.of(" 1s", "1 s", "1s ", "1h")) {
+            assertThatCode(() -> TimeDuration.ofFine(invalid)).isInstanceOf(IllegalArgumentException.class);
         }
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverterTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverterTest.java
@@ -21,6 +21,7 @@ package co.elastic.apm.agent.configuration.converter;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 
 class TimeDurationValueConverterTest {
 
@@ -30,8 +31,20 @@ class TimeDurationValueConverterTest {
         assertThat(converter.convert("1").toString()).isEqualTo("1s");
         assertThat(converter.convert("1m").toString()).isEqualTo("1m");
         assertThat(converter.convert("1ms").toString()).isEqualTo("1ms");
+        assertThat(converter.convert("1ms").getMicros()).isEqualTo(1000);
+
+        assertThatCode(() -> TimeDuration.of("1us")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void convertWithDefaultFineDuration() {
+        TimeDurationValueConverter converter = TimeDurationValueConverter.withDefaultFineDuration("s");
+        assertThat(converter.convert("1").toString()).isEqualTo("1s");
+        assertThat(converter.convert("1m").toString()).isEqualTo("1m");
+        assertThat(converter.convert("1ms").toString()).isEqualTo("1ms");
         assertThat(converter.convert("1us").toString()).isEqualTo("1us");
         assertThat(converter.convert("1us").getMicros()).isEqualTo(1);
         assertThat(converter.convert("1ms").getMicros()).isEqualTo(1000);
     }
+
 }


### PR DESCRIPTION
## What does this PR do?
Only GranularDuration config options can use microseconds (us)

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
