### PR TITLE
Fix API annotations `discardable` instrumentation

### DIFF
--- a/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureSpan.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/CaptureSpan.java
@@ -79,12 +79,13 @@ public @interface CaptureSpan {
      * <p>
      * By default, spans are discardable.
      * In some cases, spans may be discarded, for example if {@code span_min_duration} config option is set and the span does not exceed
-     * the configured threshold. Set this attribute to {@code false} to make the current span non-discardable.
+     * the configured threshold. Set this attribute to {@code "false"} (note that this needs to be a {@code String} and not a
+     * {@code boolean}) to make the current span non-discardable.
      * </p>
      * <p>
      * NOTE: making a span non-discardable implicitly makes the entire stack of active spans non-discardable as well. Child spans can still
      * be discarded.
      * </p>
      */
-    boolean discardable() default true;
+    String discardable() default "true";
 }

--- a/apm-agent-api/src/main/java/co/elastic/apm/api/Traced.java
+++ b/apm-agent-api/src/main/java/co/elastic/apm/api/Traced.java
@@ -83,12 +83,13 @@ public @interface Traced {
      * <p>
      * By default, spans are discardable. This attribute is only relevant if the annotated method results with a span.
      * In some cases, spans may be discarded, for example if {@code span_min_duration} config option is set and the span does not exceed
-     * the configured threshold. Set this attribute to {@code false} to make the current span non-discardable.
+     * the configured threshold. Set this attribute to {@code "false"} (note that this needs to be a {@code String} and not a
+     * {@code boolean})  to make the current span non-discardable.
      * </p>
      * <p>
      * NOTE: making a span non-discardable implicitly makes the entire stack of active spans non-discardable as well. Child spans can still
      * be discarded.
      * </p>
      */
-    boolean discardable() default true;
+    String discardable() default "true";
 }

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/CaptureSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/CaptureSpanInstrumentation.java
@@ -70,14 +70,14 @@ public class CaptureSpanInstrumentation extends TracerAwareInstrumentation {
             @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.CaptureSpan", method = "type") String type,
             @Nullable @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.CaptureSpan", method = "subtype") String subtype,
             @Nullable @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.CaptureSpan", method = "action") String action,
-            @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.CaptureSpan", method = "discardable") boolean discardable) {
+            @Nullable @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.CaptureSpan", method = "discardable") String discardable) {
             final AbstractSpan<?> parent = tracer.getActive();
             if (parent != null) {
                 Span span = parent.createSpan()
                     .withName(spanName.isEmpty() ? signature : spanName)
                     .activate();
                 span.setType(type, subtype, action);
-                if (!discardable) {
+                if (Boolean.FALSE.toString().equals(discardable)) {
                     span.setNonDiscardable();
                 }
                 return span;

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TracedInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TracedInstrumentation.java
@@ -72,7 +72,7 @@ public class TracedInstrumentation extends TracerAwareInstrumentation {
             @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.Traced", method = "type") String type,
             @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.Traced", method = "subtype") @Nullable String subtype,
             @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.Traced", method = "action") @Nullable String action,
-            @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.Traced", method = "discardable") boolean discardable) {
+            @AnnotationValueOffsetMappingFactory.AnnotationValueExtractor(annotationClassName = "co.elastic.apm.api.Traced", method = "discardable") @Nullable String discardable) {
 
             final AbstractSpan<?> parent = tracer.getActive();
             if (parent != null) {
@@ -81,7 +81,7 @@ public class TracedInstrumentation extends TracerAwareInstrumentation {
                     .withSubtype(subtype)
                     .withAction(action)
                     .withName(spanName.isEmpty() ? signature : spanName);
-                if (!discardable) {
+                if (Boolean.FALSE.toString().equals(discardable)) {
                     span.setNonDiscardable();
                 }
                 return span.activate();

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/SpanDiscardingTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/SpanDiscardingTest.java
@@ -137,12 +137,12 @@ public class SpanDiscardingTest extends AbstractApiTest {
         span.end();
     }
 
-    @CaptureSpan(value = "not-discarded", discardable = false)
+    @CaptureSpan(value = "not-discarded", discardable = "false")
     private void notDiscarded_captureAnnotation() {
         childSpan();
     }
 
-    @Traced(value = "not-discarded", discardable = false)
+    @Traced(value = "not-discarded", discardable = "false")
     private void notDiscarded_tracedAnnotation() {
         childSpan();
     }

--- a/docs/api-elastic.asciidoc
+++ b/docs/api-elastic.asciidoc
@@ -244,7 +244,8 @@ no span will be created.
 * `type`: The type of the span, e.g. `db` for DB span. Defaults to `app`
 * `subtype`: The subtype of the span, e.g. `mysql` for DB span. Defaults to empty string
 * `action`: The action related to the span, e.g. `query` for DB spans. Defaults to empty string
-* `discardable`: By default, spans may be discarded in certain scenarios. Set this attribute to `false` to make this span non-discardable.
+* `discardable`: By default, spans may be discarded in certain scenarios. Set this attribute to `"false"` (as a `String`, not a `boolean`!)
+to make this span non-discardable.
 
 NOTE: Using this annotation implicitly creates a Span and activates it when entering the annotated
 method. It also implicitly ends it and deactivates it before exiting the annotated method.
@@ -266,7 +267,8 @@ or a unit of work within a transaction (a span).
 * `type`: The type of the span or transaction. Defaults to `request` for transactions and `app` for spans
 * `subtype`: The subtype of the span, e.g. `mysql` for DB span. Defaults to empty string. Has no effect when a transaction is created.
 * `action`: The action related to the span, e.g. `query` for DB spans. Defaults to empty string. Has no effect when a transaction is created.
-* `discardable`: By default, spans may be discarded in certain scenarios. Set this attribute to `false` to make a span non-discardable.
+* `discardable`: By default, spans may be discarded in certain scenarios. Set this attribute to `"false"` (as a `String`, not a `boolean`!)
+to make this span non-discardable. This attribute has no effect if the created event is a Transaction.
 
 NOTE: Using this annotation implicitly creates a span or transaction and activates it when entering the annotated
 method. It also implicitly ends it and deactivates it before exiting the annotated method.


### PR DESCRIPTION
## What does this PR do?
Fixes an issue that was introduced through #2632 by the addition of the `discardable` attributes to the `@CaptureSpan` and `@Traced` annotations.

The application error looks as follows:
```
Caused by: java.lang.VerifyError: Bad type on operand stack
Exception Details:
...  
Reason:
    Type null (current frame, stack[5]) is not assignable to integer
```
The annotations instrumentation is tolerant to addition of annotation attributes, assigning such with `null`. The issue in this case is that the new attributes are of `boolean` type, which is not assignable from `null`.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->
- [x] This is a bugfix
  - [x] I have updated the unit tests and Javadoc
  - [x] I have updated the API documentation
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added integration tests that use fixed old API version
