### PR TITLE
.ci: remove End-to-End Integration Tests stage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,6 @@ pipeline {
     DOCKERHUB_SECRET = 'secret/apm-team/ci/elastic-observability-dockerhub'
     ELASTIC_DOCKER_SECRET = 'secret/apm-team/ci/docker-registry/prod'
     CODECOV_SECRET = 'secret/apm-team/ci/apm-agent-java-codecov'
-    GITHUB_CHECK_ITS_NAME = 'End-To-End Integration Tests'
-    ITS_PIPELINE = 'apm-integration-tests-selector-mbp/main'
     MAVEN_CONFIG = '-Dmaven.repo.local=.m2'
     JAVA_VERSION = "${params.JAVA_VERSION}"
     JOB_GCS_BUCKET_STASH = 'apm-ci-temp'
@@ -30,7 +28,7 @@ pipeline {
     quietPeriod(10)
   }
   triggers {
-    issueCommentTrigger("(${obltGitHubComments()}|^run (jdk compatibility|benchmark|integration|end-to-end|windows) tests)")
+    issueCommentTrigger("(${obltGitHubComments()}|^run (jdk compatibility|benchmark|integration|windows) tests)")
   }
   parameters {
     string(name: 'JAVA_VERSION', defaultValue: 'java11', description: 'Java version to build & test')
@@ -49,10 +47,6 @@ pipeline {
     // - Application Server integration tests
     // opt-in with 'ci:agent-integration'
     booleanParam(name: 'agent_integration_tests_ci', defaultValue: false, description: 'Enable Agent Integration tests')
-
-    // disabled by default, but required for merge, GH check name is ${GITHUB_CHECK_ITS_NAME}
-    // opt-in with 'ci:end-to-end' tag on PR
-    booleanParam(name: 'end_to_end_tests_ci', defaultValue: false, description: 'Enable APM End-to-End tests')
 
     // disabled by default, not required for merge
     // opt-in with 'ci:benchmarks' tag on PR
@@ -352,30 +346,6 @@ pipeline {
                 }
               }
             }
-          }
-        }
-        stage('End-To-End Integration Tests') {
-          agent none
-          when {
-            allOf {
-              expression { return env.ONLY_DOCS == "false" }
-              anyOf {
-                expression { return params.end_to_end_tests_ci }
-                expression { return env.GITHUB_COMMENT?.contains('end-to-end tests') }
-                expression { matchesPrLabel(label: 'ci:end-to-end') }
-                expression { return env.CHANGE_ID != null && !pullRequest.draft }
-                not { changeRequest() }
-              }
-            }
-          }
-          steps {
-            build(job: env.ITS_PIPELINE, propagate: false, wait: false,
-                  parameters: [string(name: 'INTEGRATION_TEST', value: 'Java'),
-                               string(name: 'BUILD_OPTS', value: "--java-agent-version ${env.GIT_BASE_COMMIT} --opbeans-java-agent-branch ${env.GIT_BASE_COMMIT}"),
-                               string(name: 'GITHUB_CHECK_NAME', value: env.GITHUB_CHECK_ITS_NAME),
-                               string(name: 'GITHUB_CHECK_REPO', value: env.REPO),
-                               string(name: 'GITHUB_CHECK_SHA1', value: env.GIT_BASE_COMMIT)])
-            githubNotify(context: "${env.GITHUB_CHECK_ITS_NAME}", description: "${env.GITHUB_CHECK_ITS_NAME} ...", status: 'PENDING', targetUrl: "${env.JENKINS_URL}search/?q=${env.ITS_PIPELINE.replaceAll('/','+')}")
           }
         }
         stage('JDK Compatibility Tests') {


### PR DESCRIPTION
## What does this PR do?

Remove the end-to-end integration test stage. See https://github.com/elastic/apm-integration-testing/issues/1523

## Checklist

- [x] This is something else
  - ~[ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~