### PR TITLE
ci: docs changeset against the previous commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -79,6 +79,11 @@ pipeline {
             // Compare with the previous git commit if possible, otherwise the target branch or the git base commit.
             def from = env.GIT_PREVIOUS_COMMIT?.trim() ? "${env.GIT_PREVIOUS_COMMIT}"
                                                        : "${env.CHANGE_TARGET?.trim() ? 'origin/${env.CHANGE_TARGET}' : env.GIT_BASE_COMMIT}"
+            // for debugging purposes only
+            echo "env.GIT_PREVIOUS_COMMIT=${env.GIT_PREVIOUS_COMMIT?.trim()}"
+            echo "env.CHANGE_TARGET=${env.CHANGE_TARGET?.trim()}"
+            echo "env.GIT_BASE_COMMIT=${env.GIT_BASE_COMMIT?.trim()}"
+            echo "isGitRegionMatch(from: ${from})"
             // Skip all the stages except docs for PR's with asciidoc and md changes only
             env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true, from: from)
             // Prepare the env variables for the benchmark results

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,8 +77,11 @@ pipeline {
         stash allowEmpty: true, name: 'source', useDefaultExcludes: false
         script {
           dir("${BASE_DIR}"){
+            // Compare with the previous git commit if possible, otherwise the target branch or the git base commit.
+            def from = env.GIT_PREVIOUS_COMMIT?.trim() ? "${env.GIT_PREVIOUS_COMMIT}"
+                                                       : "${env.CHANGE_TARGET?.trim() ? 'origin/${env.CHANGE_TARGET}' : env.GIT_BASE_COMMIT}"
             // Skip all the stages except docs for PR's with asciidoc and md changes only
-            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true)
+            env.ONLY_DOCS = isGitRegionMatch(patterns: [ '.*\\.(asciidoc|md)' ], shouldMatchAll: true, from: from)
             // Prepare the env variables for the benchmark results
             env.COMMIT_ISO_8601 = sh(script: 'git log -1 -s --format=%cI', returnStdout: true).trim()
             env.NOW_ISO_8601 = sh(script: 'date -u "+%Y-%m-%dT%H%M%SZ"', returnStdout: true).trim()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,6 +80,7 @@ pipeline {
             def from = env.GIT_PREVIOUS_COMMIT?.trim() ? "${env.GIT_PREVIOUS_COMMIT}"
                                                        : "${env.CHANGE_TARGET?.trim() ? 'origin/${env.CHANGE_TARGET}' : env.GIT_BASE_COMMIT}"
             // for debugging purposes only
+            echo "env.GIT_PREVIOUS_SUCCESSFUL_COMMIT=${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT?.trim()}"
             echo "env.GIT_PREVIOUS_COMMIT=${env.GIT_PREVIOUS_COMMIT?.trim()}"
             echo "env.CHANGE_TARGET=${env.CHANGE_TARGET?.trim()}"
             echo "env.GIT_BASE_COMMIT=${env.GIT_BASE_COMMIT?.trim()}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,7 +70,6 @@ pipeline {
     stage('Checkout') {
       options { skipDefaultCheckout() }
       steps {
-        pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
         deleteDir()
         // reference repo causes issues while running on Windows with the git-commit-id-maven-plugin
         gitCheckout(basedir: "${BASE_DIR}", githubNotifyFirstTimeContributor: true, shallow: false)
@@ -92,6 +91,11 @@ pipeline {
               // those GH checks are required, and docs build skips them we artificially make them as OK
               githubCheck(name: "Application Server integration tests", status: 'neutral');
               githubCheck(name: "Non-Application Server integration tests", status: 'neutral');
+            } else {
+              // PRs with no docs changes can be evaluated to run faster.
+              // This should avoid multiple pushes while the build is ongoing being the
+              // last one the only related to the docs.
+              pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])
             }
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -77,7 +77,7 @@ pipeline {
         script {
           dir("${BASE_DIR}"){
             // Compare with the previous git commit if possible, otherwise the target branch or the git base commit.
-            def from = env.GIT_PREVIOUS_COMMIT?.trim() ? "${env.GIT_PREVIOUS_COMMIT}"
+            def from = env.GIT_PREVIOUS_COMMIT?.trim() ? "HEAD~1"
                                                        : "${env.CHANGE_TARGET?.trim() ? 'origin/${env.CHANGE_TARGET}' : env.GIT_BASE_COMMIT}"
             // for debugging purposes only
             echo "env.GIT_PREVIOUS_SUCCESSFUL_COMMIT=${env.GIT_PREVIOUS_SUCCESSFUL_COMMIT?.trim()}"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![codecov](https://codecov.io/gh/elastic/apm-agent-java/branch/main/graph/badge.svg)](https://codecov.io/gh/elastic/apm-agent-java)
 [![Maven Central](https://img.shields.io/maven-central/v/co.elastic.apm/apm-agent-api.svg)](https://search.maven.org/search?q=g:co.elastic.apm%20AND%20a:elastic-apm-agent)
 
+
 # apm-agent-java
 
 Please fill out this survey to help us prioritizing framework support: https://docs.google.com/forms/d/e/1FAIpQLScd0RYiwZGrEuxykYkv9z8Hl3exx_LKCtjsqEo1OWx8BkLrOQ/viewform?usp=sf_link

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Maven Central](https://img.shields.io/maven-central/v/co.elastic.apm/apm-agent-api.svg)](https://search.maven.org/search?q=g:co.elastic.apm%20AND%20a:elastic-apm-agent)
 
 
+
 # apm-agent-java
 
 Please fill out this survey to help us prioritizing framework support: https://docs.google.com/forms/d/e/1FAIpQLScd0RYiwZGrEuxykYkv9z8Hl3exx_LKCtjsqEo1OWx8BkLrOQ/viewform?usp=sf_link


### PR DESCRIPTION
## What does this PR do?

Override the default behaviour when comparing the current change set with the previous one.

Avoid aborting any `ongoing` builds if a new commit is pushed and it does only contain docs changes.

## Why

Give a higher precedence to the `GIT_PREVIOUS_COMMIT` env variable, then if there are a subsequent commits within the same Pull Request, it will compare the both commits rather than the whole changeset between the PR and the main.

Ideally, this should help with running faster builds by detecting what to run smarter.

