### PR TITLE
jjbb: remove reference repo

### DIFF
--- a/.ci/jobs/apm-agent-java-mbp.yml
+++ b/.ci/jobs/apm-agent-java-mbp.yml
@@ -39,7 +39,8 @@
             recursive: true
             parent-credentials: true
             timeout: 100
-            reference-repo: /var/lib/jenkins/.git-references/apm-agent-java.git
+            ## reference-repo is *Nix based so it causes problems when running for Windows
+            ## reference-repo: /var/lib/jenkins/.git-references/apm-agent-java.git
             use-author: true
             wipe-workspace: true
     periodic-folder-trigger: 4h


### PR DESCRIPTION
## What does this PR do?

Remove the reference repo to be platform agnostic.

Otherwise,

<img width="1468" alt="image" src="https://user-images.githubusercontent.com/2871786/175985081-042a6b9a-d1d3-46c9-845e-90ac00efe7b7.png">

```
[2022-06-27T11:54:36.171Z] error: object directory /var/lib/jenkins/.git-references/apm-agent-java.git/objects does not exist; check .git/objects/info/alternates
[2022-06-27T11:54:36.171Z] error: Could not read ee8c07b22816cd6ac996925825d80cbc9aa04ac0
```

This has been discovered while verifying the plugin `git-commit-id-maven-plugin` as requested in https://github.com/git-commit-id/git-commit-id-maven-plugin/issues/591#issuecomment-1166367215