### PR TITLE
Fix 'opentelementry' typo in docs

### DIFF
--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -3,7 +3,7 @@ NOTE: For the best reading experience,
 please view this documentation at https://www.elastic.co/guide/en/apm/agent/java[elastic.co]
 endif::[]
 
-[[opentelementry-bridge]]
+[[opentelemetry-bridge]]
 === OpenTelemetry bridge
 
 NOTE: Added as experimental in 1.30.0.
@@ -16,7 +16,7 @@ it translates the calls to the OpenTelemetry API to Elastic APM and thus allows 
 
 NOTE: While manual instrumentations using the OpenTelemetry API can be adapted to the Elastic APM Java agent, it's not possible to use the instrumentations from
 https://github.com/open-telemetry/opentelemetry-java-instrumentation[opentelemetry-java-instrumentation] in the context of the Elastic APM Java agent. +
-However, you can use https://github.com/open-telemetry/opentelemetry-java-instrumentation[opentelemetry-java-instrumentation] (aka the OpenTelementry Java agent)
+However, you can use https://github.com/open-telemetry/opentelemetry-java-instrumentation[opentelemetry-java-instrumentation] (aka the OpenTelemetry Java agent)
 and send the data to APM Server.
 See the {apm-guide-ref}/open-telemetry.html[OpenTelemetry integration docs] for more details.
 

--- a/docs/api-opentracing.asciidoc
+++ b/docs/api-opentracing.asciidoc
@@ -6,7 +6,7 @@ endif::[]
 [[opentracing-bridge]]
 === OpenTracing bridge
 
-NOTE: OpenTracing is discontinued in favor of OpenTelemetry. Consider using the <<opentelementry-bridge>> instead. +
+NOTE: OpenTracing is discontinued in favor of OpenTelemetry. Consider using the <<opentelemetry-bridge>> instead. +
 Latest supported OpenTracing version: 0.33 (as of agent and OpenTracing-bridge version 1.9.0)
 
 The Elastic APM OpenTracing bridge allows creating Elastic APM `Transactions` and `Spans`,

--- a/docs/apis.asciidoc
+++ b/docs/apis.asciidoc
@@ -11,7 +11,7 @@ There are three different ways enhance the out-of-the-box instrumentation of the
 . <<public-api>> +
   A simple and stable API that is most native to the agent.
   Contains annotations to declaratively create spans.
-. <<opentelementry-bridge>> +
+. <<opentelemetry-bridge>> +
   A vendor neutral API.
   If you plan to do a lot of manual instrumentation and want to reduce vendor lock-in this is probably what you're looking for.
 . <<opentracing-bridge>> +


### PR DESCRIPTION
Fix an 'openteleme*n*try' typo in the docs.
https://www.elastic.co/guide/en/apm/agent/java/current/opentelementry-bridge.html

/cc @bmorelli25 to help track down cross-doc links

> Yes, there will likely be broken cross-doc links, but I can chase those down.