### PR TITLE
Security Manager log file fallback

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,7 +32,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
-
+* Fallback to standard output when Security Manager prevents writing to log file - {pull}2581[#2581]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/Log4j2ConfigurationFactory.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/Log4j2ConfigurationFactory.java
@@ -91,12 +91,20 @@ public class Log4j2ConfigurationFactory extends ConfigurationFactory {
                 logFile = logFile.replace(AGENT_HOME_PLACEHOLDER, agentHome);
             }
         }
-        logFile = new File(logFile).getAbsolutePath();
-        final File logDir = new File(logFile).getParentFile();
-        if (!logDir.exists()) {
-            logDir.mkdirs();
+
+        boolean canWrite;
+        try {
+            logFile = new File(logFile).getAbsolutePath();
+            final File logDir = new File(logFile).getParentFile();
+            if (!logDir.exists()) {
+                logDir.mkdirs();
+            }
+            canWrite = logDir.canWrite();
+        } catch (SecurityException e) {
+            canWrite = false;
         }
-        if (!logDir.canWrite()) {
+
+        if(!canWrite){
             System.err.println("[elastic-apm-agent] WARN Log file " + logFile + " is not writable. Falling back to System.out.");
             return SYSTEM_OUT;
         }


### PR DESCRIPTION
## What does this PR do?

When `log_file` configuration is set, but the configured Security Manager prevents access to the log file (or parent folder), we should properly fallback to using `System.out`.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
  - [x] manually tested with ES integration