### PR TITLE
docs: consistent naming of APM AWS Lambda extension

### DIFF
--- a/docs/setup-aws-lambda.asciidoc
+++ b/docs/setup-aws-lambda.asciidoc
@@ -48,7 +48,7 @@ For production environments, we recommend {apm-guide-ref}/aws-lambda-secrets-man
 
 include::./lambda/configure-lambda-widget.asciidoc[]
 
-You can optionally <<configuration, fine-tune the Java agent >> or the {apm-guide-ref}/aws-lambda-config-options.html[configuration of the{apm-lambda-ext}].
+You can optionally <<configuration, fine-tune the Java agent >> or the {apm-guide-ref}/aws-lambda-config-options.html[configuration of the {apm-lambda-ext}].
 
 That's it; After following the steps above, you're ready to go!
 Your Lambda function invocations should be traced from now on.

--- a/docs/setup-aws-lambda.asciidoc
+++ b/docs/setup-aws-lambda.asciidoc
@@ -32,14 +32,14 @@ include::{apm-aws-lambda-root}/docs/lambda-selector/lambda-attributes-selector.a
 include::{apm-aws-lambda-root}/docs/lambda-selector/extension-arn-replacement.asciidoc[]
 include::./lambda/java-arn-replacement.asciidoc[]
 
-Both the {apm-guide-ref}/aws-lambda-arch.html[APM Lambda Extension] and the Java APM Agent are added to your Lambda function as https://docs.aws.amazon.com/lambda/latest/dg/invocation-layers.html[AWS Lambda Layers]. Therefore, you need to add the corresponding Layer ARNs (identifiers) to your Lambda function.
+Both the {apm-guide-ref}/aws-lambda-arch.html[{apm-lambda-ext}] and the Java APM Agent are added to your Lambda function as https://docs.aws.amazon.com/lambda/latest/dg/invocation-layers.html[AWS Lambda Layers]. Therefore, you need to add the corresponding Layer ARNs (identifiers) to your Lambda function.
 
 include::{apm-aws-lambda-root}/docs/add-extension/add-extension-layer-widget.asciidoc[]
 
 [float]
 ==== Step 3: Configure APM on AWS Lambda
 
-The APM Lambda Extension and the APM Java agent are configured through environment variables on the AWS Lambda function.
+The {apm-lambda-ext} and the APM Java agent are configured through environment variables on the AWS Lambda function.
 
 For the minimal configuration, you will need the _APM Server URL_ to set the destination for APM data and an _{apm-guide-ref}/secret-token.html[APM Secret Token]_.
 If you prefer to use an {apm-guide-ref}/api-key.html[APM API key] instead of the APM secret token, use the `ELASTIC_APM_API_KEY` environment variable instead of `ELASTIC_APM_SECRET_TOKEN` in the following configuration.
@@ -48,7 +48,7 @@ For production environments, we recommend {apm-guide-ref}/aws-lambda-secrets-man
 
 include::./lambda/configure-lambda-widget.asciidoc[]
 
-You can optionally <<configuration, fine-tune the Java agent >> or the {apm-guide-ref}/aws-lambda-config-options.html[configuration of the APM Lambda Extension].
+You can optionally <<configuration, fine-tune the Java agent >> or the {apm-guide-ref}/aws-lambda-config-options.html[configuration of the{apm-lambda-ext}].
 
 That's it; After following the steps above, you're ready to go!
 Your Lambda function invocations should be traced from now on.


### PR DESCRIPTION
### Summary

This PR updates the _Monitoring AWS Lambda Java Functions_ guide to refer to the `Elastic APM AWS Lambda extension` by its complete name.

For https://github.com/elastic/apm-aws-lambda/issues/209.

Note: The referenced attribute (`{apm-lambda-ext}`) is defined [here](https://github.com/elastic/docs/blob/7bd515547f91733dfd4ebe52932dfe4fc3547041/shared/attributes.asciidoc#L393). 