### PR TITLE
document otel instrumentation annotations not supported

### DIFF
--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -169,3 +169,8 @@ Baggage items are silently dropped.
 [[otel-events]]
 ===== Events
 Events are silently dropped, for example `Span.current().addEvent("my event")`.
+
+[float]
+[[otel-anntations]]
+===== Annotations
+https://opentelemetry.io/docs/instrumentation/java/automatic/annotations/[OpenTelemetry instrumentation annotations] are currently ignored by Elastic APM agent and are thus not supported (see https://github.com/elastic/apm-agent-java/issues/2753[#2753]).


### PR DESCRIPTION
Document that OpenTelemetry instrumentation annotations are not supported.