### PR TITLE
fix typo, missing $ in docker push image latest variable

### DIFF
--- a/scripts/jenkins/push_docker.sh
+++ b/scripts/jenkins/push_docker.sh
@@ -60,8 +60,8 @@ then
 
   if [ ${WORKERS+x} ]  # We are on a CI worker
   then
-    retry $RETRIES docker push DOCKER_PUSH_IMAGE_LATEST || echo "Push failed after $RETRIES retries"
+    retry $RETRIES docker push $DOCKER_PUSH_IMAGE_LATEST || echo "Push failed after $RETRIES retries"
   else  # We are in a local (non-CI) environment
-    docker push DOCKER_PUSH_IMAGE_LATEST || echo "You may need to run 'docker login' first and then re-run this script"
+    docker push $DOCKER_PUSH_IMAGE_LATEST || echo "You may need to run 'docker login' first and then re-run this script"
   fi
 fi


### PR DESCRIPTION
## What does this PR do?
docker-push failed to push the latest cos there was a typo in it, this fixes that

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
