### PR TITLE
Fix word duplicate in docs

### DIFF
--- a/docs/setup-attach-api.asciidoc
+++ b/docs/setup-attach-api.asciidoc
@@ -57,7 +57,7 @@ compile "co.elastic.apm:apm-agent-attach:$elasticApmVersion"
 
 Call `ElasticApmAttacher.attach()` in the first line of your `public static void main(String[] args)` method.
 
-This example demonstrates the the usage of the `attach` API with a simple Spring Boot application:
+This example demonstrates the usage of the `attach` API with a simple Spring Boot application:
 
 [source,java]
 .MyApplication.java


### PR DESCRIPTION
## What does this PR do?
"The" is duplicated in the text. This PR removes the duplication.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [x] I have updated [docs/setup-attach-api.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/setup-attach-api.asciidoc)
