### PR TITLE
Added debug logs for proxy settings when the agent initiates connections

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
@@ -69,7 +69,7 @@ public class UrlConnectionUtils {
                 if (proxies != null && proxies.size() == 1 && proxies.get(0).equals(Proxy.NO_PROXY)) {
                     logger.debug("Opening {} without proxy (ProxySelector {})", url, proxySelectorName);
                 } else {
-                    logger.debug("Opening {} with proxy {} (ProxySelector {})", url, proxies, proxySelectorName);
+                    logger.debug("Opening {} with proxies {} (ProxySelector {})", url, proxies, proxySelectorName);
                 }
             } catch (URISyntaxException e) {
                 logger.debug("Failed to read and debug-print proxy settings for {}", url, e);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
@@ -33,13 +33,20 @@ public class UrlConnectionUtils {
         GlobalLocks.JUL_INIT_LOCK.lock();
         try {
             if (logger.isDebugEnabled()) {
-                String httpProxyHost = System.getProperty("http.proxyHost");
-                String httpProxyPort = System.getProperty("http.proxyPort");
-                String httpsProxyHost = System.getProperty("https.proxyHost");
-                String httpsProxyPort = System.getProperty("https.proxyPort");
-                String nonProxyHosts = System.getProperty("http.nonProxyHosts");
-                logger.debug("Opening URLConnection, global proxy settings: http.proxyHost={} http.proxyPort={} https.proxyHost={} https.proxyPort={} http.nonProxyHosts={}",
-                    httpProxyHost, httpProxyPort, httpsProxyHost, httpsProxyPort, nonProxyHosts);
+                String proxyHostProperty = url.getProtocol() + ".proxyHost";
+                String proxyPortProperty = url.getProtocol() + ".proxyPort";
+                String proxyHost = System.getProperty(proxyHostProperty);
+                String proxyPort = System.getProperty(proxyPortProperty);
+                String nonProxyHosts = System.getProperty("http.nonProxyHosts"); // common to http & https
+                if (proxyHost == null || proxyHost.isEmpty()) {
+                    logger.debug("Opening {} without proxy", url);
+                } else {
+                    logger.debug("Opening {} with proxy settings: {}={}, {}={}, http.nonProxyHosts={}", url,
+                        proxyHostProperty, proxyHost,
+                        proxyPortProperty, proxyPort,
+                        nonProxyHosts
+                    );
+                }
             }
             return url.openConnection();
         } finally {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
@@ -18,14 +18,29 @@
  */
 package co.elastic.apm.agent.util;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLConnection;
 
 public class UrlConnectionUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(UrlConnectionUtils.class);
+
     public static URLConnection openUrlConnectionThreadSafely(URL url) throws IOException {
         GlobalLocks.JUL_INIT_LOCK.lock();
         try {
+            if (logger.isDebugEnabled()) {
+                String httpProxyHost = System.getProperty("http.proxyHost");
+                String httpProxyPort = System.getProperty("http.proxyPort");
+                String httpsProxyHost = System.getProperty("https.proxyHost");
+                String httpsProxyPort = System.getProperty("https.proxyPort");
+                String nonProxyHosts = System.getProperty("http.nonProxyHosts");
+                logger.debug("Opening URLConnection, global proxy settings: http.proxyHost={} http.proxyPort={} https.proxyHost={} https.proxyPort={} http.nonProxyHosts={}",
+                    httpProxyHost, httpProxyPort, httpsProxyHost, httpsProxyPort, nonProxyHosts);
+            }
             return url.openConnection();
         } finally {
             GlobalLocks.JUL_INIT_LOCK.unlock();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
@@ -22,8 +22,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.net.Proxy;
+import java.net.ProxySelector;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.List;
 
 public class UrlConnectionUtils {
 
@@ -33,24 +37,43 @@ public class UrlConnectionUtils {
         GlobalLocks.JUL_INIT_LOCK.lock();
         try {
             if (logger.isDebugEnabled()) {
-                String proxyHostProperty = url.getProtocol() + ".proxyHost";
-                String proxyPortProperty = url.getProtocol() + ".proxyPort";
-                String proxyHost = System.getProperty(proxyHostProperty);
-                String proxyPort = System.getProperty(proxyPortProperty);
-                String nonProxyHosts = System.getProperty("http.nonProxyHosts"); // common to http & https
-                if (proxyHost == null || proxyHost.isEmpty()) {
-                    logger.debug("Opening {} without proxy", url);
-                } else {
-                    logger.debug("Opening {} with proxy settings: {}={}, {}={}, http.nonProxyHosts={}", url,
-                        proxyHostProperty, proxyHost,
-                        proxyPortProperty, proxyPort,
-                        nonProxyHosts
-                    );
-                }
+                debugPrintProxySettings(url);
             }
             return url.openConnection();
         } finally {
             GlobalLocks.JUL_INIT_LOCK.unlock();
+        }
+    }
+
+    private static void debugPrintProxySettings(URL url) {
+        ProxySelector proxySelector = ProxySelector.getDefault();
+        if (proxySelector == null || proxySelector.getClass().getName().equals("sun.net.spi.DefaultProxySelector")) {
+            String proxyHostProperty = url.getProtocol() + ".proxyHost";
+            String proxyPortProperty = url.getProtocol() + ".proxyPort";
+            String proxyHost = System.getProperty(proxyHostProperty);
+            String proxyPort = System.getProperty(proxyPortProperty);
+            String nonProxyHosts = System.getProperty("http.nonProxyHosts"); // common to http & https
+            if (proxyHost == null || proxyHost.isEmpty()) {
+                logger.debug("Opening {} without proxy", url);
+            } else {
+                logger.debug("Opening {} with proxy settings: {}={}, {}={}, http.nonProxyHosts={}", url,
+                    proxyHostProperty, proxyHost,
+                    proxyPortProperty, proxyPort,
+                    nonProxyHosts
+                );
+            }
+        } else {
+            try {
+                List<Proxy> proxies = proxySelector.select(url.toURI());
+                String proxySelectorName = proxySelector.getClass().getName();
+                if (proxies != null && proxies.size() == 1 && proxies.get(0).equals(Proxy.NO_PROXY)) {
+                    logger.debug("Opening {} without proxy (ProxySelector {})", url, proxySelectorName);
+                } else {
+                    logger.debug("Opening {} with Proxy {} (ProxySelector {})", url, proxies, proxySelectorName);
+                }
+            } catch (URISyntaxException e) {
+                logger.debug("Failed to read and debug-print proxy settings for {}", url, e);
+            }
         }
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/UrlConnectionUtils.java
@@ -69,7 +69,7 @@ public class UrlConnectionUtils {
                 if (proxies != null && proxies.size() == 1 && proxies.get(0).equals(Proxy.NO_PROXY)) {
                     logger.debug("Opening {} without proxy (ProxySelector {})", url, proxySelectorName);
                 } else {
-                    logger.debug("Opening {} with Proxy {} (ProxySelector {})", url, proxies, proxySelectorName);
+                    logger.debug("Opening {} with proxy {} (ProxySelector {})", url, proxies, proxySelectorName);
                 }
             } catch (URISyntaxException e) {
                 logger.debug("Failed to read and debug-print proxy settings for {}", url, e);


### PR DESCRIPTION
## What does this PR do?
Added debug logs for proxy settings when the agent initiates connections.
Won't add this one to the changelog because it's not user relevant.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
