### PR TITLE
release: configure git user

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -45,10 +45,12 @@ pipeline {
                 credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                 shallow: false
             )
-            setupAPMGitEmail(global: true)
             dir("${BASE_DIR}") {
               withEnv(["BRANCH_NAME=${BRANCH_SPECIFIER}"]){
                 withGitRelease() { // sets up the git release setup (remote branches, current workspace state, ...)
+                  // Set the git user/email to be used, otherwise withGitRelease will pick up the latest
+                  // git committer.
+                  setupAPMGitEmail()
                   stash(allowEmpty: true, name: 'source', useDefaultExcludes: false)
                 }
               }
@@ -127,6 +129,7 @@ pipeline {
                     echo "changing project version from '${snapshot_version}' to '${user_release_version}' to prepare release ${user_release_version}."
                     sh(label: "mavenVersionUpdate", script: "./mvnw --batch-mode release:update-versions -DdevelopmentVersion=${user_release_version}-SNAPSHOT")
                     sh(script: "git commit -a -m 'Version bump ${user_release_version}'")
+                    sh(label: 'debug git user', script: 'git --no-pager log -1')
                     gitPush()
                 }
 

--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -45,9 +45,7 @@ pipeline {
                 credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
                 shallow: false
             )
-            dir("${BASE_DIR}") {
-              setupAPMGitEmail()
-            }
+            setupAPMGitEmail(global: true)
             dir("${BASE_DIR}") {
               withEnv(["BRANCH_NAME=${BRANCH_SPECIFIER}"]){
                 withGitRelease() { // sets up the git release setup (remote branches, current workspace state, ...)


### PR DESCRIPTION
## What does this PR do?
Use [setupAPMGitEmail](https://github.com/elastic/apm-pipeline-library/blob/main/vars/setupAPMGitEmail.groovy) within the release context

## Why

withGitRelease configures the git user pointed to the last committer, but in this case we want to force the user
