### PR TITLE
Discourage setting a TimeDuration without a duration suffix

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
@@ -71,4 +71,8 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
     public String getDefaultDurationSuffix() {
         return defaultDurationSuffix;
     }
+
+    public boolean isCanUseMicros() {
+        return canUseMicros;
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
@@ -32,7 +32,7 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
     }
 
     public static TimeDurationValueConverter withDefaultDuration() {
-        return new TimeDurationValueConverter(null, false);
+        return new TimeDurationValueConverter("", false);
     }
 
     @Deprecated
@@ -41,23 +41,20 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
     }
 
     public static TimeDurationValueConverter withDefaultFineDuration() {
-        return new TimeDurationValueConverter(null, true);
+        return new TimeDurationValueConverter("", true);
     }
 
     public static ConfigurationOption.ConfigurationOptionBuilder<TimeDuration> durationOption(String defaultDuration) {
         return ConfigurationOption.<TimeDuration>builder(new TimeDurationValueConverter(defaultDuration, false), TimeDuration.class);
     }
 
-    public static ConfigurationOption.ConfigurationOptionBuilder<TimeDuration> fineDurationOption(String defaultDuration) {
-        return ConfigurationOption.<TimeDuration>builder(new TimeDurationValueConverter(defaultDuration, true), TimeDuration.class);
+    public static ConfigurationOption.ConfigurationOptionBuilder<TimeDuration> fineDurationOption() {
+        return ConfigurationOption.<TimeDuration>builder(new TimeDurationValueConverter("", true), TimeDuration.class);
     }
 
     @Override
     public TimeDuration convert(String s) throws IllegalArgumentException {
         if (!s.endsWith("us") && !s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
-            if (defaultDurationSuffix == null) {
-                throw new IllegalArgumentException("'" + s + "' is missing a duration suffix");
-            }
             s += defaultDurationSuffix;
         }
         return canUseMicros ? TimeDuration.ofFine(s) : TimeDuration.of(s);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
@@ -67,4 +67,8 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
     public String toString(TimeDuration value) {
         return value.toString();
     }
+
+    public String getDefaultDurationSuffix() {
+        return defaultDurationSuffix;
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
@@ -65,10 +65,6 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
         return value.toString();
     }
 
-    public String getDefaultDurationSuffix() {
-        return defaultDurationSuffix;
-    }
-
     public boolean isCanUseMicros() {
         return canUseMicros;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverter.java
@@ -31,12 +31,17 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
         this.canUseMicros = canUseMicros;
     }
 
+    public static TimeDurationValueConverter withDefaultDuration() {
+        return new TimeDurationValueConverter(null, false);
+    }
+
+    @Deprecated
     public static TimeDurationValueConverter withDefaultDuration(String defaultDurationSuffix) {
         return new TimeDurationValueConverter(defaultDurationSuffix, false);
     }
 
-    public static TimeDurationValueConverter withDefaultFineDuration(String defaultDurationSuffix) {
-        return new TimeDurationValueConverter(defaultDurationSuffix, true);
+    public static TimeDurationValueConverter withDefaultFineDuration() {
+        return new TimeDurationValueConverter(null, true);
     }
 
     public static ConfigurationOption.ConfigurationOptionBuilder<TimeDuration> durationOption(String defaultDuration) {
@@ -50,6 +55,9 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
     @Override
     public TimeDuration convert(String s) throws IllegalArgumentException {
         if (!s.endsWith("us") && !s.endsWith("ms") && !s.endsWith("s") && !s.endsWith("m")) {
+            if (defaultDurationSuffix == null) {
+                throw new IllegalArgumentException("'" + s + "' is missing a duration suffix");
+            }
             s += defaultDurationSuffix;
         }
         return canUseMicros ? TimeDuration.ofFine(s) : TimeDuration.of(s);
@@ -58,9 +66,5 @@ public class TimeDurationValueConverter extends AbstractValueConverter<TimeDurat
     @Override
     public String toString(TimeDuration value) {
         return value.toString();
-    }
-
-    public String getDefaultDurationSuffix() {
-        return defaultDurationSuffix;
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverterTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverterTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class TimeDurationValueConverterTest {
 
@@ -38,8 +39,7 @@ class TimeDurationValueConverterTest {
 
     @Test
     void convertWithDefaultFineDuration() {
-        TimeDurationValueConverter converter = TimeDurationValueConverter.withDefaultFineDuration("s");
-        assertThat(converter.convert("1").toString()).isEqualTo("1s");
+        TimeDurationValueConverter converter = TimeDurationValueConverter.withDefaultFineDuration();
         assertThat(converter.convert("1m").toString()).isEqualTo("1m");
         assertThat(converter.convert("1ms").toString()).isEqualTo("1ms");
         assertThat(converter.convert("1us").toString()).isEqualTo("1us");
@@ -47,4 +47,11 @@ class TimeDurationValueConverterTest {
         assertThat(converter.convert("1ms").getMicros()).isEqualTo(1000);
     }
 
+    @Test
+    void convertWithoutDefaultDurationSuffix() {
+        assertThatThrownBy(() -> TimeDurationValueConverter.withDefaultDuration().convert("1"))
+            .isInstanceOf(IllegalArgumentException.class).hasMessage("'1' is missing a duration suffix");
+        assertThatThrownBy(() -> TimeDurationValueConverter.withDefaultFineDuration().convert("2"))
+            .isInstanceOf(IllegalArgumentException.class).hasMessage("'2' is missing a duration suffix");
+    }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverterTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/converter/TimeDurationValueConverterTest.java
@@ -50,8 +50,8 @@ class TimeDurationValueConverterTest {
     @Test
     void convertWithoutDefaultDurationSuffix() {
         assertThatThrownBy(() -> TimeDurationValueConverter.withDefaultDuration().convert("1"))
-            .isInstanceOf(IllegalArgumentException.class).hasMessage("'1' is missing a duration suffix");
+            .isInstanceOf(IllegalArgumentException.class).hasMessage("Invalid duration '1'");
         assertThatThrownBy(() -> TimeDurationValueConverter.withDefaultFineDuration().convert("2"))
-            .isInstanceOf(IllegalArgumentException.class).hasMessage("'2' is missing a duration suffix");
+            .isInstanceOf(IllegalArgumentException.class).hasMessage("Invalid duration '2'");
     }
 }

--- a/apm-agent/src/test/resources/configuration.asciidoc.ftl
+++ b/apm-agent/src/test/resources/configuration.asciidoc.ftl
@@ -123,7 +123,7 @@ Supports the duration suffixes `us`, `ms`, `s` and `m`.
 Supports the duration suffixes `ms`, `s` and `m`.
   </#if>
 Example: `${option.defaultValueAsString}`.
-  <#if option.valueConverter.defaultDurationSuffix??>
+  <#if option.valueConverter.defaultDurationSuffix?has_content>
 The default unit for this option is `${option.valueConverter.defaultDurationSuffix}`.
   </#if>
 </#if>
@@ -180,7 +180,7 @@ Valid options: <#list option.validOptionsLabelMap?values as validOption>`${valid
   <#else>
 # Supports the duration suffixes ms, s and m. Example: ${option.defaultValueAsString}.
   </#if>
-  <#if option.valueConverter.defaultDurationSuffix??>
+  <#if option.valueConverter.defaultDurationSuffix?has_content>
 # The default unit for this option is ${option.valueConverter.defaultDurationSuffix}.
   </#if>
 </#if>

--- a/apm-agent/src/test/resources/configuration.asciidoc.ftl
+++ b/apm-agent/src/test/resources/configuration.asciidoc.ftl
@@ -119,7 +119,9 @@ ${option.description}
 <#if option.valueType?matches("TimeDuration")>
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `${option.defaultValueAsString}`.
+  <#if option.valueConverter.defaultDurationSuffix??>
 The default unit for this option is `${option.valueConverter.defaultDurationSuffix}`.
+  </#if>
 </#if>
 <#if option.validOptions?has_content>
 Valid options: <#list option.validOptionsLabelMap?values as validOption>`${validOption}`<#if validOption_has_next>, </#if></#list>
@@ -169,8 +171,9 @@ Valid options: <#list option.validOptionsLabelMap?values as validOption>`${valid
     "This setting can not be changed at runtime. Changes require a restart of the application.")}
 # Type: ${option.valueType?matches("List|Collection")?then("comma separated list", option.valueType)}
 <#if option.valueType?matches("TimeDuration")>
-# Supports the duration suffixes ms, s and m. Example: ${option.defaultValueAsString}.
+  <#if option.valueConverter.defaultDurationSuffix??>
 # The default unit for this option is ${option.valueConverter.defaultDurationSuffix}.
+  </#if>
 </#if>
 # Default value: ${option.key?matches("service_name")?then(defaultServiceName?replace("\n", "\n# ", "r"), option.defaultValueAsString!)}
 #

--- a/apm-agent/src/test/resources/configuration.asciidoc.ftl
+++ b/apm-agent/src/test/resources/configuration.asciidoc.ftl
@@ -123,9 +123,6 @@ Supports the duration suffixes `us`, `ms`, `s` and `m`.
 Supports the duration suffixes `ms`, `s` and `m`.
   </#if>
 Example: `${option.defaultValueAsString}`.
-  <#if option.valueConverter.defaultDurationSuffix?has_content>
-The default unit for this option is `${option.valueConverter.defaultDurationSuffix}`.
-  </#if>
 </#if>
 <#if option.validOptions?has_content>
 Valid options: <#list option.validOptionsLabelMap?values as validOption>`${validOption}`<#if validOption_has_next>, </#if></#list>
@@ -179,9 +176,6 @@ Valid options: <#list option.validOptionsLabelMap?values as validOption>`${valid
 # Supports the duration suffixes us, ms, s and m. Example: ${option.defaultValueAsString}.
   <#else>
 # Supports the duration suffixes ms, s and m. Example: ${option.defaultValueAsString}.
-  </#if>
-  <#if option.valueConverter.defaultDurationSuffix?has_content>
-# The default unit for this option is ${option.valueConverter.defaultDurationSuffix}.
   </#if>
 </#if>
 # Default value: ${option.key?matches("service_name")?then(defaultServiceName?replace("\n", "\n# ", "r"), option.defaultValueAsString!)}

--- a/apm-agent/src/test/resources/configuration.asciidoc.ftl
+++ b/apm-agent/src/test/resources/configuration.asciidoc.ftl
@@ -117,7 +117,11 @@ ${option.description}
 <#if option.dynamic><<configuration-dynamic, image:./images/dynamic-config.svg[] >></#if>
 
 <#if option.valueType?matches("TimeDuration")>
+  <#if option.valueConverter.canUseMicros>
+Supports the duration suffixes `us`, `ms`, `s` and `m`.
+  <#else>
 Supports the duration suffixes `ms`, `s` and `m`.
+  </#if>
 Example: `${option.defaultValueAsString}`.
   <#if option.valueConverter.defaultDurationSuffix??>
 The default unit for this option is `${option.valueConverter.defaultDurationSuffix}`.
@@ -171,6 +175,11 @@ Valid options: <#list option.validOptionsLabelMap?values as validOption>`${valid
     "This setting can not be changed at runtime. Changes require a restart of the application.")}
 # Type: ${option.valueType?matches("List|Collection")?then("comma separated list", option.valueType)}
 <#if option.valueType?matches("TimeDuration")>
+  <#if option.valueConverter.canUseMicros>
+# Supports the duration suffixes us, ms, s and m. Example: ${option.defaultValueAsString}.
+  <#else>
+# Supports the duration suffixes ms, s and m. Example: ${option.defaultValueAsString}.
+  </#if>
   <#if option.valueConverter.defaultDurationSuffix??>
 # The default unit for this option is ${option.valueConverter.defaultDurationSuffix}.
   </#if>

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -230,7 +230,6 @@ The interval at which the agent polls the stress monitors. Must be at least `1s`
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `5s`.
-The default unit for this option is `s`.
 
 [options="header"]
 |============
@@ -311,7 +310,6 @@ order to detect a change of stress state. Must be at least `1m`.
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `1m`.
-The default unit for this option is `m`.
 
 [options="header"]
 |============
@@ -1137,7 +1135,6 @@ the higher of both thresholds will determine which spans will be discarded.
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `0ms`.
-The default unit for this option is `ms`.
 
 [options="header"]
 |============
@@ -1306,7 +1303,6 @@ such as calls to a database, can be discarded using this threshold.
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `0ms`.
-The default unit for this option is `ms`.
 
 [options="header"]
 |============
@@ -2121,7 +2117,6 @@ The minimal duration of a profiling-inferred span is the same as the value of th
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `50ms`.
-The default unit for this option is `ms`.
 
 [options="header"]
 |============
@@ -2149,7 +2144,6 @@ However, increasing the sampling interval also decreases the accuracy of the dur
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `0ms`.
-The default unit for this option is `ms`.
 
 [options="header"]
 |============
@@ -2417,7 +2411,6 @@ WARNING: If timeouts are disabled or set to a high value, your app could experie
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `5s`.
-The default unit for this option is `s`.
 
 [options="header"]
 |============
@@ -2525,7 +2518,6 @@ NOTE: This value has to be lower than the APM Server's `read_timeout` setting.
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `10s`.
-The default unit for this option is `s`.
 
 [options="header"]
 |============
@@ -2579,7 +2571,6 @@ Set to `0s` to deactivate.
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `30s`.
-The default unit for this option is `s`.
 
 [options="header"]
 |============
@@ -2753,7 +2744,6 @@ To disable stack trace collection for spans completely, set the value to `-1ms`.
 
 Supports the duration suffixes `ms`, `s` and `m`.
 Example: `5ms`.
-The default unit for this option is `ms`.
 
 [options="header"]
 |============
@@ -2799,7 +2789,6 @@ The default unit for this option is `ms`.
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 5s.
-# The default unit for this option is s.
 # Default value: 5s
 #
 # stress_monitoring_interval=5s
@@ -2834,7 +2823,6 @@ The default unit for this option is `ms`.
 # This setting can be changed at runtime
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 1m.
-# The default unit for this option is m.
 # Default value: 1m
 #
 # stress_monitor_cpu_duration_threshold=1m
@@ -3307,7 +3295,6 @@ The default unit for this option is `ms`.
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 0ms.
-# The default unit for this option is ms.
 # Default value: 0ms
 #
 # trace_methods_duration_threshold=0ms
@@ -3383,7 +3370,6 @@ The default unit for this option is `ms`.
 # This setting can be changed at runtime
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 0ms.
-# The default unit for this option is ms.
 # Default value: 0ms
 #
 # span_min_duration=0ms
@@ -3845,7 +3831,6 @@ The default unit for this option is `ms`.
 # This setting can be changed at runtime
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 50ms.
-# The default unit for this option is ms.
 # Default value: 50ms
 #
 # profiling_inferred_spans_sampling_interval=50ms
@@ -3857,7 +3842,6 @@ The default unit for this option is `ms`.
 # This setting can be changed at runtime
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 0ms.
-# The default unit for this option is ms.
 # Default value: 0ms
 #
 # profiling_inferred_spans_min_duration=0ms
@@ -3997,7 +3981,6 @@ The default unit for this option is `ms`.
 # This setting can be changed at runtime
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 5s.
-# The default unit for this option is s.
 # Default value: 5s
 #
 # server_timeout=5s
@@ -4044,7 +4027,6 @@ The default unit for this option is `ms`.
 # This setting can be changed at runtime
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 10s.
-# The default unit for this option is s.
 # Default value: 10s
 #
 # api_request_time=10s
@@ -4067,7 +4049,6 @@ The default unit for this option is `ms`.
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 30s.
-# The default unit for this option is s.
 # Default value: 30s
 #
 # metrics_interval=30s
@@ -4154,7 +4135,6 @@ The default unit for this option is `ms`.
 # This setting can be changed at runtime
 # Type: TimeDuration
 # Supports the duration suffixes ms, s and m. Example: 5ms.
-# The default unit for this option is ms.
 # Default value: 5ms
 #
 # span_stack_trace_min_duration=5ms


### PR DESCRIPTION
## What does this PR do?
It is discouraged to set a `TimeDuration` without a duration suffix (see #2491). I implemented support for enforcing this behavior.

## Checklist
- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation