### PR TITLE
remove 'configuration options' header

### DIFF
--- a/apm-agent/src/test/resources/configuration.asciidoc.ftl
+++ b/apm-agent/src/test/resources/configuration.asciidoc.ftl
@@ -101,7 +101,7 @@ Click on a key to get more information.
 
 <#list config as category, options>
 [[config-${category?lower_case?replace(" ", "-")}]]
-=== ${category} configuration options
+=== ${category}
     <#list options as option>
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -195,7 +195,7 @@ Click on a key to get more information.
 ** <<config-span-stack-trace-min-duration>>
 
 [[config-circuit-breaker]]
-=== Circuit-Breaker configuration options
+=== Circuit-Breaker
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-circuit-breaker-enabled]]
@@ -382,7 +382,7 @@ monitor to decide that the CPU stress has been relieved.
 |============
 
 [[config-core]]
-=== Core configuration options
+=== Core
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-recording]]
@@ -1468,7 +1468,7 @@ Valid options: `continue`, `restart`, `restart_external`
 |============
 
 [[config-http]]
-=== HTTP configuration options
+=== HTTP
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-capture-body-content-types]]
@@ -1624,7 +1624,7 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 |============
 
 [[config-huge-traces]]
-=== Huge Traces configuration options
+=== Huge Traces
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-span-compression-enabled]]
@@ -1727,7 +1727,7 @@ Example: `0ms`.
 |============
 
 [[config-jax-rs]]
-=== JAX-RS configuration options
+=== JAX-RS
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-enable-jaxrs-annotation-inheritance]]
@@ -1778,7 +1778,7 @@ If you want to use the URI template from the `@Path` annotation, set the value t
 |============
 
 [[config-jmx]]
-=== JMX configuration options
+=== JMX
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-capture-jmx-metrics]]
@@ -1903,7 +1903,7 @@ The resulting documents in Elasticsearch look similar to this:
 |============
 
 [[config-logging]]
-=== Logging configuration options
+=== Logging
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-log-level]]
@@ -2183,7 +2183,7 @@ Valid options: `PLAIN_TEXT`, `JSON`
 |============
 
 [[config-messaging]]
-=== Messaging configuration options
+=== Messaging
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-ignore-message-queues]]
@@ -2216,7 +2216,7 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 |============
 
 [[config-metrics]]
-=== Metrics configuration options
+=== Metrics
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-dedot-custom-metrics]]
@@ -2271,7 +2271,7 @@ But if you must, you can use this option to increase the limit.
 |============
 
 [[config-profiling]]
-=== Profiling configuration options
+=== Profiling
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-profiling-inferred-spans-enabled]]
@@ -2447,7 +2447,7 @@ If unset, the value of the `java.io.tmpdir` system property will be used.
 |============
 
 [[config-reporter]]
-=== Reporter configuration options
+=== Reporter
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-secret-token]]
@@ -2820,7 +2820,7 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 |============
 
 [[config-serverless]]
-=== Serverless configuration options
+=== Serverless
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-aws-lambda-handler]]
@@ -2871,7 +2871,7 @@ For serverless functions, APM data is written in a synchronous way, thus, blocki
 |============
 
 [[config-stacktrace]]
-=== Stacktrace configuration options
+=== Stacktrace
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-application-packages]]


### PR DESCRIPTION
## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
