### PR TITLE
Promote Reactor & Weblux plugins to GA

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ version of classes that are available also in the parent (bootstrap) class loade
 * Added support for AWS SQS - {pull}2637[#2637]
 * Add <<config-trace-continuation-strategy, `trace_continuation_strategy`>> configuration option - {pull}2760[#2760]
 * Capture user from Azure SSO with Servlet-based app containers - {pull}2767[#2767]
+* Promote Webflux & Reactor to GA and enable it by default - {pull}2782[#2782]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-reactor-plugin/src/main/java/co/elastic/apm/agent/reactor/ReactorInstrumentation.java
+++ b/apm-agent-plugins/apm-reactor-plugin/src/main/java/co/elastic/apm/agent/reactor/ReactorInstrumentation.java
@@ -24,8 +24,8 @@ import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 import static net.bytebuddy.matcher.ElementMatchers.isStatic;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -53,7 +53,7 @@ public class ReactorInstrumentation extends TracerAwareInstrumentation {
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        return Arrays.asList("reactor", "experimental");
+        return Collections.singleton("reactor");
     }
 
     @Override

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/main/java/co/elastic/apm/agent/springwebclient/WebClientExchangeFunctionInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/main/java/co/elastic/apm/agent/springwebclient/WebClientExchangeFunctionInstrumentation.java
@@ -65,7 +65,7 @@ public class WebClientExchangeFunctionInstrumentation extends TracerAwareInstrum
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        return Arrays.asList("http-client", "spring-webclient", "experimental");
+        return Arrays.asList("http-client", "spring-webclient");
     }
 
     public static class AdviceClass {

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/main/java/co/elastic/apm/agent/springwebflux/WebFluxInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/main/java/co/elastic/apm/agent/springwebflux/WebFluxInstrumentation.java
@@ -20,14 +20,14 @@ package co.elastic.apm.agent.springwebflux;
 
 import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 public abstract class WebFluxInstrumentation extends TracerAwareInstrumentation {
 
     @Override
     public final Collection<String> getInstrumentationGroupNames() {
-        return Arrays.asList("spring-webflux", "experimental");
+        return Collections.singleton("spring-webflux");
     }
 
 }

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -111,7 +111,7 @@ the JVM arguments.
 |Spring Webflux
 |5.2.3+
 |Creates transactions for incoming HTTP requests, supports annotated and functional endpoints.
-|1.24.0 (experimental)
+|1.24.0 (experimental), 1.34.0 (GA)
 
 |JavaServer Faces
 |2.2.x, 2.3.x, 3.0.x
@@ -407,7 +407,7 @@ NOTE: To enable Scala Future support, you need to enable experimental plugins.
 | Reactor
 | 3.2.x+
 |The agent propagates the context for `Flux` and `Mono`.
-|1.24.0 (experimental)
+|1.24.0 (experimental), 1.34.0 (GA))
 
 
 

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -366,7 +366,7 @@ The spans are named after the schema `<method> <host>`, for example `GET elastic
 |Spring Webclient
 |5.2.3+
 |
-|1.33.0 (experimental)
+|1.33.0 (experimental), 1.34.0 (GA)
 
 |===
 
@@ -407,7 +407,7 @@ NOTE: To enable Scala Future support, you need to enable experimental plugins.
 | Reactor
 | 3.2.x+
 |The agent propagates the context for `Flux` and `Mono`.
-|1.24.0 (experimental), 1.34.0 (GA))
+|1.24.0 (experimental), 1.34.0 (GA)
 
 
 


### PR DESCRIPTION
## What does this PR do?

Promotes Webflux client and server instrumentation to GA and enable them by default
Promotes Reactor instrumentation to GA. Webflux relies on it thus transitive promotion.

## Checklist

- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
