### PR TITLE
Capture user name with Azure SSO

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ version of classes that are available also in the parent (bootstrap) class loade
 * Added support for MongoDB's 4.x Sync Driver - {pull}2241{#2241}
 * Capture keyspace in `db.instance` for Cassandra database - {pull}2684[#2684]
 * Added support for AWS SQS - {pull}2637[#2637]
+* Capture user from Azure SSO with Servlet-based app containers - {pull}2767[#2767]
 
 [float]
 ===== Bug fixes

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ version of classes that are available also in the parent (bootstrap) class loade
 * Capture keyspace in `db.instance` for Cassandra database - {pull}2684[#2684]
 * Added support for AWS SQS - {pull}2637[#2637]
 * Add <<config-trace-continuation-strategy, `trace_continuation_strategy`>> configuration option - {pull}2760[#2760]
+* Capture user from Azure SSO with Servlet-based app containers - {pull}2767[#2767]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -193,7 +193,7 @@ public abstract class ServletApiAdvice {
             if (currentTransaction != null) {
                 TransactionNameUtils.setTransactionNameByServletClass(adapter.getMethod(httpServletRequest), thiz.getClass(), currentTransaction.getAndOverrideName(PRIO_LOW_LEVEL_FRAMEWORK));
 
-                String userName = getUserFromPrincipal(adapter.getUserPrincipal(httpServletRequest));
+                String userName = ServletTransactionHelper.getUserFromPrincipal(adapter.getUserPrincipal(httpServletRequest));
                 if (userName != null) {
                     ServletTransactionHelper.setUsernameIfUnset(userName, currentTransaction.getContext());
                 }
@@ -282,41 +282,4 @@ public abstract class ServletApiAdvice {
         }
     }
 
-    @Nullable
-    private static String getUserFromPrincipal(@Nullable Principal principal) {
-        if (principal == null) {
-            return null;
-        }
-
-        String userName;
-        if (principal instanceof Map) {
-            // Microsoft/Azure SSO fallback
-            // https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
-
-            Map<?, ?> map = ((Map<?, ?>) principal);
-
-            userName = getFirstClaim(map, "preferred_username");
-            if (userName == null) {
-                userName = getFirstClaim(map, "name");
-            }
-        } else {
-            userName = principal.getName();
-        }
-
-        return userName;
-    }
-
-    @Nullable
-    private static String getFirstClaim(Map<?, ?> map, String key) {
-        // entries are stored in nested collection, even when there is a single entry
-        // https://docs.microsoft.com/en-us/azure/app-service/configure-language-java?pivots=platform-linux#tomcat-1
-        Object entry = map.get(key);
-        if (entry instanceof List) {
-            Object first = ((List<?>) entry).get(0);
-            if (first instanceof String) {
-                return (String) first;
-            }
-        }
-        return null;
-    }
 }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -310,20 +310,18 @@ public abstract class ServletApiAdvice {
     }
 
     @Nullable
-    private static String getFirstClaim(Map<?,?> map, String key){
+    private static String getFirstClaim(Map<?, ?> map, String key) {
         // entries are stored in nested collection, even when there is a single entry
         // https://docs.microsoft.com/en-us/azure/app-service/configure-language-java?pivots=platform-linux#tomcat-1
         Object entry = map.get(key);
         if (entry instanceof Collection) {
             for (Object v : (Collection<?>) entry) {
-                if (v instanceof String) {
-                    return (String) v;
+                if (v != null) {
+                    return v.toString();
                 }
             }
-        }
-
-        if (entry instanceof String) {
-            return ((String) entry);
+        } else if (entry != null) {
+            return entry.toString();
         }
         return null;
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -37,7 +37,6 @@ import co.elastic.apm.agent.util.TransactionNameUtils;
 import javax.annotation.Nullable;
 import java.security.Principal;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
@@ -195,7 +194,7 @@ public abstract class ServletApiAdvice {
                 TransactionNameUtils.setTransactionNameByServletClass(adapter.getMethod(httpServletRequest), thiz.getClass(), currentTransaction.getAndOverrideName(PRIO_LOW_LEVEL_FRAMEWORK));
 
                 String userName = getUserFromPrincipal(adapter.getUserPrincipal(httpServletRequest));
-                if(userName != null){
+                if (userName != null) {
                     ServletTransactionHelper.setUsernameIfUnset(userName, currentTransaction.getContext());
                 }
             }
@@ -284,16 +283,12 @@ public abstract class ServletApiAdvice {
     }
 
     @Nullable
-    private static String getUserFromPrincipal(@Nullable Principal principal){
+    private static String getUserFromPrincipal(@Nullable Principal principal) {
         if (principal == null) {
             return null;
         }
 
-        String userName = principal.getName();
-        if (userName != null) {
-            return userName;
-        }
-
+        String userName;
         if (principal instanceof Map) {
             // Microsoft/Azure SSO fallback
             // https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
@@ -304,6 +299,8 @@ public abstract class ServletApiAdvice {
             if (userName == null) {
                 userName = getFirstClaim(map, "name");
             }
+        } else {
+            userName = principal.getName();
         }
 
         return userName;
@@ -314,14 +311,11 @@ public abstract class ServletApiAdvice {
         // entries are stored in nested collection, even when there is a single entry
         // https://docs.microsoft.com/en-us/azure/app-service/configure-language-java?pivots=platform-linux#tomcat-1
         Object entry = map.get(key);
-        if (entry instanceof Collection) {
-            for (Object v : (Collection<?>) entry) {
-                if (v != null) {
-                    return v.toString();
-                }
+        if (entry instanceof List) {
+            Object first = ((List<?>) entry).get(0);
+            if (first instanceof String) {
+                return (String) first;
             }
-        } else if (entry != null) {
-            return entry.toString();
         }
         return null;
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -300,9 +300,9 @@ public abstract class ServletApiAdvice {
 
             Map<?, ?> map = ((Map<?, ?>) principal);
 
-            userName = getMsEntry(map, "preferred_username");
+            userName = getFirstClaim(map, "preferred_username");
             if (userName == null) {
-                userName = getMsEntry(map, "name");
+                userName = getFirstClaim(map, "name");
             }
         }
 
@@ -310,7 +310,9 @@ public abstract class ServletApiAdvice {
     }
 
     @Nullable
-    private static String getMsEntry(Map<?,?> map, String key){
+    private static String getFirstClaim(Map<?,?> map, String key){
+        // entries are stored in nested collection, even when there is a single entry
+        // https://docs.microsoft.com/en-us/azure/app-service/configure-language-java?pivots=platform-linux#tomcat-1
         Object entry = map.get(key);
         if (entry instanceof Collection) {
             for (Object v : (Collection<?>) entry) {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -169,9 +169,12 @@ public class ServletTransactionHelper {
         // https://docs.microsoft.com/en-us/azure/app-service/configure-language-java?pivots=platform-linux#tomcat-1
         Object entry = map.get(key);
         if (entry instanceof List) {
-            Object first = ((List<?>) entry).get(0);
-            if (first instanceof String) {
-                return (String) first;
+            List<?> list = (List<?>) entry;
+            if (!list.isEmpty()) {
+                Object first = ((List<?>) entry).get(0);
+                if (first != null) {
+                    return first.toString();
+                }
             }
         }
         return null;

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletTransactionHelper.java
@@ -35,8 +35,10 @@ import co.elastic.apm.agent.servlet.adapter.ServletRequestAdapter;
 import co.elastic.apm.agent.util.TransactionNameUtils;
 
 import javax.annotation.Nullable;
+import java.security.Principal;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -135,6 +137,44 @@ public class ServletTransactionHelper {
                 }
             }
         }
+    }
+
+    @Nullable
+    public static String getUserFromPrincipal(@Nullable Principal principal) {
+        if (principal == null) {
+            return null;
+        }
+
+        String userName;
+        if (principal instanceof Map) {
+            // Microsoft/Azure SSO fallback
+            // https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens
+
+            Map<?, ?> map = ((Map<?, ?>) principal);
+
+            userName = getFirstClaim(map, "preferred_username");
+            if (userName == null) {
+                userName = getFirstClaim(map, "name");
+            }
+        } else {
+            userName = principal.getName();
+        }
+
+        return userName;
+    }
+
+    @Nullable
+    private static String getFirstClaim(Map<?, ?> map, String key) {
+        // entries are stored in nested collection, even when there is a single entry
+        // https://docs.microsoft.com/en-us/azure/app-service/configure-language-java?pivots=platform-linux#tomcat-1
+        Object entry = map.get(key);
+        if (entry instanceof List) {
+            Object first = ((List<?>) entry).get(0);
+            if (first instanceof String) {
+                return (String) first;
+            }
+        }
+        return null;
     }
 
     public static void setUsernameIfUnset(@Nullable String userName, TransactionContext context) {


### PR DESCRIPTION
## What does this PR do?

When using Azure Tomcat service, the user name is not properly captured by Java agent.
This PR adds a fallback heuristic to capture the provided user name based on [official MS code samples](https://docs.microsoft.com/en-us/azure/app-service/configure-language-java?pivots=platform-linux#tomcat-1) and [documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/access-tokens).

## Checklist

- [x] validate implementation manually with Azure/Tomcat deployment
- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] ~~Added an API method or config option? Document in which version this will be introduced~~ n/a
  - [x] ~~I have made corresponding changes to the documentation~~ n/a no doc change required.
