### PR TITLE
Fix git commit ID

### DIFF
--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -13,9 +13,6 @@
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
-
-        <!-- default value that will be overloaded through commit-id plugin -->
-        <git.commit.id.abbrev>UNKNOWN</git.commit.id.abbrev>
     </properties>
 
     <dependencies>
@@ -173,9 +170,9 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
-                <version>4.0.2</version>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
+                <version>5.0.0</version>
                 <executions>
                     <execution>
                         <id>get-the-git-infos</id>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -179,6 +179,13 @@
                         <goals>
                             <goal>revision</goal>
                         </goals>
+                        <configuration>
+                            <verbose>true</verbose>
+                            <!-- enable by default when executing from CLI -->
+                            <skipViaCommandLine>false</skipViaCommandLine>
+                            <!-- use native git when executing from CLI (Jgit is unable to deal with worktrees) -->
+                            <useNativeGitViaCommandLine>true</useNativeGitViaCommandLine>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## What does this PR do?

Fixes #2565 

This fix removes the `UNKNOWN` default property and makes the build rely on the native `git` client when built from the CLI (which also include CI).

## Checklist

- [x] manual check with a worktree
- [x] manual check with main worktree (the one that has a .git folder)
- [x] check that fix works as expected on CI