### PR TITLE
ci: cache release stages

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
     string(name: 'branch_specifier', defaultValue: 'stable', description: "What branch to release from?")
     booleanParam(name: 'check_branch_ci_status', defaultValue: true, description: "Check for failing tests in the given branch (if no stable branch)?")
     booleanParam(name: 'publish_aws_lambda', defaultValue: true, description: "Whether to upload the AWS lambda")
+    booleanParam(name: 'force_build', defaultValue: false, description: "Whether to force the release build to run from scratch")
   }
   stages {
     stage('Initializing'){
@@ -68,12 +69,14 @@ pipeline {
       stages{
         stage('Check oss.sonatype.org') {
           steps {
-            // If this fails, an exception should be thrown and execution will halt
-            dir("${BASE_DIR}"){
-              script {
-                def r = sh(label: "Check Maven status", script: "./scripts/jenkins/check_maven.sh -u https://status.maven.org/api/v2/summary.json --component OSSRH", returnStatus: true)
-                if (r == 1) {
-                  error("Failing release build because Maven is the OSSRH component is not fully operational. See https://status.maven.org/ for more details.")
+            cacheStage(id: 'release-check-oss.sonatype.org') {
+              // If this fails, an exception should be thrown and execution will halt
+              dir("${BASE_DIR}"){
+                script {
+                  def r = sh(label: "Check Maven status", script: "./scripts/jenkins/check_maven.sh -u https://status.maven.org/api/v2/summary.json --component OSSRH", returnStatus: true)
+                  if (r == 1) {
+                    error("Failing release build because Maven is the OSSRH component is not fully operational. See https://status.maven.org/ for more details.")
+                  }
                 }
               }
             }
@@ -87,31 +90,37 @@ pipeline {
             }
           }
           steps {
-            // If this build is not green: https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/"${BRANCH_SPECIFIER}"/
-            whenTrue(!buildStatus(host: 'apm-ci.elastic.co', job: ['apm-agent-java', 'apm-agent-java-mbp', "${BRANCH_SPECIFIER}"], return_boolean: true)) {
-              notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] The ${BRANCH_SPECIFIER} build is not passing",
-                           body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.")
-              input(message: "WARNING! The ${BRANCH_SPECIFIER} build is not passing. Do you wish to continue?")
+            cacheStage(id: 'release-check-build-status') {
+              // If this build is not green: https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/"${BRANCH_SPECIFIER}"/
+              whenTrue(!buildStatus(host: 'apm-ci.elastic.co', job: ['apm-agent-java', 'apm-agent-java-mbp', "${BRANCH_SPECIFIER}"], return_boolean: true)) {
+                notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] The ${BRANCH_SPECIFIER} build is not passing",
+                             body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.")
+                input(message: "WARNING! The ${BRANCH_SPECIFIER} build is not passing. Do you wish to continue?")
+              }
             }
           }
         }
         stage('Require confirmation that CHANGELOG.asciidoc has been updated') {
           steps {
-            input(message: """
-            Update CHANGELOG.asciidoc to reflect the new version release:
-            Go over PRs or git log and add bug fixes and features.
-            Move release notes from the Unreleased sub-heading to the correct [[release-notes-{major}.x]] sub-heading (Example PR for 1.13.0 release).
+            cacheStage(id: 'release-check-changelog') {
+              input(message: """
+              Update CHANGELOG.asciidoc to reflect the new version release:
+              Go over PRs or git log and add bug fixes and features.
+              Move release notes from the Unreleased sub-heading to the correct [[release-notes-{major}.x]] sub-heading (Example PR for 1.13.0 release).
 
-            Click 'Proceed' to confirm that this step has been completed and changes have been pushed or Abort to stop the build.
-            """
-            )
-            dir("${BASE_DIR}") {
-              git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba', url: 'git@github.com:elastic/apm-agent-java.git', branch: 'main')
+              Click 'Proceed' to confirm that this step has been completed and changes have been pushed or Abort to stop the build.
+              """
+              )
+              dir("${BASE_DIR}") {
+                git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba', url: 'git@github.com:elastic/apm-agent-java.git', branch: 'main')
+              }
             }
           }
         }
         stage('Set release version') {
           steps {
+            // TODO: this is the tricky part regarding the caching... as we need to store the previous execution
+            //       somewhere to be consumed
             dir("${BASE_DIR}"){
               script {
                 def snapshot_version = mvnVersion(showQualifiers: true)
@@ -143,28 +152,34 @@ pipeline {
         }
         stage('Wait on internal CI') {
           steps {
-            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be pushed",
-                          body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.")
-            input(message: "Start the release job on the internal CI. Click 'Proceed' once the job has succeeded or click 'Abort' if the release has failed and then manually undo the release.")
+            cacheStage(id: 'release-wait-internal-ci') {
+              notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be pushed",
+                            body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.")
+              input(message: "Start the release job on the internal CI. Click 'Proceed' once the job has succeeded or click 'Abort' if the release has failed and then manually undo the release.")
+            }
           }
         }
         stage('Nexus release') {
           steps {
-            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be published in Nexus",
-                         body: "Please go to (<https://oss.sonatype.org/|here>) to proceed with the manual nexus release. Login details in LastPass")
-            input(message: "Go to https://oss.sonatype.org and proceed with the steps to close and release the staging artifact.")
+            cacheStage(id: 'release-nexus') {
+              notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be published in Nexus",
+                           body: "Please go to (<https://oss.sonatype.org/|here>) to proceed with the manual nexus release. Login details in LastPass")
+              input(message: "Go to https://oss.sonatype.org and proceed with the steps to close and release the staging artifact.")
+            }
           }
         }
         stage('Major Branch create/update') {
           steps {
-            dir("${BASE_DIR}") {
-              script {
-                sh(script: ".ci/release/update_major_branch.sh ${RELEASE_VERSION}")
-                gitPush(args: "-f ${BRANCH_DOT_X}")
+            cacheStage(id: 'release-major-branch-create-update') {
+              dir("${BASE_DIR}") {
+                script {
+                  sh(script: ".ci/release/update_major_branch.sh ${RELEASE_VERSION}")
+                  gitPush(args: "-f ${BRANCH_DOT_X}")
 
-                def isMajor = env.RELEASE_VERSION.endsWith(".0.0")
-                if (isMajor) {
-                  input message: "This was a major version release. Please update the conf.yml in the docs repo before continuing", ok "Continue"
+                  def isMajor = env.RELEASE_VERSION.endsWith(".0.0")
+                  if (isMajor) {
+                    input message: "This was a major version release. Please update the conf.yml in the docs repo before continuing", ok "Continue"
+                  }
                 }
               }
             }
@@ -179,17 +194,19 @@ pipeline {
             PATH_PREFIX = 'jobs/elastic+apm-agent-java+release/src/github.com/elastic/apm-agent-java/target/checkout/elastic-apm-agent/target'
           }
           steps {
-            setEnvVar('ELASTIC_LAYER_NAME', "elastic-apm-java${env.RELEASE_AWS_LAMBDA_VERSION}")
-            withAWSEnv(secret: 'secret/observability-team/ci/service-account/apm-aws-lambda', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id',
-                       forceInstallation: true, version: '2.4.10') {
-              // Fetch lambda file
-              googleStorageDownload(bucketUri: "gs://internal-ci-artifacts/${env.PATH_PREFIX}/${env.SOURCE_AWS_FILE}",
-                                    credentialsId: "${JOB_GCS_CREDENTIALS}",
-                                    localDirectory: "${BASE_DIR}/elastic-apm-agent/target",
-                                    pathPrefix: env.PATH_PREFIX)
-              dir("${BASE_DIR}"){
-                sh(label: 'make publish-in-all-aws-regions', script: 'make -C .ci publish-in-all-aws-regions')
-                sh(label: 'make create-arn-file', script: 'make -C .ci create-arn-file')
+            cacheStage(id: 'release-publish-aws-lambda') {
+              setEnvVar('ELASTIC_LAYER_NAME', "elastic-apm-java${env.RELEASE_AWS_LAMBDA_VERSION}")
+              withAWSEnv(secret: 'secret/observability-team/ci/service-account/apm-aws-lambda', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id',
+                         forceInstallation: true, version: '2.4.10') {
+                // Fetch lambda file
+                googleStorageDownload(bucketUri: "gs://internal-ci-artifacts/${env.PATH_PREFIX}/${env.SOURCE_AWS_FILE}",
+                                      credentialsId: "${JOB_GCS_CREDENTIALS}",
+                                      localDirectory: "${BASE_DIR}/elastic-apm-agent/target",
+                                      pathPrefix: env.PATH_PREFIX)
+                dir("${BASE_DIR}"){
+                  sh(label: 'make publish-in-all-aws-regions', script: 'make -C .ci publish-in-all-aws-regions')
+                  sh(label: 'make create-arn-file', script: 'make -C .ci create-arn-file')
+                }
               }
             }
           }
@@ -201,34 +218,40 @@ pipeline {
         }
         stage('Create GitHub release draft') {
           steps {
-            dir("${BASE_DIR}"){
-              script {
-                def arnFile = ".ci/${SUFFIX_ARN_FILE}"
-                setEnvVar('ARN_CONTENT', fileExists(arnFile) ? readFile(arnFile) : '')
-                // Construct the URL with anchor for the release notes
-                // Ex: https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-1.x.html#release-notes-1.13.0
-                def finalUrl = "https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-${BRANCH_DOT_X}.html#release-notes-${RELEASE_VERSION}"
-                githubEnv()
-                def ret = githubReleaseCreate(
-                        draft: true,
-                        tagName: "${RELEASE_TAG}",
-                        releaseName: "Release ${RELEASE_VERSION}",
-                        body: "[Release Notes for ${RELEASE_VERSION}](${finalUrl}) \n ${ARN_CONTENT}")
-                env.RELEASE_ID = ret['id']
-                env.RELEASE_NOTES_URL = finalUrl
+            // This stage consumes env variables generated in a previous stage...
+            cacheStage(id: 'release-create-github-release-draft') {
+              dir("${BASE_DIR}"){
+                script {
+                  def arnFile = ".ci/${SUFFIX_ARN_FILE}"
+                  setEnvVar('ARN_CONTENT', fileExists(arnFile) ? readFile(arnFile) : '')
+                  // Construct the URL with anchor for the release notes
+                  // Ex: https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-1.x.html#release-notes-1.13.0
+                  def finalUrl = "https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-${BRANCH_DOT_X}.html#release-notes-${RELEASE_VERSION}"
+                  githubEnv()
+                  def ret = githubReleaseCreate(
+                          draft: true,
+                          tagName: "${RELEASE_TAG}",
+                          releaseName: "Release ${RELEASE_VERSION}",
+                          body: "[Release Notes for ${RELEASE_VERSION}](${finalUrl}) \n ${ARN_CONTENT}")
+                  env.RELEASE_ID = ret['id']
+                  env.RELEASE_NOTES_URL = finalUrl
+                }
               }
             }
           }
         }
         stage('Wait for artifact to be available in Maven Central') {
           steps {
-            dir("${BASE_DIR}"){
-              script {
-                waitUntil(initialRecurrencePeriod: 60000) {
-                  script {
-                    def ret = sh(script: ".ci/release/wait_maven_artifact_published.sh ${RELEASE_VERSION}", returnStatus: true)
-                    echo "Waiting for the artifacts to be published on Sonatype"
-                    return ret == 0
+            // This stage consumes env variables generated in a previous stage...
+            cacheStage(id: 'release-wait-artifact-available-central') {
+              dir("${BASE_DIR}"){
+                script {
+                  waitUntil(initialRecurrencePeriod: 60000) {
+                    script {
+                      def ret = sh(script: ".ci/release/wait_maven_artifact_published.sh ${RELEASE_VERSION}", returnStatus: true)
+                      echo "Waiting for the artifacts to be published on Sonatype"
+                      return ret == 0
+                    }
                   }
                 }
               }
@@ -237,37 +260,45 @@ pipeline {
         }
         stage('Update Cloudfoundry') {
           steps {
-            dir("${BASE_DIR}"){
-              sh(script: ".ci/release/update_cloudfoundry.sh ${RELEASE_VERSION}")
-              gitPush()
+            // This stage consumes env variables generated in a previous stage...
+            cacheStage(id: 'release-update-cloud-foundry') {
+              dir("${BASE_DIR}"){
+                sh(script: ".ci/release/update_cloudfoundry.sh ${RELEASE_VERSION}")
+                gitPush()
+              }
             }
           }
         }
         stage('Build and push Docker images') {
           steps {
-            dir("${BASE_DIR}"){
-              // fetch agent artifact from remote repository
-              withEnv(["SONATYPE_FALLBACK=1"]) {
-                sh(label: "Build Docker image", script: "./scripts/jenkins/build_docker.sh")
-                  // Get Docker registry credentials
-                  dockerLogin(secret: "${ELASTIC_DOCKER_SECRET}", registry: 'docker.elastic.co', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id')
-                  sh(label: "Push Docker image", script: "./scripts/jenkins/push_docker.sh")
+            cacheStage(id: 'build-push-docker-images') {
+              dir("${BASE_DIR}"){
+                // fetch agent artifact from remote repository
+                withEnv(["SONATYPE_FALLBACK=1"]) {
+                  sh(label: "Build Docker image", script: "./scripts/jenkins/build_docker.sh")
+                    // Get Docker registry credentials
+                    dockerLogin(secret: "${ELASTIC_DOCKER_SECRET}", registry: 'docker.elastic.co', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id')
+                    sh(label: "Push Docker image", script: "./scripts/jenkins/push_docker.sh")
+                }
               }
             }
           }
         }
         stage('Publish release on GitHub') {
           steps {
-            dir("${BASE_DIR}"){
-              waitUntil(initialRecurrencePeriod: 60000) {
-                script {
-                  echo "Waiting for the release notes to be available"
-                    def ret = sh(script: ".ci/release/wait_release_notes_published.sh ${RELEASE_VERSION}", returnStatus: true)
-                    return ret == 0
+            // This stage consumes env variables generated in a previous stage...
+            cacheStage(id: 'release-publish-github-release') {
+              dir("${BASE_DIR}"){
+                waitUntil(initialRecurrencePeriod: 60000) {
+                  script {
+                    echo "Waiting for the release notes to be available"
+                      def ret = sh(script: ".ci/release/wait_release_notes_published.sh ${RELEASE_VERSION}", returnStatus: true)
+                      return ret == 0
+                  }
                 }
+                githubEnv()
+                githubReleasePublish(id: "${env.RELEASE_ID}", name: "Release ${RELEASE_VERSION}")
               }
-              githubEnv()
-              githubReleasePublish(id: "${env.RELEASE_ID}", name: "Release ${RELEASE_VERSION}")
             }
           }
         }
@@ -277,15 +308,18 @@ pipeline {
             REPO_NAME = 'opbeans-java'
           }
           steps {
-            deleteDir()
-            git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-                url: "git@github.com:elastic/${REPO_NAME}.git",
-                branch: 'main')
-            sh(script: ".ci/bump-version.sh ${RELEASE_VERSION}", label: 'Bump version')
-            // The opbeans-java pipeline will trigger a release for the main branch
-            gitPush()
-            // The opbeans-java pipeline will trigger a release for the release tag
-            gitCreateTag(tag: "${RELEASE_TAG}")
+            // This stage consumes env variables generated in a previous stage...
+            cacheStage(id: 'release-opbeans') {
+              deleteDir()
+              git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                  url: "git@github.com:elastic/${REPO_NAME}.git",
+                  branch: 'main')
+              sh(script: ".ci/bump-version.sh ${RELEASE_VERSION}", label: 'Bump version')
+              // The opbeans-java pipeline will trigger a release for the main branch
+              gitPush()
+              // The opbeans-java pipeline will trigger a release for the release tag
+              gitCreateTag(tag: "${RELEASE_TAG}")
+            }
           }
         }
       }
@@ -308,4 +342,12 @@ def notifyStatus(def args = [:]) {
                       to: "${env.NOTIFY_TO}",
                       subject: args.subject,
                       body: args.body)
+}
+
+
+def cacheStage(def args = [:], Closure body){
+  // credentials are tied to the internal-ci controller that should have access to the beats-ci-temp bucket
+  stageStatusCache(id: args.id, bucket: 'beats-ci-temp', credentialsId: 'internal-ci-gcs-plugin-file-credentials', runAlways: params.force_build){
+    body()
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Support to rerun the same build for the same commit without running the stages that already passed.

This is handy when the release pipeline can fail for some unexpected reasons, but the previous stages that went through successfully should not be executed again.

Additionally, the behaviour can be changed by the new input parameter called `force_build`

## Caveats

It uses the git commit for the existing given branch, if for some reason the branch is updated this pipeline will not be able to cache anything.

## Actions

- [ ] Configure the bucket permissions
- [ ] Implement the env variable caching