### PR TITLE
Enforcing correct CI workers for benchmarks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ pipeline {
     booleanParam(name: 'end_to_end_tests_ci', defaultValue: false, description: 'Enable APM End-to-End tests')
 
     // disabled by default, not required for merge
+    // opt-in with 'ci:benchmarks' tag on PR
     booleanParam(name: 'bench_ci', defaultValue: false, description: 'Enable benchmarks')
 
     // disabled by default, not required for merge
@@ -300,6 +301,7 @@ pipeline {
                 anyOf {
                   branch 'main'
                   expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
+                  expression { matchesPrLabel(label: 'ci:benchmarks') }
                   expression { return params.bench_ci }
                 }
               }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -289,7 +289,7 @@ pipeline {
              * The result JSON files are also archive into Jenkins.
              */
             stage('Benchmarks') {
-              agent { label 'metal' }
+              agent { label 'linux && metal' }
               options { skipDefaultCheckout() }
               environment {
                 NO_BUILD = "true"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -317,6 +317,9 @@ pipeline {
                 }
               }
               post {
+                cleanup {
+                  deleteDir()
+                }
                 always {
                   archiveArtifacts(allowEmptyArchive: true,
                     artifacts: "${BASE_DIR}/${RESULT_FILE}",

--- a/scripts/jenkins/run-benchmarks.sh
+++ b/scripts/jenkins/run-benchmarks.sh
@@ -28,6 +28,10 @@ function setUp() {
     then
         CORE_INDEX=7
         BASE_FREQ="1.9GHz"
+    elif [ "${CPU_MODEL}" == "12th Gen Intel(R) Core(TM) i5-12500 " ]
+    then
+        CORE_INDEX=11
+        BASE_FREQ="3.0GHz"
     else
         >&2 echo "Cannot determine base frequency for CPU model [${CPU_MODEL}]. Please adjust the build script."
         exit 1

--- a/scripts/jenkins/run-benchmarks.sh
+++ b/scripts/jenkins/run-benchmarks.sh
@@ -28,10 +28,6 @@ function setUp() {
     then
         CORE_INDEX=7
         BASE_FREQ="1.9GHz"
-    elif [ "${CPU_MODEL}" == "12th Gen Intel(R) Core(TM) i5-12500 " ]
-    then
-        CORE_INDEX=11
-        BASE_FREQ="3.0GHz"
     else
         >&2 echo "Cannot determine base frequency for CPU model [${CPU_MODEL}]. Please adjust the build script."
         exit 1


### PR DESCRIPTION
Context: benchmarks script failing on new CI processor - https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-java%2Fapm-agent-java-mbp/detail/main/285/pipeline:
```
CPU_MODEL='12th Gen Intel(R) Core(TM) i5-12500 '
...
Cannot determine base frequency for CPU model [12th Gen Intel(R) Core(TM) i5-12500 ]. Please adjust the build script.
```

Based on Intel's processor's [spec](https://ark.intel.com/content/www/us/en/ark/products/96144/intel-core-i512500-processor-18m-cache-up-to-4-60-ghz.html).

@kuisathaverat Do you think a `ci:benchmarks` label to tell CI to run benchmarks for PRs would be useful?