### PR TITLE
Update Elasticsearch API client and tests to 8.5.1

### DIFF
--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-api-client-test/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-api-client-test/pom.xml
@@ -11,7 +11,7 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <version.elasticsearch-java>8.5.0</version.elasticsearch-java>
+        <version.elasticsearch-java>8.5.1</version.elasticsearch-java>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
 

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-api-client-test/pom.xml
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-api-client-test/pom.xml
@@ -11,7 +11,7 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <version.elasticsearch-java>7.17.2</version.elasticsearch-java>
+        <version.elasticsearch-java>8.5.0</version.elasticsearch-java>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
     </properties>
 


### PR DESCRIPTION
Closes #2868 

Tests are updated according to [the removal of mapping types](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/removal-of-types.html)