### PR TITLE
[docs] Update asciidoc syntax to fix list rendering

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,7 +65,7 @@ compare them against `main` branch values as a baseline to know if a given code 
 1. Import the repository as a maven project
 1. After importing, select the IntelliJ profile in Maven Projects sidebar
 
-   <img width="268" alt="Maven profiles" src="https://user-images.githubusercontent.com/2163464/43443771-22e3ba3c-94a2-11e8-9bd8-5ed73b7e975a.png">   
+   <img width="268" alt="Maven profiles" src="https://user-images.githubusercontent.com/2163464/43443771-22e3ba3c-94a2-11e8-9bd8-5ed73b7e975a.png">
 1. This project makes heavy use of the `javax.annotation.Nonnull` and `javax.annotation.Nullable` annotations.
    In order for the IDE to properly understand these annotations and to show warnings when invariants are violated,
    there are a few things which need to be configured.
@@ -255,16 +255,25 @@ See [`apm-agent-plugins/README.md`](apm-agent-plugins/README.md)
 ### Documenting
 
 HTML Documentation is generated from text files stored in `docs` folder using [AsciiDoc](http://asciidoc.org/) format.
-The ``configuration.asciidoc`` file is generated from running `co.elastic.apm.agent.configuration.ConfigurationExporter`,
-all the other asciidoc text files are written manually.
+The `configuration.asciidoc` file is generated from running `co.elastic.apm.agent.configuration.ConfigurationExporter`
+(e.g. via `./mvnw test -Dtest="ConfigurationExporterTest" -DfailIfNoTests=false`). All the other asciidoc text files
+are written manually.
 
 A preview of the documentation is generated for each pull-request.
 Click on the build `Details` of the `elasticsearch-ci/docs` job and go to the bottom of the `Console Output` to see the link.
 
 This step is part of Elasticsearch CI, and the build job is [the following](https://elasticsearch-ci.elastic.co/view/Docs/job/elastic+docs+apm-agent-java+pull-request/).
 
-In order to generate a local copy of agent documentation, you will need to clone [docs](https://github.com/elastic/docs) repository
-and follow [those instructions](https://github.com/elastic/docs#for-a-local-repo).
+In order to generate a local copy of agent documentation, you will need to clone/update the [docs](https://github.com/elastic/docs)
+and [apm-aws-lambda](https://github.com/elastic/apm-aws-lambda) repositories and run the following.
+(The `--direct_html --open` options tells the doc build container to serve the docs at <http://localhost:8000>.
+See [the "docs" repo README](https://github.com/elastic/docs#for-a-local-repo) for more details.)
+
+```
+../docs/build_docs --resource ../apm-aws-lambda/docs \
+  --doc ./docs/index.asciidoc \
+  --direct_html --open
+```
 
 ### Releasing
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -787,7 +787,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
             "However, in certain cases it can be helpful to not use the incoming `traceparent` header. Some example use cases:\n\n" +
             "* An Elastic-monitored service is receiving requests with `traceparent` headers from unmonitored services.\n" +
             "* An Elastic-monitored service is publicly exposed, and does not want tracing data (trace-ids, sampling decisions) to possibly be spoofed by user requests.\n\n" +
-            "Valid values are:\n" +
+            "Valid values are:\n\n" +
             "* 'continue': The default behavior. An incoming `traceparent` value is used to continue the trace and determine the sampling decision.\n" +
             "* 'restart': Always ignores the `traceparent` header of incoming requests. A new trace-id will be generated and the sampling decision" +
             " will be made based on transaction_sample_rate. A span link will be made to the incoming `traceparent`.\n" +

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1456,6 +1456,7 @@ This option allows some control over how the APM agent handles W3C trace-context
 * An Elastic-monitored service is publicly exposed, and does not want tracing data (trace-ids, sampling decisions) to possibly be spoofed by user requests.
 
 Valid values are:
+
 * 'continue': The default behavior. An incoming `traceparent` value is used to continue the trace and determine the sampling decision.
 * 'restart': Always ignores the `traceparent` header of incoming requests. A new trace-id will be generated and the sampling decision will be made based on transaction_sample_rate. A span link will be made to the incoming `traceparent`.
 * 'restart_external': If an incoming request includes the `es` vendor flag in `tracestate`, then any `traceparent` will be considered internal and will be handled as described for 'continue' above. Otherwise, any `traceparent` is considered external and will be handled as described for 'restart' above.
@@ -3788,6 +3789,7 @@ Example: `5ms`.
 # * An Elastic-monitored service is publicly exposed, and does not want tracing data (trace-ids, sampling decisions) to possibly be spoofed by user requests.
 # 
 # Valid values are:
+# 
 # * 'continue': The default behavior. An incoming `traceparent` value is used to continue the trace and determine the sampling decision.
 # * 'restart': Always ignores the `traceparent` header of incoming requests. A new trace-id will be generated and the sampling decision will be made based on transaction_sample_rate. A span link will be made to the incoming `traceparent`.
 # * 'restart_external': If an incoming request includes the `es` vendor flag in `tracestate`, then any `traceparent` will be considered internal and will be handled as described for 'continue' above. Otherwise, any `traceparent` is considered external and will be handled as described for 'restart' above.


### PR DESCRIPTION
## What does this PR do?

This fixes the asciidoc syntax to fix the rendering of the `<ul>` for [`trace_continuation_strategy` docs](https://www.elastic.co/guide/en/apm/agent/java/current/config-core.html#config-trace-continuation-strategy).

**before**
<img width="871" alt="Screen Shot 2022-12-07 at 8 24 42 AM" src="https://user-images.githubusercontent.com/46866/206234437-8e13f81e-74f8-42cc-865a-32db9a175f3b.png">

**after** ([link to PR docs build](https://apm-agent-java_2919.docs-preview.app.elstc.co/guide/en/apm/agent/java/master/config-core.html#config-trace-continuation-strategy))
![Screen Shot 2022-12-07 at 8 27 17 AM](https://user-images.githubusercontent.com/46866/206234995-0e070e08-88cd-4296-9b42-f4ea470fb9ff.png)

This also tweaks the ["Documenting" section of the contributor guide](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#documenting) showing the specific commands to regenerate `configuration.asciidoc` and to build the docs and view them locally.  I'm totally fine dropping this part of the change if you'd prefer to keep CONTRIBUTING.md more succinct.

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
