### PR TITLE
EOL table has been moved to central EOL Policy page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -276,7 +276,7 @@ For illustration purpose, `1.2.3` will be the target release version, and the gi
 1. Update [`CHANGELOG.asciidoc`](CHANGELOG.asciidoc) to reflect the new version release:
    1. Go over PRs or git log and add bug fixes and features.
    1. Move release notes from the `Unreleased` sub-heading to the correct `[[release-notes-{major}.x]]` sub-heading ([Example PR](https://github.com/elastic/apm-agent-java/pull/1027/files) for 1.13.0 release).
-1. For major releases, update the EOL table in [`upgrading.asciidoc`](docs/upgrading.asciidoc).
+1. For major releases, [create an issue](https://github.com/elastic/website-requests/issues/new) to request an update of the [EOL table](https://www.elastic.co/support/eol).
 1. Review Maven project version, you must have `${project.version}` equal to `1.2.3-SNAPSHOT`, `-SNAPSHOT` suffix will be removed during release process.
    1. If needed, use following command to update version - `mvn release:update-versions`, then commit and push changes.
 1. Execute the release Jenkins job on the internal ci server. This job is same as the snapshot-build job, but it also:

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -28,10 +28,3 @@ forward on future development and innovation.
 Our https://www.elastic.co/support/eol[End of life policy] defines how long a given release is considered supported,
 as well as how long a release is considered still in active development or maintenance.
 The table below is a simplified description of this policy.
-
-[options="header"]
-|====
-|Agent version |EOL Date |Maintained until
-|1.x.x  |2024-01-20 |2.0.0
-|====
-

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -27,4 +27,3 @@ We love all our products, but sometimes we must say goodbye to a release so that
 forward on future development and innovation.
 Our https://www.elastic.co/support/eol[End of life policy] defines how long a given release is considered supported,
 as well as how long a release is considered still in active development or maintenance.
-The table below is a simplified description of this policy.


### PR DESCRIPTION
APM Agents are listed now in the central EOL policy table: https://www.elastic.co/support/eol