### PR TITLE
Fix log4j init with SecurityManager

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -29,6 +29,7 @@ endif::[]
 * Fixed service name discovery based on MANIFEST.MF file through `ServletContainerInitializer#onStartup` on Jakarta Servlet containers -
 {pull}2546[#2546]
 * Fix shaded classloader package definition - {pull}2566[#2566]
+* Fix logging initialization with Security Manager - {pull}2568[#2568]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/Log4jLoggerFactoryBridge.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/Log4jLoggerFactoryBridge.java
@@ -28,19 +28,15 @@ import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 
 /**
- * Based on {@code org.apache.logging.slf4j.Log4jLoggerFactory}
+ * Based on {@code org.apache.logging.slf4j.Log4jLoggerFactory}.
+ * <p>
+ * This class does not implement {@link ILoggerFactory} directly but through the super class implementation that has
+ * a method matching {@link ILoggerFactory#getLogger(String)}. Given this method is caller-sensitive then we can't
+ * implement it directly without side effects.
  */
 public class Log4jLoggerFactoryBridge extends AbstractLoggerAdapter<Logger> implements ILoggerFactory {
 
-    private static final String FQCN = Log4jLoggerFactoryBridge.class.getName();
-    private static final String PACKAGE = "co.elastic.apm.agent.sdk.logging";
-
-    @Override
-    public Logger getLogger(String name) {
-        // parent class AbstractLoggerAdapter already 'implements' the method because it has the same signature
-        // this provides an actual implementation of ILoggerFactory while delegating explicitly to the parent impl.
-        return super.getLogger(name);
-    }
+    private static final String LOGGER_FACTORY = "co.elastic.apm.agent.sdk.logging.LoggerFactory";
 
     public static void shutdown() {
         LoggerContextFactory factory = LogManager.getFactory();
@@ -60,7 +56,12 @@ public class Log4jLoggerFactoryBridge extends AbstractLoggerAdapter<Logger> impl
 
     @Override
     protected LoggerContext getContext() {
-        final Class<?> anchor = StackLocatorUtil.getCallerClass(FQCN, PACKAGE);
-        return anchor == null ? LogManager.getContext() : getContext(StackLocatorUtil.getCallerClass(anchor));
+        // the logger context is defined by the class that calls LoggerFactory
+        final Class<?> factoryCaller = StackLocatorUtil.getCallerClass(LOGGER_FACTORY);
+        if (factoryCaller == null) {
+            return LogManager.getContext();
+        }
+        return getContext(factoryCaller);
     }
+
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/Log4jLoggerFactoryBridge.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/Log4jLoggerFactoryBridge.java
@@ -27,9 +27,6 @@ import org.apache.logging.log4j.spi.LoggerContext;
 import org.apache.logging.log4j.spi.LoggerContextFactory;
 import org.apache.logging.log4j.util.StackLocatorUtil;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 /**
  * Based on {@code org.apache.logging.slf4j.Log4jLoggerFactory}
  */
@@ -39,15 +36,10 @@ public class Log4jLoggerFactoryBridge extends AbstractLoggerAdapter<Logger> impl
     private static final String PACKAGE = "co.elastic.apm.agent.sdk.logging";
 
     @Override
-    public Logger getLogger(final String name) {
-        // we have to wrap into a doPrivileged call because the logging initialization often requires
-        // elevated privileges, for example to access the classloader when running with a security manager.
-        return AccessController.doPrivileged(new PrivilegedAction<Logger>() {
-            @Override
-            public Logger run() {
-                return Log4jLoggerFactoryBridge.super.getLogger(name);
-            }
-        });
+    public Logger getLogger(String name) {
+        // parent class AbstractLoggerAdapter already 'implements' the method because it has the same signature
+        // this provides an actual implementation of ILoggerFactory while delegating explicitly to the parent impl.
+        return super.getLogger(name);
     }
 
     public static void shutdown() {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/logging/LoggingConfigurationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/logging/LoggingConfigurationTest.java
@@ -136,11 +136,16 @@ class LoggingConfigurationTest {
 
         // stagemonitor relies on slf4j, which should be bridged to the same log4j registries and get the same configuration
         assertThat(configOptionLogger.isTraceEnabled()).isFalse();
-        assertThat(testLog4jContextFactory.getContext(configOptionLogger.getName())).isEqualTo(agentLoggerContext);
+        assertThat(testLog4jContextFactory.getContext(configOptionLogger.getName()))
+            .describedAs("configuration logger context should be the same as the agent logger context")
+            .isEqualTo(agentLoggerContext);
 
         LoggerContext pluginLoggerContext = testLog4jContextFactory.getContext(pluginLogger.getName());
         assertThat(pluginLoggerContext).isNotNull();
-        assertThat(pluginLoggerContext).isNotEqualTo(agentLoggerContext);
+        assertThat(pluginLoggerContext)
+            .describedAs("plugin logger context should be distinct from agent logger context")
+            .isNotEqualTo(agentLoggerContext);
+
         assertThat(pluginLoggerContext.getName()).startsWith(IndyPluginClassLoader.class.getName());
         assertThat(pluginLogger.isTraceEnabled()).isFalse();
 
@@ -231,7 +236,7 @@ class LoggingConfigurationTest {
             private final Map<ClassLoader, LoggerContext> contextMap = new HashMap<>();
 
             @Override
-            public LoggerContext getContext(String fqcn, ClassLoader loader, boolean currentContext) {
+            public LoggerContext getContext(String fqcn, @Nullable ClassLoader loader, boolean currentContext) {
                 if (loader == null) {
                     loader = ClassLoader.getSystemClassLoader();
                 }

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/logging/LoggerFactory.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/logging/LoggerFactory.java
@@ -18,6 +18,9 @@
  */
 package co.elastic.apm.agent.sdk.logging;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 public class LoggerFactory {
 
     private static volatile ILoggerFactory iLoggerFactory;
@@ -32,11 +35,19 @@ public class LoggerFactory {
      * @param name The name of the logger.
      * @return logger
      */
-    public static Logger getLogger(String name) {
+    public static Logger getLogger(final String name) {
         if (iLoggerFactory == null) {
             return NoopLogger.INSTANCE;
         }
-        return iLoggerFactory.getLogger(name);
+
+        // we have to wrap into a doPrivileged call because the logging initialization often requirest
+        // elevated privileges, for example to access the classloader when running with a security manager.
+        return AccessController.doPrivileged(new PrivilegedAction<Logger>() {
+            @Override
+            public Logger run() {
+                return iLoggerFactory.getLogger(name);
+            }
+        });
     }
 
     /**

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/logging/LoggerFactory.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/logging/LoggerFactory.java
@@ -18,6 +18,9 @@
  */
 package co.elastic.apm.agent.sdk.logging;
 
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
 public class LoggerFactory {
 
     private static volatile ILoggerFactory iLoggerFactory;
@@ -36,8 +39,12 @@ public class LoggerFactory {
         if (iLoggerFactory == null) {
             return NoopLogger.INSTANCE;
         }
-
-        return iLoggerFactory.getLogger(name);
+        return AccessController.doPrivileged(new PrivilegedAction<Logger>() {
+            @Override
+            public Logger run() {
+                return iLoggerFactory.getLogger(name);
+            }
+        });
     }
 
     /**

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/logging/LoggerFactory.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/logging/LoggerFactory.java
@@ -18,9 +18,6 @@
  */
 package co.elastic.apm.agent.sdk.logging;
 
-import java.security.AccessController;
-import java.security.PrivilegedAction;
-
 public class LoggerFactory {
 
     private static volatile ILoggerFactory iLoggerFactory;
@@ -40,14 +37,7 @@ public class LoggerFactory {
             return NoopLogger.INSTANCE;
         }
 
-        // we have to wrap into a doPrivileged call because the logging initialization often requirest
-        // elevated privileges, for example to access the classloader when running with a security manager.
-        return AccessController.doPrivileged(new PrivilegedAction<Logger>() {
-            @Override
-            public Logger run() {
-                return iLoggerFactory.getLogger(name);
-            }
-        });
+        return iLoggerFactory.getLogger(name);
     }
 
     /**


### PR DESCRIPTION
## What does this PR do?

Relates to #2550 

Simply wraps the logger init in a `doPrivileged` block to get the proper permissions when a Security Manager is present.

Moving the `doPrivileged` wrapping down to the `getLogger`  or `getContext` methods in `Log4jFactoryBridge` does not work as expected and we get other permission errors with ES, so we keep it in the caller side.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
  - [x] manually testing with ES
