### PR TITLE
Fix SQS instrumentation within messaging transactions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ endif::[]
 * Fix some span-compression concurrency issues - {pull}2865[#2865]
 * Add warning when agent is accidentally started on a JVM/JDK command-line tool - {pull}2924[#2924]
 * Fix `NullPointerException` caused by the Elasticsearch REST client instrumentation when collecting dropped span metrics - {pull}2959[#2959]
+* Fix SQS Instrumentation for Non-MessageReceive actions to avoid NoSuchElementException - {pull}2979[#2979]
 
 ===== Potentially breaking changes
 

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/main/java/co/elastic/apm/agent/awssdk/v1/helper/SQSHelper.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/main/java/co/elastic/apm/agent/awssdk/v1/helper/SQSHelper.java
@@ -122,6 +122,11 @@ public class SQSHelper extends AbstractSQSInstrumentationHelper<Request<?>, Exec
     }
 
     @Override
+    protected boolean isReceiveMessageRequest(Request<?> request) {
+        return request instanceof ReceiveMessageRequest;
+    }
+
+    @Override
     protected void setMessageContext(@Nullable Message sqsMessage, @Nullable String queueName, co.elastic.apm.agent.impl.context.Message message) {
         if (queueName != null) {
             message.withQueue(queueName);

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/main/java/co/elastic/apm/agent/awssdk/v2/helper/SQSHelper.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/main/java/co/elastic/apm/agent/awssdk/v2/helper/SQSHelper.java
@@ -114,6 +114,11 @@ public class SQSHelper extends AbstractSQSInstrumentationHelper<SdkRequest, Exec
         return null;
     }
 
+    @Override
+    protected boolean isReceiveMessageRequest(SdkRequest request) {
+        return request instanceof ReceiveMessageRequest;
+    }
+
     public void modifyRequestObject(@Nullable Span span, ClientExecutionParams clientExecutionParams, ExecutionContext executionContext) {
         SdkRequest sdkRequest = clientExecutionParams.getInput();
         SdkRequest newRequestObj = null;

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/SQSClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/SQSClientIT.java
@@ -50,6 +50,7 @@ import java.util.Collections;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 public class SQSClientIT extends AbstractSQSClientIT {
     private SqsClient sqs;
@@ -165,6 +166,74 @@ public class SQSClientIT extends AbstractSQSClientIT {
 
         assertThat(reporter.getSpans()).noneMatch(AbstractSpan::isSync);
         transaction.deactivate().end();
+    }
+
+    @Test
+    public void testNonReceiveMessageWithinMessagingTransaction() {
+        sqs.createQueue(CreateQueueRequest.builder().queueName(SQS_QUEUE_NAME).build());
+
+        final StringBuilder queueUrl = new StringBuilder();
+        queueUrl.append(sqs.getQueueUrl(GetQueueUrlRequest.builder().queueName(SQS_QUEUE_NAME).build()).queueUrl());
+
+        Transaction transaction = startTestRootTransaction("sqs-test");
+        transaction.withType("messaging");
+
+        sqs.sendMessage(SendMessageRequest.builder()
+            .queueUrl(queueUrl.toString())
+            .messageBody(MESSAGE_BODY)
+            .build());
+
+        transaction.deactivate().end();
+
+        assertThat(reporter.getFirstTransaction()).isNotNull();
+        assertThat(reporter.getFirstTransaction().getNameAsString()).isEqualTo("sqs-test");
+        assertThat(reporter.getFirstSpan()).isNotNull();
+        assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("SQS SEND to " + SQS_QUEUE_NAME);
+    }
+
+    @Test
+    public void testAsnycNonReceiveMessageWithinMessagingTransaction() {
+        sqsAsync.createQueue(CreateQueueRequest.builder().queueName(SQS_QUEUE_NAME).build()).join();
+
+        final StringBuilder queueUrl = new StringBuilder();
+        queueUrl.append(sqsAsync.getQueueUrl(GetQueueUrlRequest.builder().queueName(SQS_QUEUE_NAME).build()).join().queueUrl());
+
+        Transaction transaction = startTestRootTransaction("sqs-test");
+        transaction.withType("messaging");
+
+        sqsAsync.sendMessage(SendMessageRequest.builder()
+            .queueUrl(queueUrl.toString())
+            .messageBody(MESSAGE_BODY)
+            .build()).join();
+
+        transaction.deactivate().end();
+
+        assertThat(reporter.getFirstTransaction()).isNotNull();
+        assertThat(reporter.getFirstTransaction().getNameAsString()).isEqualTo("sqs-test");
+        assertThat(reporter.getFirstSpan()).isNotNull();
+        assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("SQS SEND to " + SQS_QUEUE_NAME);
+    }
+
+    @Test
+    public void testReceiveMessageWithinMessagingTransaction() {
+        when(messagingConfiguration.shouldEndMessagingTransactionOnPoll()).thenReturn(false);
+        sqs.createQueue(CreateQueueRequest.builder().queueName(SQS_QUEUE_NAME).build());
+
+        final StringBuilder queueUrl = new StringBuilder();
+        queueUrl.append(sqs.getQueueUrl(GetQueueUrlRequest.builder().queueName(SQS_QUEUE_NAME).build()).queueUrl());
+
+        Transaction transaction = startTestRootTransaction("sqs-test");
+        transaction.withType("messaging");
+
+        sqs.receiveMessage(ReceiveMessageRequest.builder().queueUrl(queueUrl.toString()).build());
+
+        transaction.deactivate().end();
+
+
+        assertThat(reporter.getFirstTransaction()).isNotNull();
+        assertThat(reporter.getFirstTransaction().getNameAsString()).isEqualTo("sqs-test");
+        assertThat(reporter.getFirstSpan()).isNotNull();
+        assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("SQS POLL from " + SQS_QUEUE_NAME);
     }
 
     @Override

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-common/src/main/java/co/elastic/apm/agent/awssdk/common/AbstractSQSInstrumentationHelper.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-common/src/main/java/co/elastic/apm/agent/awssdk/common/AbstractSQSInstrumentationHelper.java
@@ -75,6 +75,7 @@ public abstract class AbstractSQSInstrumentationHelper<R, C, MessageT> extends A
     @Nullable
     protected abstract String getMessageAttribute(MessageT sqsMessage, String key);
 
+    protected abstract boolean isReceiveMessageRequest(R request);
 
     protected AbstractSQSInstrumentationHelper(ElasticApmTracer tracer, IAwsSdkDataSource<R, C> awsSdkDataSource) {
         super(tracer, awsSdkDataSource);
@@ -135,7 +136,7 @@ public abstract class AbstractSQSInstrumentationHelper<R, C, MessageT> extends A
     public Span startSpan(R request, URI httpURI, C context) {
         AbstractSpan<?> activeSpan = tracer.getActive();
 
-        if (messagingConfiguration.shouldEndMessagingTransactionOnPoll() && activeSpan instanceof Transaction) {
+        if (isReceiveMessageRequest(request) && messagingConfiguration.shouldEndMessagingTransactionOnPoll() && activeSpan instanceof Transaction) {
             Transaction transaction = (Transaction) activeSpan;
             if (MESSAGING_TYPE.equals(transaction.getType())) {
                 transaction.deactivate().end();


### PR DESCRIPTION
Fixes a bug in the SQS instrumentation. Adds tests for that scenario.

## Buggy behavior

When an SQS span was created **within** a `messaging` type transaction (as parent), the transaction was ended immediately independent of the SQS action type.

While this behavior is expected as the default behavior of the config option `end_messaging_transaction_on_poll` for actions that POLL a message (i.e. `ReceiveMessage` request), this should not happen for all types of SQS requests (e.g. SendMessage, etc.).

This PR limits the above behavior to `ReceiveMessage` requests.


