### PR TITLE
Correct links to Lambda extension docs

### DIFF
--- a/docs/lambda/configure-lambda.asciidoc
+++ b/docs/lambda/configure-lambda.asciidoc
@@ -12,6 +12,7 @@ To configure APM through the AWS Management Console:
 AWS_LAMBDA_EXEC_WRAPPER       = /opt/elastic-apm-handler  # use this exact fixed value
 ELASTIC_APM_LAMBDA_APM_SERVER = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN      = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
+ELASTIC_APM_SEND_STRATEGY     = background                # recommended for steady load scenarios
 ----
 
 --
@@ -49,6 +50,7 @@ Resources:
             AWS_LAMBDA_EXEC_WRAPPER: /opt/elastic-apm-handler
             ELASTIC_APM_LAMBDA_APM_SERVER: <YOUR-APM-SERVER-URL>
             ELASTIC_APM_SECRET_TOKEN: <YOUR-APM-SECRET-TOKEN>
+            ELASTIC_APM_SEND_STRATEGY: background
 ...
 ----
 
@@ -68,6 +70,7 @@ functions:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/elastic-apm-handler
       ELASTIC_APM_LAMBDA_APM_SERVER: <YOUR-APM-SERVER-URL>
       ELASTIC_APM_SECRET_TOKEN: <YOUR-APM-SECRET-TOKEN>
+      ELASTIC_APM_SEND_STRATEGY: background
 ...
 ----
 
@@ -86,6 +89,7 @@ resource "aws_lambda_function" "your_lambda_function" {
       AWS_LAMBDA_EXEC_WRAPPER       = "/opt/elastic-apm-handler"
       ELASTIC_APM_LAMBDA_APM_SERVER = "<YOUR-APM-SERVER-URL>"
       ELASTIC_APM_SECRET_TOKEN      = "<YOUR-APM-SECRET-TOKEN>"
+      ELASTIC_APM_SEND_STRATEGY     = "background"
     }
   }
 }
@@ -107,6 +111,7 @@ In this case, you will only need to configure the following three environment va
 AWS_LAMBDA_EXEC_WRAPPER       = "/opt/elastic-apm-handler"
 ELASTIC_APM_LAMBDA_APM_SERVER = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN      = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
+ELASTIC_APM_SEND_STRATEGY     = "background"
 ----
 
 If your container image is based on a different base image (not including the AWS Lambda runtime utilities),
@@ -122,6 +127,7 @@ ELASTIC_APM_CENTRAL_CONFIG     = "false"
 ELASTIC_APM_CLOUD_PROVIDER     = "none"
 ELASTIC_APM_LAMBDA_APM_SERVER  = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN       = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
+ELASTIC_APM_SEND_STRATEGY      = "background"
 ----
 
 // end::container-with-agent[]

--- a/docs/lambda/configure-lambda.asciidoc
+++ b/docs/lambda/configure-lambda.asciidoc
@@ -12,7 +12,7 @@ To configure APM through the AWS Management Console:
 AWS_LAMBDA_EXEC_WRAPPER       = /opt/elastic-apm-handler  # use this exact fixed value
 ELASTIC_APM_LAMBDA_APM_SERVER = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN      = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
-ELASTIC_APM_SEND_STRATEGY     = background                # recommended for steady load scenarios
+ELASTIC_APM_SEND_STRATEGY     = background                <1>
 ----
 
 --
@@ -28,7 +28,7 @@ To configure APM through the AWS command line interface execute the following co
 [source,bash]
 ----
 aws lambda update-function-configuration --function-name yourLambdaFunctionName \
-    --environment "Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/elastic-apm-handler,ELASTIC_APM_LAMBDA_APM_SERVER=<YOUR-APM-SERVER-URL>,ELASTIC_APM_SECRET_TOKEN=<YOUR-APM-SECRET-TOKEN>}"
+    --environment "Variables={AWS_LAMBDA_EXEC_WRAPPER=/opt/elastic-apm-handler,ELASTIC_APM_LAMBDA_APM_SERVER=<YOUR-APM-SERVER-URL>,ELASTIC_APM_SECRET_TOKEN=<YOUR-APM-SECRET-TOKEN>,ELASTIC_APM_SEND_STRATEGY=background}" <1>
 ----
 
 // end::cli-with-agent[]
@@ -50,7 +50,7 @@ Resources:
             AWS_LAMBDA_EXEC_WRAPPER: /opt/elastic-apm-handler
             ELASTIC_APM_LAMBDA_APM_SERVER: <YOUR-APM-SERVER-URL>
             ELASTIC_APM_SECRET_TOKEN: <YOUR-APM-SECRET-TOKEN>
-            ELASTIC_APM_SEND_STRATEGY: background
+            ELASTIC_APM_SEND_STRATEGY: background <1>
 ...
 ----
 
@@ -70,7 +70,7 @@ functions:
       AWS_LAMBDA_EXEC_WRAPPER: /opt/elastic-apm-handler
       ELASTIC_APM_LAMBDA_APM_SERVER: <YOUR-APM-SERVER-URL>
       ELASTIC_APM_SECRET_TOKEN: <YOUR-APM-SECRET-TOKEN>
-      ELASTIC_APM_SEND_STRATEGY: background
+      ELASTIC_APM_SEND_STRATEGY: background <1>
 ...
 ----
 
