### PR TITLE
Updated mockserver to latest for ARM support

### DIFF
--- a/integration-tests/application-server-integration-tests/pom.xml
+++ b/integration-tests/application-server-integration-tests/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-client-java</artifactId>
-            <version>5.4.1</version>
+            <version>5.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -90,7 +90,7 @@ public abstract class AbstractServletContainerIntegrationTest {
     private static final Path pathToAttach;
     private static final Path pathToSlimAttach;
 
-    static boolean ENABLE_DEBUGGING = true;
+    static boolean ENABLE_DEBUGGING = false;
     static boolean ENABLE_RUNTIME_ATTACH = true;
 
     /**
@@ -589,8 +589,8 @@ public abstract class AbstractServletContainerIntegrationTest {
         assertThat(agent).isNotNull();
         assertThat(agent.get("ephemeral_id")).isNotNull();
         JsonNode container = metadata.get("system").get("container");
-        //assertThat(container).isNotNull();
-        //assertThat(container.get("id").textValue()).isEqualTo(servletContainer.getContainerId());
+        assertThat(container).isNotNull();
+        assertThat(container.get("id").textValue()).isEqualTo(servletContainer.getContainerId());
     }
 
     private void addSpans(List<JsonNode> spans, JsonNode payload) {

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -46,7 +46,6 @@ import org.testcontainers.utility.MountableFile;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -91,7 +90,7 @@ public abstract class AbstractServletContainerIntegrationTest {
     private static final Path pathToAttach;
     private static final Path pathToSlimAttach;
 
-    static boolean ENABLE_DEBUGGING = false;
+    static boolean ENABLE_DEBUGGING = true;
     static boolean ENABLE_RUNTIME_ATTACH = true;
 
     /**
@@ -105,6 +104,7 @@ public abstract class AbstractServletContainerIntegrationTest {
     private static MockServerContainer mockServerContainer = new MockServerContainer()
         //.withLogConsumer(TestContainersUtils.createSlf4jLogConsumer(MockServerContainer.class))
         .withNetworkAliases("apm-server")
+        .waitingFor(Wait.forHttp(MockServerContainer.HEALTH_ENDPOINT).forStatusCode(200))
         .withNetwork(Network.SHARED);
     private static OkHttpClient httpClient;
 
@@ -589,8 +589,8 @@ public abstract class AbstractServletContainerIntegrationTest {
         assertThat(agent).isNotNull();
         assertThat(agent.get("ephemeral_id")).isNotNull();
         JsonNode container = metadata.get("system").get("container");
-        assertThat(container).isNotNull();
-        assertThat(container.get("id").textValue()).isEqualTo(servletContainer.getContainerId());
+        //assertThat(container).isNotNull();
+        //assertThat(container.get("id").textValue()).isEqualTo(servletContainer.getContainerId());
     }
 
     private void addSpans(List<JsonNode> spans, JsonNode payload) {

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/MockServerContainer.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/MockServerContainer.java
@@ -27,10 +27,12 @@ import org.testcontainers.containers.GenericContainer;
  */
 public class MockServerContainer extends GenericContainer<MockServerContainer> {
 
+    public static final String HEALTH_ENDPOINT = "/mockserver/status";
     private MockServerClient client;
 
     public MockServerContainer() {
-        super("jamesdbloom/mockserver:mockserver-5.4.1");
+        super("mockserver/mockserver:5.14.0");
+        addEnv("MOCKSERVER_LIVENESS_HTTP_GET_PATH", HEALTH_ENDPOINT);
         addExposedPorts(1080);
     }
 


### PR DESCRIPTION
## What does this PR do?
Upgrade mockserver of the integration tests to 5.14.0. This version now has a Arm64 image, enabling at least some of our itnegration tests (e.g. Tomcat) to run locally on M1 Macs.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is something else
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
