### PR TITLE
Shortcut attacher discovery and fork

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,9 @@ endif::[]
 [float]
 ===== Breaking changes
 
+[[release-notes-1.35.0]]
+==== 1.35.0 - YYYY/MM/DD
+
 [float]
 ===== Features
 * Add support for log correlation for `java.util.logging` (JUL) - {pull}2724[#2724]
@@ -33,6 +36,8 @@ endif::[]
 * Improved instrumentation for legacy Apache HttpClient (when not using an `HttpUriRequest`, such as `BasicHttpRequest`)
 * Prevented exclusion of agent-packages via `classes_excluded_from_instrumentation` to avoid unintended side effects
 * Add Tomcat support for log reformatting - {pull}2839[#2839]
+* Attacher CLI: added a `--no-fork` config to opt out from executing a forked process as different user. If `--no-fork` is used
+alongside discovery rules that contain only `--include-pid` rules, the attacher will not execute JVM discovery - {pull}2863[#2863]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/AgentAttacher.java
+++ b/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/AgentAttacher.java
@@ -555,7 +555,9 @@ public class AgentAttacher {
             out.println("        If provided, this program continuously runs and attaches to all running and starting JVMs which match the --exclude and --include filters.");
             out.println();
             out.println("    --no-fork");
-            out.println("        If provided, this program will not fork and attempt to attach directly as the current user.");
+            out.println("        By default, when the attacher program is ran by user A and the target process is ran by user B, ");
+            out.println("        the attacher will attempt to start another process as user B. ");
+            out.println("        If this configuration option is provided, the attacher will not fork. Instead, it will attempt to attach directly as the current user.");
             out.println();
             out.println("    --include-all");
             out.println("        Includes all JVMs for attachment.");

--- a/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/AgentAttacher.java
+++ b/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/AgentAttacher.java
@@ -45,6 +45,8 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 import java.util.Scanner;
 import java.util.Set;
 
@@ -61,15 +63,9 @@ public class AgentAttacher {
     // reduces the risk of exposing them in heap dumps
     private final Set<String> alreadySeenJvmPids = new HashSet<>();
     private final UserRegistry userRegistry = UserRegistry.empty();
-    private final JvmDiscoverer jvmDiscoverer;
 
-    private AgentAttacher(Arguments arguments) throws Exception {
+    private AgentAttacher(Arguments arguments) {
         this.arguments = arguments;
-        // fail fast if no attachment provider is working
-        GetAgentProperties.getAgentAndSystemProperties(JvmInfo.CURRENT_PID, userRegistry.getCurrentUser());
-        this.jvmDiscoverer = new JvmDiscoverer.Compound(Arrays.asList(
-            JvmDiscoverer.ForHotSpotVm.withDiscoveredTempDirs(userRegistry),
-            new JvmDiscoverer.UsingPs(userRegistry)));
     }
 
     private static Logger initLogging(Arguments arguments) {
@@ -150,7 +146,7 @@ public class AgentAttacher {
             logger.debug("attacher arguments : {}", arguments);
         }
         try {
-            new AgentAttacher(arguments).handleNewJvmsLoop();
+            new AgentAttacher(arguments).doAttach();
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
         }
@@ -180,9 +176,40 @@ public class AgentAttacher {
         arguments.setAgentJar(downloadedJarPath.toFile());
     }
 
-    private void handleNewJvmsLoop() throws Exception {
+    private void doAttach() {
+        try {
+            DiscoveryRules discoveryRules = arguments.getDiscoveryRules();
+            if (!discoveryRules.isDiscoveryRequired() && arguments.isNoFork()) {
+                attachToSpecificPidsAsCurrentUser();
+            } else {
+                discoverAndAttachLoop(discoveryRules);
+            }
+        } catch (Exception e) {
+            logger.error("Error during attachment", e);
+        }
+    }
+
+    private void attachToSpecificPidsAsCurrentUser() throws Exception {
+        // a shortcut for a simple usage of attaching to specific PIDs using the current user, which means we can avoid all
+        // JVM discovery logic and user-switches
+        Set<String> includePids = arguments.getIncludePids();
+        for (String includePid : includePids) {
+            Properties properties = GetAgentProperties.getAgentAndSystemProperties(includePid, userRegistry.getCurrentUser());
+            attach(JvmInfo.withCurrentUser(includePid, properties));
+        }
+    }
+
+    private void discoverAndAttachLoop(final DiscoveryRules discoveryRules) throws Exception {
+        // fail fast if no attachment provider is working
+        GetAgentProperties.getAgentAndSystemProperties(JvmInfo.CURRENT_PID, userRegistry.getCurrentUser());
+
+        JvmDiscoverer jvmDiscoverer = new JvmDiscoverer.Compound(Arrays.asList(
+            JvmDiscoverer.ForHotSpotVm.withDiscoveredTempDirs(userRegistry),
+            new JvmDiscoverer.UsingPs(userRegistry))
+        );
+
         while (true) {
-            handleNewJvms(jvmDiscoverer.discoverJvms(), arguments.getDiscoveryRules());
+            handleNewJvms(jvmDiscoverer.discoverJvms(), discoveryRules);
             if (!arguments.isContinuous()) {
                 break;
             }
@@ -230,12 +257,10 @@ public class AgentAttacher {
     }
 
     private void onJvmMatch(JvmInfo jvmInfo) throws Exception {
-        final Map<String, String> agentArgs = getAgentArgs(jvmInfo);
         if (arguments.isList()) {
             System.out.println(jvmInfo.toString(arguments.isListVmArgs()));
         } else {
-            logger.info("Attaching the Elastic APM agent to {} with arguments {}", jvmInfo, agentArgs);
-            if (attach(jvmInfo, agentArgs)) {
+            if (attach(jvmInfo)) {
                 logger.info("Done");
             } else {
                 logger.error("Unable to attach to JVM with PID = {}", jvmInfo.getPid());
@@ -243,7 +268,10 @@ public class AgentAttacher {
         }
     }
 
-    private boolean attach(JvmInfo jvmInfo, Map<String, String> agentArgs) {
+    private boolean attach(JvmInfo jvmInfo) throws Exception {
+        final Map<String, String> agentArgs = getAgentArgs(jvmInfo);
+        logger.info("Attaching the Elastic APM agent to {} with arguments {}", jvmInfo, agentArgs);
+
         UserRegistry.User user = jvmInfo.getUser(userRegistry);
         if (user == null) {
             logger.error("Could not load user {}", jvmInfo.getUserName());
@@ -315,25 +343,29 @@ public class AgentAttacher {
 
     static class Arguments {
         private final DiscoveryRules rules;
+        private final Set<String> includePids;
         private final Map<String, String> config;
         private final String argsProvider;
         private final boolean help;
         private final boolean list;
         private final boolean continuous;
+        private final boolean noFork;
         private final Level logLevel;
         private final String logFile;
         private final boolean listVmArgs;
         private final String downloadAgentVersion;
         private File agentJar;
 
-        private Arguments(DiscoveryRules rules, Map<String, String> config, String argsProvider, boolean help,
-                          boolean list, boolean listVmArgs, boolean continuous, Level logLevel, String logFile,
+        private Arguments(DiscoveryRules rules, Set<String> includePids, Map<String, String> config, String argsProvider, boolean help,
+                          boolean list, boolean listVmArgs, boolean continuous, boolean noFork, Level logLevel, String logFile,
                           String agentJarString, String downloadAgentVersion) {
             this.rules = rules;
+            this.includePids = includePids;
             this.help = help;
             this.list = list;
             this.listVmArgs = listVmArgs;
             this.continuous = continuous;
+            this.noFork = noFork;
             this.logLevel = logLevel;
             this.logFile = logFile;
             this.downloadAgentVersion = downloadAgentVersion;
@@ -357,12 +389,14 @@ public class AgentAttacher {
 
         static Arguments parse(String... args) {
             DiscoveryRules rules = new DiscoveryRules();
+            Set<String> includePids = new HashSet<>();
             Map<String, String> config = new LinkedHashMap<>();
             String argsProvider = null;
             boolean help = args.length == 0;
             boolean list = false;
             boolean listVmArgs = false;
             boolean continuous = false;
+            boolean noFork = false;
             String currentArg = "";
             Level logLevel = Level.INFO;
             String logFile = null;
@@ -387,6 +421,9 @@ public class AgentAttacher {
                         case "-c":
                         case "--continuous":
                             continuous = true;
+                            break;
+                        case "--no-fork":
+                            noFork = true;
                             break;
                         case "--include-all":
                             rules.includeAll();
@@ -435,7 +472,11 @@ public class AgentAttacher {
                             rules.excludeUser(arg);
                             break;
                         case "--include-pid":
+                            // "include-pid" rules do not require discovery, however we add them to the discovery rules because
+                            // theoretically they may be used AFTER other exclusion rules, in which case we need to make sure we only
+                            // match against them in the correct order
                             rules.includePid(arg);
+                            includePids.add(Objects.requireNonNull(arg));
                             break;
                         case "-C":
                         case "--config":
@@ -463,7 +504,8 @@ public class AgentAttacher {
                     }
                 }
             }
-            return new Arguments(rules, config, argsProvider, help, list, listVmArgs, continuous, logLevel, logFile, agentJar, downloadedAgentVersion);
+            return new Arguments(rules, includePids, config, argsProvider, help, list, listVmArgs, continuous, noFork, logLevel, logFile,
+                agentJar, downloadedAgentVersion);
         }
 
         // -ab -> -a -b
@@ -511,6 +553,9 @@ public class AgentAttacher {
             out.println();
             out.println("    -c, --continuous");
             out.println("        If provided, this program continuously runs and attaches to all running and starting JVMs which match the --exclude and --include filters.");
+            out.println();
+            out.println("    --no-fork");
+            out.println("        If provided, this program will not fork and attempt to attach directly as the current user.");
             out.println();
             out.println("    --include-all");
             out.println("        Includes all JVMs for attachment.");
@@ -578,8 +623,16 @@ public class AgentAttacher {
             return continuous;
         }
 
+        boolean isNoFork() {
+            return noFork;
+        }
+
         public DiscoveryRules getDiscoveryRules() {
             return rules;
+        }
+
+        public Set<String> getIncludePids() {
+            return includePids;
         }
 
         public boolean isListVmArgs() {

--- a/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/DiscoveryRules.java
+++ b/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/DiscoveryRules.java
@@ -59,7 +59,7 @@ class DiscoveryRules {
     }
 
     public void includePid(String pid) {
-        include(new PidMatcher(pid));
+        discoveryRules.add(new DiscoveryRule(new PidMatcher(pid), MatcherType.INCLUDE, false));
     }
 
     public void excludePid(String pid) {
@@ -72,6 +72,15 @@ class DiscoveryRules {
 
     public void excludeUser(String user) {
         exclude(new UserMatcher(user));
+    }
+
+    public boolean isDiscoveryRequired() {
+        for (DiscoveryRule discoveryRule : discoveryRules) {
+            if (discoveryRule.isDiscoveryRequired()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public boolean isMatching(JvmInfo vm, UserRegistry userRegistry) {
@@ -122,11 +131,21 @@ class DiscoveryRules {
     public static class DiscoveryRule implements Matcher {
 
         private final Matcher matcher;
-
         private final MatcherType matcherType;
+
+        /**
+         * Defining whether this rule requires executing JVM discovery operations
+         */
+        private final boolean isDiscoveryRequired;
+
         private DiscoveryRule(Matcher matcher, MatcherType matcherType) {
+            this(matcher, matcherType, true);
+        }
+
+        private DiscoveryRule(Matcher matcher, MatcherType matcherType, boolean isDiscoveryRequired) {
             this.matcher = matcher;
             this.matcherType = matcherType;
+            this.isDiscoveryRequired = isDiscoveryRequired;
         }
 
         public static DiscoveryRule include(Matcher matcher) {
@@ -139,6 +158,10 @@ class DiscoveryRules {
 
         public MatcherType getMatchingType() {
             return matcherType;
+        }
+
+        public boolean isDiscoveryRequired() {
+            return isDiscoveryRequired;
         }
 
         @Override

--- a/apm-agent-attach-cli/src/test/java/co/elastic/apm/attach/AgentAttacherTest.java
+++ b/apm-agent-attach-cli/src/test/java/co/elastic/apm/attach/AgentAttacherTest.java
@@ -38,6 +38,7 @@ class AgentAttacherTest {
         assertThat(AgentAttacher.Arguments.parse("--list-vmargs").isListVmArgs()).isTrue();
         assertThat(AgentAttacher.Arguments.parse("-c").isContinuous()).isTrue();
         assertThat(AgentAttacher.Arguments.parse("--continuous").isContinuous()).isTrue();
+        assertThat(AgentAttacher.Arguments.parse("--no-fork").isNoFork()).isTrue();
         assertThat(AgentAttacher.Arguments.parse("--include-pid", "42").getDiscoveryRules().getIncludeRules()).hasSize(1);
         assertThat(AgentAttacher.Arguments.parse("--config", "foo=bar", "baz=qux").getConfig()).containsEntry("foo", "bar").containsEntry("baz", "qux");
         assertThat(AgentAttacher.Arguments.parse("-C", "foo=bar", "-C", "baz=qux").getConfig()).containsEntry("foo", "bar").containsEntry("baz", "qux");

--- a/apm-agent-attach-cli/src/test/java/co/elastic/apm/attach/DiscoveryRulesTest.java
+++ b/apm-agent-attach-cli/src/test/java/co/elastic/apm/attach/DiscoveryRulesTest.java
@@ -76,6 +76,16 @@ class DiscoveryRulesTest {
     }
 
     @Test
+    void testDiscoveryRequired() {
+        assertThat(discoveryRules.isDiscoveryRequired()).isFalse();
+        discoveryRules.includePid("1");
+        discoveryRules.includePid("2");
+        assertThat(discoveryRules.isDiscoveryRequired()).isFalse();
+        discoveryRules.excludePid("3");
+        assertThat(discoveryRules.isDiscoveryRequired()).isTrue();
+    }
+
+    @Test
     void testExcludeNotIncluded() {
         discoveryRules.includePid("1");
         discoveryRules.excludePid("2");

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/JvmAttachUtils.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/JvmAttachUtils.java
@@ -52,5 +52,4 @@ public class JvmAttachUtils {
             throw new IllegalStateException("Error during attachment using: " + accessor, e);
         }
     }
-
 }

--- a/docs/setup-attach-cli.asciidoc
+++ b/docs/setup-attach-cli.asciidoc
@@ -97,7 +97,9 @@ If provided, this program continuously runs and attaches to all running and star
 *--no-fork* added[1.35.0]::
 +
 --
-If provided, this program will not fork and attempt to attach directly as the current user.
+By default, when the attacher program is ran by user A and the target process is ran by user B, the attacher will attempt to start another
+process as user B.
+If this configuration option is provided, the attacher will not fork. Instead, it will attempt to attach directly as the current user.
 --
 
 *--include-all*::

--- a/docs/setup-attach-cli.asciidoc
+++ b/docs/setup-attach-cli.asciidoc
@@ -94,7 +94,7 @@ NOTE: The JVM arguments may contain sensitive information, such as passwords pro
 If provided, this program continuously runs and attaches to all running and starting JVMs which match the `--exclude` and `--include` filters.
 --
 
-*--no-fork*::
+*--no-fork* added[1.35.0]::
 +
 --
 If provided, this program will not fork and attempt to attach directly as the current user.

--- a/docs/setup-attach-cli.asciidoc
+++ b/docs/setup-attach-cli.asciidoc
@@ -94,6 +94,12 @@ NOTE: The JVM arguments may contain sensitive information, such as passwords pro
 If provided, this program continuously runs and attaches to all running and starting JVMs which match the `--exclude` and `--include` filters.
 --
 
+*--no-fork*::
++
+--
+If provided, this program will not fork and attempt to attach directly as the current user.
+--
+
 *--include-all*::
 +
 --


### PR DESCRIPTION
## What does this PR do?
Closes #2713 

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added unit tests
  - [x] I have tested manually
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [x] I have made corresponding changes to the documentation


Tested manually on:
- *macOS*: using Java 17.0.2, attachment succeeded and agent functions as expected, but the attacher ends with an error related to JNA library loading: `Caused by: java.lang.UnsatisfiedLinkError: Can't load library: /Users/eyalkoren/Library/Caches/JNA/temp/jna5306318620723725866.tmp`
- *Amazon Linux 2*: using Java 11.0.15 - works as expected