### PR TITLE
release: add opbeans stage

### DIFF
--- a/.ci/jobs/apm-agent-java-mbp.yml
+++ b/.ci/jobs/apm-agent-java-mbp.yml
@@ -12,8 +12,8 @@
             discover-pr-forks-strategy: merge-current
             discover-pr-forks-trust: permission
             discover-pr-origin: merge-current
-            discover-tags: true
-            head-filter-regex: '(main|PR-.*|v\d+\.\d+\.\d+.*)'
+            discover-tags: false
+            head-filter-regex: '(main|PR-.*)'
             notification-context: 'apm-ci'
             repo: apm-agent-java
             repo-owner: elastic

--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -270,6 +270,23 @@ pipeline {
             }
           }
         }
+        stage('Opbeans') {
+          environment {
+            // The gitPush and gitCreateTag steps require this env variable
+            REPO_NAME = 'opbeans-java'
+          }
+          steps {
+            deleteDir()
+            git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                url: "git@github.com:elastic/${REPO_NAME}.git",
+                branch: 'main')
+            sh(script: ".ci/bump-version.sh ${RELEASE_VERSION}", label: 'Bump version')
+            // The opbeans-java pipeline will trigger a release for the main branch
+            gitPush()
+            // The opbeans-java pipeline will trigger a release for the release tag
+            gitCreateTag(tag: "${RELEASE_VERSION}")
+          }
+        }
       }
       post {
         failure {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -95,12 +95,6 @@ pipeline {
     }
     stage('Builds') {
       options { skipDefaultCheckout() }
-      when {
-        // Tags are not required to be built/tested.
-        not {
-          tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
-        }
-      }
       environment {
         HOME = "${env.WORKSPACE}"
         JAVA_HOME = "${env.HUDSON_HOME}/.java/${env.JAVA_VERSION}"
@@ -431,10 +425,7 @@ pipeline {
     }
     stage('Releases') {
       when {
-        anyOf {
-          branch 'main'
-          tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
-        }
+        branch 'main'
       }
       stages {
         stage('Stable') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -458,6 +458,7 @@ pipeline {
             }
           }
         }
+      }
     }
   }
   post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,6 @@ pipeline {
     GITHUB_CHECK_ITS_NAME = 'End-To-End Integration Tests'
     ITS_PIPELINE = 'apm-integration-tests-selector-mbp/main'
     MAVEN_CONFIG = '-Dmaven.repo.local=.m2'
-    OPBEANS_REPO = 'opbeans-java'
     JAVA_VERSION = "${params.JAVA_VERSION}"
     JOB_GCS_BUCKET_STASH = 'apm-ci-temp'
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
@@ -459,34 +458,6 @@ pipeline {
             }
           }
         }
-        stage('AfterRelease') {
-          options { skipDefaultCheckout() }
-          when {
-            tag pattern: 'v\\d+\\.\\d+\\.\\d+', comparator: 'REGEXP'
-          }
-          stages {
-            stage('Opbeans') {
-              environment {
-                REPO_NAME = "${OPBEANS_REPO}"
-              }
-              steps {
-                deleteDir()
-                dir("${OPBEANS_REPO}"){
-                  git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-                      url: "git@github.com:elastic/${OPBEANS_REPO}.git",
-                      branch: 'main')
-                  // It's required to transform the tag value to the artifact version
-                  sh script: ".ci/bump-version.sh ${env.BRANCH_NAME.replaceAll('^v', '')}", label: 'Bump version'
-                  // The opbeans-java pipeline will trigger a release for the main branch
-                  gitPush()
-                  // The opbeans-java pipeline will trigger a release for the release tag
-                  gitCreateTag(tag: "${env.BRANCH_NAME}")
-                }
-              }
-            }
-          }
-        }
-      }
     }
   }
   post {


### PR DESCRIPTION
## What does this PR do?

Stop running the `opbeans` stage in the main pipeline when a release tag is created and use the post-release pipeline to run the same stage.
