### PR TITLE
fix comma missing from json dropped stats, adding test case

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,7 +32,7 @@ endif::[]
 
 [float]
 ===== Bug fixes
-
+* Fixed multiple dropped stats types in a transaction producing invalid JSON: {pull}2589[#2589]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -1189,6 +1189,9 @@ public class DslJsonSerializer implements PayloadSerializer {
             if (i++ >= 128) {
                 break;
             }
+            if (i > 1) {
+                jw.writeByte(COMMA);
+            }
             jw.writeByte(OBJECT_START);
             writeField("destination_service_resource", stats.getKey().getDestinationServiceResource());
             writeField("outcome", stats.getKey().getOutcome().toString());

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/FastExitSpanTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/FastExitSpanTest.java
@@ -75,7 +75,7 @@ class FastExitSpanTest {
     }
 
     @Test
-    void testCompositeExitSpanBelowDuration() {
+    void testCompositeExitSpanBelowDurationAndMoreThanOneDroppedSpanStatsEntry() {
         Transaction transaction = startTransaction();
         try {
             Span span = startExitSpan(transaction, 0L);
@@ -83,6 +83,11 @@ class FastExitSpanTest {
             startExitSpan(transaction, 10_000L).end(20_000L);
             startExitSpan(transaction, 20_000L).end(30_000L);
             assertThat(span.isComposite()).isTrue();
+            //second span destination to ensure more than one dropped span stats entry
+            Span span2 = startExitSpan(transaction, 30_000L, "mysql");
+            span2.end(40_000L);
+            startExitSpan(transaction, 40_000L, "mysql").end(50_000L);
+            assertThat(span2.isComposite()).isTrue();
         } finally {
             transaction.end();
         }
@@ -91,7 +96,7 @@ class FastExitSpanTest {
 
         SpanCount spanCount = reporter.getFirstTransaction().getSpanCount();
         assertThat(spanCount.getReported().get()).isEqualTo(0);
-        assertThat(spanCount.getDropped().get()).isEqualTo(3);
+        assertThat(spanCount.getDropped().get()).isEqualTo(5);
 
         DroppedSpanStats droppedSpanStats = reporter.getFirstTransaction().getDroppedSpanStats();
         assertThat(droppedSpanStats.getStats("postgresql", Outcome.SUCCESS).getCount()).isEqualTo(3);
@@ -145,7 +150,10 @@ class FastExitSpanTest {
     }
 
     protected Span startExitSpan(AbstractSpan<?> parent, long startTimestamp) {
-        Span span = parent.createExitSpan().withName("Some Name").withType("db").withSubtype("postgresql");
+    return startExitSpan(parent, startTimestamp, "postgresql");
+    }
+    protected Span startExitSpan(AbstractSpan<?> parent, long startTimestamp, String subtype) {
+        Span span = parent.createExitSpan().withName("Some Name").withType("db").withSubtype(subtype);
         span.getContext().getDestination().withAddress("127.0.0.1").withPort(5432);
         span.setStartTimestamp(startTimestamp);
 


### PR DESCRIPTION
## What does this PR do?
Per discussion https://discuss.elastic.co/t/apm-span-sample-fail-to-collect-on-child-service-using-1-30-0-java-agent/302861/3 if more than one dropped stats type is present in the dropped stats for a transaction, the json writer emits incorrect json. This PR fixes that and adds a test case that fails without the json writer fix

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
