### PR TITLE
increase timeout for MicrometerInstrumentationStepTest.testStepVsCumulativeMultiple

### DIFF
--- a/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerInstrumentationStepTest.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerInstrumentationStepTest.java
@@ -139,7 +139,7 @@ public class MicrometerInstrumentationStepTest {
                 }
             }).start();
         }
-        reporter.awaitUntilAsserted(5000, () ->
+        reporter.awaitUntilAsserted(20000, () ->
             assertThat(countFooBars()).isEqualTo(result));
     }
 


### PR DESCRIPTION
increase timeout for MicrometerInstrumentationStepTest.testStepVsCumulativeMultiple micrometer flaky test. I think it's just slow on the more constrained CI vCPUs so bump the timeout right up to where if it fails it's likely not a CPU load issue
