### PR TITLE
Add basic span links capabilities

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -265,13 +265,13 @@ public class TraceContext implements Recyclable {
     }
 
     @SuppressWarnings("unchecked")
-    public static <C> ChildContextCreatorTwoArg<C, TextHeaderGetter<C>> getFromTraceContextTextHeaders() {
-        return (ChildContextCreatorTwoArg<C, TextHeaderGetter<C>>) FROM_TRACE_CONTEXT_TEXT_HEADERS;
+    public static <C> ChildContextCreatorTwoArg<C, HeaderGetter<String, C>> getFromTraceContextTextHeaders() {
+        return (ChildContextCreatorTwoArg<C, HeaderGetter<String, C>>) FROM_TRACE_CONTEXT_TEXT_HEADERS;
     }
 
     @SuppressWarnings("unchecked")
-    public static <C> ChildContextCreatorTwoArg<C, BinaryHeaderGetter<C>> getFromTraceContextBinaryHeaders() {
-        return (ChildContextCreatorTwoArg<C, BinaryHeaderGetter<C>>) FROM_TRACE_CONTEXT_BINARY_HEADERS;
+    public static <C> ChildContextCreatorTwoArg<C, HeaderGetter<byte[], C>> getFromTraceContextBinaryHeaders() {
+        return (ChildContextCreatorTwoArg<C, HeaderGetter<byte[], C>>) FROM_TRACE_CONTEXT_BINARY_HEADERS;
     }
 
     public static ChildContextCreator<Tracer> fromActive() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/objectpool/ObjectPoolFactory.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/objectpool/ObjectPoolFactory.java
@@ -21,6 +21,7 @@ package co.elastic.apm.agent.objectpool;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
 import org.jctools.queues.atomic.AtomicQueueFactory;
@@ -56,6 +57,15 @@ public class ObjectPoolFactory {
                 @Override
                 public ErrorCapture createInstance() {
                     return new ErrorCapture(tracer);
+                }
+            });
+    }
+
+    public ObjectPool<TraceContext> createSpanLinkPool(int maxCapacity, final ElasticApmTracer tracer) {
+        return createRecyclableObjectPool(maxCapacity, new Allocator<TraceContext>() {
+                @Override
+                public TraceContext createInstance() {
+                    return TraceContext.with64BitId(tracer);
                 }
             });
     }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
@@ -18,7 +18,6 @@
  */
 package co.elastic.apm.agent;
 
-import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.configuration.SpyConfiguration;
 import co.elastic.apm.agent.context.ClosableLifecycleListenerAdapter;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
@@ -26,8 +25,6 @@ import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
 import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
 import co.elastic.apm.agent.report.ApmServerClient;
 import co.elastic.apm.agent.report.Reporter;
-import co.elastic.apm.agent.report.ReporterConfiguration;
-import co.elastic.apm.agent.util.Version;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import static org.mockito.ArgumentMatchers.any;

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/SpanTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/SpanTest.java
@@ -19,22 +19,37 @@
 package co.elastic.apm.agent.impl.transaction;
 
 import co.elastic.apm.agent.MockTracer;
+import co.elastic.apm.agent.impl.BinaryHeaderMapAccessor;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
 import co.elastic.apm.agent.impl.sampling.ConstantSampler;
