### PR TITLE
Fix AWS instrumentation destination.service.resource handling

### DIFF
--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/DynamoDbClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/DynamoDbClientIT.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
+import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -166,6 +167,17 @@ public class DynamoDbClientIT extends AbstractAwsClientIT {
     @Override
     protected String type() {
         return "db";
+    }
+
+    @Override
+    protected String subtype() {
+        return "dynamodb";
+    }
+
+    @Nullable
+    @Override
+    protected String expectedTargetName(@Nullable String entityName) {
+        return null;
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/DynamoDbClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/DynamoDbClientIT.java
@@ -177,7 +177,7 @@ public class DynamoDbClientIT extends AbstractAwsClientIT {
     @Nullable
     @Override
     protected String expectedTargetName(@Nullable String entityName) {
-        return null;
+        return localstack.getRegion();
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/S3ClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/S3ClientIT.java
@@ -31,6 +31,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
+import javax.annotation.Nullable;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
 
@@ -84,6 +86,17 @@ public class S3ClientIT extends AbstractAwsClientIT {
     @Override
     protected String type() {
         return "storage";
+    }
+
+    @Override
+    protected String subtype() {
+        return "s3";
+    }
+
+    @Nullable
+    @Override
+    protected String expectedTargetName(@Nullable String entityName) {
+        return entityName; //entityName is BUCKET_NAME
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/SQSClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/SQSClientIT.java
@@ -40,6 +40,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
+import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
@@ -240,6 +241,17 @@ public class SQSClientIT extends AbstractSQSClientIT {
     @Override
     protected String type() {
         return "messaging";
+    }
+
+    @Override
+    protected String subtype() {
+        return "sqs";
+    }
+
+    @Nullable
+    @Override
+    protected String expectedTargetName(@Nullable String entityName) {
+        return entityName; //entityName is queue name
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/SQSJmsClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/SQSJmsClientIT.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.localstack.LocalStackContainer;
 
+import javax.annotation.Nullable;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
@@ -272,6 +273,17 @@ public class SQSJmsClientIT extends AbstractAwsClientIT {
     @Override
     protected String type() {
         return "messaging";
+    }
+
+    @Override
+    protected String subtype() {
+        return "sqs";
+    }
+
+    @Nullable
+    @Override
+    protected String expectedTargetName(@Nullable String entityName) {
+        return entityName; //entityName is queue name
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/DynamoDbClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/DynamoDbClientIT.java
@@ -207,7 +207,7 @@ public class DynamoDbClientIT extends AbstractAwsClientIT {
     @Nullable
     @Override
     protected String expectedTargetName(@Nullable String entityName) {
-        return null;
+        return localstack.getRegion();
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/DynamoDbClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/DynamoDbClientIT.java
@@ -42,6 +42,7 @@ import software.amazon.awssdk.services.dynamodb.model.QueryRequest;
 import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 
+import javax.annotation.Nullable;
 import java.util.AbstractMap;
 import java.util.Arrays;
 import java.util.Collections;
@@ -196,6 +197,17 @@ public class DynamoDbClientIT extends AbstractAwsClientIT {
     @Override
     protected String type() {
         return "db";
+    }
+
+    @Override
+    protected String subtype() {
+        return "dynamodb";
+    }
+
+    @Nullable
+    @Override
+    protected String expectedTargetName(@Nullable String entityName) {
+        return null;
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/S3ClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/S3ClientIT.java
@@ -40,6 +40,8 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
+import javax.annotation.Nullable;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 
@@ -112,6 +114,17 @@ public class S3ClientIT extends AbstractAwsClientIT {
     @Override
     protected String type() {
         return "storage";
+    }
+
+    @Override
+    protected String subtype() {
+        return "s3";
+    }
+
+    @Nullable
+    @Override
+    protected String expectedTargetName(@Nullable String entityName) {
+        return entityName; //entityName is bucket name
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/SQSClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/SQSClientIT.java
@@ -45,6 +45,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 
+import javax.annotation.Nullable;
 import java.util.Collections;
 import java.util.function.Consumer;
 
@@ -223,6 +224,17 @@ public class SQSClientIT extends AbstractSQSClientIT {
     @Override
     protected String type() {
         return "messaging";
+    }
+
+    @Override
+    protected String subtype() {
+        return "sqs";
+    }
+
+    @Nullable
+    @Override
+    protected String expectedTargetName(@Nullable String entityName) {
+        return entityName; //entityName is queue name
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/SQSJmsClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/SQSJmsClientIT.java
@@ -41,6 +41,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 
+import javax.annotation.Nullable;
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
@@ -277,6 +278,17 @@ public class SQSJmsClientIT extends AbstractAwsClientIT {
     @Override
     protected String type() {
         return "messaging";
+    }
+
+    @Override
+    protected String subtype() {
+        return "sqs";
+    }
+
+    @Nullable
+    @Override
+    protected String expectedTargetName(@Nullable String entityName) {
+        return entityName; //entityName is queue name
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-common/src/main/java/co/elastic/apm/agent/awssdk/common/AbstractAwsSdkInstrumentationHelper.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-common/src/main/java/co/elastic/apm/agent/awssdk/common/AbstractAwsSdkInstrumentationHelper.java
@@ -49,8 +49,7 @@ public abstract class AbstractAwsSdkInstrumentationHelper<R, C> {
 
         span.getContext().getServiceTarget()
             .withType(type)
-            .withName(name)
-            .withNameOnlyDestinationResource();
+            .withName(name);
 
         span.getContext().getDestination()
             .getCloud()

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-common/src/main/java/co/elastic/apm/agent/awssdk/common/AbstractDynamoDBInstrumentationHelper.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-common/src/main/java/co/elastic/apm/agent/awssdk/common/AbstractDynamoDBInstrumentationHelper.java
@@ -58,7 +58,7 @@ public abstract class AbstractDynamoDBInstrumentationHelper<R, C> extends Abstra
             }
         }
 
-        setDestinationContext(span, httpURI, sdkRequest, context, DYNAMO_DB_TYPE, null);
+        setDestinationContext(span, httpURI, sdkRequest, context, DYNAMO_DB_TYPE, region);
     }
 
     @Nullable


### PR DESCRIPTION
## What does this PR do?
Closes #2946, closes #2849 .

While implementing these fixes I enhanced the test cases of all AWS instrumentations to check for the correct `service.target.*` and `destination.service.resource` fields.
These tests unconvered that at least to my reading we currently deviate from the spec for `DynamoDB`:
Currently `service.target.name` is always `null` for `DynamoDB`, according to the [spec](https://github.com/elastic/apm/blob/main/specs/agents/tracing-instrumentation-db.md#aws-dynamodb) it should be the AWS region instead.

I changed the `DynamoDB` instrumentation to follow the spec with this PR aswell. If my reading is wrong here, we should remove this change from the PR.

<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix