### PR TITLE
Updated dependabot config making updates-entries unique as required by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,7 +49,7 @@ updates:
       - dependency-name: "com.amazonaws:aws-java-sdk"
       - dependency-name: "software.amazon.awssdk:*"
   - package-ecosystem: "maven"
-    directory: "/"
+    directory: "/apm-agent-plugins"
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 5


### PR DESCRIPTION
Currently dependabot complains about our config:

```
The property '#/updates/1' is a duplicate. Update configs must have a unique combination of 'package-ecosystem', 'directory', and 'target-branch'
```

With this PR I attempt to trick dependabot into still evaluating both of our `updates`-rules at least on the `apm-agent-plugins` submodules, from which to my understanding the monthly-exemptions originate.

If the maven dependabot strategy is implemented as [described here](https://github.com/dependabot/dependabot-core/issues/222#issuecomment-382708255), it should hopefully work. Unfortunately I wasn't able to find any actual documentation on the behaviour with overlapping directories.

We will see whether after this PR dependabot still continues opening PRs weekly for the `apm-agent-plugins` or not.