### PR TITLE
Increase CI build timeout

### DIFF
--- a/.ci/jobs/apm-agent-java-mbp.yml
+++ b/.ci/jobs/apm-agent-java-mbp.yml
@@ -38,7 +38,7 @@
             disable: false
             recursive: true
             parent-credentials: true
-            timeout: 100
+            timeout: 180
             ## reference-repo is *Nix based so it causes problems when running for Windows
             ## reference-repo: /var/lib/jenkins/.git-references/apm-agent-java.git
             use-author: true

--- a/.ci/jobs/apm-agent-java-mbp.yml
+++ b/.ci/jobs/apm-agent-java-mbp.yml
@@ -38,7 +38,7 @@
             disable: false
             recursive: true
             parent-credentials: true
-            timeout: 180
+            timeout: 120
             ## reference-repo is *Nix based so it causes problems when running for Windows
             ## reference-repo: /var/lib/jenkins/.git-references/apm-agent-java.git
             use-author: true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     JOB_GCS_CREDENTIALS = 'apm-ci-gcs-plugin'
   }
   options {
-    timeout(time: 90, unit: 'MINUTES')
+    timeout(time: 120, unit: 'MINUTES')
     buildDiscarder(logRotator(numToKeepStr: '20', artifactNumToKeepStr: '20', daysToKeepStr: '30'))
     timestamps()
     ansiColor('xterm')


### PR DESCRIPTION
## What does this PR do?

Increase the build timeout to 2h (from slightly more than 1.5h, which currently triggers the timeout).
