### PR TITLE
Disable CPU overhead test due to flakyness

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/AgentOverheadMetricsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/AgentOverheadMetricsTest.java
@@ -27,6 +27,7 @@ import co.elastic.apm.agent.report.ReporterConfiguration;
 import co.elastic.apm.agent.util.ExecutorUtils;
 import com.sun.management.ThreadMXBean;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -69,6 +70,7 @@ public class AgentOverheadMetricsTest {
     }
 
     @Test
+    @Disabled("due to flakyness")
     public void checkCpuMetrics() throws InterruptedException {
         //make sure that the OS provides a value for cpuLoad
         awaitNonZeroProcessCpuLoad();


### PR DESCRIPTION
Sad PR :( looks like #2918 didn't fix everything, the CPU-metrics test is still flaky in the CI for unclear reasons (See https://github.com/elastic/apm-agent-java/issues/2903#issuecomment-1402060114)
