### PR TITLE
Fix Opbeans tag on release

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -284,7 +284,7 @@ pipeline {
             // The opbeans-java pipeline will trigger a release for the main branch
             gitPush()
             // The opbeans-java pipeline will trigger a release for the release tag
-            gitCreateTag(tag: "${RELEASE_VERSION}")
+            gitCreateTag(tag: "${RELEASE_TAG}")
           }
         }
       }


### PR DESCRIPTION
Opbeans needs to be tagged with the same tag format as Java agent : `v1.2.3`, not `1.2.3`.

While the Opbeans build job was triggered on the tag being created, the parts that publish the docker image (defined in the [common opbeans pipeline](https://github.com/elastic/apm-pipeline-library/blob/main/vars/opbeansPipeline.groovy)) are filtering on the tag format, so as a result the docker image publication was skipped. The publication on the `main` branch is not impacted and properly updates the `latest` tag on docker.

This was fixed for the `1.31.0` release by manually replacing the `1.31.0` tag with `v1.31.0` (which triggered this : [jenkins build](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-java%2Fopbeans-java-mbp/detail/v1.31.0/1/pipeline))

We have to merge it as-is, the fix should be effective on the next release.