### PR TITLE
[Flakey test] Trying to stablize AsyncTraceMethodInstrumentationTest

### DIFF
--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/AsyncTraceMethodInstrumentationTest.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/AsyncTraceMethodInstrumentationTest.java
@@ -39,7 +39,6 @@ import java.util.concurrent.Future;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.when;
 
 class AsyncTraceMethodInstrumentationTest {
 
@@ -53,9 +52,8 @@ class AsyncTraceMethodInstrumentationTest {
         reporter = mockInstrumentationSetup.getReporter();
         ConfigurationRegistry config = mockInstrumentationSetup.getConfig();
         coreConfiguration = config.getConfig(CoreConfiguration.class);
-        when(coreConfiguration.getTraceMethods()).thenReturn(Arrays.asList(
-            MethodMatcher.of("private co.elastic.apm.agent.concurrent.AsyncTraceMethodInstrumentationTest$TestAsyncTraceMethodsClass#*"))
-        );
+        MethodMatcher testTraceMethodMatcher = MethodMatcher.of("private co.elastic.apm.agent.concurrent.AsyncTraceMethodInstrumentationTest$TestAsyncTraceMethodsClass#*");
+        doReturn(Arrays.asList(testTraceMethodMatcher)).when(coreConfiguration).getTraceMethods();
 
         for (String tag : testInfo.getTags()) {
             TimeDuration duration = TimeDuration.of(tag.split("=")[1]);
@@ -68,6 +66,7 @@ class AsyncTraceMethodInstrumentationTest {
         }
 
         tracer = mockInstrumentationSetup.getTracer();
+        assertThat(tracer.getConfig(CoreConfiguration.class).getTraceMethods()).containsExactly(testTraceMethodMatcher);
         ElasticApmAgent.initInstrumentation(tracer, ByteBuddyAgent.install());
     }
 


### PR DESCRIPTION
Trying to fix random failures of this tests, like [this one](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-java%2Fapm-agent-java-mbp/detail/PR-2530/22/pipeline/).

Symptom:
```
Expected size: 1 but was: 0 in:
[]
	at co.elastic.apm.agent.concurrent.AsyncTraceMethodInstrumentationTest.testWithCrossedThreshold_Generic(AsyncTraceMethodInstrumentationTest.java:107)
	at ...
```

Possible reason: the `trace_methods` mockito setting that is required for this test is not properly applied, as the failed test stdout log does not contain `Applying instrumentation co.elastic.apm.agent.tracemethods.TraceMethodInstrumentation` and the instrumentation statistics don't contain this instrumentation as well:
```
2022-04-04 14:56:02,967 [main] INFO  co.elastic.apm.agent.bci.InstrumentationStatsLifecycleListener - Used instrumentation groups: [concurrent, executor, executor-collection, fork-join]
2022-04-04 14:56:02,969 [main] DEBUG co.elastic.apm.agent.bci.InstrumentationStatsLifecycleListener - Total time spent matching: 257,697,533ns
| Advice name                                        | Type ns         | Method ns       |
| ExecutorInstrumentation$ExecutorRunnableInstrumentation |     158,025,601 |      13,030,263 |
| ExecutorInstrumentation$ExecutorInvokeAnyAllInstrumentation |      16,329,958 |       8,931,580 |
| ExecutorInstrumentation$ExecutorCallableInstrumentation |      19,408,603 |       4,656,022 |
| ExecutorInstrumentation$ForkJoinPoolInstrumentation |      14,109,011 |       1,938,759 |
| ForkJoinTaskInstrumentation                        |       8,331,729 |         880,288 |
| SystemSingleEnvVariablesInstrumentation            |       4,283,984 |         635,255 |
| SystemAllEnvVariablesInstrumentation               |       2,933,219 |         645,812 |
| WarmupInstrumentation                              |       3,557,449 |               0 |

```