### PR TITLE
Increase transaction count timeout

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockReporter.java
@@ -426,6 +426,12 @@ public class MockReporter implements Reporter {
             .isEqualTo(count));
     }
 
+    public void awaitTransactionCount(int count, long timeoutMs) {
+        awaitUntilAsserted(timeoutMs, () -> assertThat(getNumReportedTransactions())
+            .describedAs("expecting %d transactions, transactions = %s", count, transactions)
+            .isEqualTo(count));
+    }
+
     public void awaitSpanCount(int count) {
         awaitUntilAsserted(() -> assertThat(getNumReportedSpans())
             .describedAs("expecting %d spans", count)

--- a/apm-agent-plugins/apm-quartz-job-plugin/apm-quartz-1-plugin/src/test/java/co/elastic/apm/agent/quartzjob/Quartz1JobTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-quartz-job-plugin/apm-quartz-1-plugin/src/test/java/co/elastic/apm/agent/quartzjob/Quartz1JobTransactionNameInstrumentationTest.java
@@ -21,10 +21,12 @@ package co.elastic.apm.agent.quartzjob;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.transaction.Outcome;
 import co.elastic.apm.agent.impl.transaction.Transaction;
+import org.junit.jupiter.api.Test;
 import org.quartz.Job;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
+import org.quartz.SchedulerException;
 import org.quartz.SimpleTrigger;
 
 import javax.annotation.Nullable;
@@ -34,9 +36,17 @@ import static org.awaitility.Awaitility.await;
 
 class Quartz1JobTransactionNameInstrumentationTest extends AbstractJobTransactionNameInstrumentationTest {
 
+    @Test
+    void test100Times() throws SchedulerException {
+        for (int i = 0; i < 100; i++) {
+            super.testJobWithResult();
+            reporter.reset();
+        }
+    }
+
     @Override
     public Transaction verifyTransactionFromJobDetails(JobDetail job, Outcome expectedOutcome) {
-        reporter.awaitTransactionCount(1);
+        reporter.awaitTransactionCount(1, 2000);
 
         Transaction transaction = reporter.getFirstTransaction();
         await().untilAsserted(() -> assertThat(reporter.getTransactions().size()).isEqualTo(1));

--- a/apm-agent-plugins/apm-quartz-job-plugin/apm-quartz-1-plugin/src/test/java/co/elastic/apm/agent/quartzjob/Quartz1JobTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-quartz-job-plugin/apm-quartz-1-plugin/src/test/java/co/elastic/apm/agent/quartzjob/Quartz1JobTransactionNameInstrumentationTest.java
@@ -21,12 +21,10 @@ package co.elastic.apm.agent.quartzjob;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.transaction.Outcome;
 import co.elastic.apm.agent.impl.transaction.Transaction;
-import org.junit.jupiter.api.Test;
 import org.quartz.Job;
 import org.quartz.JobDetail;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
-import org.quartz.SchedulerException;
 import org.quartz.SimpleTrigger;
 
 import javax.annotation.Nullable;
@@ -35,14 +33,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 class Quartz1JobTransactionNameInstrumentationTest extends AbstractJobTransactionNameInstrumentationTest {
-
-    @Test
-    void test100Times() throws SchedulerException {
-        for (int i = 0; i < 100; i++) {
-            super.testJobWithResult();
-            reporter.reset();
-        }
-    }
 
     @Override
     public Transaction verifyTransactionFromJobDetails(JobDetail job, Outcome expectedOutcome) {


### PR DESCRIPTION
Checking whether latest CI failures (e.g. [309](https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/main/309/) and [310](https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/main/310/)) are related to insufficient time allowed for transactions to be reported.

Checklist:
- [x] verify in build tests that the `test100Times()` test had been executed and passed
- [x] remove the `test100Times()` test