### PR TITLE
[PoC] Automatically capture JMX metrics

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/JvmFdMetrics.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/JvmFdMetrics.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.metrics.builtin;
+
+import co.elastic.apm.agent.context.AbstractLifecycleListener;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.metrics.DoubleSupplier;
+import co.elastic.apm.agent.metrics.Labels;
+import co.elastic.apm.agent.metrics.MetricRegistry;
+import com.sun.management.UnixOperatingSystemMXBean;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.OperatingSystemMXBean;
+
+public class JvmFdMetrics extends AbstractLifecycleListener {
+
+    @Override
+    public void start(ElasticApmTracer tracer) {
+        bindTo(tracer.getMetricRegistry());
+    }
+
+    void bindTo(final MetricRegistry registry) {
+        final OperatingSystemMXBean mxBean = ManagementFactory.getOperatingSystemMXBean();
+        if (mxBean instanceof UnixOperatingSystemMXBean) {
+            final UnixOperatingSystemMXBean unixMxBean = (UnixOperatingSystemMXBean) mxBean;
+            registry.add("jvm.fd.used", Labels.EMPTY, new DoubleSupplier() {
+                @Override
+                public double get() {
+                    return unixMxBean.getOpenFileDescriptorCount();
+                }
+            });
+            registry.addUnlessNegative("jvm.fd.max", Labels.EMPTY, new DoubleSupplier() {
+                @Override
+                public double get() {
+                    return unixMxBean.getMaxFileDescriptorCount();
+                }
+            });
+        }
+
+
+    }
+}

--- a/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.context.LifecycleListener
+++ b/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.context.LifecycleListener
@@ -3,6 +3,7 @@ co.elastic.apm.agent.bci.InstrumentationStatsLifecycleListener
 co.elastic.apm.agent.metrics.builtin.JvmMemoryMetrics
 co.elastic.apm.agent.metrics.builtin.SystemMetrics
 co.elastic.apm.agent.metrics.builtin.CGroupMetrics
+co.elastic.apm.agent.metrics.builtin.JvmFdMetrics
 co.elastic.apm.agent.metrics.builtin.JvmGcMetrics
 co.elastic.apm.agent.metrics.builtin.ThreadMetrics
 co.elastic.apm.agent.impl.circuitbreaker.CircuitBreaker

