### PR TITLE
avoid warn enable_log_correlation in remote config

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ version of classes that are available also in the parent (bootstrap) class loade
 * Fix stack frame exclusion patterns - {pull}2758[#2758]
 * Fix `NullPointerException` with compressed spans - {pull}2755[#2755]
 * Fix empty servlet path with proper fallback - {pull}2748[#2748]
+* Avoid warning when log correlation option is provided in remote config - {pull}2765[#2765]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-common/src/test/java/co/elastic/apm/agent/awssdk/common/AbstractSQSClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-common/src/test/java/co/elastic/apm/agent/awssdk/common/AbstractSQSClientIT.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.awssdk.common;
 
 import co.elastic.apm.agent.configuration.CoreConfiguration;


### PR DESCRIPTION
## What does this PR do?

Remove warning in the logs when log correlation is enabled through remote config:
```
WARN  co.elastic.apm.agent.configuration.ApmServerConfigurationSource - Received unknown remote configuration key enable_log_correlation
```

Now that log correlation is always enabled in the Java agent this should just be ignored.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