@@ -89,7 +89,7 @@ resource "aws_lambda_function" "your_lambda_function" {
       AWS_LAMBDA_EXEC_WRAPPER       = "/opt/elastic-apm-handler"
       ELASTIC_APM_LAMBDA_APM_SERVER = "<YOUR-APM-SERVER-URL>"
       ELASTIC_APM_SECRET_TOKEN      = "<YOUR-APM-SECRET-TOKEN>"
-      ELASTIC_APM_SEND_STRATEGY     = "background"
+      ELASTIC_APM_SEND_STRATEGY     = "background" <1>
     }
   }
 }
@@ -111,7 +111,7 @@ In this case, you will only need to configure the following three environment va
 AWS_LAMBDA_EXEC_WRAPPER       = "/opt/elastic-apm-handler"
 ELASTIC_APM_LAMBDA_APM_SERVER = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN      = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
-ELASTIC_APM_SEND_STRATEGY     = "background"
+ELASTIC_APM_SEND_STRATEGY     = "background" <1>
 ----
 
 If your container image is based on a different base image (not including the AWS Lambda runtime utilities),
@@ -127,7 +127,7 @@ ELASTIC_APM_CENTRAL_CONFIG     = "false"
 ELASTIC_APM_CLOUD_PROVIDER     = "none"
 ELASTIC_APM_LAMBDA_APM_SERVER  = <YOUR-APM-SERVER-URL>     # this is your APM Server URL
 ELASTIC_APM_SECRET_TOKEN       = <YOUR-APM-SECRET-TOKEN>   # this is your APM secret token
-ELASTIC_APM_SEND_STRATEGY      = "background"
+ELASTIC_APM_SEND_STRATEGY      = "background" <1>
 ----
 
 // end::container-with-agent[]

--- a/docs/setup-aws-lambda.asciidoc
+++ b/docs/setup-aws-lambda.asciidoc
@@ -32,7 +32,7 @@ include::{apm-aws-lambda-root}/docs/lambda-selector/lambda-attributes-selector.a
 include::{apm-aws-lambda-root}/docs/lambda-selector/extension-arn-replacement.asciidoc[]
 include::./lambda/java-arn-replacement.asciidoc[]
 
-Both the {apm-guide-ref}/aws-lambda-arch.html[{apm-lambda-ext}] and the Java APM Agent are added to your Lambda function as https://docs.aws.amazon.com/lambda/latest/dg/invocation-layers.html[AWS Lambda Layers]. Therefore, you need to add the corresponding Layer ARNs (identifiers) to your Lambda function.
+Both the {apm-lambda-ref}/aws-lambda-arch.html[{apm-lambda-ext}] and the Java APM Agent are added to your Lambda function as https://docs.aws.amazon.com/lambda/latest/dg/invocation-layers.html[AWS Lambda Layers]. Therefore, you need to add the corresponding Layer ARNs (identifiers) to your Lambda function.
 
 include::{apm-aws-lambda-root}/docs/add-extension/add-extension-layer-widget.asciidoc[]
 
@@ -44,11 +44,11 @@ The {apm-lambda-ext} and the APM Java agent are configured through environment v
 For the minimal configuration, you will need the _APM Server URL_ to set the destination for APM data and an _{apm-guide-ref}/secret-token.html[APM Secret Token]_.
 If you prefer to use an {apm-guide-ref}/api-key.html[APM API key] instead of the APM secret token, use the `ELASTIC_APM_API_KEY` environment variable instead of `ELASTIC_APM_SECRET_TOKEN` in the following configuration.
 
-For production environments, we recommend {apm-guide-ref}/aws-lambda-secrets-manager.html[using the AWS Secrets Manager to store your APM authentication key] instead of providing the secret value as plaintext in the environment variables.
+For production environments, we recommend {apm-lambda-ref}/aws-lambda-secrets-manager.html[using the AWS Secrets Manager to store your APM authentication key] instead of providing the secret value as plaintext in the environment variables.
 
 include::./lambda/configure-lambda-widget.asciidoc[]
 
-You can optionally <<configuration, fine-tune the Java agent >> or the {apm-guide-ref}/aws-lambda-config-options.html[configuration of the {apm-lambda-ext}].
+You can optionally <<configuration, fine-tune the Java agent >> or the {apm-lambda-ref}/aws-lambda-config-options.html[configuration of the {apm-lambda-ext}].
 
 That's it; After following the steps above, you're ready to go!
 Your Lambda function invocations should be traced from now on.

--- a/docs/setup-aws-lambda.asciidoc
+++ b/docs/setup-aws-lambda.asciidoc
@@ -47,6 +47,7 @@ If you prefer to use an {apm-guide-ref}/api-key.html[APM API key] instead of the
 For production environments, we recommend {apm-lambda-ref}/aws-lambda-secrets-manager.html[using the AWS Secrets Manager to store your APM authentication key] instead of providing the secret value as plaintext in the environment variables.
 
 include::./lambda/configure-lambda-widget.asciidoc[]
+<1> The {apm-lambda-ref}/aws-lambda-config-options.html#_elastic_apm_send_strategy[`ELASTIC_APM_SEND_STRATEGY`] defines when APM data is sent to your Elastic APM backend. To reduce the execution time of your lambda functions, we recommend to use the `background` strategy in production environments with steady load scenarios.
 
 You can optionally <<configuration, fine-tune the Java agent >> or the {apm-lambda-ref}/aws-lambda-config-options.html[configuration of the {apm-lambda-ext}].
 


### PR DESCRIPTION
- AWS Lambda extension docs moved from the APM Guide to their own docs. Fixing links.
- added `background` as recommended send strategy in the docs