### PR TITLE
[1.x] docs: fix release date (#2540)

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,7 +30,7 @@ endif::[]
 === Java Agent version 1.x
 
 [[release-notes-1.30.0]]
-==== 1.30.0 - 2020/03/22
+==== 1.30.0 - 2022/03/22
 
 [float]
 ===== Potentially breaking changes


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `1.x`:
 - [docs: fix release date (#2540)](https://github.com/elastic/apm-agent-java/pull/2540)

<!--- Backport version: 8.1.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)