### PR TITLE
Stop testing Jboss EAP 70

### DIFF
--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JBossIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JBossIT.java
@@ -48,7 +48,7 @@ public class JBossIT extends AbstractServletContainerIntegrationTest {
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
             {"jboss-eap-6/eap64-openshift"},
-            {"jboss-eap-7/eap70-openshift"},
+//            {"jboss-eap-7/eap70-openshift"}, // disabled as not available anymore in public registry
             {"jboss-eap-7/eap71-openshift"},
             {"jboss-eap-7/eap72-openshift"}
         });


### PR DESCRIPTION
## What does this PR do?

Trying to pull docker image from un-authenticated registry now fails with following message
```
docker image pull registry.access.redhat.com/jboss-eap-7/eap70-openshift:latest
```

```
Error response from daemon: unsupported: Not Found, or unsupported. V2 schema 1 manifest digest are no longer supported for image pulls. Use the equivalent schema 2 manifest digest instead. For more information see https://access.redhat.com/articles/6138332
```

As a consequence we have to stop testing this version for now to prevent blocking most builds.
