### PR TITLE
Possible Reactor context loss in TracedSubscriber and WebClientSubscriber fix

### DIFF
--- a/apm-agent-plugins/apm-reactor-plugin/src/main/java/co/elastic/apm/agent/reactor/TracedSubscriber.java
+++ b/apm-agent-plugins/apm-reactor-plugin/src/main/java/co/elastic/apm/agent/reactor/TracedSubscriber.java
@@ -54,20 +54,20 @@ public class TracedSubscriber<T> implements CoreSubscriber<T> {
 
     private final Tracer tracer;
 
-    private final Context context;
-
     TracedSubscriber(CoreSubscriber<? super T> subscriber, Tracer tracer, AbstractSpan<?> context) {
         this.subscriber = subscriber;
         this.tracer = tracer;
         contextMap.put(this, context);
-
-        // store our span/transaction into reactor context for later lookup without relying on active tracer state
-        this.context = subscriber.currentContext().put(AbstractSpan.class, context);
     }
 
     @Override
     public Context currentContext() {
-        return context;
+        final AbstractSpan<?> context = getContext();
+        if (context != null) {
+            return subscriber.currentContext().put(AbstractSpan.class, context);
+        } else {
+            return subscriber.currentContext();
+        }
     }
 
     /**

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/main/java/co/elastic/apm/agent/springwebclient/WebClientSubscriber.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/main/java/co/elastic/apm/agent/springwebclient/WebClientSubscriber.java
@@ -21,7 +21,6 @@ package co.elastic.apm.agent.springwebclient;
 import co.elastic.apm.agent.collections.WeakConcurrentProviderImpl;
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.impl.context.web.ResultUtil;
-import co.elastic.apm.agent.impl.transaction.Outcome;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakMap;
 import org.reactivestreams.Subscription;
@@ -29,6 +28,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import reactor.core.CoreSubscriber;
+import reactor.util.context.Context;
 
 import javax.annotation.Nullable;
 
@@ -47,6 +47,11 @@ public class WebClientSubscriber<T> implements CoreSubscriber<T>, Subscription {
         this.tracer = tracer;
 
         spanMap.put(this, span);
+    }
+
+    @Override
+    public Context currentContext() {
+        return subscriber.currentContext();
     }
 
     @Override


### PR DESCRIPTION
After activating/attaching of agent to java process all custom information stored by Mono.contextWrite(..) becomes unreachable later in subscriber

## Steps to reproduce
Store something in the context
```
webClient
  .get()
  .uri(...)
  .exchangeToMono(...)
  .contextWrite(ctx -> ctx.put("KEY_1", "VAL_1"));
```

And later if we'll try to get `context.get("KEY_1")` this info from the context in a subscriber we'll get `NoSuchElementException`

Without activating/attaching of agent we'll get this info from the context.

Looks like the problem is in `co.elastic.apm.agent.reactor.TracedSubscriber` and `co.elastic.apm.agent.springwebclient.WebClientSubscriber`. 
In `TracedSubscriber` the real subscriber's context is stored in the constructor but should be obtained each time in currentContext() 
```
@Override
public Context currentContext() {
    final AbstractSpan<?> context = getContext();
    if (context != null) {
        return subscriber.currentContext().put(AbstractSpan.class, context);
    } else {
        return subscriber.currentContext();
    }
}
```

In `WebClientSubscriber` default implementation of method `currentContext()` in parent `CoreSubscriber` recreates empty context but should delegate this call to a real subscriber:
```
@Override
public Context currentContext() {
    return subscriber.currentContext();
}
```
