### PR TITLE
Increase timeout in MicrometerConfigInstrumentationTest

### DIFF
--- a/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerConfigInstrumentationTest.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerConfigInstrumentationTest.java
@@ -68,7 +68,7 @@ public class MicrometerConfigInstrumentationTest {
         SimpleMeterRegistry registryOneSecondStep = new SimpleMeterRegistry(oneSecondStepSimpleConfig, Clock.SYSTEM);
         registryOneSecondStep.counter("bar").increment();
 
-        reporter.awaitUntilAsserted(3000, () ->
+        reporter.awaitUntilAsserted(5000, () ->
             assertThat(getSpecialCounterValue()).isEqualTo(oneSecondStepSimpleConfig.hashCode()));
     }
 
@@ -80,7 +80,7 @@ public class MicrometerConfigInstrumentationTest {
         SimpleMeterRegistry registryOneSecondStep = new SimpleMeterRegistry(oneSecondStepSimpleConfig, Clock.SYSTEM);
         registryOneSecondStep.counter("bar").increment();
 
-        reporter.awaitUntilAsserted(3000, () ->
+        reporter.awaitUntilAsserted(5000, () ->
             assertThat(getSpecialCounterValue()).isEqualTo(oneSecondStepSimpleConfig.hashCode()));
     }
 


### PR DESCRIPTION
Trying to eliminate [`MicrometerConfigInstrumentationTest` failures on CI](https://apm-ci.elastic.co/blue/organizations/jenkins/apm-agent-java%2Fapm-agent-java-mbp/detail/main/448/pipeline).

I was able to reproduce it locally only once, then seeing it pass hundreds of times. Both tests consistently take more than 1 sec on my laptop, some times not far from 3 seconds, so without investigating too much, I just tried to increase the timeout. 

@jackshirazi if you have a better idea on what to look into, please do. Otherwise, we can only apply this for now and invest more time in it if we see more of those.