### PR TITLE
Fix missing otel transaction attributes

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -47,6 +47,7 @@ import co.elastic.apm.agent.impl.metadata.RuntimeInfo;
 import co.elastic.apm.agent.impl.metadata.Service;
 import co.elastic.apm.agent.impl.metadata.SystemInfo;
 import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Composite;
 import co.elastic.apm.agent.impl.transaction.DroppedSpanStats;
 import co.elastic.apm.agent.impl.transaction.Faas;
@@ -671,6 +672,7 @@ public class DslJsonSerializer implements PayloadSerializer {
         if (transaction.isSampled()) {
             serializeDroppedSpanStats(transaction.getDroppedSpanStats());
         }
+        serializeOTel(transaction);
         double sampleRate = traceContext.getSampleRate();
         if (!Double.isNaN(sampleRate)) {
             writeField("sample_rate", sampleRate);
@@ -724,7 +726,7 @@ public class DslJsonSerializer implements PayloadSerializer {
         jw.writeByte(OBJECT_END);
     }
 
-    private void serializeOTel(Span span) {
+    private void serializeOTel(AbstractSpan<?> span) {
         OTelSpanKind kind = span.getOtelKind();
         Map<String, Object> attributes = span.getOtelAttributes();
         boolean hasAttributes = !attributes.isEmpty();


### PR DESCRIPTION
## What does this PR do?

Transactions created through the OTel bridge were missing the `otel` attributes map when sending data to apm-server.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
