### PR TITLE
Add bootstrap check for JVM tools

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -26,6 +26,7 @@ endif::[]
 [float]
 ===== Bug fixes
 * Use `127.0.0.1` as defaut for `server_url` to prevent ipv6 ambiguity - {pull}2927[#2927]
+* Self-disable the agent if accidentally started on a JVM/JDK command-line tool - {pull}2924[#2924]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/BootstrapChecks.java
+++ b/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/BootstrapChecks.java
@@ -36,7 +36,9 @@ class BootstrapChecks {
 
     static BootstrapChecks defaults() {
         return new BootstrapChecks(!Boolean.parseBoolean(System.getProperty("elastic.apm.disable_bootstrap_checks")),
-            new JavaVersionBootstrapCheck(JvmRuntimeInfo.ofCurrentVM()), new VerifyNoneBootstrapCheck(ManagementFactory.getRuntimeMXBean()));
+            new JavaVersionBootstrapCheck(JvmRuntimeInfo.ofCurrentVM()),
+            new VerifyNoneBootstrapCheck(ManagementFactory.getRuntimeMXBean()),
+            new JvmToolBootstrapCheck(System.getProperty("sun.java.command")));
     }
 
     /**
@@ -57,7 +59,7 @@ class BootstrapChecks {
             if (bootstrapChecksEnabled) {
                 isPassing = false;
                 System.err.println("[elastic-apm-agent] WARN Failed to start agent because of failing bootstrap checks.");
-                System.err.println("[elastic-apm-agent] INFO To override Java version verification, set the 'elastic.apm.disable_bootstrap_checks' System property to 'true'.");
+                System.err.println("[elastic-apm-agent] INFO To override Java bootstrap checks, set the 'elastic.apm.disable_bootstrap_checks' System property to 'true'.");
             } else {
                 System.err.println("[elastic-apm-agent] WARN Bootstrap checks have failed. The agent will still start because bootstrap check have been disabled.");
             }

--- a/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
+++ b/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
@@ -33,6 +33,10 @@ public class JvmToolBootstrapCheck implements BootstrapCheck {
     public void doBootstrapCheck(BootstrapCheckResult result) {
         // JDK tools like 'jps' or 'keytool' should not be instrumented as it just makes them slower
         // they can be instrumented as a side effect of setting a global JAVA_TOOL_OPTIONS env variable
+        //
+        // When this happens there is a message in standard error output: "Picked up JAVA_TOOL_OPTIONS: <...>"
+        // The bootstrap checks errors & warnings are written to standard error too, thus the warning message
+        // is likely to be written just next to this JVM message.
         checkJdkTool(cmd, result);
     }
 

--- a/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
+++ b/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
@@ -44,11 +44,14 @@ public class JvmToolBootstrapCheck implements BootstrapCheck{
         }
 
         String[] parts = cmd.split("/");
-        if (parts.length != 2) {
-            return false;
+        if (parts.length == 2) {
+            // JDK with module system
+            return parts[0].startsWith("jdk.") ||
+                parts[0].startsWith("java.");
+        } else if (parts.length == 1) {
+            return cmd.startsWith("sun.") || cmd.startsWith("com.sun.") || cmd.startsWith("jdk.");
         }
 
-        return parts[0].startsWith("jdk.") ||
-            parts[0].startsWith("java.");
+        return false;
     }
 }

--- a/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
+++ b/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
@@ -59,7 +59,7 @@ public class JvmToolBootstrapCheck implements BootstrapCheck {
             result.addWarn("Unexpected JVM command line syntax: " + jvmCmd);
         }
         if (isJdkTool) {
-            result.addWarn(String.format("JVM tool detected: '%s' agent will self-disable", jvmCmd));
+            result.addWarn(String.format("JVM tool detected: '%s', agent instrumentation on JVM tools adds unnecessary performance overhead", jvmCmd));
         }
     }
 }

--- a/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
+++ b/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
@@ -56,10 +56,10 @@ public class JvmToolBootstrapCheck implements BootstrapCheck {
         } else if (parts.length == 1) {
             isJdkTool = jvmCmd.startsWith("sun.") || jvmCmd.startsWith("com.sun.") || jvmCmd.startsWith("jdk.");
         } else {
-            result.addError("Unexpected JVM command line syntax: " + jvmCmd);
+            result.addWarn("Unexpected JVM command line syntax: " + jvmCmd);
         }
         if (isJdkTool) {
-            result.addError(String.format("JVM tool detected: '%s' agent will self-disable", jvmCmd));
+            result.addWarn(String.format("JVM tool detected: '%s' agent will self-disable", jvmCmd));
         }
     }
 }

--- a/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
+++ b/elastic-apm-agent/src/main/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheck.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.premain;
+
+import javax.annotation.Nullable;
+
+public class JvmToolBootstrapCheck implements BootstrapCheck{
+
+    @Nullable
+    private final String cmd;
+
+    public JvmToolBootstrapCheck(String jvmCmd) {
+        this.cmd = jvmCmd;
+    }
+
+    @Override
+    public void doBootstrapCheck(BootstrapCheckResult result) {
+        // JDK tools like 'jps' or 'keytool' should not be instrumented as it just makes them slower
+        // they can be instrumented as a side effect of setting a global JAVA_TOOL_OPTIONS env variable
+        if (isJdkTool()) {
+            result.addError(String.format("JVM tool detected: '%s' agent will self-disable", cmd));
+        }
+    }
+
+    public boolean isJdkTool() {
+        if (cmd == null) {
+            return false;
+        }
+
+        String[] parts = cmd.split("/");
+        if (parts.length != 2) {
+            return false;
+        }
+
+        return parts[0].startsWith("jdk.") ||
+            parts[0].startsWith("java.");
+    }
+}

--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheckTest.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheckTest.java
@@ -96,15 +96,15 @@ class JvmToolBootstrapCheckTest {
     void testJdkTool(String cmd) {
         BootstrapCheck.BootstrapCheckResult result = new BootstrapCheck.BootstrapCheckResult();
         JvmToolBootstrapCheck.checkJdkTool(cmd, result);
-        assertThat(result.hasErrors())
-            .describedAs("command '%s' should be detected as a JDK tool")
+        assertThat(result.hasWarnings())
+            .describedAs("command '%s' should be detected as a JDK tool", cmd)
                 .isTrue();
 
-        assertThat(result.getErrors()).hasSize(1);
-        assertThat(result.getErrors().get(0)).contains("JVM tool detected");
+        assertThat(result.getWarnings()).hasSize(1);
+        assertThat(result.getWarnings().get(0)).contains("JVM tool detected");
 
-        assertThat(result.hasWarnings())
-            .describedAs("no warning expected")
+        assertThat(result.hasErrors())
+            .describedAs("no error expected")
             .isFalse();
     }
 
@@ -125,22 +125,29 @@ class JvmToolBootstrapCheckTest {
     void checkOtherNotJdkTool(String cmd) {
         BootstrapCheck.BootstrapCheckResult result = new BootstrapCheck.BootstrapCheckResult();
         JvmToolBootstrapCheck.checkJdkTool(cmd, result);
-        assertThat(result.hasErrors())
-            .describedAs("command '%s' should issue an error to help us enhance the heuristic")
+
+        assertThat(result.hasWarnings())
+            .describedAs("command '%s' should issue a warning to help us enhance the heuristic")
             .isTrue();
 
-        assertThat(result.getErrors()).hasSize(1);
-        assertThat(result.getErrors().get(0)).describedAs("warning message should include original command").contains(cmd);
+        assertThat(result.getWarnings()).hasSize(1);
+        assertThat(result.getWarnings().get(0)).describedAs("warning message should include original command").contains(cmd);
+
+        assertThat(result.hasErrors())
+            .describedAs("no error expected")
+            .isFalse();
     }
 
     private static void checkNotJdkTool(@Nullable String cmd) {
         BootstrapCheck.BootstrapCheckResult result = new BootstrapCheck.BootstrapCheckResult();
         JvmToolBootstrapCheck.checkJdkTool(cmd, result);
-        assertThat(result.hasErrors())
+
+        assertThat(result.hasWarnings())
             .describedAs("command '%s' should not be detected as a JDK tool", cmd)
             .isFalse();
-        assertThat(result.hasWarnings())
-            .describedAs("no warning expected")
+
+        assertThat(result.hasErrors())
+            .describedAs("no error expected")
             .isFalse();
     }
 

--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheckTest.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheckTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.premain;
 
 import org.junit.jupiter.api.Test;
@@ -13,6 +31,7 @@ class JvmToolBootstrapCheckTest {
     // this list was computed by trying every binary in ${JAVA_HOME}/bin folder
     @ParameterizedTest
     @ValueSource(strings = {
+        // JDK 11+
         "java.base/com.sun.java.util.jar.pack.Driver",
         "java.base/sun.security.tools.keytool.Main",
         "java.rmi/sun.rmi.registry.RegistryImpl",
@@ -28,7 +47,51 @@ class JvmToolBootstrapCheckTest {
         "jdk.jlink/jdk.tools.jlink.internal.Main",
         "jdk.jlink/jdk.tools.jmod.Main",
         "jdk.jshell/jdk.internal.jshell.tool.JShellToolProvider",
-        "jdk.rmic/sun.rmi.rmic.Main"
+        "jdk.rmic/sun.rmi.rmic.Main",
+        // JDK 8 (before JPMS)
+        "com.sun.corba.se.impl.activation.ORBD",
+        "com.sun.corba.se.impl.activation.ServerTool",
+        "com.sun.corba.se.impl.naming.cosnaming.TransientNameServer",
+        "com.sun.javafx.tools.packager.Main",
+        "com.sun.java.util.jar.pack.Driver",
+        "com.sun.tools.corba.se.idl.toJavaPortable.Compile",
+        "com.sun.tools.example.debug.tty.TTY",
+        "com.sun.tools.extcheck.Main",
+        "com.sun.tools.hat.Main",
+        "com.sun.tools.internal.jxc.SchemaGenerator",
+        "com.sun.tools.internal.ws.WsGen",
+        "com.sun.tools.internal.ws.WsImport",
+        "com.sun.tools.internal.xjc.Driver",
+        "com.sun.tools.javac.Main",
+        "com.sun.tools.javadoc.Main",
+        "com.sun.tools.javah.Main",
+        "com.sun.tools.javap.Main",
+        "com.sun.tools.jdeps.Main",
+        "com.sun.tools.script.shell.Main",
+        "jdk.jfr.internal.tool.Main",
+        "jdk.nashorn.tools.Shell",
+        "sun.applet.Main",
+        "sun.jvm.hotspot.CLHSDB",
+        "sun.jvm.hotspot.HSDB",
+        "sun.jvm.hotspot.jdi.SADebugServer",
+        "sun.rmi.registry.RegistryImpl",
+        "sun.rmi.rmic.Main",
+        "sun.rmi.server.Activation",
+        "sun.rmi.transport.proxy.CGIHandler",
+        "sun.security.tools.jarsigner.Main",
+        "sun.security.tools.keytool.Main",
+        "sun.security.tools.policytool.PolicyTool",
+        "sun.tools.jar.Main",
+        "sun.tools.jcmd.JCmd",
+        "sun.tools.jconsole.JConsole",
+        "sun.tools.jinfo.JInfo",
+        "sun.tools.jmap.JMap",
+        "sun.tools.jps.Jps",
+        "sun.tools.jstack.JStack",
+        "sun.tools.jstatd.Jstatd",
+        "sun.tools.jstat.Jstat",
+        "sun.tools.native2ascii.Main",
+        "sun.tools.serialver.SerialVer",
     })
     void testJdkTool(String cmd) {
         assertThat(new JvmToolBootstrapCheck(cmd).isJdkTool())

--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheckTest.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/JvmToolBootstrapCheckTest.java
@@ -1,0 +1,51 @@
+package co.elastic.apm.agent.premain;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import javax.annotation.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class JvmToolBootstrapCheckTest {
+
+    // this list was computed by trying every binary in ${JAVA_HOME}/bin folder
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "java.base/com.sun.java.util.jar.pack.Driver",
+        "java.base/sun.security.tools.keytool.Main",
+        "java.rmi/sun.rmi.registry.RegistryImpl",
+        "java.rmi/sun.rmi.server.Activation",
+        "jdk.aot/jdk.tools.jaotc.Main",
+        "jdk.hotspot.agent/sun.jvm.hotspot.SALauncher",
+        "jdk.jartool/sun.security.tools.jarsigner.Main",
+        "jdk.javadoc/jdk.javadoc.internal.tool.Main",
+        "jdk.jcmd/sun.tools.jcmd.JCmd",
+        "jdk.jcmd/sun.tools.jps.Jps",
+        "jdk.jfr/jdk.jfr.internal.tool.Main",
+        "jdk.jlink/jdk.tools.jimage.Main",
+        "jdk.jlink/jdk.tools.jlink.internal.Main",
+        "jdk.jlink/jdk.tools.jmod.Main",
+        "jdk.jshell/jdk.internal.jshell.tool.JShellToolProvider",
+        "jdk.rmic/sun.rmi.rmic.Main"
+    })
+    void testJdkTool(String cmd) {
+        assertThat(new JvmToolBootstrapCheck(cmd).isJdkTool())
+            .describedAs("command '%s' should be detected as a JDK tool")
+            .isTrue();
+    }
+
+    @Test
+    void checkNotJdkTool() {
+        checkNotJdkTool(null);
+        checkNotJdkTool("");
+    }
+
+    private static void checkNotJdkTool(@Nullable String cmd) {
+        assertThat(new JvmToolBootstrapCheck(cmd).isJdkTool())
+            .describedAs("command '%s' should not be detected as a JDK tool")
+            .isFalse();
+    }
+
+}

--- a/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/ShadedClassLoaderTest.java
+++ b/elastic-apm-agent/src/test/java/co/elastic/apm/agent/premain/ShadedClassLoaderTest.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.URLClassLoader;
 import java.util.List;
 import java.util.Objects;
 import java.util.jar.JarEntry;


### PR DESCRIPTION
## What does this PR do?

In some environments, it might be common to add the agent by using the `JAVA_TOOL_OPTIONS` environment variable to provide the `-javaagent:...` JVM flag.

One downside is that all the JVM tools that also use the JVM will also try to start the agent, hence trying to instrument them and make them slower.

While running `jar` or `javac` or `javadoc` is quite unlikely in production, it is quite common to have a few invocations of `jps` to list JVM processes or `keytool` to import certificates.

When testing this change with all non-interactive JDK 11 binaries in `${JAVA_HOME}/bin` (thus `jconsole`, `jshell`, ... are excluded), we get a significant performance improvement measured through `time` : 

Before:
`71.21s user 2.53s system 249% cpu 29.539 total`

After:
`12.88s user 1.01s system 176% cpu 7.857 total`

For reference, without any agent:
`4.28s user 0.52s system 152% cpu 3.140 total`


## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
- [x] manually testing with JDK 11, 8 and 7 by setting `JAVA_TOOL_OPTIONS` with `-javaagent:...` and try to start all JVM binaries in `${JAVA_HOME}/bin` folder.
