### PR TITLE
Added instrumentation group to `WarmupInstrumentation`

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bbwarmup/WarmupInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bbwarmup/WarmupInstrumentation.java
@@ -60,7 +60,7 @@ public class WarmupInstrumentation extends TracerAwareInstrumentation {
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        return Collections.emptyList();
+        return Collections.singletonList("instrumentation-warmup");
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?
`WarmupInstrumentation` should have an instrumentation group, so it can be enabled when using `enable_instrumentations` configuration option.

## Checklist
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
