### PR TITLE
Avoid context propagation from agent threads and Executors

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/ExecutorUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/ExecutorUtilsTest.java
@@ -34,8 +34,9 @@ class ExecutorUtilsTest {
     @Test
     void testSingleThreadSchedulingDaemonPool() throws ExecutionException, InterruptedException, TimeoutException {
         final String threadPurpose = "test-single-scheduling-pool";
-        ThreadPoolExecutor singleThreadDaemonPool = ExecutorUtils.createSingleThreadSchedulingDaemonPool(threadPurpose);
-        executeTestOnThreadPool(singleThreadDaemonPool, threadPurpose, 1);
+        ThreadPoolExecutor singleThreadSchedulingDaemonPool = ExecutorUtils.createSingleThreadSchedulingDaemonPool(threadPurpose);
+        executeTestOnThreadPool(singleThreadSchedulingDaemonPool, threadPurpose, 1);
+        assertThat(ExecutorUtils.isAgentExecutor(singleThreadSchedulingDaemonPool)).isTrue();
     }
 
     @Test
@@ -43,13 +44,15 @@ class ExecutorUtilsTest {
         final String threadPurpose = "test-single-pool";
         ThreadPoolExecutor singleThreadDaemonPool = ExecutorUtils.createSingleThreadDaemonPool(threadPurpose, 5);
         executeTestOnThreadPool(singleThreadDaemonPool, threadPurpose, 1);
+        assertThat(ExecutorUtils.isAgentExecutor(singleThreadDaemonPool)).isTrue();
     }
 
     @Test
     void testThreadDaemonPool() throws ExecutionException, InterruptedException, TimeoutException {
-        final String threadPurpose = "test-single-pool";
-        ThreadPoolExecutor singleThreadDaemonPool = ExecutorUtils.createThreadDaemonPool(threadPurpose, 3, 5);
-        executeTestOnThreadPool(singleThreadDaemonPool, threadPurpose, 3);
+        final String threadPurpose = "test-pool";
+        ThreadPoolExecutor threadDaemonPool = ExecutorUtils.createThreadDaemonPool(threadPurpose, 3, 5);
+        executeTestOnThreadPool(threadDaemonPool, threadPurpose, 3);
+        assertThat(ExecutorUtils.isAgentExecutor(threadDaemonPool)).isTrue();
     }
 
     private void executeTestOnThreadPool(ThreadPoolExecutor singleThreadDaemonPool, String threadPurpose, int maxPoolSize)

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ExecutorInstrumentation.java
@@ -20,6 +20,7 @@ package co.elastic.apm.agent.concurrent;
 
 import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import co.elastic.apm.agent.sdk.state.GlobalVariables;
+import co.elastic.apm.agent.util.ExecutorUtils;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned.ToArguments.ToArgument;
 import net.bytebuddy.description.NamedElement;
@@ -99,7 +100,8 @@ public abstract class ExecutorInstrumentation extends TracerAwareInstrumentation
     }
 
     private static boolean isExcluded(@Advice.This Executor executor) {
-        return excludedClasses.contains(executor.getClass().getName());
+        return excludedClasses.contains(executor.getClass().getName()) ||
+            ExecutorUtils.isAgentExecutor(executor);
     }
 
     public static class ExecutorRunnableInstrumentation extends ExecutorInstrumentation {

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/JavaConcurrent.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/JavaConcurrent.java
@@ -19,6 +19,7 @@
 package co.elastic.apm.agent.concurrent;
 
 import co.elastic.apm.agent.collections.WeakConcurrentProviderImpl;
+import co.elastic.apm.agent.common.ThreadUtils;
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.sdk.DynamicTransformer;
@@ -65,6 +66,7 @@ public class JavaConcurrent {
 
     private static boolean shouldAvoidContextPropagation(@Nullable Object executable) {
         return executable == null ||
+            Thread.currentThread().getName().startsWith(ThreadUtils.ELASTIC_APM_THREAD_PREFIX) ||
             EXCLUDED_EXECUTABLE_TYPES.contains(executable.getClass().getName()) ||
             needsContext.get() == Boolean.FALSE;
     }


### PR DESCRIPTION
Disabling context propagation from agent threads and when submitting tasks/runnables/callables to agent executors.

This started by investigation of CI flakiness at `CommonsExecAsyncInstrumentationTest` (example: https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/main/313/) that is apparently related to our test causing metadata to start threads on which they execute processes for metadata discovery (eg `uname -n`), which invokes our process instrumentation and so forth.

But besides eliminating test issues, IIANM such exclusion of context propagation on agent threads is the right thing to do anyway. 