### PR TITLE
Fix Vert.x instrumentation for 4.3.2

### DIFF
--- a/apm-agent-plugins/apm-vertx/apm-vertx4-plugin/pom.xml
+++ b/apm-agent-plugins/apm-vertx/apm-vertx4-plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
-        <version.vertx>[4.0.0,)</version.vertx>
+        <version.vertx>4.3.2</version.vertx>
     </properties>
 
     <dependencies>

--- a/apm-agent-plugins/apm-vertx/apm-vertx4-plugin/src/main/java/co/elastic/apm/agent/vertx/v4/web/WebInstrumentation.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx4-plugin/src/main/java/co/elastic/apm/agent/vertx/v4/web/WebInstrumentation.java
@@ -46,7 +46,6 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesNoArguments;
 
-@SuppressWarnings("JavadocReference")
 public abstract class WebInstrumentation extends Vertx4Instrumentation {
 
     @Override
@@ -55,12 +54,12 @@ public abstract class WebInstrumentation extends Vertx4Instrumentation {
     }
 
     /**
-     * Instruments {@link io.vertx.core.impl.ContextImpl#tracer}} to return a noop tracer in case no tracer has been specified.
+     * Instruments {@link io.vertx.core.impl.ContextInternal#tracer}} to return a noop tracer in case no tracer has been specified.
      */
     public static class ContextImplTracerInstrumentation extends WebInstrumentation {
         @Override
         public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-            return named("io.vertx.core.impl.ContextImpl")
+            return nameStartsWith("io.vertx.core.impl.").and(hasSuperType(named("io.vertx.core.impl.ContextInternal")))
                 .and(not(isInterface()));
         }
 


### PR DESCRIPTION
Also fixes Javadoc task

## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

The latest release of Vert.x 4.3.2 broke our build. The Javadoc task fails because `io.vertx.core.impl.ContextImpl` has been [renamed](https://github.com/eclipse-vertx/vert.x/commit/a3e6ae5a8e40c5627350f1c1fa1b5bd9cb231f19) to `io.vertx.core.impl.ContextBase`.
A couple of thoughts to make things more resilient:
* We shouldn’t use version ranges, such as `<version.vertx>[4.0.0,)</version.vertx>`. Instead, use the latest version and rely on dependabot to update the version. This way, our existing test won’t break and we’ll still get notified when a new release of a library breaks our instrumentation.
* When instrumenting internal classes, we should make sure to make the instrumentation less dependent on exact class names. For example, instead of a type matcher like `named("io.vertx.core.impl.ContextImpl")`, use `nameStartsWith("io.vertx.core.impl.").and(hasSuperType(named("io.vertx.core.impl.ContextInternal")))`

https://github.com/elastic/apm-agent-java/blob/97b8aa17236a8a633e8317552f338ca7747d0aad/apm-agent-plugins/apm-vertx/apm-vertx4-plugin/src/main/java/co/elastic/apm/agent/vertx/v4/web/WebInstrumentation.java#L63-L64

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
