### PR TITLE
WebSocket requests should be captured with transaction type request

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ endif::[]
 [float]
 ===== Potentially breaking changes
 * Create the JDBC spans as exit spans- {pull}2484[#2484]
+* WebSocket requests are now captured with transaction type request instead of custom - {pull}2501[#2501]
 
 [float]
 ===== Features

--- a/apm-agent-plugins/apm-jakarta-websocket-plugin/src/main/java/co/elastic/apm/agent/websocket/BaseServerEndpointInstrumentation.java
+++ b/apm-agent-plugins/apm-jakarta-websocket-plugin/src/main/java/co/elastic/apm/agent/websocket/BaseServerEndpointInstrumentation.java
@@ -87,11 +87,11 @@ public abstract class BaseServerEndpointInstrumentation extends TracerAwareInstr
             if (currentTransaction == null) {
                 Transaction rootTransaction = tracer.startRootTransaction(Thread.currentThread().getContextClassLoader());
                 if (rootTransaction != null) {
-                    setTransactionName(rootTransaction, signature, frameworkName, frameworkVersion);
+                    setTransactionTypeAndName(rootTransaction, signature, frameworkName, frameworkVersion);
                     return rootTransaction.activate();
                 }
             } else {
-                setTransactionName(currentTransaction, signature, frameworkName, frameworkVersion);
+                setTransactionTypeAndName(currentTransaction, signature, frameworkName, frameworkVersion);
             }
 
             return null;
@@ -112,7 +112,8 @@ public abstract class BaseServerEndpointInstrumentation extends TracerAwareInstr
             }
         }
 
-        private static void setTransactionName(Transaction transaction, String signature, String frameworkName, @Nullable String frameworkVersion) {
+        private static void setTransactionTypeAndName(Transaction transaction, String signature, String frameworkName, @Nullable String frameworkVersion) {
+            transaction.withType(Transaction.TYPE_REQUEST);
             transaction.withName(signature, PRIO_HIGH_LEVEL_FRAMEWORK, false);
             transaction.setFrameworkName(frameworkName);
             transaction.setFrameworkVersion(frameworkVersion);

--- a/apm-agent-plugins/apm-jakarta-websocket-plugin/src/test/java/co/elastic/apm/agent/websocket/BaseServerEndpointInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jakarta-websocket-plugin/src/test/java/co/elastic/apm/agent/websocket/BaseServerEndpointInstrumentationTest.java
@@ -96,6 +96,7 @@ abstract class BaseServerEndpointInstrumentationTest extends AbstractInstrumenta
 
     private void assertReportedTransactionNameAndFramework(String methodName) {
         Transaction transaction = reporter.getFirstTransaction();
+        assertThat(transaction.getType()).isEqualTo("request");
         assertThat(transaction.getNameAsString()).isEqualTo(getWebSocketServerEndpointClassName() + '#' + methodName);
         assertThat(transaction.getFrameworkName()).isEqualTo(getFrameworkName());
         assertThat(transaction.getFrameworkVersion()).isEqualTo(getFrameworkVersion());


### PR DESCRIPTION
## What does this PR do?
WebSocket requests should be captured with transaction type request instead of custom.

## Checklist
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix