### PR TITLE
Jakarta websocket upgrade to 2.1.0

### DIFF
--- a/apm-agent-plugins/apm-jakarta-websocket-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jakarta-websocket-plugin/pom.xml
@@ -25,8 +25,14 @@
         <dependency>
             <groupId>jakarta.websocket</groupId>
             <artifactId>jakarta.websocket-api</artifactId>
-            <version>2.0.0</version>
+            <version>2.1.0</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.websocket</groupId>
+            <artifactId>jakarta.websocket-client-api</artifactId>
+            <version>2.1.0</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/apm-agent-plugins/apm-jakarta-websocket-plugin/src/test/java/co/elastic/apm/agent/websocket/JakartaServerEndpointInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jakarta-websocket-plugin/src/test/java/co/elastic/apm/agent/websocket/JakartaServerEndpointInstrumentationTest.java
@@ -38,6 +38,6 @@ class JakartaServerEndpointInstrumentationTest extends BaseServerEndpointInstrum
 
     @Override
     protected String getFrameworkVersion() {
-        return "2.0.0";
+        return "2.1.0";
     }
 }

--- a/apm-agent-plugins/apm-jakarta-websocket-plugin/src/test/java/co/elastic/apm/agent/websocket/JakartaServerEndpointInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jakarta-websocket-plugin/src/test/java/co/elastic/apm/agent/websocket/JakartaServerEndpointInstrumentationTest.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.apm.agent.websocket;
 
+import co.elastic.apm.agent.util.VersionUtils;
 import co.elastic.apm.agent.websocket.endpoint.JakartaServerEndpoint;
 
 class JakartaServerEndpointInstrumentationTest extends BaseServerEndpointInstrumentationTest {
@@ -38,6 +39,6 @@ class JakartaServerEndpointInstrumentationTest extends BaseServerEndpointInstrum
 
     @Override
     protected String getFrameworkVersion() {
-        return "2.1.0";
+        return VersionUtils.getVersion(jakarta.websocket.server.ServerEndpoint.class, "jakarta.websocket", "jakarta.websocket-api");
     }
 }

--- a/apm-agent-plugins/apm-jakarta-websocket-plugin/src/test/java/co/elastic/apm/agent/websocket/JavaxServerEndpointInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jakarta-websocket-plugin/src/test/java/co/elastic/apm/agent/websocket/JavaxServerEndpointInstrumentationTest.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.apm.agent.websocket;
 
+import co.elastic.apm.agent.util.VersionUtils;
 import co.elastic.apm.agent.websocket.endpoint.JavaxServerEndpoint;
 
 class JavaxServerEndpointInstrumentationTest extends BaseServerEndpointInstrumentationTest {
@@ -38,6 +39,6 @@ class JavaxServerEndpointInstrumentationTest extends BaseServerEndpointInstrumen
 
     @Override
     protected String getFrameworkVersion() {
-        return "1.1";
+        return VersionUtils.getVersion(javax.websocket.server.ServerEndpoint.class, "javax.websocket", "javax.websocket-api");
     }
 }


### PR DESCRIPTION
Closes #2623 

The main issue it that the annotations we use in our tests were removed from `jakarta.websocket-api`, so I added a `test` dependency on `jakarta.websocket-client-api`.

The thing is that even without this issue, next upgrade of the library will fail as well due to the [static framework version check](https://github.com/elastic/apm-agent-java/blob/53204c6986e2e00ae0bc354d0aefc4259a61eb64/apm-agent-plugins/apm-jakarta-websocket-plugin/src/test/java/co/elastic/apm/agent/websocket/JakartaServerEndpointInstrumentationTest.java#L41). 
I assume the original intention was to avoid using the same `VersionUtils.getVersion()` logic in the assertion as in the instrumentation, but this will be an issue keeping it up to date. I think within the scope of this test, it is enough to see that the framework is set and has the same value you get from `VersionUtils.getVersion()`. The `VersionUtils` functionality is tested through `VersionUtilsTest`.