### PR TITLE
Fixed AWS lambda support for missing AWS events classes

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -25,6 +25,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
+* Fixed AWS Lambda instrumentation for AWS handler classes with input object types that are not AWS Events classes  - {pull}2551[#2551]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-awslambda-plugin/src/main/java/co/elastic/apm/agent/awslambda/RequestHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-awslambda-plugin/src/main/java/co/elastic/apm/agent/awslambda/RequestHandlerInstrumentation.java
@@ -74,7 +74,7 @@ public class RequestHandlerInstrumentation extends AbstractAwsLambdaHandlerInstr
                 Transaction transaction = (Transaction) transactionObj;
 
                 if (output != null && output.getClass().getName().startsWith("com.amazonaws.services.lambda.runtime.events")) {
-                    // handler uses aws events, it's save to assume that the AWS events classes are available
+                    // handler uses aws events, it's safe to assume that the AWS events classes are available
                     AWSEventsHelper.finalizeTransaction(transaction, output, thrown);
                 } else {
                     // Fallback instrumentation (AWS events classes might be not available)

--- a/apm-agent-plugins/apm-awslambda-plugin/src/main/java/co/elastic/apm/agent/awslambda/RequestHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-awslambda-plugin/src/main/java/co/elastic/apm/agent/awslambda/RequestHandlerInstrumentation.java
@@ -18,22 +18,11 @@
  */
 package co.elastic.apm.agent.awslambda;
 
-import co.elastic.apm.agent.awslambda.helper.APIGatewayProxyV1TransactionHelper;
-import co.elastic.apm.agent.awslambda.helper.APIGatewayProxyV2TransactionHelper;
+import co.elastic.apm.agent.awslambda.helper.AWSEventsHelper;
 import co.elastic.apm.agent.awslambda.helper.PlainTransactionHelper;
-import co.elastic.apm.agent.awslambda.helper.S3TransactionHelper;
-import co.elastic.apm.agent.awslambda.helper.SNSTransactionHelper;
-import co.elastic.apm.agent.awslambda.helper.SQSTransactionHelper;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
-import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
-import com.amazonaws.services.lambda.runtime.events.S3Event;
-import com.amazonaws.services.lambda.runtime.events.SNSEvent;
-import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -67,26 +56,14 @@ public class RequestHandlerInstrumentation extends AbstractAwsLambdaHandlerInstr
 
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-        public static Object handlerEnter(@Advice.Argument(value = 0) Object input, @Advice.Argument(value = 1) Context lambdaContext) {
-            if (input instanceof APIGatewayV2HTTPEvent && ((APIGatewayV2HTTPEvent) input).getRequestContext() != null
-                && ((APIGatewayV2HTTPEvent) input).getRequestContext().getHttp() != null) {
-                // API Gateway V2 trigger
-                return APIGatewayProxyV2TransactionHelper.getInstance().startTransaction((APIGatewayV2HTTPEvent) input, lambdaContext);
-            } else if (input instanceof APIGatewayProxyRequestEvent && ((APIGatewayProxyRequestEvent) input).getRequestContext() != null) {
-                // API Gateway V1 trigger
-                return APIGatewayProxyV1TransactionHelper.getInstance().startTransaction((APIGatewayProxyRequestEvent) input, lambdaContext);
-            } else if (input instanceof SQSEvent) {
-                // SQS trigger
-                return SQSTransactionHelper.getInstance().startTransaction((SQSEvent) input, lambdaContext);
-            } else if (input instanceof SNSEvent) {
-                // SNS trigger
-                return SNSTransactionHelper.getInstance().startTransaction((SNSEvent) input, lambdaContext);
-            } else if (input instanceof S3Event) {
-                // S3 event trigger
-                return S3TransactionHelper.getInstance().startTransaction((S3Event) input, lambdaContext);
+        public static Object handlerEnter(@Nullable @Advice.Argument(value = 0) Object input, @Advice.Argument(value = 1) Context lambdaContext) {
+            if (input != null && input.getClass().getName().startsWith("com.amazonaws.services.lambda.runtime.events")) {
+                // handler uses aws events, it's save to assume that the AWS events classes are available
+                return AWSEventsHelper.startTransaction(input, lambdaContext);
+            } else {
+                // Fallback instrumentation (AWS events classes might be not available)
+                return PlainTransactionHelper.getInstance().startTransaction(input, lambdaContext);
             }
-            // Fallback instrumentation
-            return PlainTransactionHelper.getInstance().startTransaction(input, lambdaContext);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, inline = false, onThrowable = Throwable.class)
@@ -95,12 +72,12 @@ public class RequestHandlerInstrumentation extends AbstractAwsLambdaHandlerInstr
                                        @Nullable @Advice.Return Object output) {
             if (transactionObj instanceof Transaction) {
                 Transaction transaction = (Transaction) transactionObj;
-                if (output instanceof APIGatewayV2HTTPResponse) {
-                    APIGatewayProxyV2TransactionHelper.getInstance().finalizeTransaction(transaction, (APIGatewayV2HTTPResponse) output, thrown);
-                } else if (output instanceof APIGatewayProxyResponseEvent) {
-                    APIGatewayProxyV1TransactionHelper.getInstance().finalizeTransaction(transaction, (APIGatewayProxyResponseEvent) output, thrown);
+
+                if (output != null && output.getClass().getName().startsWith("com.amazonaws.services.lambda.runtime.events")) {
+                    // handler uses aws events, it's save to assume that the AWS events classes are available
+                    AWSEventsHelper.finalizeTransaction(transaction, output, thrown);
                 } else {
-                    // use PlainTransactionHelper for all triggers that do not expect an output
+                    // Fallback instrumentation (AWS events classes might be not available)
                     PlainTransactionHelper.getInstance().finalizeTransaction(transaction, output, thrown);
                 }
             }

--- a/apm-agent-plugins/apm-awslambda-plugin/src/main/java/co/elastic/apm/agent/awslambda/RequestHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-awslambda-plugin/src/main/java/co/elastic/apm/agent/awslambda/RequestHandlerInstrumentation.java
@@ -58,7 +58,7 @@ public class RequestHandlerInstrumentation extends AbstractAwsLambdaHandlerInstr
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object handlerEnter(@Nullable @Advice.Argument(value = 0) Object input, @Advice.Argument(value = 1) Context lambdaContext) {
             if (input != null && input.getClass().getName().startsWith("com.amazonaws.services.lambda.runtime.events")) {
-                // handler uses aws events, it's save to assume that the AWS events classes are available
+                // handler uses aws events, it's safe to assume that the AWS events classes are available
                 return AWSEventsHelper.startTransaction(input, lambdaContext);
             } else {
                 // Fallback instrumentation (AWS events classes might be not available)

--- a/apm-agent-plugins/apm-awslambda-plugin/src/main/java/co/elastic/apm/agent/awslambda/helper/AWSEventsHelper.java
+++ b/apm-agent-plugins/apm-awslambda-plugin/src/main/java/co/elastic/apm/agent/awslambda/helper/AWSEventsHelper.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.awslambda.helper;
+
+import co.elastic.apm.agent.impl.transaction.Transaction;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPEvent;
+import com.amazonaws.services.lambda.runtime.events.APIGatewayV2HTTPResponse;
+import com.amazonaws.services.lambda.runtime.events.S3Event;
+import com.amazonaws.services.lambda.runtime.events.SNSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+
+import javax.annotation.Nullable;
+
+public class AWSEventsHelper {
+
+    @Nullable
+    public static Transaction startTransaction(Object input, Context lambdaContext) {
+        if (input instanceof APIGatewayV2HTTPEvent && ((APIGatewayV2HTTPEvent) input).getRequestContext() != null
+            && ((APIGatewayV2HTTPEvent) input).getRequestContext().getHttp() != null) {
+            // API Gateway V2 trigger
+            return APIGatewayProxyV2TransactionHelper.getInstance().startTransaction((APIGatewayV2HTTPEvent) input, lambdaContext);
+        } else if (input instanceof APIGatewayProxyRequestEvent && ((APIGatewayProxyRequestEvent) input).getRequestContext() != null) {
+            // API Gateway V1 trigger
+            return APIGatewayProxyV1TransactionHelper.getInstance().startTransaction((APIGatewayProxyRequestEvent) input, lambdaContext);
+        } else if (input instanceof SQSEvent) {
+            // SQS trigger
+            return SQSTransactionHelper.getInstance().startTransaction((SQSEvent) input, lambdaContext);
+        } else if (input instanceof SNSEvent) {
+            // SNS trigger
+            return SNSTransactionHelper.getInstance().startTransaction((SNSEvent) input, lambdaContext);
+        } else if (input instanceof S3Event) {
+            // S3 event trigger
+            return S3TransactionHelper.getInstance().startTransaction((S3Event) input, lambdaContext);
+        }
+        return PlainTransactionHelper.getInstance().startTransaction(input, lambdaContext);
+    }
+
+    public static void finalizeTransaction(Transaction transaction, Object output, @Nullable Throwable thrown) {
+        if (output instanceof APIGatewayV2HTTPResponse) {
+            APIGatewayProxyV2TransactionHelper.getInstance().finalizeTransaction(transaction, (APIGatewayV2HTTPResponse) output, thrown);
+        } else if (output instanceof APIGatewayProxyResponseEvent) {
+            APIGatewayProxyV1TransactionHelper.getInstance().finalizeTransaction(transaction, (APIGatewayProxyResponseEvent) output, thrown);
+        } else {
+            // use PlainTransactionHelper for all triggers that do not expect an output
+            PlainTransactionHelper.getInstance().finalizeTransaction(transaction, output, thrown);
+        }
+    }
+}


### PR DESCRIPTION
When AWS handlers are using core types (e.g. String, Integer) as generic type for the handler class (instead of one of the AWS events types from the `com.amazonaws.services.lambda.runtime.events` package), then the current instrumentation throws a ClassNotFound exception because the `com.amazonaws.services.lambda.runtime.events` package might be not available.

This PR fixes this case.

- [x] successfully tested on AWS Lambda with the Hello world case in which the `events` package is not available