### PR TITLE
Interrupted thread callsite resolution

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ version of classes that are available also in the parent (bootstrap) class loade
 * Fix stack frame exclusion patterns - {pull}2758[#2758]
 * Fix `NullPointerException` with compressed spans - {pull}2755[#2755]
 * Fix empty servlet path with proper fallback - {pull}2748[#2748]
+* Fix 'ClosedByInterruptException` during indy bootstrap method resolution - {pull}2752[#2752]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
@@ -59,16 +59,16 @@ public class PackageScanner {
         List<String> list;
         try {
             list = doGetClassNames(basePackage, classLoader);
-        } catch (ClosedByInterruptException e){
+        } catch (ClosedByInterruptException e) {
             // clears the 'interrupted' status, expected to return true as exception was thrown
-            if(Thread.interrupted()){
+            if (Thread.interrupted()) {
 
                 list = doGetClassNames(basePackage, classLoader);
 
                 // restore the 'interrupted' status
                 Thread.currentThread().interrupt();
             } else {
-                throw new IllegalStateException("unexpected thread state",e);
+                throw new IllegalStateException("unexpected thread state", e);
             }
 
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
@@ -61,14 +61,15 @@ public class PackageScanner {
             list = doGetClassNames(basePackage, classLoader);
         } catch (ClosedByInterruptException e) {
             // clears the 'interrupted' status, expected to return true as exception was thrown
-            if (Thread.interrupted()) {
+            boolean interrupted = Thread.interrupted();
 
+            try {
                 list = doGetClassNames(basePackage, classLoader);
-
-                // restore the 'interrupted' status
-                Thread.currentThread().interrupt();
-            } else {
-                throw new IllegalStateException("unexpected thread state", e);
+            } finally {
+                if (interrupted) {
+                    // restore the 'interrupted' status
+                    Thread.currentThread().interrupt();
+                }
             }
 
         }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/PackageScanner.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.channels.ClosedByInterruptException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -48,6 +49,34 @@ public class PackageScanner {
      * @throws URISyntaxException
      */
     public static List<String> getClassNames(final String basePackage, ClassLoader classLoader) throws IOException, URISyntaxException {
+        // This method is called from indy instrumentation call site method resolution, which happens within the application
+        // threads. Those threads being owned by the application, they could have been interrupted and have their
+        // 'interrupted' status still set, which in turn makes the IO read throw 'ClosedByInterruptException'.
+        //
+        // When this happens, we can clear the 'interrupted' status, retry once and then restore the 'interrupted'
+        // state as it was before this method was called.
+
+        List<String> list;
+        try {
+            list = doGetClassNames(basePackage, classLoader);
+        } catch (ClosedByInterruptException e){
+            // clears the 'interrupted' status, expected to return true as exception was thrown
+            if(Thread.interrupted()){
+
+                list = doGetClassNames(basePackage, classLoader);
+
+                // restore the 'interrupted' status
+                Thread.currentThread().interrupt();
+            } else {
+                throw new IllegalStateException("unexpected thread state",e);
+            }
+
+        }
+
+        return list;
+    }
+
+    private static List<String> doGetClassNames(String basePackage, ClassLoader classLoader) throws IOException, URISyntaxException {
         String baseFolderResource = basePackage.replace('.', '/');
         final List<String> classNames = new ArrayList<>();
         Enumeration<URL> resources = classLoader.getResources(baseFolderResource);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/PackageScannerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/PackageScannerTest.java
@@ -74,6 +74,10 @@ class PackageScannerTest {
                         throw new RuntimeException(e);
                     }
 
+                    assertThat(Thread.interrupted())
+                        .describedAs("thread interrupted status should be preserved after getClassNames invocation")
+                        .isTrue();
+
                     end.countDown();
                 }
             };

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/PackageScannerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/PackageScannerTest.java
@@ -22,6 +22,13 @@ import co.elastic.apm.agent.bci.ElasticApmAgent;
 import net.bytebuddy.ByteBuddy;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class PackageScannerTest {
@@ -45,4 +52,40 @@ class PackageScannerTest {
     void getClassNamesOfNonExistentPackage() throws Exception {
         assertThat(PackageScanner.getClassNames("foo.bar", ElasticApmAgent.getAgentClassLoader())).isEmpty();
     }
+
+    @Test
+    void threadInterruptSafe() throws InterruptedException, IOException {
+
+        CountDownLatch end = new CountDownLatch(1);
+
+        URL testJar = Test.class.getProtectionDomain().getCodeSource().getLocation();
+        try (final URLClassLoader classLoader = new URLClassLoader(new URL[]{testJar})) {
+
+            Thread t = new Thread() {
+                @Override
+                public void run() {
+
+                    // intentionally interrupt the thread, which leaves the thread in "interrupted" state
+                    interrupt();
+
+                    try {
+                        assertThat(PackageScanner.getClassNames(Test.class.getPackageName(), classLoader)).isNotEmpty();
+                    } catch (Exception e) {
+                        throw new RuntimeException(e);
+                    }
+
+                    end.countDown();
+                }
+            };
+
+            t.start();
+
+            assertThat(end.await(1, TimeUnit.SECONDS))
+                .describedAs("abnormal test task termination")
+                .isTrue();
+        }
+    }
+
+
+
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/PackageScannerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/PackageScannerTest.java
@@ -74,7 +74,7 @@ class PackageScannerTest {
                         throw new RuntimeException(e);
                     }
 
-                    assertThat(Thread.interrupted())
+                    assertThat(isInterrupted())
                         .describedAs("thread interrupted status should be preserved after getClassNames invocation")
                         .isTrue();
 


### PR DESCRIPTION
## What does this PR do?

When an application thread was interrupted and the `interrupted` status hasn't been cleared, it makes the instrumentation call site resolution fail with `ClosedByInterruptException`, hence making the instrumentation fail and resolve to a no-op.

When this happens, a stack trace similar to the following is visible in the agent logs;
```
(...) ERROR co.elastic.apm.agent.bci.IndyBootstrap - null
java.nio.channels.ClosedByInterruptException: null
        at java.nio.channels.spi.AbstractInterruptibleChannel.end(AbstractInterruptibleChannel.java:199) ~[?:?]
        at sun.nio.ch.FileChannelImpl.endBlocking(FileChannelImpl.java:162) ~[?:?]
        at sun.nio.ch.FileChannelImpl.size(FileChannelImpl.java:388) ~[?:?]
        at jdk.nio.zipfs.ZipFileSystem.findEND(ZipFileSystem.java:973) ~[jdk.zipfs:?]
        at jdk.nio.zipfs.ZipFileSystem.initCEN(ZipFileSystem.java:1048) ~[jdk.zipfs:?]
        at jdk.nio.zipfs.ZipFileSystem.<init>(ZipFileSystem.java:116) ~[jdk.zipfs:?]
        at jdk.nio.zipfs.ZipFileSystemProvider.newFileSystem(ZipFileSystemProvider.java:106) ~[jdk.zipfs:?]
        at java.nio.file.FileSystems.newFileSystem(FileSystems.java:337) ~[?:?]
        at java.nio.file.FileSystems.newFileSystem(FileSystems.java:286) ~[?:?]
        at co.elastic.apm.agent.util.PackageScanner.getClassNames(PackageScanner.java:61) ~[elastic-apm-agent.jar:1.33.0]
        at co.elastic.apm.agent.bci.IndyBootstrap.getClassNamesFromBundledPlugin(IndyBootstrap.java:440) ~[elastic-apm-agent.jar:1.33.0]
        at co.elastic.apm.agent.bci.IndyBootstrap.bootstrap(IndyBootstrap.java:399) [elastic-apm-agent.jar:1.33.0]
        at jdk.internal.reflect.GeneratedMethodAccessor19.invoke(Unknown Source) ~[?:?]
        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
        at java.lang.IndyBootstrapDispatcher.bootstrap(IndyBootstrapDispatcher.java:60) [?:?]
        at java.lang.invoke.BootstrapMethodInvoker.invoke(BootstrapMethodInvoker.java:138) [?:?]
        at java.lang.invoke.CallSite.makeSite(CallSite.java:307) [?:?]
        at java.lang.invoke.MethodHandleNatives.linkCallSiteImpl(MethodHandleNatives.java:258) [?:?]
        at java.lang.invoke.MethodHandleNatives.linkCallSite(MethodHandleNatives.java:248) [?:?]
```

A similar instance of this issue has already been reported in the forum [here](https://discuss.elastic.co/t/co-elastic-apm-agent-bci-indybootstrap-null-closedbyinterruptexception/309095).

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
