### PR TITLE
docs: Remove log correlation

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
@@ -149,14 +149,6 @@ public class LoggingConfiguration extends ConfigurationOptionProvider {
         .dynamic(false)
         .buildWithDefault(DEFAULT_LOG_FILE);
 
-    private final ConfigurationOption<Boolean> logCorrelationEnabled = ConfigurationOption.booleanOption()
-        .key("enable_log_correlation")
-        .configurationCategory(LOGGING_CATEGORY)
-        .description("DEPRECATED - since agent version 1.30.0, log correlation is on by default. If you wish to disable it, \n" +
-            "this can be done through the <<config-disable-instrumentations>> config.")
-        .dynamic(false)
-        .buildWithDefault(true);
-
     private final ConfigurationOption<LogEcsReformatting> logEcsReformatting = ConfigurationOption.enumOption(LogEcsReformatting.class)
         .key("log_ecs_reformatting")
         .configurationCategory(LOGGING_CATEGORY)

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -150,7 +150,6 @@ Click on a key to get more information.
 * <<config-logging>>
 ** <<config-log-level>>
 ** <<config-log-file>>
-** <<config-enable-log-correlation>>
 ** <<config-log-ecs-reformatting>>
 ** <<config-log-ecs-reformatting-additional-fields>>
 ** <<config-log-ecs-formatter-allow-list>>
@@ -1869,30 +1868,6 @@ When logging to std out, the log will be formatted as plain-text.
 |============
 | Java System Properties      | Property file   | Environment
 | `elastic.apm.log_file` | `log_file` | `ELASTIC_APM_LOG_FILE`
-|============
-
-// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
-[float]
-[[config-enable-log-correlation]]
-==== `enable_log_correlation`
-
-DEPRECATED - since agent version 1.30.0, log correlation is on by default. If you wish to disable it, 
-this can be done through the <<config-disable-instrumentations>> config.
-
-
-
-
-[options="header"]
-|============
-| Default                          | Type                | Dynamic
-| `true` | Boolean | false
-|============
-
-
-[options="header"]
-|============
-| Java System Properties      | Property file   | Environment
-| `elastic.apm.enable_log_correlation` | `enable_log_correlation` | `ELASTIC_APM_ENABLE_LOG_CORRELATION`
 |============
 
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
@@ -3791,15 +3766,6 @@ Example: `5ms`.
 # Default value: System.out
 #
 # log_file=System.out
-
-# DEPRECATED - since agent version 1.30.0, log correlation is on by default. If you wish to disable it, 
-# this can be done through the <<config-disable-instrumentations>> config.
-#
-# This setting can not be changed at runtime. Changes require a restart of the application.
-# Type: Boolean
-# Default value: true
-#
-# enable_log_correlation=true
 
 # Specifying whether and how the agent should automatically reformat application logs 
 # into {ecs-logging-ref}/index.html[ECS-compatible JSON], suitable for ingestion into Elasticsearch for 

--- a/docs/log-correlation.asciidoc
+++ b/docs/log-correlation.asciidoc
@@ -9,6 +9,10 @@ endif::[]
 Log correlation allows you to navigate to all logs belonging to a particular trace and vice-versa:
 for a specific log, see in which context it has been logged and which parameters the user provided.
 
+NOTE: Starting in APM agent version 1.30.0, log correlation is enabled by default.
+In previous versions, log correlation must be explicitly enabled by setting
+the `enable_log_correlation` configuration variable to `true`.
+
 [float]
 [[log-correlation-ingest]]
 === Step 1: Ingest your application logs into Elasticsearch


### PR DESCRIPTION
## What does this PR do?

This PR removes the `enable_log_correlation` docs now that cross-repo links have been removed.

Closes https://github.com/elastic/apm-agent-java/issues/2535.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
