### PR TITLE
Skip deploying of java 17 subprojects

### DIFF
--- a/apm-agent-java-17/pom.xml
+++ b/apm-agent-java-17/pom.xml
@@ -17,6 +17,7 @@
     </modules>
 
     <properties>
+        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <!-- for licence header plugin -->
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
 


### PR DESCRIPTION
## What does this PR do?
During the last release I noticed that our release job attempts to deploy the new java 17-specific subprojects aswell, which is not intentional to my knowledge.

