### PR TITLE
guard against NPE in bb warmup error handling

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/ErrorLoggingListener.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/ErrorLoggingListener.java
@@ -35,7 +35,7 @@ public class ErrorLoggingListener extends AgentBuilder.Listener.Adapter {
                 typeName,
                 ((MinimumClassFileVersionValidator.UnsupportedClassFileVersionException)throwable).getMinVersion());
         } else {
-            if (throwable instanceof net.bytebuddy.pool.TypePool$Resolution$NoSuchTypeException) {
+            if (throwable instanceof net.bytebuddy.pool.TypePool.Resolution.NoSuchTypeException) {
                 logger.info(typeName + " refers to a missing class.");
                 logger.debug("ByteBuddy type resolution stack trace: ", throwable);
             } else {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/ErrorLoggingListener.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/ErrorLoggingListener.java
@@ -35,7 +35,7 @@ public class ErrorLoggingListener extends AgentBuilder.Listener.Adapter {
                 typeName,
                 ((MinimumClassFileVersionValidator.UnsupportedClassFileVersionException)throwable).getMinVersion());
         } else {
-            if (throwable != null && throwable.getMessage() != null && throwable.getMessage().contains("Cannot resolve type description")) {
+            if (throwable instanceof net.bytebuddy.pool.TypePool$Resolution$NoSuchTypeException) {
                 logger.info(typeName + " refers to a missing class.");
                 logger.debug("ByteBuddy type resolution stack trace: ", throwable);
             } else {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/ErrorLoggingListener.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/bytebuddy/ErrorLoggingListener.java
@@ -35,7 +35,7 @@ public class ErrorLoggingListener extends AgentBuilder.Listener.Adapter {
                 typeName,
                 ((MinimumClassFileVersionValidator.UnsupportedClassFileVersionException)throwable).getMinVersion());
         } else {
-            if (throwable.getMessage().contains("Cannot resolve type description")) {
+            if (throwable != null && throwable.getMessage() != null && throwable.getMessage().contains("Cannot resolve type description")) {
                 logger.info(typeName + " refers to a missing class.");
                 logger.debug("ByteBuddy type resolution stack trace: ", throwable);
             } else {

--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/lettuce/Lettuce5VersionsIT.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/lettuce/Lettuce5VersionsIT.java
@@ -41,7 +41,7 @@ public class Lettuce5VersionsIT {
         return Arrays.asList(new Object[][] {
             { List.of("io.lettuce:lettuce-core:5.2.1.RELEASE", "io.netty:netty-all:4.1.43.Final") },
             { List.of("io.lettuce:lettuce-core:5.1.8.RELEASE", "io.netty:netty-all:4.1.38.Final") },
-            { List.of("io.lettuce:lettuce-core:5.0.5.RELEASE", "io.netty:netty-all:4.1.28.Final") },
+            { List.of("io.lettuce:lettuce-core:5.0.5.RELEASE", "io.netty:netty-all:4.1.28.Final", "io.projectreactor:reactor-core:3.1.6.RELEASE") },
         });
     }
 


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