--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxAutoMetrics.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxAutoMetrics.java
@@ -1,0 +1,295 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.jmx;
+
+import co.elastic.apm.agent.metrics.DoubleSupplier;
+import co.elastic.apm.agent.metrics.Labels;
+import co.elastic.apm.agent.metrics.MetricRegistry;
+
+import javax.annotation.Nullable;
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.MBeanServerDelegate;
+import javax.management.MBeanServerNotification;
+import javax.management.MalformedObjectNameException;
+import javax.management.Notification;
+import javax.management.NotificationListener;
+import javax.management.ObjectInstance;
+import javax.management.ObjectName;
+import javax.management.openmbean.CompositeData;
+import javax.management.relation.MBeanServerNotificationFilter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class JmxAutoMetrics {
+
+    private final MetricRegistry registry;
+    private final MBeanServer mbs;
+    private final NotificationListener listener;
+
+    private final List<Registration> registrations = new ArrayList<>();
+
+    public JmxAutoMetrics(MetricRegistry registry, final MBeanServer mbs) {
+        this.registry = registry;
+        this.mbs = mbs;
+        this.listener = new NotificationListener() {
+            @Override
+            public void handleNotification(Notification notification, Object handback) {
+                if (!(notification instanceof MBeanServerNotification)) {
+                    return;
+                }
+
+                MBeanServerNotification mBeanServerNotification = ((MBeanServerNotification) notification);
+                if (!mBeanServerNotification.getType().equals(MBeanServerNotification.REGISTRATION_NOTIFICATION)) {
+                    return;
+                }
+
+                ObjectName newObjectName = mBeanServerNotification.getMBeanName();
+
+                for (Registration registrations : registrations) {
+                    registrations.newMbeanNotification(mbs, newObjectName);
+                }
+            }
+        };
+    }
+
+    public void registerAll() {
+
+        MBeanServerNotificationFilter filter = new MBeanServerNotificationFilter();
+        filter.enableAllObjectNames();
+        filter.enableType(MBeanServerNotification.REGISTRATION_NOTIFICATION);
+
+        try {
+            mbs.addNotificationListener(MBeanServerDelegate.DELEGATE_NAME, listener, filter, null);
+        } catch (InstanceNotFoundException e) {
+            throw new IllegalStateException(e);
+        }
+
+        // Tomcat
+        // thread pools, Catalina:type=ThreadPool,name=*
+        tomcatThreadPool(registry, mbs, "connectionCount", "tomcat.threadpool.connection.used"); // TODO rename to 'usage'
+        tomcatThreadPool(registry, mbs, "maxConnections", "tomcat.threadpool.connection.max"); // TODO rename to 'limit'
+        tomcatThreadPool(registry, mbs, "currentThreadCount", "tomcat.threads.count"); // TODO rename to 'usage' + breakdown 'idle' by difference
+        tomcatThreadPool(registry, mbs, "currentThreadsBusy", "tomcat.threads.busy"); // TODO rename to 'usage' + breakdown 'busy'
+        tomcatThreadPool(registry, mbs, "maxThreads", "tomcat.threads.max"); // TODO : rename to 'limit'
+        // datasources Catalina:type=DataSource,host=localhost,context=*,class=javax.sql.DataSource,name=*
+        tomcatDatasource(registry, mbs, "numActive", "tomcat.datasource.used"); // TODO : rename to usage + breakdown 'active'
+        tomcatDatasource(registry, mbs, "numIdle", "tomcat.datasource.idle"); // TODO : rename to usage + breakdown 'idle'
+        tomcatDatasource(registry, mbs, "maxTotal", "tomcat.datasource.max"); // TODO : rename to 'limit'
+        // sessions Catalina:type=Manager,host=*,context=*
+        tomcatSessions(registry, mbs, "activeSessions", "tomcat.sessions.used"); // TODO : rename to 'usage'
+        tomcatSessions(registry, mbs, "maxActiveSessions", "tomcat.sessions.max"); // TODO : rename to 'limit'
+        // transferred bytes Catalina:type=RequestProcessor,worker=*,name=*
+        tomcatBytesTransferred(registry, mbs, "bytesReceived", "tomcat.bytes.received"); // TODO check OTel conventions here
+        tomcatBytesTransferred(registry, mbs, "bytesSent", "tomcat.bytes.sent");
+
+        for (Registration reg : registrations) {
+            reg.initialSearch(mbs);
+        }
+
+    }
+
+    private void tomcatBytesTransferred(final MetricRegistry registry, final MBeanServer mbs, final String attribute, final String metric){
+        register("Catalina:type=RequestProcessor,worker=*,name=*", attribute, new RegisterCallback() {
+            @Override
+            public void onRegister(ObjectName objectName, String attributeName) {
+                registry.add(
+                    metric,
+                    Labels.Mutable.of("name", objectName.getKeyProperty("name"))
+                        .add("worker", objectName.getKeyProperty("worker")),
+                    attributeSupplier(mbs, objectName, attributeName));
+            }
+        });
+    }
+
+    private void tomcatSessions(final MetricRegistry registry, final MBeanServer mbs, final String attribute, final String metric) {
+        register("Catalina:type=Manager,host=*,context=*", attribute, new RegisterCallback() {
+            @Override
+            public void onRegister(ObjectName objectName, String attributeName) {
+                registry.add(
+                    metric,
+                    Labels.Mutable.of("host", objectName.getKeyProperty("host"))
+                        .add("context", objectName.getKeyProperty("context")),
+                    attributeSupplier(mbs, objectName, attributeName));
+            }
+        });
+    }
+
+
+    private void tomcatThreadPool(final MetricRegistry registry, final MBeanServer mbs, final String attribute, final String metric) {
+        register("Catalina:type=ThreadPool,name=*", attribute, new RegisterCallback() {
+            @Override
+            public void onRegister(ObjectName objectName, String attributeName) {
+                registry.add(
+                    metric,
+                    Labels.Mutable.of("name", normalizeTomcatName(objectName)),
+                    attributeSupplier(mbs, objectName, attributeName));
+            }
+        });
+    }
+
+    private void tomcatDatasource(final MetricRegistry registry, final MBeanServer mbs, final String attribute, final String metric){
+        register("Catalina:type=DataSource,host=localhost,context=*,class=javax.sql.DataSource,name=*", attribute, new RegisterCallback() {
+            @Override
+            public void onRegister(ObjectName objectName, String attributeName) {
+                registry.add(
+                    metric,
+                    // 'context' is ignored as the datasource is shared, we rely on metric set for de-duplication
+                    Labels.Mutable.of("name", normalizeTomcatName(objectName)),
+                    attributeSupplier(mbs, objectName, attributeName)
+                );
+            }
+        });
+    }
+
+    private String normalizeTomcatName(ObjectName objectName) {
+        String value = objectName.getKeyProperty("name");
+        if (value.startsWith("\"") && value.endsWith("\"")) {
+            value = value.substring(1, value.length() - 1);
+        }
+        return value;
+    }
+
+    private DoubleSupplier attributeSupplier(final MBeanServer mbs, final ObjectName objectName, final String attribute) {
+        return new DoubleSupplier() {
+            @Override
+            public double get() {
+                Object attr = getAttribute(mbs, objectName, attribute);
+                if (attr instanceof Number) {
+                    double value = ((Number) attr).doubleValue();
+                    // We have to filter when capturing the metric value and not only at registration because it is
+                    // common to have a metrics, for example with pool limits that have no value on startup with a value of -1
+                    // but they can still change at runtime.
+                    if (value < 0) {
+                        value = Double.NaN;
+                    }
+                    return value;
+                } else {
+                    throw new IllegalArgumentException(String.format("unexpected attribute type for %s %s", objectName, attribute));
+                }
+            }
+        };
+    }
+
+    private static DoubleSupplier compositeAttributeSupplier(final MBeanServer mbs, final ObjectName objectName, final String attribute, final String compositeKey) {
+        return new DoubleSupplier() {
+            @Override
+            public double get() {
+                Object attr = getAttribute(mbs, objectName, attribute);
+                if (attr instanceof CompositeData) {
+                    Object value = ((CompositeData) attr).get(compositeKey);
+                    if (value instanceof Number) {
+                        return ((Number) value).doubleValue();
+                    }
+                }
+                throw new IllegalArgumentException(String.format("unexpected attribute type for %s %s %s", objectName, attribute, compositeKey));
+            }
+        };
+    }
+
+
+    private interface RegisterCallback {
+        void onRegister(ObjectName objectName, String attributeName);
+    }
+
+    private interface RegisterCompositeCallback {
+        void register(ObjectName objectName, String attributeName, String compositeKey);
+    }
+
+    private static abstract class Registration {
+        protected ObjectName objectName;
+        protected String attribute;
+
+        private static class ForSimpleAttribute extends Registration {
+            private final RegisterCallback cb;
+
+            public ForSimpleAttribute(ObjectName objectName, String attribute, RegisterCallback cb) {
+                super(objectName, attribute);
+                this.cb = cb;
+            }
+
+            protected void executeCallback(ObjectName matchingObjectName){
+                cb.onRegister(matchingObjectName, attribute);
+            }
+        }
+
+        public static Registration forSimpleAttribute(ObjectName objectName, String attribute, RegisterCallback cb){
+            return new ForSimpleAttribute(objectName, attribute, cb);
+        }
+
+        protected Registration(ObjectName objectName, String attribute) {
+            this.objectName = objectName;
+            this.attribute = attribute;
+        }
+
+        protected abstract void executeCallback(ObjectName matchingObjectName);
+
+        public void newMbeanNotification(MBeanServer mbs, ObjectName newObjectName) {
+            if (objectName.apply(newObjectName) && mbs.queryMBeans(newObjectName, null).size() > 0) {
+                executeCallback(newObjectName);
+            }
+        }
+
+        public void initialSearch(MBeanServer mbs){
+            Set<ObjectInstance> instances = mbs.queryMBeans(objectName, null);
+            for (ObjectInstance instance : instances) {
+                executeCallback(instance.getObjectName());
+            }
+        }
+    }
+
+    private void register(String objectName, String attribute, RegisterCallback cb) {
+        registrations.add(Registration.forSimpleAttribute(getObjectName(objectName), attribute, cb));
+    }
+
+    private void tryRegisterComposite(MBeanServer mbs, String objectName, String attribute, String compositeKey, RegisterCompositeCallback cb) {
+        ObjectName objName = getObjectName(objectName);
+        Object attr = getAttribute(mbs, objName, attribute);
+        if (attr instanceof CompositeData) {
+            Object compositeValue = ((CompositeData) attr).get(compositeKey);
+            if (compositeValue != null) {
+                cb.register(objName, attribute, compositeKey);
+            }
+        }
+    }
+
+    private static ObjectName getObjectName(String s) {
+        try {
+            return new ObjectName(s);
+        } catch (MalformedObjectNameException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    @Nullable
+    private static Object getAttribute(MBeanServer mbs, ObjectName objectName, String attribute) {
+        try {
+            return mbs.getAttribute(objectName, attribute);
+        } catch (InstanceNotFoundException | AttributeNotFoundException e) {
+            // ignore if absent
+            return null;
+        } catch (JMException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+}

--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxConfiguration.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxConfiguration.java
@@ -133,7 +133,15 @@ public class JmxConfiguration extends ConfigurationOptionProvider {
         .configurationCategory("JMX")
         .buildWithDefault(Collections.<JmxMetric>emptyList());
 
+    private final ConfigurationOption<Boolean> autoJmxMetrics = ConfigurationOption.<Boolean>booleanOption()
+        .key("auto_jmx_metrics_enabled")
+        .buildWithDefault(false);
+
     ConfigurationOption<List<JmxMetric>> getCaptureJmxMetrics() {
         return captureJmxMetrics;
+    }
+
+    ConfigurationOption<Boolean> getAutoJmxMetrics() {
+        return autoJmxMetrics;
     }
 }

--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxConfiguration.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxConfiguration.java
@@ -133,15 +133,17 @@ public class JmxConfiguration extends ConfigurationOptionProvider {
         .configurationCategory("JMX")
         .buildWithDefault(Collections.<JmxMetric>emptyList());
 
-    private final ConfigurationOption<Boolean> autoJmxMetrics = ConfigurationOption.<Boolean>booleanOption()
-        .key("auto_jmx_metrics_enabled")
+    private final ConfigurationOption<Boolean> captureAutoJmxMetrics = ConfigurationOption.booleanOption()
+        .key("capture_auto_jmx_metrics")
+        .dynamic(true)
+        .configurationCategory("JMX")
         .buildWithDefault(false);
 
     ConfigurationOption<List<JmxMetric>> getCaptureJmxMetrics() {
         return captureJmxMetrics;
     }
-
-    ConfigurationOption<Boolean> getAutoJmxMetrics() {
-        return autoJmxMetrics;
+    ConfigurationOption<Boolean> getCaptureAutoJmxMetrics() {
+        return captureAutoJmxMetrics;
     }
+
 }

--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetric.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetric.java
@@ -40,6 +40,8 @@ public class JmxMetric {
     private static final String OBJECT_NAME = "object_name";
     private static final String ATTRIBUTE = "attribute";
     private static final String METRIC_NAME = "metric_name";
+    private static final String METRIC_PREFIX = "metric_prefix";
+    private static final String METRIC_DEFAULT_PREFIX = "jvm.jmx.";
     private final ObjectName objectName;
     private final List<Attribute> attributes;
 
@@ -147,7 +149,6 @@ public class JmxMetric {
         public static final String IGNORE = "ignore";
         private final String stringRepresentation;
         private final String jmxAttributeName;
-        @Nullable
         private final String metricName;
 
         public static Attribute valueOf(final String s) {
@@ -161,20 +162,20 @@ public class JmxMetric {
                     objectName = new ObjectName(s);
                 }
                 Set<String> unknownProperties = new HashSet<>(objectName.getKeyPropertyList().keySet());
-                unknownProperties.removeAll(Arrays.asList(IGNORE, METRIC_NAME));
+                unknownProperties.removeAll(Arrays.asList(IGNORE, METRIC_NAME, METRIC_PREFIX));
                 if (!unknownProperties.isEmpty()) {
                     throw new IllegalArgumentException("Unknown properties: " + unknownProperties);
                 }
-                return new Attribute(s, objectName.getDomain(), objectName.getKeyProperty(METRIC_NAME));
+                return new Attribute(s, objectName.getDomain(), objectName.getKeyProperty(METRIC_NAME), objectName.getKeyProperty(METRIC_PREFIX));
             } catch (MalformedObjectNameException e) {
                 throw new IllegalArgumentException("Invalid syntax for attribute[" + s + "] (" + e.getMessage() + ")", e);
             }
         }
 
-        private Attribute(String stringRepresentation, String jmxAttributeName, @Nullable String metricName) {
+        private Attribute(String stringRepresentation, String jmxAttributeName, @Nullable String metricName, @Nullable String metricPrefix) {
             this.stringRepresentation = stringRepresentation;
             this.jmxAttributeName = jmxAttributeName;
-            this.metricName = metricName;
+            this.metricName = (metricPrefix != null ? metricPrefix : METRIC_DEFAULT_PREFIX) + (metricName != null ? metricName : jmxAttributeName);
         }
 
         public String getJmxAttributeName() {
@@ -182,7 +183,7 @@ public class JmxMetric {
         }
 
         public String getMetricName() {
-            return metricName != null ? metricName : jmxAttributeName;
+            return metricName;
         }
 
         @Override

--- a/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/main/java/co/elastic/apm/agent/jmx/JmxMetricTracker.java
@@ -54,7 +54,6 @@ import java.util.concurrent.TimeUnit;
 
 public class JmxMetricTracker extends AbstractLifecycleListener {
 
-    private static final String JMX_PREFIX = "jvm.jmx.";
     private static final Logger logger = LoggerFactory.getLogger(JmxMetricTracker.class);
     @Nullable
     private volatile Thread logManagerPropertyPoller;
@@ -322,7 +321,7 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
                     value = server.getAttribute(objectName, attribute.getJmxAttributeName());
                     if (value instanceof Number) {
                         logger.debug("Found number attribute {}={}", attribute.getJmxAttributeName(), value);
-                        registrations.add(new JmxMetricRegistration(JMX_PREFIX + attribute.getMetricName(),
+                        registrations.add(new JmxMetricRegistration(attribute.getMetricName(),
                             Labels.Mutable.of(objectName.getKeyPropertyList()),
                             attribute.getJmxAttributeName(),
                             null,
@@ -332,7 +331,7 @@ public class JmxMetricTracker extends AbstractLifecycleListener {
                         for (final String key : compositeValue.getCompositeType().keySet()) {
                             if (compositeValue.get(key) instanceof Number) {
                                 logger.debug("Found composite number attribute {}.{}={}", attribute.getJmxAttributeName(), key, value);
-                                registrations.add(new JmxMetricRegistration(JMX_PREFIX + attribute.getMetricName() + "." + key,
+                                registrations.add(new JmxMetricRegistration(attribute.getMetricName() + "." + key,
                                     Labels.Mutable.of(objectName.getKeyPropertyList()),
                                     attribute.getJmxAttributeName(),
                                     key,

--- a/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricValueConverterTest.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricValueConverterTest.java
@@ -28,6 +28,27 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 class JmxMetricValueConverterTest {
 
     @Test
+    void testMetricName() {
+        testMetricName("object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionCount]",
+            "jvm.jmx.CollectionCount", "CollectionCount");
+
+        testMetricName("object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionCount:metric_name=collection_count]",
+            "jvm.jmx.collection_count", "CollectionCount");
+
+        testMetricName("object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionCount:metric_name=collection_count,metric_prefix=my.prefix.]",
+            "my.prefix.collection_count", "CollectionCount");
+    }
+
+    private static void testMetricName(String s, String expectedMetricName, String expectedJmxAttributeName) {
+        JmxMetric metric = JmxMetric.valueOf(s);
+        assertThat(metric.getAttributes()).hasSize(1);
+        metric.getAttributes().forEach(a -> {
+            assertThat(a.getMetricName()).isEqualTo(expectedMetricName);
+            assertThat(a.getJmxAttributeName()).isEqualTo(expectedJmxAttributeName);
+        });
+    }
+
+    @Test
     void testFromString() {
         JmxMetric expected = JmxMetric.valueOf("object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionCount:metric_name=collection_count]");
         assertThat(JmxMetric.valueOf(expected.toString())).isEqualTo(expected);

--- a/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricValueConverterTest.java
+++ b/apm-agent-plugins/apm-jmx-plugin/src/test/java/co/elastic/apm/agent/jmx/JmxMetricValueConverterTest.java
@@ -32,11 +32,8 @@ class JmxMetricValueConverterTest {
         testMetricName("object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionCount]",
             "jvm.jmx.CollectionCount", "CollectionCount");
 
-        testMetricName("object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionCount:metric_name=collection_count]",
-            "jvm.jmx.collection_count", "CollectionCount");
-
-        testMetricName("object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionCount:metric_name=collection_count,metric_prefix=my.prefix.]",
-            "my.prefix.collection_count", "CollectionCount");
+        testMetricName("object_name[java.lang:type=GarbageCollector,name=*] attribute[CollectionTime:metric_name=collection_time]",
+            "jvm.jmx.collection_time", "CollectionTime");
     }
 
     private static void testMetricName(String s, String expectedMetricName, String expectedJmxAttributeName) {


### PR DESCRIPTION
## What does this PR do?

Implements a PoC for capturing known JMX metrics automatically, for now limited to Tomcat application servers.
This PR is not meant to be merged as-is and would require proper specification of the metrics names and their definitions first.

## Checklist

- [ ] Allow to disable the feature at runtime
- [ ] Define the metrics naming conventions and definitions for the capture metrics, maybe align to OpenTelemetry naming strategy
- [ ] Maybe modify the existing conventions we have for JVM metrics to make them fit OpenTelemetry naming conventions
- [ ] Validate the Tomcat metrics relevance from an ops perspective (compare with similar tools/dashboards might help).