### PR TITLE
remove transaction.status from otel transactions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,7 +38,8 @@ the agent will now include the database name in the dependency, thus `mysql/my-d
 
 [float]
 ===== Bug fixes
-* Fix missing attributes in bridged OTel transactions {pull}2657[#2657]
+* Fix missing attributes in bridged OTel transactions - {pull}2657[#2657]
+* Fix `transaction.result` with bridged OTel transactions - {pull}2660[#2660]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/test/resources/specs/otel_bridge.feature
+++ b/apm-agent-core/src/test/resources/specs/otel_bridge.feature
@@ -70,7 +70,7 @@ Feature: OpenTelemetry bridge
     And OTel span ends
     Then Elastic bridged object is a transaction
     Then Elastic bridged transaction outcome is "<outcome>"
-    Then Elastic bridged transaction result is null
+    Then Elastic bridged transaction result is not set
     Examples:
       | status | outcome |
       | unset  | unknown |

--- a/apm-agent-core/src/test/resources/specs/otel_bridge.feature
+++ b/apm-agent-core/src/test/resources/specs/otel_bridge.feature
@@ -70,6 +70,7 @@ Feature: OpenTelemetry bridge
     And OTel span ends
     Then Elastic bridged object is a transaction
     Then Elastic bridged transaction outcome is "<outcome>"
+    Then Elastic bridged transaction result is null
     Examples:
       | status | outcome |
       | unset  | unknown |

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/sdk/OTelSpan.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/sdk/OTelSpan.java
@@ -88,17 +88,6 @@ public class OTelSpan implements Span {
 
     @Override
     public Span setStatus(StatusCode statusCode, String description) {
-        if (span instanceof Transaction) {
-            Transaction t = (Transaction) span;
-            switch (statusCode) {
-                case OK:
-                    t.withResultIfUnset("OK");
-                    break;
-                case ERROR:
-                    t.withResultIfUnset("Error");
-                    break;
-            }
-        }
         switch (statusCode) {
             case ERROR:
                 span.withUserOutcome(Outcome.FAILURE);

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/test/java/specs/OTelBridgeStepsDefinitions.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/test/java/specs/OTelBridgeStepsDefinitions.java
@@ -308,6 +308,11 @@ public class OTelBridgeStepsDefinitions {
 
     }
 
+    @Then("Elastic bridged transaction result is null")
+    public void bridgedTransactionResultNull(){
+        assertThat(getBridgedTransaction().getResult()).isNull();
+    }
+
     @Then("Elastic bridged span service target type is {string} and name is {string}")
     public void bridgedSpanTargetServiceType(String type, String name) {
         ServiceTarget serviceTarget = getBridgedSpan().getContext().getServiceTarget();

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/test/java/specs/OTelBridgeStepsDefinitions.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/test/java/specs/OTelBridgeStepsDefinitions.java
@@ -308,7 +308,7 @@ public class OTelBridgeStepsDefinitions {
 
     }
 
-    @Then("Elastic bridged transaction result is null")
+    @Then("Elastic bridged transaction result is not set")
     public void bridgedTransactionResultNull() {
         assertThat(getBridgedTransaction().getResult()).isNull();
     }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/test/java/specs/OTelBridgeStepsDefinitions.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/test/java/specs/OTelBridgeStepsDefinitions.java
@@ -309,7 +309,7 @@ public class OTelBridgeStepsDefinitions {
     }
 
     @Then("Elastic bridged transaction result is null")
-    public void bridgedTransactionResultNull(){
+    public void bridgedTransactionResultNull() {
         assertThat(getBridgedTransaction().getResult()).isNull();
     }
 


### PR DESCRIPTION
## What does this PR do?

Removes the `transaction.result` field value for transactions that are created through the OTel bridge.

When the value is set in the intake protocol, APM server currently keeps the provided value, removing it allows to infer the value from OTel attributes values and stay consistent with native OTLP intake.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
  - [x] backport changes to Spec + OTel bridge gherkin to upstream APM repo : https://github.com/elastic/apm/pull/649