+import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 class SpanTest {
 
+    private ElasticApmTracer tracer;
+
+    @BeforeEach
+    void setUp() {
+        tracer = MockTracer.createRealTracer();
+    }
+
     @Test
     void resetState() {
-        Span span = new Span(MockTracer.create())
+        Span span = new Span(tracer)
             .withName("SELECT FROM product_types")
             .withType("db")
             .withSubtype("postgresql")
@@ -55,7 +70,7 @@ class SpanTest {
 
     @Test
     void testOutcomeExplicitlyToUnknown() {
-        Transaction transaction = MockTracer.createRealTracer().startRootTransaction(null);
+        Transaction transaction = tracer.startRootTransaction(null);
         assertThat(transaction).isNotNull();
         Span span = transaction.createSpan()
             .withName("SELECT FROM product_types")
@@ -72,7 +87,7 @@ class SpanTest {
 
     @Test
     void normalizeEmptyFields() {
-        Span span = new Span(MockTracer.create())
+        Span span = new Span(tracer)
             .withName("span");
 
         assertThat(span.withType("").getType()).isNull();
@@ -84,23 +99,16 @@ class SpanTest {
     @MethodSource("typeTestArguments")
     void normalizeType(String type, String expectedType) {
 
-        ElasticApmTracer tracer = MockTracer.createRealTracer();
         Transaction transaction = new Transaction(tracer);
-
         transaction.start(TraceContext.asRoot(), null, 0, ConstantSampler.of(true));
         try {
             Span span = new Span(tracer);
-
             span.start(TraceContext.fromParent(), transaction, -1L);
-
             assertThat(span.getType())
                 .describedAs("span type should not be set by default")
                 .isNull();
-
             span.withType(type);
-
             span.end();
-
             assertThat(span.getType()).isEqualTo(expectedType);
         } finally {
             transaction.end();
@@ -114,5 +122,37 @@ class SpanTest {
             Arguments.of(null, "custom"),
             Arguments.of("my-type", "my-type")
         );
+    }
+
+    @Test
+    void testSpanLinks() {
+        TestObjectPoolFactory objectPoolFactory = (TestObjectPoolFactory) tracer.getObjectPoolFactory();
+        Transaction transaction = tracer.startRootTransaction(null);
+        Span testSpan = Objects.requireNonNull(transaction).createSpan();
+        assertThat(objectPoolFactory.getSpanLinksPool().getObjectsInPool()).isEqualTo(0);
+        assertThat(objectPoolFactory.getSpanLinksPool().getRequestedObjectCount()).isEqualTo(0);
+        assertThat(testSpan.getSpanLinks()).isEmpty();
+        Span parent1 = transaction.createSpan();
+        Map<String, String> textTraceContextCarrier = new HashMap<>();
+        parent1.propagateTraceContext(textTraceContextCarrier, TextHeaderMapAccessor.INSTANCE);
+        testSpan.addSpanLink(TraceContext.getFromTraceContextTextHeaders(), TextHeaderMapAccessor.INSTANCE, textTraceContextCarrier);
+        assertThat(objectPoolFactory.getSpanLinksPool().getObjectsInPool()).isEqualTo(0);
+        assertThat(objectPoolFactory.getSpanLinksPool().getRequestedObjectCount()).isEqualTo(1);
+        assertThat(testSpan.getSpanLinks()).hasSize(1);
+        Span parent2 = transaction.createSpan();
+        Map<String, byte[]> binaryTraceContextCarrier = new HashMap<>();
+        parent2.propagateTraceContext(binaryTraceContextCarrier, BinaryHeaderMapAccessor.INSTANCE);
+        testSpan.addSpanLink(TraceContext.getFromTraceContextBinaryHeaders(), BinaryHeaderMapAccessor.INSTANCE, binaryTraceContextCarrier);
+        assertThat(objectPoolFactory.getSpanLinksPool().getObjectsInPool()).isEqualTo(0);
+        assertThat(objectPoolFactory.getSpanLinksPool().getRequestedObjectCount()).isEqualTo(2);
+        List<TraceContext> spanLinks = testSpan.getSpanLinks();
+        assertThat(spanLinks).hasSize(2);
+        assertThat(spanLinks.get(0).getTraceId()).isEqualTo(parent1.getTraceContext().getTraceId());
+        assertThat(spanLinks.get(0).getParentId()).isEqualTo(parent1.getTraceContext().getId());
+        assertThat(spanLinks.get(1).getTraceId()).isEqualTo(parent2.getTraceContext().getTraceId());
+        assertThat(spanLinks.get(1).getParentId()).isEqualTo(parent2.getTraceContext().getId());
+        testSpan.resetState();
+        assertThat(objectPoolFactory.getSpanLinksPool().getObjectsInPool()).isEqualTo(2);
+        assertThat(testSpan.getSpanLinks()).isEmpty();
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/TestObjectPoolFactory.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/TestObjectPoolFactory.java
@@ -21,6 +21,7 @@ package co.elastic.apm.agent.objectpool;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.objectpool.impl.BookkeeperObjectPool;
 
@@ -39,6 +40,7 @@ public class TestObjectPoolFactory extends ObjectPoolFactory {
     private BookkeeperObjectPool<Transaction> transactionPool;
     private BookkeeperObjectPool<Span> spanPool;
     private BookkeeperObjectPool<ErrorCapture> errorPool;
+    private BookkeeperObjectPool<TraceContext> spanLinksPool;
 
     @Override
     protected <T extends Recyclable> ObjectPool<T> createRecyclableObjectPool(int maxCapacity, Allocator<T> allocator) {
@@ -108,6 +110,12 @@ public class TestObjectPoolFactory extends ObjectPoolFactory {
         return errorPool;
     }
 
+    @Override
+    public ObjectPool<TraceContext> createSpanLinkPool(int maxCapacity, ElasticApmTracer tracer) {
+        spanLinksPool = (BookkeeperObjectPool<TraceContext>) super.createSpanLinkPool(maxCapacity, tracer);
+        return spanLinksPool;
+    }
+
     public BookkeeperObjectPool<Transaction> getTransactionPool() {
         return transactionPool;
     }
@@ -118,5 +126,9 @@ public class TestObjectPoolFactory extends ObjectPoolFactory {
 
     public BookkeeperObjectPool<ErrorCapture> getErrorPool() {
         return errorPool;
+    }
+
+    public BookkeeperObjectPool<TraceContext> getSpanLinksPool() {
+        return spanLinksPool;
     }
 }


### PR DESCRIPTION
## What does this PR do?
Closes #2489:
- [x] Adding basic span links capabilities
- [ ] Add span link to polling spans in all messaging plugins
- [ ] Kafka: when there is an active transaction before the beginning of the iteration - create a message-handling span for each record with a single link to the sending span, if such exists. Otherwise- create a transaction per record
- [ ] [SpringAmqpBatchMessageListenerInstrumentation](https://github.com/elastic/apm-agent-java/blob/2a60d89e8d981c34b41cf4fd417eb938662c8873/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-spring/src/main/java/co/elastic/apm/agent/rabbitmq/SpringAmqpBatchMessageListenerInstrumentation.java) - same as Kafka (if makes sense)
- [ ] AWS Lambda functions triggered by SNS/SQS: create one transaction always and add span links
- [ ] Add to changelog and elsewhere in documentation if required