### PR TITLE
Enabled spring RestTemplate tests for spring 6

### DIFF
--- a/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-test/src/test/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateVersionsIT.java
+++ b/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-test/src/test/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateVersionsIT.java
@@ -43,8 +43,11 @@ package co.elastic.apm.agent.resttemplate;
  */
 
 import co.elastic.apm.agent.TestClassWithDependencyRunner;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -62,29 +65,48 @@ public class SpringRestTemplateVersionsIT {
         "4.1.0.RELEASE|true",
         "4.2.0.RELEASE|true",
         "4.3.0.RELEASE|true",
-        "5.0.0.RELEASE|true",
-        "5.1.0.RELEASE|true",
-        "5.2.0.RELEASE|true",
-        "[5.3.0,6.0.0)|true" // using ivy range specifier to make test against later versions
     })
-    void testVersion(String version, boolean isSupported) throws Exception {
+    void testVersion4AndOlder(String version, boolean isSupported) throws Exception {
+        testVersionImpl(version, isSupported, List.of("org.slf4j:jcl-over-slf4j:1.7.30"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "5.0.0.RELEASE",
+        "5.1.0.RELEASE",
+        "5.2.0.RELEASE",
+        "[5.3.0,6.0.0)", // using ivy range specifier to make test against later versions
+    })
+    void testVersion5(String version) throws Exception {
+        testVersionImpl(version, true, List.of(String.format("org.springframework:spring-jcl:%s", version)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "[6.0.0,7.0.0)" // using ivy range specifier to make test against later versions
+    })
+    @EnabledForJreRange(min = JRE.JAVA_17, disabledReason = "Spring 6 requires JDK 17")
+    void testVersion6(String version) throws Exception {
+        testVersionImpl(version, true, List.of(
+            String.format("org.springframework:spring-jcl:%s", version),
+            "io.micrometer:micrometer-observation:1.10.2",
+            "io.micrometer:micrometer-commons:1.10.2"
+        ));
+    }
+
+    void testVersionImpl(String version, boolean isSupported, List<String> additionalDependencies) throws Exception {
         List<String> dependencies = Stream.of(
-            "spring-webmvc",
-            "spring-aop",
-            "spring-beans",
-            "spring-context",
-            "spring-core",
-            "spring-expression",
-            "spring-web")
+                "spring-webmvc",
+                "spring-aop",
+                "spring-beans",
+                "spring-context",
+                "spring-core",
+                "spring-expression",
+                "spring-web")
             .map(s -> String.format("org.springframework:%s:%s", s, version))
             .collect(Collectors.toList());
 
-        if (version.startsWith("5.")) {
-            dependencies.add(String.format("org.springframework:spring-jcl:%s", version));
-        } else {
-            dependencies.add("org.slf4j:jcl-over-slf4j:1.7.30");
-        }
-
+        dependencies.addAll(additionalDependencies);
 
         Class<?> testClass = SprintRestTemplateIntegration.class;
         Class<?>[] otherClasses = new Class<?>[0];
@@ -95,6 +117,5 @@ public class SpringRestTemplateVersionsIT {
         TestClassWithDependencyRunner runner = new TestClassWithDependencyRunner(dependencies, testClass, otherClasses);
         runner.run();
     }
-
 
 }


### PR DESCRIPTION
## What does this PR do?
Extended the Spring RestTemplate integration tests to test with spring 6 if the JVM version is at least 17.

## Checklist

- [x] This is something else
  - ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
