### PR TITLE
Fix windows build

### DIFF
--- a/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/test/java/co/elastic/apm/agent/log4j2/Log4j2InstrumentationTest.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/test/java/co/elastic/apm/agent/log4j2/Log4j2InstrumentationTest.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.RandomAccessFileAppender;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -95,7 +96,10 @@ public class Log4j2InstrumentationTest extends LoggingInstrumentationTest {
         @Override
         public void open() {
             log4j2Logger = LogManager.getLogger("Test-File-Logger");
-            ((org.apache.logging.log4j.core.Logger) log4j2Logger).getContext().setConfigLocation(configLocation);
+            assertThat(log4j2Logger).isInstanceOf(org.apache.logging.log4j.core.Logger.class);
+
+            LoggerContext loggerContext = ((org.apache.logging.log4j.core.Logger) log4j2Logger).getContext();
+            loggerContext.setConfigLocation(configLocation);
         }
 
         @Override
@@ -105,8 +109,8 @@ public class Log4j2InstrumentationTest extends LoggingInstrumentationTest {
 
         @Override
         public String getLogFilePath() {
-            assertThat(log4j2Logger).isNotNull();
-            assertThat(log4j2Logger).isInstanceOf(org.apache.logging.log4j.core.Logger.class);
+            assertThat(log4j2Logger)
+                .isInstanceOf(org.apache.logging.log4j.core.Logger.class);
             org.apache.logging.log4j.core.Logger logger = (org.apache.logging.log4j.core.Logger) log4j2Logger;
 
             assertThat(logger.getAppenders()).containsKey("FILE");

--- a/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/test/java/co/elastic/apm/agent/log4j2/Log4j2InstrumentationTest.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/test/java/co/elastic/apm/agent/log4j2/Log4j2InstrumentationTest.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.Appender;
 import org.apache.logging.log4j.core.appender.RandomAccessFileAppender;
 import org.apache.logging.log4j.core.config.ConfigurationFactory;
 import org.junit.jupiter.api.AfterAll;
@@ -36,6 +37,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Since the agent core uses log4j 2.12.4, and since both agent core and tests are loaded by the system class loader in unit tests,
@@ -102,7 +105,15 @@ public class Log4j2InstrumentationTest extends LoggingInstrumentationTest {
 
         @Override
         public String getLogFilePath() {
-            return ((RandomAccessFileAppender) ((org.apache.logging.log4j.core.Logger) log4j2Logger).getAppenders().get("FILE")).getFileName();
+            assertThat(log4j2Logger).isNotNull();
+            assertThat(log4j2Logger).isInstanceOf(org.apache.logging.log4j.core.Logger.class);
+            org.apache.logging.log4j.core.Logger logger = (org.apache.logging.log4j.core.Logger) log4j2Logger;
+
+            assertThat(logger.getAppenders()).containsKey("FILE");
+            Appender fileAppender = logger.getAppenders().get("FILE");
+            assertThat(fileAppender).isInstanceOf(RandomAccessFileAppender.class);
+
+            return ((RandomAccessFileAppender) fileAppender).getFileName();
         }
 
         @Override

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -181,10 +181,6 @@
                         </goals>
                         <configuration>
                             <verbose>true</verbose>
-                            <!-- enable by default when executing from CLI -->
-<!--                            <skipViaCommandLine>false</skipViaCommandLine>-->
-                            <!-- use native git when executing from CLI (Jgit is unable to deal with worktrees) -->
-                            <useNativeGitViaCommandLine>true</useNativeGitViaCommandLine>
                         </configuration>
                     </execution>
                 </executions>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -182,7 +182,7 @@
                         <configuration>
                             <verbose>true</verbose>
                             <!-- enable by default when executing from CLI -->
-                            <skipViaCommandLine>false</skipViaCommandLine>
+<!--                            <skipViaCommandLine>false</skipViaCommandLine>-->
                             <!-- use native git when executing from CLI (Jgit is unable to deal with worktrees) -->
                             <useNativeGitViaCommandLine>true</useNativeGitViaCommandLine>
                         </configuration>

--- a/elastic-apm-agent/pom.xml
+++ b/elastic-apm-agent/pom.xml
@@ -23,6 +23,22 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>git-worktree</id>
+            <activation>
+                <file>
+                    <!-- in a secondary worktree, '.git' is a file, not a folder -->
+                    <missing>.git/HEAD</missing>
+                </file>
+            </activation>
+            <properties>
+                <!-- when using git worktrees, native git client is required as JGit does not support this yet -->
+                <maven.gitcommitid.nativegit>true</maven.gitcommitid.nativegit>
+            </properties>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -298,19 +298,6 @@
                 </plugins>
             </build>
         </profile>
-        <profile>
-            <id>git-worktree</id>
-            <activation>
-                <file>
-                    <!-- in a secondary worktree, '.git' is a file, not a folder -->
-                    <missing>.git/HEAD</missing>
-                </file>
-            </activation>
-            <properties>
-                <!-- when using git worktrees, native git client is required as JGit does not support this yet -->
-                <maven.gitcommitid.nativegit>true</maven.gitcommitid.nativegit>
-            </properties>
-        </profile>
     </profiles>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -298,6 +298,19 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>git-worktree</id>
+            <activation>
+                <file>
+                    <!-- in a secondary worktree, '.git' is a file, not a folder -->
+                    <missing>.git/HEAD</missing>
+                </file>
+            </activation>
+            <properties>
+                <!-- when using git worktrees, native git client is required as JGit does not support this yet -->
+                <maven.gitcommitid.nativegit>true</maven.gitcommitid.nativegit>
+            </properties>
+        </profile>
     </profiles>
 
     <build>


### PR DESCRIPTION
The `-Dmaven.gitcommitid.skip=...`  maven CLI argument gets ignored when we also add `skipViaCommandLine` in the plugin configuration.

Found the underlying issue details in the source code : https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/315

This configuration was initially added as an attempt to keep the build compatible with git-worktrees (which I'm personally heavily reliant on). The proper (and seamless) fix is to activate a maven profile to switch to `git` native client only when required instead of skipping the whole `git-commit-id` plugin through configuration.