### PR TITLE
Adding the ability to disable TraceContext header injection

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,17 @@ endif::[]
 [float]
 ===== Bug fixes
 
+[[release-notes-1.37.0]]
+==== 1.37.0 - YYYY/MM/DD
+
+[float]
+===== Features
+* Added the <<config-disable-outgoing-tracecontext-headers>> config option to disable injection of `tracecontext` on outgoing
+communication - {pull}2996[#2996]
+
+[float]
+===== Bug fixes
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -704,8 +704,8 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .key("disable_outgoing_tracecontext_headers")
         .tags("added[1.37.0]")
         .configurationCategory(CORE_CATEGORY)
-        .description("Use this option to disable TraceContext headers injection to any outgoing communication. \n\n" +
-            "NOTE: disabling TraceContext headers injection means that {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] \n" +
+        .description("Use this option to disable `tracecontext` headers injection to any outgoing communication. \n\n" +
+            "NOTE: Disabling `tracecontext` headers injection means that {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] \n" +
             "will not work on downstream services.")
         .dynamic(true)
         .buildWithDefault(false);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -700,6 +700,16 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
         .dynamic(true)
         .buildWithDefault(true);
 
+    private final ConfigurationOption<Boolean> disableOutgoingTraceContextHeaders = ConfigurationOption.booleanOption()
+        .key("disable_outgoing_tracecontext_headers")
+        .tags("added[1.37.0]")
+        .configurationCategory(CORE_CATEGORY)
+        .description("Use this option to disable TraceContext headers injection to any outgoing communication. \n\n" +
+            "NOTE: disabling TraceContext headers injection means that {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] \n" +
+            "will not work on downstream services.")
+        .dynamic(true)
+        .buildWithDefault(false);
+
     private final ConfigurationOption<Integer> tracestateHeaderSizeLimit = ConfigurationOption.integerOption()
         .key("tracestate_header_size_limit")
         .tags("added[1.14.0]")
@@ -970,6 +980,10 @@ public class CoreConfiguration extends ConfigurationOptionProvider {
 
     public boolean isElasticTraceparentHeaderEnabled() {
         return useElasticTraceparentHeader.get();
+    }
+
+    public boolean isOutgoingTraceContextHeadersInjectionDisabled() {
+        return disableOutgoingTraceContextHeaders.get();
     }
 
     public int getTracestateSizeLimit() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -545,6 +545,11 @@ public class TraceContext implements Recyclable {
      * @param <C>          the header carrier type, for example - an HTTP request
      */
     <C> void propagateTraceContext(C carrier, TextHeaderSetter<C> headerSetter) {
+        if (coreConfiguration.isOutgoingTraceContextHeadersInjectionDisabled()) {
+            logger.debug("Outgoing TraceContext header injection is disabled");
+            return;
+        }
+
         String outgoingTraceParent = getOutgoingTraceParentTextHeader().toString();
 
         headerSetter.setHeader(W3C_TRACE_PARENT_TEXTUAL_HEADER_NAME, outgoingTraceParent, carrier);
@@ -568,6 +573,10 @@ public class TraceContext implements Recyclable {
      * @return true if Trace Context headers were set; false otherwise
      */
     <C> boolean propagateTraceContext(C carrier, BinaryHeaderSetter<C> headerSetter) {
+        if (coreConfiguration.isOutgoingTraceContextHeadersInjectionDisabled()) {
+            logger.debug("Outgoing TraceContext header injection is disabled");
+            return false;
+        }
         byte[] buffer = headerSetter.getFixedLengthByteArray(TRACE_PARENT_BINARY_HEADER_NAME, BINARY_FORMAT_EXPECTED_LENGTH);
         if (buffer == null || buffer.length != BINARY_FORMAT_EXPECTED_LENGTH) {
             logger.warn("Header setter {} failed to provide a byte buffer with the proper length. Allocating a buffer for each header.",

--- a/apm-agent-plugins/apm-finagle-httpclient-plugin/src/test/java/co/elastic/apm/agent/finaglehttpclient/FinagleHttpClientTest.java
+++ b/apm-agent-plugins/apm-finagle-httpclient-plugin/src/test/java/co/elastic/apm/agent/finaglehttpclient/FinagleHttpClientTest.java
@@ -56,7 +56,7 @@ public class FinagleHttpClientTest extends AbstractHttpClientInstrumentationTest
             service.close();
         }
 
-        verifyHttpSpan("localhost", "/", 200, true, true);
+        verifyHttpSpan("localhost", "/", 200, true, true, true);
     }
 
     @Test
@@ -72,7 +72,7 @@ public class FinagleHttpClientTest extends AbstractHttpClientInstrumentationTest
             service.close();
         }
 
-        Span span = verifyHttpSpan("sub-host", "/", 0, false, true);
+        Span span = verifyHttpSpan("sub-host", "/", 0, false, true, false);
         assertThat(reporter.getErrors()).hasSize(1);
         ErrorCapture error = reporter.getFirstError();
         assertThat(error.getTraceContext().getTraceId()).isEqualTo(span.getTraceContext().getTraceId());

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -19,6 +19,8 @@
 package co.elastic.apm.agent.httpclient;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.configuration.CoreConfiguration;
+import co.elastic.apm.agent.configuration.converter.TimeDuration;
 import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
 import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.context.Http;
@@ -59,6 +61,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.seeOther;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.mockito.Mockito.doReturn;
 
 public abstract class AbstractHttpClientInstrumentationTest extends AbstractInstrumentationTest {
 
@@ -104,8 +107,15 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
     public void testHttpCall() {
         String path = "/";
         performGetWithinTransaction(path);
-
         verifyHttpSpan(path);
+    }
+
+    @Test
+    public void testDisabledOutgoingHeaders() {
+        doReturn(true).when(config.getConfig(CoreConfiguration.class)).isOutgoingTraceContextHeadersInjectionDisabled();
+        String path = "/";
+        performGetWithinTransaction(path);
+        verifyHttpSpan("localhost", path, 200, true, false, false);
     }
 
     @Test
@@ -246,10 +256,10 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
     }
 
     protected Span verifyHttpSpan(String host, String path, int status, boolean requestExecuted) {
-        return verifyHttpSpan(host, path, status, requestExecuted, false);
+        return verifyHttpSpan(host, path, status, requestExecuted, false, requestExecuted);
     }
 
-    protected Span verifyHttpSpan(String host, String path, int status, boolean requestExecuted, boolean isHttps) {
+    protected Span verifyHttpSpan(String host, String path, int status, boolean requestExecuted, boolean isHttps, boolean expectTraceContextHeaders) {
         assertThat(reporter.getFirstSpan(500)).isNotNull();
         assertThat(reporter.getSpans()).hasSize(1);
         Span span = reporter.getSpans().get(0);
@@ -287,7 +297,13 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
             .hasNameOnlyDestinationResource();
 
         if (requestExecuted) {
-            verifyTraceContextHeaders(span, path);
+            if (expectTraceContextHeaders) {
+                verifyTraceContextHeaders(span, path);
+            } else {
+                findLoggedRequests(path).forEach(request ->
+                    assertThat(TraceContext.containsTraceContextTextHeaders(request, HeaderAccessor.INSTANCE)).isFalse()
+                );
+            }
         }
 
         return span;
@@ -301,16 +317,8 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         Map<String, String> headerMap = new HashMap<>();
         span.propagateTraceContext(headerMap, TextHeaderMapAccessor.INSTANCE);
         assertThat(headerMap).isNotEmpty();
-        final AtomicReference<List<LoggedRequest>> loggedRequests = new AtomicReference<>();
-        Awaitility.await()
-            .pollInterval(1, TimeUnit.MILLISECONDS)
-            .timeout(1000, TimeUnit.MILLISECONDS)
-            .untilAsserted(() -> {
-                List<LoggedRequest> tmp = wireMockRule.findAll(anyRequestedFor(urlPathEqualTo(path)));
-                loggedRequests.set(tmp);
-                assertThat(tmp).isNotEmpty();
-            });
-        loggedRequests.get().forEach(request -> {
+        final List<LoggedRequest> loggedRequests = findLoggedRequests(path);
+        loggedRequests.forEach(request -> {
             assertThat(TraceContext.containsTraceContextTextHeaders(request, HeaderAccessor.INSTANCE)).isTrue();
             AtomicInteger headerCount = new AtomicInteger();
             HeaderAccessor.INSTANCE.forEach(
@@ -326,6 +334,19 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
             assertThat(transaction.getTraceContext().getTraceId()).isEqualTo(span.getTraceContext().getTraceId());
             assertThat(transaction.getTraceContext().getParentId()).isEqualTo(span.getTraceContext().getId());
         });
+    }
+
+    private List<LoggedRequest> findLoggedRequests(String path) {
+        final AtomicReference<List<LoggedRequest>> loggedRequests = new AtomicReference<>();
+        Awaitility.await()
+            .pollInterval(1, TimeUnit.MILLISECONDS)
+            .timeout(1000, TimeUnit.MILLISECONDS)
+            .untilAsserted(() -> {
+                List<LoggedRequest> tmp = wireMockRule.findAll(anyRequestedFor(urlPathEqualTo(path)));
+                loggedRequests.set(tmp);
+                assertThat(tmp).isNotEmpty();
+            });
+        return loggedRequests.get();
     }
 
     private static class HeaderAccessor implements TextHeaderGetter<LoggedRequest> {

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
@@ -28,6 +28,7 @@ import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.common.util.WildcardMatcher;
 import co.elastic.apm.agent.springwebflux.testapp.GreetingWebClient;
 import co.elastic.apm.agent.springwebflux.testapp.WebFluxApplication;
+import co.elastic.apm.agent.testutils.DisabledOnAppleSilicon;
 import co.elastic.apm.agent.util.PotentiallyMultiValuedMap;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.AfterAll;
@@ -92,6 +93,7 @@ public abstract class AbstractServerInstrumentationTest extends AbstractInstrume
     protected abstract GreetingWebClient getClient();
 
     @Test
+    @DisabledOnAppleSilicon
     void dispatchError() {
         StepVerifier.create(client.getHandlerError())
             .expectErrorMatches(expectClientError(500))

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -129,6 +129,7 @@ Click on a key to get more information.
 ** <<config-config-file>>
 ** <<config-plugins-dir>>
 ** <<config-use-elastic-traceparent-header>>
+** <<config-disable-outgoing-tracecontext-headers>>
 ** <<config-span-min-duration>>
 ** <<config-cloud-provider>>
 ** <<config-enable-public-api-annotation-inheritance>>
@@ -1325,6 +1326,32 @@ for backwards compatibility with older versions of Elastic APM agents.
 |============
 | Java System Properties      | Property file   | Environment
 | `elastic.apm.use_elastic_traceparent_header` | `use_elastic_traceparent_header` | `ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER`
+|============
+
+// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
+[float]
+[[config-disable-outgoing-tracecontext-headers]]
+==== `disable_outgoing_tracecontext_headers` (added[1.37.0])
+
+Use this option to disable TraceContext headers injection to any outgoing communication. 
+
+NOTE: disabling TraceContext headers injection means that {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] 
+will not work on downstream services.
+
+<<configuration-dynamic, image:./images/dynamic-config.svg[] >>
+
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `false` | Boolean | true
+|============
+
+
+[options="header"]
+|============
+| Java System Properties      | Property file   | Environment
+| `elastic.apm.disable_outgoing_tracecontext_headers` | `disable_outgoing_tracecontext_headers` | `ELASTIC_APM_DISABLE_OUTGOING_TRACECONTEXT_HEADERS`
 |============
 
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
@@ -3781,6 +3808,17 @@ Example: `5ms`.
 # Default value: true
 #
 # use_elastic_traceparent_header=true
+
+# Use this option to disable TraceContext headers injection to any outgoing communication. 
+# 
+# NOTE: disabling TraceContext headers injection means that {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] 
+# will not work on downstream services.
+#
+# This setting can be changed at runtime
+# Type: Boolean
+# Default value: false
+#
+# disable_outgoing_tracecontext_headers=false
 
 # Sets the minimum duration of spans.
 # Spans that execute faster than this threshold are attempted to be discarded.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1333,9 +1333,9 @@ for backwards compatibility with older versions of Elastic APM agents.
 [[config-disable-outgoing-tracecontext-headers]]
 ==== `disable_outgoing_tracecontext_headers` (added[1.37.0])
 
-Use this option to disable TraceContext headers injection to any outgoing communication. 
+Use this option to disable `tracecontext` headers injection to any outgoing communication. 
 
-NOTE: disabling TraceContext headers injection means that {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] 
+NOTE: Disabling `tracecontext` headers injection means that {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] 
 will not work on downstream services.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
@@ -3809,9 +3809,9 @@ Example: `5ms`.
 #
 # use_elastic_traceparent_header=true
 
-# Use this option to disable TraceContext headers injection to any outgoing communication. 
+# Use this option to disable `tracecontext` headers injection to any outgoing communication. 
 # 
-# NOTE: disabling TraceContext headers injection means that {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] 
+# NOTE: Disabling `tracecontext` headers injection means that {apm-guide-ref}/apm-distributed-tracing.html[distributed tracing] 
 # will not work on downstream services.
 #
 # This setting can be changed at runtime


### PR DESCRIPTION
## What does this PR do?
Adding the ability to disable TraceContext headers on outgoing requests.
An example for when this may be useful is described in a [forum topic](https://discuss.elastic.co/t/how-to-disable-tracestate-and-traceparent-headers/324164)

## Checklist
- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [x] I have made corresponding changes to the documentation
