### PR TITLE
Added support for collecting statistics about dropped exit spans

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ endif::[]
 * Added support for compressing spans - {pull}2477[#2477]
 * Added microsecond durations with `us` as unit - {pull}2496[#2496]
 * Added support for dropping fast exit spans - {pull}2491[#2491]
+* Added support for collecting statistics about dropped exit spans - {pull}2505[#2505]
 
 [float]
 ===== Performance improvements

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -383,6 +383,10 @@ public class ElasticApmTracer implements Tracer {
 
     public void endSpan(Span span) {
         if (!span.isSampled()) {
+            Transaction transaction = span.getTransaction();
+            if (transaction != null) {
+                transaction.captureDroppedSpan(span);
+            }
             span.decrementReferences();
             return;
         }
@@ -401,7 +405,7 @@ public class ElasticApmTracer implements Tracer {
             logger.debug("Discarding span {}", span);
             Transaction transaction = span.getTransaction();
             if (transaction != null) {
-                transaction.getSpanCount().getDropped().incrementAndGet();
+                transaction.captureDroppedSpan(span);
             }
             span.decrementReferences();
             return;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/DroppedSpanStats.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/DroppedSpanStats.java
@@ -122,8 +122,7 @@ public class DroppedSpanStats implements Iterable<Map.Entry<DroppedSpanStats.Sta
             return;
         }
 
-        StatsKey statsKey = statsKeyObjectPool.createInstance().init(resource, span.getOutcome());
-        Stats stats = getOrCreateStats(statsKey);
+        Stats stats = getOrCreateStats(resource.toString(), span.getOutcome());
         if (stats == null) {
             return;
         }
@@ -136,7 +135,8 @@ public class DroppedSpanStats implements Iterable<Map.Entry<DroppedSpanStats.Sta
         stats.sum.addAndGet(span.getDuration());
     }
 
-    private Stats getOrCreateStats(StatsKey statsKey) {
+    private Stats getOrCreateStats(String resource, Outcome oucome) {
+        StatsKey statsKey = statsKeyObjectPool.createInstance().init(resource, oucome);
         Stats stats = statsMap.get(statsKey);
         if (stats != null || statsMap.size() > 127) {
             statsKeyObjectPool.recycle(statsKey);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/DroppedSpanStats.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/DroppedSpanStats.java
@@ -1,0 +1,131 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.impl.transaction;
+
+import co.elastic.apm.agent.objectpool.Recyclable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class DroppedSpanStats implements Iterable<Map.Entry<DroppedSpanStats.StatsKey, DroppedSpanStats.StatsValue>>, Recyclable {
+
+    public static class StatsKey {
+        private final String destinationServiceResource;
+        private final Outcome outcome;
+
+        public StatsKey(CharSequence destinationServiceResource, Outcome outcome) {
+            this.destinationServiceResource = destinationServiceResource.toString();
+            this.outcome = outcome;
+        }
+
+        public String getDestinationServiceResource() {
+            return destinationServiceResource;
+        }
+
+        public Outcome getOutcome() {
+            return outcome;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            StatsKey statsKey = (StatsKey) o;
+            return destinationServiceResource.equals(statsKey.destinationServiceResource) && outcome == statsKey.outcome;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(destinationServiceResource, outcome);
+        }
+    }
+
+    public static class StatsValue {
+        private final AtomicInteger count = new AtomicInteger(0);
+        private final AtomicLong sum = new AtomicLong(0L);
+
+        public int getCount() {
+            return count.get();
+        }
+
+        public long getSum() {
+            return sum.get();
+        }
+    }
+
+    private final ConcurrentMap<StatsKey, StatsValue> statsMap = new ConcurrentHashMap<>();
+
+    StatsValue getStats(String destinationServiceResource, Outcome outcome) {
+        return statsMap.get(new StatsKey(destinationServiceResource, outcome));
+    }
+
+    public void captureDroppedSpan(Span span) {
+        StringBuilder resource = span.getContext().getDestination().getService().getResource();
+        if (!span.isExit() || resource.length() == 0) {
+            return;
+        }
+
+        StatsValue stats = getStats(new StatsKey(resource, span.getOutcome()));
+        if (stats == null) {
+            return;
+        }
+
+        if (span.isComposite()) {
+            stats.count.addAndGet(span.getComposite().getCount());
+        } else {
+            stats.count.incrementAndGet();
+        }
+        stats.sum.addAndGet(span.getDuration());
+    }
+
+    private StatsValue getStats(StatsKey statsKey) {
+        StatsValue statsValue = statsMap.get(statsKey);
+        if (statsValue != null) {
+            return statsValue;
+        }
+
+        synchronized (this) {
+            statsValue = statsMap.get(statsKey);
+            if (statsValue != null) {
+                return statsValue;
+            }
+            if (statsMap.size() < 128) {
+                statsValue = new StatsValue();
+                statsMap.put(statsKey, statsValue);
+                return statsValue;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public Iterator<Map.Entry<StatsKey, StatsValue>> iterator() {
+        return statsMap.entrySet().iterator();
+    }
+
+    @Override
+    public void resetState() {
+        statsMap.clear();
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -55,6 +55,7 @@ public class Transaction extends AbstractSpan<Transaction> {
      */
     private final TransactionContext context = new TransactionContext();
     private final SpanCount spanCount = new SpanCount();
+    private final DroppedSpanStats droppedSpanStats = new DroppedSpanStats();
     /**
      * type: subtype: timer
      * <p>
@@ -263,6 +264,17 @@ public class Transaction extends AbstractSpan<Transaction> {
         return spanCount;
     }
 
+    public void captureDroppedSpan(Span span) {
+        if (span.isSampled()) {
+            spanCount.getDropped().incrementAndGet();
+        }
+        droppedSpanStats.captureDroppedSpan(span);
+    }
+
+    public DroppedSpanStats getDroppedSpanStats() {
+        return droppedSpanStats;
+    }
+
     boolean isSpanLimitReached() {
         return getSpanCount().isSpanLimitReached(maxSpans);
     }
@@ -277,6 +289,7 @@ public class Transaction extends AbstractSpan<Transaction> {
         context.resetState();
         result = null;
         spanCount.resetState();
+        droppedSpanStats.resetState();
         type = null;
         noop = false;
         maxSpans = 0;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -1127,7 +1127,7 @@ public class DslJsonSerializer implements PayloadSerializer {
             jw.writeByte(OBJECT_START);
             writeField("destination_service_resource", stats.getKey().getDestinationServiceResource());
             writeField("outcome", stats.getKey().getOutcome().toString());
-            writeFieldName("destination");
+            writeFieldName("duration");
             jw.writeByte(OBJECT_START);
             writeField("count", stats.getValue().getCount());
             writeFieldName("sum");

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -1123,7 +1123,7 @@ public class DslJsonSerializer implements PayloadSerializer {
     private void serializeDroppedSpanStats(final DroppedSpanStats droppedSpanStats) {
         writeFieldName("dropped_spans_stats");
         jw.writeByte(ARRAY_START);
-        for (Map.Entry<DroppedSpanStats.StatsKey, DroppedSpanStats.StatsValue> stats : droppedSpanStats) {
+        for (Map.Entry<DroppedSpanStats.StatsKey, DroppedSpanStats.Stats> stats : droppedSpanStats) {
             jw.writeByte(OBJECT_START);
             writeField("destination_service_resource", stats.getKey().getDestinationServiceResource());
             writeField("outcome", stats.getKey().getOutcome().toString());

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -1123,7 +1123,12 @@ public class DslJsonSerializer implements PayloadSerializer {
     private void serializeDroppedSpanStats(final DroppedSpanStats droppedSpanStats) {
         writeFieldName("dropped_spans_stats");
         jw.writeByte(ARRAY_START);
+
+        int i = 0;
         for (Map.Entry<DroppedSpanStats.StatsKey, DroppedSpanStats.Stats> stats : droppedSpanStats) {
+            if (i++ >= 128) {
+                break;
+            }
             jw.writeByte(OBJECT_START);
             writeField("destination_service_resource", stats.getKey().getDestinationServiceResource());
             writeField("outcome", stats.getKey().getOutcome().toString());

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/FastExitSpanTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/FastExitSpanTest.java
@@ -68,6 +68,10 @@ class FastExitSpanTest {
         SpanCount spanCount = reporter.getFirstTransaction().getSpanCount();
         assertThat(spanCount.getReported().get()).isEqualTo(0);
         assertThat(spanCount.getDropped().get()).isEqualTo(1);
+
+        DroppedSpanStats droppedSpanStats = reporter.getFirstTransaction().getDroppedSpanStats();
+        assertThat(droppedSpanStats.getStats("postgresql", Outcome.SUCCESS).getCount()).isEqualTo(1);
+        assertThat(droppedSpanStats.getStats("postgresql", Outcome.SUCCESS).getSum()).isEqualTo(49_999L);
     }
 
     @Test
@@ -88,6 +92,10 @@ class FastExitSpanTest {
         SpanCount spanCount = reporter.getFirstTransaction().getSpanCount();
         assertThat(spanCount.getReported().get()).isEqualTo(0);
         assertThat(spanCount.getDropped().get()).isEqualTo(3);
+
+        DroppedSpanStats droppedSpanStats = reporter.getFirstTransaction().getDroppedSpanStats();
+        assertThat(droppedSpanStats.getStats("postgresql", Outcome.SUCCESS).getCount()).isEqualTo(3);
+        assertThat(droppedSpanStats.getStats("postgresql", Outcome.SUCCESS).getSum()).isEqualTo(30_000L);
     }
 
     @Test
@@ -104,6 +112,9 @@ class FastExitSpanTest {
         SpanCount spanCount = reporter.getFirstTransaction().getSpanCount();
         assertThat(spanCount.getReported().get()).isEqualTo(1);
         assertThat(spanCount.getDropped().get()).isEqualTo(0);
+
+        DroppedSpanStats droppedSpanStats = reporter.getFirstTransaction().getDroppedSpanStats();
+        assertThat(droppedSpanStats.getStats("postgresql", Outcome.SUCCESS)).isNull();
     }
 
     @Test
@@ -124,6 +135,9 @@ class FastExitSpanTest {
         SpanCount spanCount = reporter.getFirstTransaction().getSpanCount();
         assertThat(spanCount.getReported().get()).isEqualTo(1);
         assertThat(spanCount.getDropped().get()).isEqualTo(2);
+
+        DroppedSpanStats droppedSpanStats = reporter.getFirstTransaction().getDroppedSpanStats();
+        assertThat(droppedSpanStats.getStats("postgresql", Outcome.SUCCESS)).isNull();
     }
 
     private Transaction startTransaction() {


### PR DESCRIPTION
## What does this PR do?
Fixes #2084

## Checklist
- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation