### PR TITLE
ci: pin baremetal with jdk17

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -284,7 +284,8 @@ pipeline {
              * The result JSON files are also archive into Jenkins.
              */
             stage('Benchmarks') {
-              agent { label 'microbenchmarks-pool' }
+              // As long as jdk17 is not available then let's pin the worker with jdk17
+              agent { label 'microbenchmarks-pool && worker-1799328' }
               options { skipDefaultCheckout() }
               environment {
                 NO_BUILD = "true"


### PR DESCRIPTION
## What does this PR do?

Pin baremetal win jdk17 so benchmarks are keep working while waiting for the CI systems owners to apply the required configuration in those machines.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
