### PR TITLE
Weblogic empty servlet path fallback

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -43,6 +43,7 @@ version of classes that are available also in the parent (bootstrap) class loade
 * Fix `NullPointerException` in `AmazonHttpClientInstrumentation` - {pull}2740[#2740]
 * Fix stack frame exclusion patterns - {pull}2758[#2758]
 * Fix `NullPointerException` with compressed spans - {pull}2755[#2755]
+* Fix empty servlet path with proper fallback - {pull}2748[#2748]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -239,10 +239,23 @@ public abstract class ServletApiAdvice {
                     }
                 }
 
-                servletTransactionHelper.onAfter(transaction, t == null ? t2 : t, adapter.isCommitted(httpServletResponse), adapter.getStatus(httpServletResponse),
-                    overrideStatusCodeOnThrowable, adapter.getMethod(httpServletRequest), parameterMap, adapter.getServletPath(httpServletRequest),
-                    adapter.getPathInfo(httpServletRequest), contentTypeHeader, true
-                );
+                String contextPath = adapter.getContextPath(adapter.getServletContext(httpServletRequest));
+                String pathInfo = adapter.getPathInfo(httpServletRequest);
+                String requestURI = adapter.getRequestURI(httpServletRequest);
+
+                String normalizedServletPath = servletTransactionHelper.normalizeServletPath(requestURI, contextPath, adapter.getServletPath(httpServletRequest), pathInfo);
+
+                servletTransactionHelper.onAfter(
+                    transaction, t == null ? t2 : t,
+                    adapter.isCommitted(httpServletResponse),
+                    adapter.getStatus(httpServletResponse),
+                    overrideStatusCodeOnThrowable,
+                    adapter.getMethod(httpServletRequest),
+                    parameterMap,
+                    normalizedServletPath,
+                    pathInfo,
+                    contentTypeHeader,
+                    true);
             }
         }
         if (span != null) {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -239,11 +239,14 @@ public abstract class ServletApiAdvice {
                     }
                 }
 
-                String contextPath = adapter.getContextPath(adapter.getServletContext(httpServletRequest));
+                ServletContext servletContext = adapter.getServletContext(httpServletRequest);
+                String servletPath = adapter.getServletPath(httpServletRequest);
                 String pathInfo = adapter.getPathInfo(httpServletRequest);
