### PR TITLE
Fix flaky tests due to reporter-Mockito race condition

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
@@ -25,6 +25,7 @@ import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
 import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
 import co.elastic.apm.agent.report.ApmServerClient;
 import co.elastic.apm.agent.report.Reporter;
+import co.elastic.apm.agent.util.Version;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -77,6 +78,11 @@ public class MockTracer {
             .build();
 
         tracer.start(false);
+        //The line below is a fix for flaky-test issue #2842
+        //The tracer will asynchronously create a health + version lookup of the ApmServer
+        //As this request relies on the ReporterConfiguration, this can lead to a race condition when mocking the ReporterConfiguration concurrently
+        //The call below ensures that the asynchronous request has finished before returning.
+        tracer.getApmServerClient().isAtLeast(Version.of("0.0"));
         return tracer;
     }
 


### PR DESCRIPTION
## What does this PR do?
Fixes #2842.

I have had a closer look at what happens on tracer start, the Apm-server health and version check seems to be the only concurrent task.

I have documented how to provoke a failure due to the race condition within the issue.

## Checklist
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
