### PR TITLE
[CI] report optional checks as passing for doc PRs.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
         script {
           dir("${BASE_DIR}"){
             // Skip all the stages except docs for PR's with asciidoc and md changes only
-            env.ONLY_DOCS = isGitRegionMatch(patterns: [ 'Jenkinsfile|.*\\.(asciidoc|md)' ], shouldMatchAll: true)
+            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
             // Prepare the env variables for the benchmark results
             env.COMMIT_ISO_8601 = sh(script: 'git log -1 -s --format=%cI', returnStdout: true).trim()
             env.NOW_ISO_8601 = sh(script: 'date -u "+%Y-%m-%dT%H%M%SZ"', returnStdout: true).trim()


### PR DESCRIPTION
When building docs, we skip most of the build pipeline and code-related tests.

In order to satisfy the branch protection rules, we need to artificially validate some required checks by marking them as `neutral`:
![Screenshot from 2022-04-29 13-47-23](https://user-images.githubusercontent.com/763082/165938719-544f752d-ba1b-4cfa-a661-8f3a39545f7e.png)


### Background

In Jenkins pipeline, there is currently no way to have a `skipped` block in `post` what would allow to still validate the GH checks when the steps are disabled : https://issues.jenkins.io/browse/JENKINS-49944 .

Using the `neutral` check status allows to indicate that the check was skipped : https://github.community/t/does-a-neutral-check-run-conclusion-satisfy-a-required-check/13706/5, see related [GH API doc](https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api), but does still makes the mandatory check valid.

### Alternative(s)

We could try to find a way to extend the default `stage` definition in order to wrap the whole `stage` execution with the proper GH checks notifications and also allow to report as `neutral` the check when the `stage` is skipped (not really sure if that's possible, and it sounds complicated for a corner-case usage).