### PR TITLE
Update ASM version to 9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
         <version.json-schema-validator>1.0.72</version.json-schema-validator>
         <!-- Byte Buddy and ASM must be kept in sync -->
         <version.byte-buddy>1.12.18</version.byte-buddy>
-        <version.asm>9.3</version.asm>
+        <version.asm>9.4</version.asm>
         <version.cucumber>5.4.0</version.cucumber>
 
         <!-- used both for plugin & annotations dependency -->


### PR DESCRIPTION
## What does this PR do?

Re-sync the ASM version with byte-buddy.

Because dependabot opens two distinct PRs for updating `asm` and `bytebuddy`:
- we closed https://github.com/elastic/apm-agent-java/pull/2846 as there was no byte-buddy update.
- I forgot to check the asm version when merging https://github.com/elastic/apm-agent-java/pull/2851

