### PR TITLE
Finalize Vert.x 3.x HTTP 1 transactions when response completes

### DIFF
--- a/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/main/java/co/elastic/apm/agent/vertx/v3/web/http2/Http2ServerResponseImplEndInstrumentation.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/main/java/co/elastic/apm/agent/vertx/v3/web/http2/Http2ServerResponseImplEndInstrumentation.java
@@ -42,7 +42,7 @@ public abstract class Http2ServerResponseImplEndInstrumentation extends WebInstr
     }
 
     /**
-     * Instruments {@link Http2ServerResponseImpl#write(ByteBuf, boolean)}to remove transaction mapping for this response.
+     * Instruments {@link Http2ServerResponseImpl#write(ByteBuf, boolean)} to remove transaction mapping for this response.
      */
     public static class WriteInstrumentation extends Http2ServerResponseImplEndInstrumentation {
         @Override
@@ -60,7 +60,7 @@ public abstract class Http2ServerResponseImplEndInstrumentation extends WebInstr
 
             @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
             public static void writeExit(@Advice.This Http2ServerResponseImpl response,
-                                    @Advice.Argument(1) boolean end) {
+                                         @Advice.Argument(1) boolean end) {
                 if (end) {
                     Transaction transaction = WebHelper.getInstance().removeTransactionMapping(response);
                     log.debug("VERTX-DEBUG: removing transaction {} mapping to response {}", transaction, response);

--- a/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-vertx/apm-vertx3-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -7,10 +7,11 @@ co.elastic.apm.agent.vertx.v3.TaskQueueInstrumentation
 # vertx web
 co.elastic.apm.agent.vertx.v3.web.WebInstrumentation$RouteInstrumentation
 co.elastic.apm.agent.vertx.v3.web.WebInstrumentation$RequestBufferInstrumentation
-co.elastic.apm.agent.vertx.v3.web.HttpServerRequestImplEndInstrumentation
 co.elastic.apm.agent.vertx.v3.web.HttpServerRequestWrapperInstrumentation
 co.elastic.apm.agent.vertx.v3.web.http1.Http1StartTransactionInstrumentation
+co.elastic.apm.agent.vertx.v3.web.http1.Http1EndTransactionInstrumentation
 co.elastic.apm.agent.vertx.v3.web.http2.Http2StartTransactionInstrumentation
+co.elastic.apm.agent.vertx.v3.web.http2.Http2ServerRequestImplEndInstrumentation
 co.elastic.apm.agent.vertx.v3.web.http2.Http2ServerResponseImplEndInstrumentation$WriteInstrumentation
 co.elastic.apm.agent.vertx.v3.web.http2.Http2ServerResponseImplEndInstrumentation$CloseInstrumentation
 


### PR DESCRIPTION
## What does this PR do?
A followup on #2564 - in Vert.x HTTP 1 request processing, the engine considers response completion as the end of request handling. The logic introduced in #2564 ends the transaction based on request end event, thus causes mismatch between the reported transaction duration and the request handling duration measured by Vert.x. 
This PR tries to eliminate this discrepancy by ending the transaction at the same time as measured by Vert.x.

## Checklist
- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - ~~[ ] I have added tests that would fail without this fix~~
  - [ ] This fix was verified by the reporting user
