### PR TITLE
Fix NPE in spring-mvc

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,6 +53,7 @@ endif::[]
 * Fix security manager issues on OpenJDK 17, with errors like: `java.lang.UnsupportedOperationException: Could not access Unsafe class` -
 {pull}2874[#2874]
 * Fix security manager compatibility with Tomcat - {pull}2871[#2871]
+* Fix NPE with Spring MVC - {pull}2896[#2896]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/ViewRenderInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/ViewRenderInstrumentation.java
@@ -69,7 +69,10 @@ public class ViewRenderInstrumentation extends TracerAwareInstrumentation {
 
             if (thiz instanceof AbstractView) {
                 AbstractView view = (AbstractView) thiz;
-                span.appendToName(" ").appendToName(view.getBeanName());
+                String beanName = view.getBeanName();
+                if (beanName != null) {
+                    span.appendToName(" ").appendToName(beanName);
+                }
             }
             span.activate();
             return span;

--- a/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/ViewRenderInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc-plugin/src/main/java/co/elastic/apm/agent/springwebmvc/ViewRenderInstrumentation.java
@@ -31,6 +31,7 @@ import org.springframework.web.servlet.view.AbstractView;
 import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -44,7 +45,7 @@ public class ViewRenderInstrumentation extends TracerAwareInstrumentation {
     private static final String SPAN_TYPE = "template";
     private static final String SPAN_ACTION = "render";
     private static final String DISPATCHER_SERVLET_RENDER_METHOD = "View#render";
-    private static Map<String, String> subTypeCache = new ConcurrentHashMap<>();
+    private static final Map<String, String> subTypeCache = new ConcurrentHashMap<>();
 
     @Override
     public String getAdviceClassName() {
@@ -53,8 +54,9 @@ public class ViewRenderInstrumentation extends TracerAwareInstrumentation {
 
     public static class ViewRenderAdviceService {
 
+        @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-        public static Object beforeExecute(@Advice.This @Nullable Object thiz) {
+        public static Object beforeExecute(@Advice.This Object thiz) {
             if (tracer.getActive() == null) {
                 return null;
             }
@@ -140,7 +142,7 @@ public class ViewRenderInstrumentation extends TracerAwareInstrumentation {
 
     @Override
     public Collection<String> getInstrumentationGroupNames() {
-        return Arrays.asList("spring-view-render");
+        return Collections.singleton("spring-view-render");
     }
 }
 


### PR DESCRIPTION
## What does this PR do?

Fixes NPE when the spring mvc view name is `null`.
This is triggered when with opbeans-java with a simple `curl http://localhost:8080/`


```
java.lang.NullPointerException
        at co.elastic.apm.agent.impl.transaction.AbstractSpan.appendToName(AbstractSpan.java:331)
        at co.elastic.apm.agent.impl.transaction.AbstractSpan.appendToName(AbstractSpan.java:327)
        at co.elastic.apm.agent.springwebmvc.ViewRenderInstrumentation$ViewRenderAdviceService.beforeExecute(ViewRenderInstrumentation.java:72)
        at org.springframework.web.servlet.view.AbstractView.render(AbstractView.java:307)
        ....
```

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
