### PR TITLE
also support SIDs when getting instance from Oracle jdbc connections

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -28,7 +28,7 @@ endif::[]
 
 [float]
 ===== Features
-* Cool new feature: {pull}2526[#2526]
+* Capture Oracle SID in connection string - {pull}2709[#2709]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaData.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaData.java
@@ -247,7 +247,9 @@ public class ConnectionMetaData {
                     if (host != null && !builder.hasHost()) { // first value wins
                         builder.withHost(host).withPort(port);
                     }
-                } else if (nodeName.equals("instance_name") || (nodeName.equals("service_name") && !builder.hasInstance())) {
+                } else if (nodeName.equals("instance_name")
+                        || (nodeName.equals("service_name") && !builder.hasInstance())
+                        || (nodeName.equals("sid") && !builder.hasInstance())) {
                     builder.withInstance(treeNode.value.toString().trim());
                 }
 

--- a/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaDataTest.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/test/java/co/elastic/apm/agent/jdbc/helper/ConnectionMetaDataTest.java
@@ -72,6 +72,9 @@ class ConnectionMetaDataTest {
         testUrl("jdbc:oracle:thin:@(description=" +
             "(address=(protocol=tcp)(host=localhost)(port=6203))" +
             "(connect_data=(server=dedicated)(service_name=db.fqdn.org.de)))", "oracle", "localhost", 6203, "db.fqdn.org.de");
+        testUrl("jdbc:oracle:thin:@(description=" +
+                "(address=(protocol=tcp)(host=localhost)(port=6203))" +
+                "(connect_data=(server=dedicated)(sid=db)))", "oracle", "localhost", 6203, "db");
 
         // intentional parsing error with extra ')' before '(address='
         testUrl("jdbc:oracle:thin:@(description=)(address=(protocol=tcp)(host=localhost)(port=6203))(connect_data=" +


### PR DESCRIPTION
## What does this PR do?
I found that the Kibana service map only shows services of oracle database with its name when using the service_name. When connecting using the SID it only shows as `oracle`.
Possible workaround: Set the servicename for the database and use the servicename

This PR gathers the low-hanging fruit: It reads the instance from the SID the same way as from SERVICE_NAME.  
  
To discuss: This really was the lowhanging fruit - as the SID (e.g. DB instead of servicename DB.COMPANY.COM) may not be unique. I am not sure if we should add the hostname to the instance to make it unique - e.g. host:port/SID - what o you think?

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have made corresponding changes to the documentation