-                String requestURI = adapter.getRequestURI(httpServletRequest);
-
-                String normalizedServletPath = servletTransactionHelper.normalizeServletPath(requestURI, contextPath, adapter.getServletPath(httpServletRequest), pathInfo);
+                if (servletPath == null || servletPath.length() == 0 && servletContext != null) {
+                    String contextPath = adapter.getContextPath(servletContext);
+                    String requestURI = adapter.getRequestURI(httpServletRequest);
+                    servletPath = servletTransactionHelper.normalizeServletPath(requestURI, contextPath, servletPath, pathInfo);
+                }
 
                 servletTransactionHelper.onAfter(
                     transaction, t == null ? t2 : t,
@@ -252,7 +255,7 @@ public abstract class ServletApiAdvice {
                     overrideStatusCodeOnThrowable,
                     adapter.getMethod(httpServletRequest),
                     parameterMap,
-                    normalizedServletPath,
+                    servletPath,
                     pathInfo,
                     contentTypeHeader,
                     true);

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -242,7 +242,7 @@ public abstract class ServletApiAdvice {
                 ServletContext servletContext = adapter.getServletContext(httpServletRequest);
                 String servletPath = adapter.getServletPath(httpServletRequest);
                 String pathInfo = adapter.getPathInfo(httpServletRequest);
-                if (servletPath == null || servletPath.length() == 0 && servletContext != null) {
+                if ((servletPath == null || servletPath.isEmpty()) && servletContext != null) {
                     String contextPath = adapter.getContextPath(servletContext);
                     String requestURI = adapter.getRequestURI(httpServletRequest);
                     servletPath = servletTransactionHelper.normalizeServletPath(requestURI, contextPath, servletPath, pathInfo);

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -146,29 +146,34 @@ public class ServletTransactionHelper {
 
     public String normalizeServletPath(String requestURI, @Nullable String contextPath, @Nullable String servletPath, @Nullable String pathInfo) {
         String path = servletPath;
-        if (path == null || path.isEmpty()) {
-            logger.debug("Weblogic fallback applied. requestURI = {}, contextPath = {}, servletPath = {}, pathInfo = {}", requestURI, contextPath, servletPath, pathInfo);
-
-            int start = 0;
-            int end = requestURI.length();
-            if (contextPath != null && contextPath.length() > 0) {
-                if (!contextPath.equals("/")) {
-                    start = contextPath.length();
-                }
-            }
-            if (pathInfo != null) {
-                end -= pathInfo.length();
-            }
-
-            if (start == end) {
-                // use complete request URI instead of an empty string as fallback
-                path = requestURI;
-            } else {
-                path = requestURI.substring(start, end);
-            }
-
-            logger.debug("servlet path normalized to {}", path);
+        if (path != null && !path.isEmpty()) {
+            return path;
         }
+
+        logger.debug("Empty servlet path fallback applied. requestURI = {}, contextPath = {}, servletPath = {}, pathInfo = {}", requestURI, contextPath, servletPath, pathInfo);
+
+        int start = 0;
+        int end = requestURI.length();
+        boolean hasPathInfo = false;
+
+        if (pathInfo != null && pathInfo.length() > 0) {
+            end -= pathInfo.length();
+            hasPathInfo = true;
+        }
+
+        if (contextPath != null && contextPath.length() > 0) {
+            if (!contextPath.equals("/")) {
+                start = contextPath.length();
+            }
+        }
+
+        if (hasPathInfo || end != start) {
+            path = requestURI.substring(start, end);
+        } else {
+            path = requestURI;
+        }
+
+        logger.debug("servlet path normalized to {}", path);
 
         return path;
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -159,7 +159,14 @@ public class ServletTransactionHelper {
             if (pathInfo != null) {
                 end -= pathInfo.length();
             }
-            path = requestURI.substring(start, end);
+
+            if (start == end) {
+                // use complete request URI instead of an empty string as fallback
+                path = requestURI;
+            } else {
+                path = requestURI.substring(start, end);
+            }
+
             logger.debug("servlet path normalized to {}", path);
         }
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -150,7 +150,9 @@ public class ServletTransactionHelper {
             return path;
         }
 
-        logger.debug("Empty servlet path fallback applied. requestURI = {}, contextPath = {}, servletPath = {}, pathInfo = {}", requestURI, contextPath, servletPath, pathInfo);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Empty servlet path fallback applied. requestURI = {}, contextPath = {}, servletPath = {}, pathInfo = {}", requestURI, contextPath, servletPath, pathInfo);
+        }
 
         int start = 0;
         int end = requestURI.length();

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -144,13 +144,31 @@ public class ServletTransactionHelper {
         }
     }
 
+    public String normalizeServletPath(String requestURI, @Nullable String contextPath, @Nullable String servletPath, @Nullable String pathInfo) {
+        String path = servletPath;
+        if (path == null || path.isEmpty()) {
+            logger.debug("Weblogic fallback applied. requestURI = {}, contextPath = {}, servletPath = {}, pathInfo = {}", requestURI, contextPath, servletPath, pathInfo);
+
+            int start = 0;
+            int end = requestURI.length();
+            if (contextPath != null && contextPath.length() > 0) {
+                if (!contextPath.equals("/")) {
+                    start = contextPath.length();
+                }
+            }
+            if (pathInfo != null) {
+                end -= pathInfo.length();
+            }
+            path = requestURI.substring(start, end);
+            logger.debug("servlet path normalized to {}", path);
+        }
+
+        return path;
+    }
+
     public void onAfter(Transaction transaction, @Nullable Throwable exception, boolean committed, int status,
                         boolean overrideStatusCodeOnThrowable, String method, @Nullable Map<String, String[]> parameterMap,
                         @Nullable String servletPath, @Nullable String pathInfo, @Nullable String contentTypeHeader, boolean deactivate) {
-        if (servletPath == null) {
-            // the servlet path is specified as non-null but WebLogic does return null...
-            servletPath = "";
-        }
         try {
             // thrown the first time a JSP is invoked in order to register it
             if (exception != null && "weblogic.servlet.jsp.AddToMapException".equals(exception.getClass().getName())) {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JakartaServletApiAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JakartaServletApiAdapter.java
@@ -196,6 +196,7 @@ public class JakartaServletApiAdapter implements ServletApiAdapter<HttpServletRe
     }
 
     @Override
+    @Nullable
     public String getPathInfo(HttpServletRequest servletRequest) {
         return servletRequest.getPathInfo();
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
@@ -194,6 +194,7 @@ public class JavaxServletApiAdapter implements ServletApiAdapter<HttpServletRequ
     }
 
     @Override
+    @Nullable
     public String getPathInfo(HttpServletRequest servletRequest) {
         return servletRequest.getPathInfo();
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/ServletRequestAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/ServletRequestAdapter.java
@@ -75,6 +75,7 @@ public interface ServletRequestAdapter<HttpServletRequest, ServletContext> {
     @Nullable
     String getServletPath(HttpServletRequest servletRequest);
 
+    @Nullable
     String getPathInfo(HttpServletRequest servletRequest);
 
     Object getIncludeServletPathAttribute(HttpServletRequest servletRequest);

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
@@ -103,7 +103,6 @@ class ServletTransactionHelperTest extends AbstractInstrumentationTest {
             servletPath -> {
                 // reconstruct servlet path from URI
                 assertThat(servletTransactionHelper.normalizeServletPath("/context/servlet", "/context", servletPath, null)).isEqualTo("/servlet");
-                assertThat(servletTransactionHelper.normalizeServletPath("/context/servlet", "/context", servletPath, null)).isEqualTo("/servlet");
 
                 // reconstruct servlet path from URI with empty/null/root context path
                 assertThat(servletTransactionHelper.normalizeServletPath("/servlet", "", servletPath, null)).isEqualTo("/servlet");
@@ -114,6 +113,10 @@ class ServletTransactionHelperTest extends AbstractInstrumentationTest {
                 assertThat(servletTransactionHelper.normalizeServletPath("/context/servlet/info", "/context", servletPath, "/info")).isEqualTo("/servlet");
                 assertThat(servletTransactionHelper.normalizeServletPath("/servlet/info", "/", servletPath, "/info")).isEqualTo("/servlet");
                 assertThat(servletTransactionHelper.normalizeServletPath("/servlet/info", null, servletPath, "/info")).isEqualTo("/servlet");
+
+                // limit case where the complete requestURI equals the context path
+                assertThat(servletTransactionHelper.normalizeServletPath("/context/servlet", "/context/servlet", servletPath, null)).isEqualTo("/context/servlet");
+
             }
         );
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
@@ -116,6 +116,11 @@ class ServletTransactionHelperTest extends AbstractInstrumentationTest {
 
                 // limit case where the complete requestURI equals the context path
                 assertThat(servletTransactionHelper.normalizeServletPath("/context/servlet", "/context/servlet", servletPath, null)).isEqualTo("/context/servlet");
+                assertThat(servletTransactionHelper.normalizeServletPath("/context/servlet", "/context/servlet", servletPath, "")).isEqualTo("/context/servlet");
+
+                // limit case where the pathInfo contains the request path, the servlet path should be empty
+                assertThat(servletTransactionHelper.normalizeServletPath("/request/uri", null, servletPath, "/request/uri")).isEqualTo("");
+                assertThat(servletTransactionHelper.normalizeServletPath("/request/uri", "", servletPath, "/request/uri")).isEqualTo("");
 
             }
         );

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/ServletTransactionHelperTest.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.stream.Stream;
 
 import static co.elastic.apm.agent.impl.transaction.AbstractSpan.PRIO_LOW_LEVEL_FRAMEWORK;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -91,6 +92,31 @@ class ServletTransactionHelperTest extends AbstractInstrumentationTest {
         Transaction transaction = new Transaction(MockTracer.create());
         servletTransactionHelper.applyDefaultTransactionName(method, path, null, transaction);
         return transaction.getNameAsString();
+    }
+
+    @Test
+    void testServletPathNormalization() {
+        // use servlet path when provided and not empty
+        assertThat(servletTransactionHelper.normalizeServletPath("/ignored/ignored-servlet", "/ignored", "/servlet", null)).isEqualTo("/servlet");
+
+        Stream.of("", null).forEach(
+            servletPath -> {
+                // reconstruct servlet path from URI
+                assertThat(servletTransactionHelper.normalizeServletPath("/context/servlet", "/context", servletPath, null)).isEqualTo("/servlet");
+                assertThat(servletTransactionHelper.normalizeServletPath("/context/servlet", "/context", servletPath, null)).isEqualTo("/servlet");
+
+                // reconstruct servlet path from URI with empty/null/root context path
+                assertThat(servletTransactionHelper.normalizeServletPath("/servlet", "", servletPath, null)).isEqualTo("/servlet");
+                assertThat(servletTransactionHelper.normalizeServletPath("/servlet", "/", servletPath, null)).isEqualTo("/servlet");
+                assertThat(servletTransactionHelper.normalizeServletPath("/servlet", null, servletPath, null)).isEqualTo("/servlet");
+
+                // reconstruct servlet path from URI with empty/null/root context path + path info
+                assertThat(servletTransactionHelper.normalizeServletPath("/context/servlet/info", "/context", servletPath, "/info")).isEqualTo("/servlet");
+                assertThat(servletTransactionHelper.normalizeServletPath("/servlet/info", "/", servletPath, "/info")).isEqualTo("/servlet");
+                assertThat(servletTransactionHelper.normalizeServletPath("/servlet/info", null, servletPath, "/info")).isEqualTo("/servlet");
+            }
+        );
+
     }
 
 }

--- a/integration-tests/simple-webapp/src/main/webapp/WEB-INF/web.xml
+++ b/integration-tests/simple-webapp/src/main/webapp/WEB-INF/web.xml
@@ -27,6 +27,15 @@
         <url-pattern>/servlet</url-pattern>
     </servlet-mapping>
 
+    <servlet-mapping>
+        <!--
+        allows testing servlet mapping with wildcard, can make servlet path to be empty/null according to spec
+        but in practice this behavior relies on app server implementation and might differ.
+        -->
+        <servlet-name>TestServlet</servlet-name>
+        <url-pattern>/test-servlet/*</url-pattern>
+    </servlet-mapping>
+
     <servlet>
         <servlet-name>AsyncDispatchServlet</servlet-name>
         <servlet-class>co.elastic.webapp.AsyncDispatchTestServlet</servlet-class>


### PR DESCRIPTION
## What does this PR do?

Improves Servlet path naming on Weblogic when `use_path_as_transaction_name=true` is set.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
