### PR TITLE
Simplify `ExecutorUtils.isAgentExecutor()`

### DIFF
--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ExecutorServiceInstrumentationTest.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ExecutorServiceInstrumentationTest.java
@@ -26,6 +26,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
+import test.CurrentThreadExecutor;
 
 import java.util.Arrays;
 import java.util.Collections;

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ScheduledExecutorServiceTest.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/co/elastic/apm/agent/concurrent/ScheduledExecutorServiceTest.java
@@ -24,8 +24,8 @@ import co.elastic.apm.agent.impl.transaction.Transaction;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import test.CustomScheduledThreadPoolExecutor;
 
-import java.util.concurrent.Callable;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -41,17 +41,7 @@ public class ScheduledExecutorServiceTest extends AbstractInstrumentationTest {
     @BeforeEach
     void setUp() {
         transaction = tracer.startRootTransaction(null).withName("transaction").activate();
-        scheduler = new ScheduledThreadPoolExecutor(1) {
-            @Override
-            public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
-                return super.schedule(callable, delay, unit);
-            }
-
-            @Override
-            public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
-                return super.schedule(command, delay, unit);
-            }
-        };
+        scheduler = new CustomScheduledThreadPoolExecutor(1);
     }
 
     @AfterEach

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/test/CurrentThreadExecutor.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/test/CurrentThreadExecutor.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.concurrent;
+package test;
 
 import java.util.concurrent.Executor;
 

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/test/CustomScheduledThreadPoolExecutor.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/test/CustomScheduledThreadPoolExecutor.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class CustomScheduledThreadPoolExecutor extends ScheduledThreadPoolExecutor {
+
+    public CustomScheduledThreadPoolExecutor(int corePoolSize) {
+        super(corePoolSize);
+    }
+
+    @Override
+        public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+            return super.schedule(callable, delay, unit);
+        }
+
+        @Override
+        public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+            return super.schedule(command, delay, unit);
+        }
+}

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/test/package-info.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/test/java/test/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+/**
+ * A package outside the root agent package, so that its test custom Executors will escape the
+ * {@link co.elastic.apm.agent.util.ExecutorUtils#isAgentExecutor(java.util.concurrent.Executor) ExecutorUtils.isAgentExecutor()} check
+ */
+@NonnullApi
+package test;
+
+import co.elastic.apm.agent.sdk.NonnullApi;


### PR DESCRIPTION
I just realized that the `ExecutorUtils.isAgentExecutor()` utility added in #2723 can be simplified by only looking at executor class name, thus avoiding the added overhead of weak-reference maintenance and more importantly- the concurrency-safe frequent lookups.