### PR TITLE
Add test for unsampled Transaction

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -1360,6 +1360,19 @@ class DslJsonSerializerTest {
         assertThat(jsonSpan.get("sample_rate").asDouble()).isEqualTo(0.42d);
     }
 
+    @Test
+    void testNonSampledTransaction() {
+        Sampler sampler = mock(Sampler.class);
+        doReturn(false).when(sampler).isSampled(any(Id.class));
+        doReturn(0.42d).when(sampler).getSampleRate();
+        Transaction transaction = createRootTransaction(sampler);
+        TraceContext transactionContext = transaction.getTraceContext();
+        assertThat(transactionContext.isSampled()).isFalse();
+        assertThat(transactionContext.getSampleRate()).isEqualTo(0.0d);
+        JsonNode transactionSpan = readJsonString(serializer.toJsonString(transaction));
+        assertThat(transactionSpan.get("sample_rate").asDouble()).isEqualTo(0.0d);
+    }
+
     @ParameterizedTest
     @ValueSource(booleans = {true, false})
     void multiValueHeaders(boolean supportsMulti) {


### PR DESCRIPTION
Verifying that the serialized Transaction document contains `"sample_rate" : 0.0` when the transaction is unsampled.
Transaction document created by the added test is:
```json
{
  "timestamp" : 0,
  "name" : "unnamed",
  "id" : "950e98c344a24138",
  "trace_id" : "9a93c07ebaffc38039a73890352f0eb9",
  "type" : "type",
  "duration" : 0.0,
  "outcome" : "unknown",
  "context" : {
    "request" : {
      "method" : "GET",
      "url" : {
        "full" : "http://localhost:8080/foo/bar",
        "port" : "-1",
        "protocol" : null
      },
      "http_version" : null
    },
    "tags" : { }
  },
  "span_count" : {
    "dropped" : 0,
    "started" : 0
  },
  "sample_rate" : 0.0,
  "sampled" : false
}
```