### PR TITLE
release: support an interactive pipeline

### DIFF
--- a/.ci/release/Jenkinsfile
+++ b/.ci/release/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
     string(name: 'branch_specifier', defaultValue: 'stable', description: "What branch to release from?")
     booleanParam(name: 'check_branch_ci_status', defaultValue: true, description: "Check for failing tests in the given branch (if no stable branch)?")
     booleanParam(name: 'publish_aws_lambda', defaultValue: true, description: "Whether to upload the AWS lambda")
+    booleanParam(name: 'interactive', defaultValue: false, description: "Whether to run an interactive release, step by step.")
   }
   stages {
     stage('Initializing'){
@@ -68,12 +69,18 @@ pipeline {
       stages{
         stage('Check oss.sonatype.org') {
           steps {
-            // If this fails, an exception should be thrown and execution will halt
-            dir("${BASE_DIR}"){
-              script {
-                def r = sh(label: "Check Maven status", script: "./scripts/jenkins/check_maven.sh -u https://status.maven.org/api/v2/summary.json --component OSSRH", returnStatus: true)
-                if (r == 1) {
-                  error("Failing release build because Maven is the OSSRH component is not fully operational. See https://status.maven.org/ for more details.")
+            setEnvVar('STAGE_STAGE_SONARSONAR', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_STAGE_SONARSONAR', askAndWait(message: "Do you wish to run the oss.sonatype.org stage?"))
+            }
+            whenTrue(env.STAGE_STAGE_SONARSONAR?.equals('true')) {
+              // If this fails, an exception should be thrown and execution will halt
+              dir("${BASE_DIR}"){
+                script {
+                  def r = sh(label: "Check Maven status", script: "./scripts/jenkins/check_maven.sh -u https://status.maven.org/api/v2/summary.json --component OSSRH", returnStatus: true)
+                  if (r == 1) {
+                    error("Failing release build because Maven is the OSSRH component is not fully operational. See https://status.maven.org/ for more details.")
+                  }
                 }
               }
             }
@@ -87,84 +94,121 @@ pipeline {
             }
           }
           steps {
-            // If this build is not green: https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/"${BRANCH_SPECIFIER}"/
-            whenTrue(!buildStatus(host: 'apm-ci.elastic.co', job: ['apm-agent-java', 'apm-agent-java-mbp', "${BRANCH_SPECIFIER}"], return_boolean: true)) {
-              notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] The ${BRANCH_SPECIFIER} build is not passing",
-                           body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.")
-              input(message: "WARNING! The ${BRANCH_SPECIFIER} build is not passing. Do you wish to continue?")
+            setEnvVar('STAGE_BUILD_STATUS', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_BUILD_STATUS', askAndWait(message: "Do you wish to run the build status stage?"))
+            }
+            whenTrue(env.STAGE_BUILD_STATUS?.equals('true')) {
+              // If this build is not green: https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/"${BRANCH_SPECIFIER}"/
+              whenTrue(!buildStatus(host: 'apm-ci.elastic.co', job: ['apm-agent-java', 'apm-agent-java-mbp', "${BRANCH_SPECIFIER}"], return_boolean: true)) {
+                notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] The ${BRANCH_SPECIFIER} build is not passing",
+                             body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.")
+                input(message: "WARNING! The ${BRANCH_SPECIFIER} build is not passing. Do you wish to continue?")
+              }
             }
           }
         }
         stage('Require confirmation that CHANGELOG.asciidoc has been updated') {
           steps {
-            input(message: """
-            Update CHANGELOG.asciidoc to reflect the new version release:
-            Go over PRs or git log and add bug fixes and features.
-            Move release notes from the Unreleased sub-heading to the correct [[release-notes-{major}.x]] sub-heading (Example PR for 1.13.0 release).
+            setEnvVar('STAGE_CHANGELOG', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_CHANGELOG', askAndWait(message: "Do you wish to run the CHANGELOG.asciidoc stage?"))
+            }
+            whenTrue(env.STAGE_CHANGELOG?.equals('true')) {
+              input(message: """
+              Update CHANGELOG.asciidoc to reflect the new version release:
+              Go over PRs or git log and add bug fixes and features.
+              Move release notes from the Unreleased sub-heading to the correct [[release-notes-{major}.x]] sub-heading (Example PR for 1.13.0 release).
 
-            Click 'Proceed' to confirm that this step has been completed and changes have been pushed or Abort to stop the build.
-            """
-            )
-            dir("${BASE_DIR}") {
-              git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba', url: 'git@github.com:elastic/apm-agent-java.git', branch: 'main')
+              Click 'Proceed' to confirm that this step has been completed and changes have been pushed or Abort to stop the build.
+              """
+              )
+              dir("${BASE_DIR}") {
+                git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba', url: 'git@github.com:elastic/apm-agent-java.git', branch: 'main')
+              }
             }
           }
         }
         stage('Set release version') {
           steps {
-            dir("${BASE_DIR}"){
-              script {
-                def snapshot_version = mvnVersion(showQualifiers: true)
-                def release_version = snapshot_version.minus('-SNAPSHOT')
-                def user_release_version = input(message: "Please enter version to release:", parameters: [[
-                    $class: 'StringParameterDefinition',
-                    name: 'Release version',
-                    defaultValue: "${release_version}",
-                    description: "Current project version is ${snapshot_version}, will be released as ${release_version} if unchanged. Input release version without '-SNAPSHOT' suffix"
-                  ]])
+            setEnvVar('STAGE_SET_RELEASE', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_SET_RELEASE', askAndWait(message: "Do you wish to set the Releave Version automaticaly?"))
+            }
+            // TODO: input to gather those details manually instead
+            whenTrue((env.STAGE_SET_RELEASE?.equals('true'))) {
+              dir("${BASE_DIR}"){
+                script {
+                  def snapshot_version = mvnVersion(showQualifiers: true)
+                  def release_version = snapshot_version.minus('-SNAPSHOT')
+                  def user_release_version = input(message: "Please enter version to release:", parameters: [[
+                      $class: 'StringParameterDefinition',
+                      name: 'Release version',
+                      defaultValue: "${release_version}",
+                      description: "Current project version is ${snapshot_version}, will be released as ${release_version} if unchanged. Input release version without '-SNAPSHOT' suffix"
+                    ]])
 
-                if( release_version.equals(user_release_version) ) {
-                    echo "changing project version '${snapshot_version}' not required to release ${release_version}"
-                } else {
-                    echo "changing project version from '${snapshot_version}' to '${user_release_version}' to prepare release ${user_release_version}."
-                    sh(label: "mavenVersionUpdate", script: "./mvnw --batch-mode release:update-versions -DdevelopmentVersion=${user_release_version}-SNAPSHOT")
-                    sh(script: "git commit -a -m 'Version bump ${user_release_version}'")
-                    sh(label: 'debug git user', script: 'git --no-pager log -1')
-                    gitPush()
+                  if( release_version.equals(user_release_version) ) {
+                      echo "changing project version '${snapshot_version}' not required to release ${release_version}"
+                  } else {
+                      echo "changing project version from '${snapshot_version}' to '${user_release_version}' to prepare release ${user_release_version}."
+                      sh(label: "mavenVersionUpdate", script: "./mvnw --batch-mode release:update-versions -DdevelopmentVersion=${user_release_version}-SNAPSHOT")
+                      sh(script: "git commit -a -m 'Version bump ${user_release_version}'")
+                      sh(label: 'debug git user', script: 'git --no-pager log -1')
+                      gitPush()
+                  }
+
+                  env.RELEASE_TAG = "v" + user_release_version
+                  env.RELEASE_VERSION = user_release_version
+                  env.BRANCH_DOT_X = user_release_version.substring(0, user_release_version.indexOf('.'))+'.x'
+                  env.RELEASE_AWS_LAMBDA_VERSION = '-ver-' + user_release_version.replaceAll('\\.', '-')
                 }
-
-                env.RELEASE_TAG = "v" + user_release_version
-                env.RELEASE_VERSION = user_release_version
-                env.BRANCH_DOT_X = user_release_version.substring(0, user_release_version.indexOf('.'))+'.x'
-                env.RELEASE_AWS_LAMBDA_VERSION = '-ver-' + user_release_version.replaceAll('\\.', '-')
               }
             }
           }
         }
         stage('Wait on internal CI') {
           steps {
-            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be pushed",
-                          body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.")
-            input(message: "Start the release job on the internal CI. Click 'Proceed' once the job has succeeded or click 'Abort' if the release has failed and then manually undo the release.")
+            setEnvVar('STAGE_INTERNAL_CI', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_INTERNAL_CI', askAndWait(message: "Do you wish to wait for internal CI?"))
+            }
+            whenTrue(env.STAGE_INTERNAL_CI?.equals('true')) {
+              notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be pushed",
+                            body: "Please go to (<${env.BUILD_URL}input|here>) to approve or reject within 12 hours.")
+              input(message: "Start the release job on the internal CI. Click 'Proceed' once the job has succeeded or click 'Abort' if the release has failed and then manually undo the release.")
+            }
           }
         }
         stage('Nexus release') {
           steps {
-            notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be published in Nexus",
-                         body: "Please go to (<https://oss.sonatype.org/|here>) to proceed with the manual nexus release. Login details in LastPass")
-            input(message: "Go to https://oss.sonatype.org and proceed with the steps to close and release the staging artifact.")
+            setEnvVar('STAGE_NEXUS_RELEASE', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_NEXUS_RELEASE', askAndWait(message: "Do you wish to run the nexus release stage?"))
+            }
+            whenTrue(env.STAGE_NEXUS_RELEASE?.equals('true')) {
+              notifyStatus(slackStatus: 'warning', subject: "[${env.REPO}] Release ready to be published in Nexus",
+                           body: "Please go to (<https://oss.sonatype.org/|here>) to proceed with the manual nexus release. Login details in LastPass")
+              input(message: "Go to https://oss.sonatype.org and proceed with the steps to close and release the staging artifact.")
+            }
           }
         }
         stage('Major Branch create/update') {
           steps {
-            dir("${BASE_DIR}") {
-              script {
-                sh(script: ".ci/release/update_major_branch.sh ${RELEASE_VERSION}")
-                gitPush(args: "-f ${BRANCH_DOT_X}")
+            setEnvVar('STAGE_MAJOR_CREATE_UPDATE', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_MAJOR_CREATE_UPDATE', askAndWait(message: "Do you wish to run the major branch creation/update stage?"))
+            }
+            whenTrue(env.STAGE_MAJOR_CREATE_UPDATE?.equals('true')) {
+              dir("${BASE_DIR}") {
+                script {
+                  sh(script: ".ci/release/update_major_branch.sh ${RELEASE_VERSION}")
+                  gitPush(args: "-f ${BRANCH_DOT_X}")
 
-                def isMajor = env.RELEASE_VERSION.endsWith(".0.0")
-                if (isMajor) {
-                  input message: "This was a major version release. Please update the conf.yml in the docs repo before continuing", ok "Continue"
+                  def isMajor = env.RELEASE_VERSION.endsWith(".0.0")
+                  if (isMajor) {
+                    input message: "This was a major version release. Please update the conf.yml in the docs repo before continuing", ok "Continue"
+                  }
                 }
               }
             }
@@ -179,17 +223,23 @@ pipeline {
             PATH_PREFIX = 'jobs/elastic+apm-agent-java+release/src/github.com/elastic/apm-agent-java/target/checkout/elastic-apm-agent/target'
           }
           steps {
-            setEnvVar('ELASTIC_LAYER_NAME', "elastic-apm-java${env.RELEASE_AWS_LAMBDA_VERSION}")
-            withAWSEnv(secret: 'secret/observability-team/ci/service-account/apm-aws-lambda', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id',
-                       forceInstallation: true, version: '2.4.10') {
-              // Fetch lambda file
-              googleStorageDownload(bucketUri: "gs://internal-ci-artifacts/${env.PATH_PREFIX}/${env.SOURCE_AWS_FILE}",
-                                    credentialsId: "${JOB_GCS_CREDENTIALS}",
-                                    localDirectory: "${BASE_DIR}/elastic-apm-agent/target",
-                                    pathPrefix: env.PATH_PREFIX)
-              dir("${BASE_DIR}"){
-                sh(label: 'make publish-in-all-aws-regions', script: 'make -C .ci publish-in-all-aws-regions')
-                sh(label: 'make create-arn-file', script: 'make -C .ci create-arn-file')
+            setEnvVar('STAGE_AWS_LAMBDA', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_AWS_LAMBDA', askAndWait(message: "Do you wish to run the AWS lambda publishing stage?"))
+            }
+            whenTrue(env.STAGE_AWS_LAMBDA?.equals('true')) {
+              setEnvVar('ELASTIC_LAYER_NAME', "elastic-apm-java${env.RELEASE_AWS_LAMBDA_VERSION}")
+              withAWSEnv(secret: 'secret/observability-team/ci/service-account/apm-aws-lambda', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id',
+                         forceInstallation: true, version: '2.4.10') {
+                // Fetch lambda file
+                googleStorageDownload(bucketUri: "gs://internal-ci-artifacts/${env.PATH_PREFIX}/${env.SOURCE_AWS_FILE}",
+                                      credentialsId: "${JOB_GCS_CREDENTIALS}",
+                                      localDirectory: "${BASE_DIR}/elastic-apm-agent/target",
+                                      pathPrefix: env.PATH_PREFIX)
+                dir("${BASE_DIR}"){
+                  sh(label: 'make publish-in-all-aws-regions', script: 'make -C .ci publish-in-all-aws-regions')
+                  sh(label: 'make create-arn-file', script: 'make -C .ci create-arn-file')
+                }
               }
             }
           }
@@ -201,34 +251,46 @@ pipeline {
         }
         stage('Create GitHub release draft') {
           steps {
-            dir("${BASE_DIR}"){
-              script {
-                def arnFile = ".ci/${SUFFIX_ARN_FILE}"
-                setEnvVar('ARN_CONTENT', fileExists(arnFile) ? readFile(arnFile) : '')
-                // Construct the URL with anchor for the release notes
-                // Ex: https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-1.x.html#release-notes-1.13.0
-                def finalUrl = "https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-${BRANCH_DOT_X}.html#release-notes-${RELEASE_VERSION}"
-                githubEnv()
-                def ret = githubReleaseCreate(
-                        draft: true,
-                        tagName: "${RELEASE_TAG}",
-                        releaseName: "Release ${RELEASE_VERSION}",
-                        body: "[Release Notes for ${RELEASE_VERSION}](${finalUrl}) \n ${ARN_CONTENT}")
-                env.RELEASE_ID = ret['id']
-                env.RELEASE_NOTES_URL = finalUrl
+            setEnvVar('STAGE_RELEASE_DRAFT', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_RELEASE_DRAFT', askAndWait(message: "Do you wish to run the GitHub release draft stage?"))
+            }
+            whenTrue(env.STAGE_RELEASE_DRAFT?.equals('true')) {
+              dir("${BASE_DIR}"){
+                script {
+                  def arnFile = ".ci/${SUFFIX_ARN_FILE}"
+                  setEnvVar('ARN_CONTENT', fileExists(arnFile) ? readFile(arnFile) : '')
+                  // Construct the URL with anchor for the release notes
+                  // Ex: https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-1.x.html#release-notes-1.13.0
+                  def finalUrl = "https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-${BRANCH_DOT_X}.html#release-notes-${RELEASE_VERSION}"
+                  githubEnv()
+                  def ret = githubReleaseCreate(
+                          draft: true,
+                          tagName: "${RELEASE_TAG}",
+                          releaseName: "Release ${RELEASE_VERSION}",
+                          body: "[Release Notes for ${RELEASE_VERSION}](${finalUrl}) \n ${ARN_CONTENT}")
+                  env.RELEASE_ID = ret['id']
+                  env.RELEASE_NOTES_URL = finalUrl
+                }
               }
             }
           }
         }
         stage('Wait for artifact to be available in Maven Central') {
           steps {
-            dir("${BASE_DIR}"){
-              script {
-                waitUntil(initialRecurrencePeriod: 60000) {
-                  script {
-                    def ret = sh(script: ".ci/release/wait_maven_artifact_published.sh ${RELEASE_VERSION}", returnStatus: true)
-                    echo "Waiting for the artifacts to be published on Sonatype"
-                    return ret == 0
+            setEnvVar('STAGE_WAIT_MAVEN_CENTRAL', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_WAIT_MAVEN_CENTRAL', askAndWait(message: "Do you wish to run the Maven Central stage?"))
+            }
+            whenTrue(env.STAGE_WAIT_MAVEN_CENTRAL?.equals('true')) {
+              dir("${BASE_DIR}"){
+                script {
+                  waitUntil(initialRecurrencePeriod: 60000) {
+                    script {
+                      def ret = sh(script: ".ci/release/wait_maven_artifact_published.sh ${RELEASE_VERSION}", returnStatus: true)
+                      echo "Waiting for the artifacts to be published on Sonatype"
+                      return ret == 0
+                    }
                   }
                 }
               }
@@ -237,37 +299,55 @@ pipeline {
         }
         stage('Update Cloudfoundry') {
           steps {
-            dir("${BASE_DIR}"){
-              sh(script: ".ci/release/update_cloudfoundry.sh ${RELEASE_VERSION}")
-              gitPush()
+            setEnvVar('STAGE_CLOUDFOUNDRY', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_CLOUDFOUNDRY', askAndWait(message: "Do you wish to run the CloudFoundry stage?"))
+            }
+            whenTrue(env.STAGE_CLOUDFOUNDRY?.equals('true')) {
+              dir("${BASE_DIR}"){
+                sh(script: ".ci/release/update_cloudfoundry.sh ${RELEASE_VERSION}")
+                gitPush()
+              }
             }
           }
         }
         stage('Build and push Docker images') {
           steps {
-            dir("${BASE_DIR}"){
-              // fetch agent artifact from remote repository
-              withEnv(["SONATYPE_FALLBACK=1"]) {
-                sh(label: "Build Docker image", script: "./scripts/jenkins/build_docker.sh")
-                  // Get Docker registry credentials
-                  dockerLogin(secret: "${ELASTIC_DOCKER_SECRET}", registry: 'docker.elastic.co', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id')
-                  sh(label: "Push Docker image", script: "./scripts/jenkins/push_docker.sh")
+            setEnvVar('STAGE_DOCKER', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_DOCKER', askAndWait(message: "Do you wish to run the Docker images stage?"))
+            }
+            whenTrue(env.STAGE_DOCKER?.equals('true')) {
+              dir("${BASE_DIR}"){
+                // fetch agent artifact from remote repository
+                withEnv(["SONATYPE_FALLBACK=1"]) {
+                  sh(label: "Build Docker image", script: "./scripts/jenkins/build_docker.sh")
+                    // Get Docker registry credentials
+                    dockerLogin(secret: "${ELASTIC_DOCKER_SECRET}", registry: 'docker.elastic.co', role_id: 'apm-vault-role-id', secret_id: 'apm-vault-secret-id')
+                    sh(label: "Push Docker image", script: "./scripts/jenkins/push_docker.sh")
+                }
               }
             }
           }
         }
         stage('Publish release on GitHub') {
           steps {
-            dir("${BASE_DIR}"){
-              waitUntil(initialRecurrencePeriod: 60000) {
-                script {
-                  echo "Waiting for the release notes to be available"
-                    def ret = sh(script: ".ci/release/wait_release_notes_published.sh ${RELEASE_VERSION}", returnStatus: true)
-                    return ret == 0
+            setEnvVar('STAGE_GITHUB_RELEASE', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_GITHUB_RELEASE', askAndWait(message: "Do you wish to run the GitHub release stage?"))
+            }
+            whenTrue(env.STAGE_DOCKER?.equals('true')) {
+              dir("${BASE_DIR}"){
+                waitUntil(initialRecurrencePeriod: 60000) {
+                  script {
+                    echo "Waiting for the release notes to be available"
+                      def ret = sh(script: ".ci/release/wait_release_notes_published.sh ${RELEASE_VERSION}", returnStatus: true)
+                      return ret == 0
+                  }
                 }
+                githubEnv()
+                githubReleasePublish(id: "${env.RELEASE_ID}", name: "Release ${RELEASE_VERSION}")
               }
-              githubEnv()
-              githubReleasePublish(id: "${env.RELEASE_ID}", name: "Release ${RELEASE_VERSION}")
             }
           }
         }
@@ -277,15 +357,21 @@ pipeline {
             REPO_NAME = 'opbeans-java'
           }
           steps {
-            deleteDir()
-            git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
-                url: "git@github.com:elastic/${REPO_NAME}.git",
-                branch: 'main')
-            sh(script: ".ci/bump-version.sh ${RELEASE_VERSION}", label: 'Bump version')
-            // The opbeans-java pipeline will trigger a release for the main branch
-            gitPush()
-            // The opbeans-java pipeline will trigger a release for the release tag
-            gitCreateTag(tag: "${RELEASE_TAG}")
+            setEnvVar('STAGE_OPBEANS', 'true')
+            whenTrue(params.interactive) {
+              setEnvVar('STAGE_OPBEANS', askAndWait(message: "Do you wish to run the Opbeans stage?"))
+            }
+            whenTrue(env.STAGE_OPBEANS?.equals('true')) {
+              deleteDir()
+              git(credentialsId: 'f6c7695a-671e-4f4f-a331-acdce44ff9ba',
+                  url: "git@github.com:elastic/${REPO_NAME}.git",
+                  branch: 'main')
+              sh(script: ".ci/bump-version.sh ${RELEASE_VERSION}", label: 'Bump version')
+              // The opbeans-java pipeline will trigger a release for the main branch
+              gitPush()
+              // The opbeans-java pipeline will trigger a release for the release tag
+              gitCreateTag(tag: "${RELEASE_TAG}")
+            }
           }
         }
       }


### PR DESCRIPTION
### What

Support for an interactive pipeline, so every stage will require a prompt confirmation.

### Why

This is handy when something happens during the release, and you would like to rerun the pipeline but skipping some stages.


### Implementation details

Rather than running from a particular stage onwards, this interactive pipeline will allow further granularity about what stage should be run individually, a bit tedious but worthy in terms of running one stage from the middle if needed, besides a bit less complex 

### Actions

- [ ] Agree with the team
- [ ] `Set release version` requires an input parameter to gather some env variables