### PR TITLE
Add test case for alternative code path in legacy Apache HttpClient instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -30,6 +30,7 @@ endif::[]
 ===== Features
 * Add support for log correlation for `java.util.logging` (JUL) - {pull}2724[#2724]
 * Add support for spring-kafka batch listeners - {pull}2815[#2815]
+* Improved instrumentation for legacy Apache HttpClient (when not using an `HttpUriRequest`, such as `BasicHttpRequest`)
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientBasicHttpRequestInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientBasicHttpRequestInstrumentationTest.java
@@ -18,13 +18,20 @@
  */
 package co.elastic.apm.agent.httpclient;
 
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.message.BasicHttpRequest;
+import org.apache.http.util.EntityUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
-public class LegacyApacheHttpClientInstrumentationTest extends AbstractHttpClientInstrumentationTest {
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URL;
+
+public class LegacyApacheHttpClientBasicHttpRequestInstrumentationTest extends AbstractHttpClientInstrumentationTest {
 
     @SuppressWarnings("deprecation")
     private static DefaultHttpClient client;
@@ -37,13 +44,18 @@ public class LegacyApacheHttpClientInstrumentationTest extends AbstractHttpClien
 
     @AfterClass
     public static void close() {
-        client.close();
+        client.getConnectionManager().shutdown();
     }
 
     @Override
     protected void performGet(String path) throws Exception {
-        try (CloseableHttpResponse response = client.execute(new HttpGet(path))) {
-            response.getEntity();
+        Method execute = client.getClass().getMethod("execute", HttpHost.class, HttpRequest.class);
+        try {
+            URL url = new URL(path);
+            HttpResponse response = (HttpResponse) execute.invoke(client, new HttpHost(url.getHost(), url.getPort()), new BasicHttpRequest("GET", path));
+            EntityUtils.consume(response.getEntity());
+        } catch (InvocationTargetException e) {
+            throw (Exception) e.getTargetException();
         }
     }
 }

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientHttpUriRequestInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientHttpUriRequestInstrumentationTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.httpclient;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class LegacyApacheHttpClientHttpUriRequestInstrumentationTest extends AbstractHttpClientInstrumentationTest {
+
+    @SuppressWarnings("deprecation")
+    private static DefaultHttpClient client;
+
+    @BeforeClass
+    @SuppressWarnings("deprecation")
+    public static void setUp() {
+        client = new DefaultHttpClient();
+    }
+
+    @AfterClass
+    public static void close() {
+        client.getConnectionManager().shutdown();
+    }
+
+    @Override
+    protected void performGet(String path) throws Exception {
+        Method execute = client.getClass().getMethod("execute", HttpUriRequest.class);
+        try {
+            HttpResponse response = (HttpResponse) execute.invoke(client, new HttpGet(path));
+            EntityUtils.consume(response.getEntity());
+        } catch (InvocationTargetException e) {
+            throw (Exception) e.getTargetException();
+        }
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientVersionIT.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientVersionIT.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.httpclient;
 
 import co.elastic.apm.agent.TestClassWithDependencyRunner;
@@ -15,16 +33,16 @@ public class LegacyApacheHttpClientVersionIT {
 
 
     public LegacyApacheHttpClientVersionIT(List<String> dependencies) throws Exception {
-        this.runner = new TestClassWithDependencyRunner(dependencies, "co.elastic.apm.agent.httpclient.LegacyApacheHttpClientInstrumentationTest");
+        this.runner = new TestClassWithDependencyRunner(dependencies, LegacyApacheHttpClientBasicHttpRequestInstrumentationTest.class);
     }
 
     @Parameterized.Parameters(name = "{0}")
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {List.of("org.apache.httpcomponents:httpcore:4.0")},
-            {List.of("org.apache.httpcomponents:httpcore:4.0.1")},
-            {List.of("org.apache.httpcomponents:httpcore:4.1.4")},
-            {List.of("org.apache.httpcomponents:httpcore:4.2.5")}
+            {List.of("org.apache.httpcomponents:httpclient:4.0")},
+            {List.of("org.apache.httpcomponents:httpclient:4.0.1")},
+            {List.of("org.apache.httpcomponents:httpclient:4.1.3")},
+            {List.of("org.apache.httpcomponents:httpclient:4.2.5")}
         });
     }
 

--- a/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientVersionIT.java
+++ b/apm-agent-plugins/apm-apache-httpclient-plugin/src/test/java/co/elastic/apm/agent/httpclient/LegacyApacheHttpClientVersionIT.java
@@ -29,11 +29,12 @@ import java.util.List;
 @RunWith(Parameterized.class)
 public class LegacyApacheHttpClientVersionIT {
 
-    private final TestClassWithDependencyRunner runner;
-
+    private final TestClassWithDependencyRunner runner1;
+    private final TestClassWithDependencyRunner runner2;
 
     public LegacyApacheHttpClientVersionIT(List<String> dependencies) throws Exception {
-        this.runner = new TestClassWithDependencyRunner(dependencies, LegacyApacheHttpClientBasicHttpRequestInstrumentationTest.class);
+        this.runner1 = new TestClassWithDependencyRunner(dependencies, LegacyApacheHttpClientBasicHttpRequestInstrumentationTest.class);
+        this.runner2 = new TestClassWithDependencyRunner(dependencies, LegacyApacheHttpClientHttpUriRequestInstrumentationTest.class);
     }
 
     @Parameterized.Parameters(name = "{0}")
@@ -47,7 +48,12 @@ public class LegacyApacheHttpClientVersionIT {
     }
 
     @Test
-    public void test() {
-        runner.run();
+    public void legacyApacheHttpClientBasicHttpRequestInstrumentationTest() {
+        runner1.run();
+    }
+
+    @Test
+    public void legacyApacheHttpClientHttpUriRequestInstrumentationTest() {
+        runner2.run();
     }
 }


### PR DESCRIPTION
Amends #2834 and adds a test case for the new branch. Also adds a changelog