### PR TITLE
Adding null check to `AmazonHttpClientInstrumentation`

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,6 +40,7 @@ version of classes that are available also in the parent (bootstrap) class loade
 ===== Bug fixes
 * Fix unexpected side-effects of `toString` calls within reactor instrumentation - {pull}2708[#2708]
 * Fix Vert.x instrumentation for 4.3.2 - {pull}2700[#2700]
+* Fix `NullPointerException` in `AmazonHttpClientInstrumentation` - {pull}2740[#2740]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/main/java/co/elastic/apm/agent/awssdk/v1/AmazonHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/main/java/co/elastic/apm/agent/awssdk/v1/AmazonHttpClientInstrumentation.java
@@ -67,6 +67,10 @@ public class AmazonHttpClientInstrumentation extends TracerAwareInstrumentation 
         public static Object enterInvoke(@Advice.Argument(value = 0) Request<?> request,
                                          @Advice.Argument(value = 3) ExecutionContext executionContext) {
             String awsService = request.getHandlerContext(HandlerContextKey.SERVICE_ID);
+            if (awsService == null) {
+                return null;
+            }
+
             Span span = null;
             if (awsService.startsWith("S3")) {
                 span = S3Helper.getInstance().startSpan(request, request.getEndpoint(), executionContext);


### PR DESCRIPTION
Closes #2739 

Assuming that when the handler context map doesn't contain the `ServiceId` key, it is neither S3 nor DynamoDB related request. If this assumption is wrong, this doesn't close it and further investigation reqired.