### PR TITLE
Fix agent log sending

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/ApmServerLogAppender.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/ApmServerLogAppender.java
@@ -46,13 +46,14 @@ public class ApmServerLogAppender extends AbstractAppender {
     private static ApmServerLogAppender INSTANCE;
 
     @Nullable
-    private LoggingConfiguration config;
+    private volatile LoggingConfiguration config;
     @Nullable
-    private Reporter reporter;
+    private volatile Reporter reporter;
 
     private final ArrayList<LogEvent> buffer;
 
-    private ApmServerLogAppender(String name, Layout<?> layout) {
+    // package protected for testing
+    ApmServerLogAppender(String name, Layout<?> layout) {
         // recursive calls filtering is done through a filter on the appender ref, not on the appender itself
         super(name, null , layout, true, null);
         this.buffer = new ArrayList<>();
@@ -75,7 +76,7 @@ public class ApmServerLogAppender extends AbstractAppender {
             INSTANCE = new ApmServerLogAppender(name, layout);
         }
 
-        return new ApmServerLogAppender(name, layout);
+        return INSTANCE;
     }
 
     @Override

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/logging/ApmServerLogAppenderTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/logging/ApmServerLogAppenderTest.java
@@ -67,6 +67,14 @@ class ApmServerLogAppenderTest {
         appender.getInitListener().init(tracer);
 
         assertThatThrownBy(() -> appender.getInitListener().init(tracer), "should throw when trying to init more than once");
+
+        // testing singleton invariants, while being implementation details matter here
+        assertThat(ApmServerLogAppender.getInstance())
+            .describedAs("singleton instance should be set by the factory")
+            .isSameAs(appender);
+        assertThat(ApmServerLogAppender.createAppender("test", layout))
+            .describedAs("factory method should only create once and return the singleton afterwards")
+            .isSameAs(appender);
     }
 
     @ParameterizedTest
@@ -74,7 +82,9 @@ class ApmServerLogAppenderTest {
     void bufferingAndInit(boolean enabled) throws Exception {
 
         EcsLayout layout = fakeLayout();
-        ApmServerLogAppender appender = ApmServerLogAppender.createAppender("test", layout);
+
+        // using constructor to avoid singleton that won't allow more than one instance
+        ApmServerLogAppender appender = new ApmServerLogAppender("test", layout);
         ApmServerReporter reporter = mock(ApmServerReporter.class);
 
         int expectedBufferSize = 1024;

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/logging/ApmServerLogAppenderTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/logging/ApmServerLogAppenderTest.java
@@ -26,11 +26,15 @@ import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.impl.Log4jLogEvent;
 import org.apache.logging.log4j.message.SimpleMessage;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
 
+import javax.annotation.Nullable;
+import java.lang.reflect.Field;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -47,6 +51,24 @@ import static org.mockito.Mockito.verifyNoInteractions;
 class ApmServerLogAppenderTest {
 
     private static final Instant BASE_CLOCK = Instant.now();
+
+    @Nullable
+    private Object previousInstanceValue;
+    private Field instanceField;
+
+    @BeforeEach
+    public void before() throws Exception {
+        // use introspection to reset the instance to a known null value, while perserving the original value
+        instanceField = ApmServerLogAppender.class.getDeclaredField("INSTANCE");
+        instanceField.setAccessible(true);
+        previousInstanceValue = instanceField.get(null);
+        instanceField.set(null, null);
+    }
+
+    @AfterEach
+    public void after() throws Exception {
+        instanceField.set(null, previousInstanceValue);
+    }
 
     @Test
     void createAndInit() throws Exception {


### PR DESCRIPTION
## What does this PR do?

Fixes the apm agent not able to send its own logs.
No changelog requires as it hasn't been released yet.

## Checklist

- [x] This is a bugfix
  - [x] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~ n/a
  - [x] I have added tests that would fail without this fix
