### PR TITLE
Avoid NPE in afterEndSpan

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,7 @@ endif::[]
 ===== Bug fixes
 * Remove `context.db` fields from S3 instrumentation - {pull}2821[#2821]
 * Allowed OpenTelemetry `Span.updateName` to update names provided by elastic - {pull}2838[#2838]
+* Prevent random `NullPointerException` when span compression is not possible - {pull}2859[#2859]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
@@ -285,8 +285,8 @@ public class Span extends AbstractSpan<Span> implements Recyclable {
             }
             if (!buffered.tryToCompress(this)) {
                 if (parent.bufferedSpan.compareAndSet(buffered, this)) {
-                    this.tracer.endSpan(buffered);
                     parent.decrementReferences();
+                    this.tracer.endSpan(buffered);
                 } else {
                     parent.decrementReferences();
                     // the failed update would ideally lead to a compression attempt with the new buffer,


### PR DESCRIPTION
## What does this PR do?

Fixes NPE reported [in our forum](https://discuss.elastic.co/t/npe-using-apm-agent-1-34-1/317179).

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
