### PR TITLE
Update AWS SDK dependencies monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,3 +40,20 @@ updates:
       - dependency-name: "org.slf4j:slf4j-api"
         # A static arbitrary version used within our external plugin test
         versions: ["<=1.7.25"]
+      # Since these AWS dependencies are heavy and are being released very frequently, we ignore in the weekly update and update monthly
+      - dependency-name: "com.amazonaws:aws-java-sdk-s3"
+      - dependency-name: "com.amazonaws:aws-java-sdk-dynamodb"
+      - dependency-name: "com.amazonaws:aws-java-sdk"
+      - dependency-name: "software.amazon.awssdk:*"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "@elastic/apm-agent-java"
+    allow:
+      - dependency-name: "com.amazonaws:aws-java-sdk-s3"
+      - dependency-name: "com.amazonaws:aws-java-sdk-dynamodb"
+      - dependency-name: "com.amazonaws:aws-java-sdk"
+      - dependency-name: "software.amazon.awssdk:*"


### PR DESCRIPTION
Using the maven version range syntax (e.g. `[1.12.1,0`) is not an option as it causes huge delays when resolving dependencies.
Simple resolving also takes some time, and since these dependencies are release VERY frequently, we don't want our local maven caches to become invalid on every update. Since our AWS SDK plugins rely on internal APIs, we still want to make sure we stay compatible with latest versions, so we will update monthly.