### PR TITLE
Switch to fully automated release based on nexus-staging-maven-plugin

### DIFF
--- a/apm-agent-plugins/apm-kafka-plugin/apm-kafka-spring-plugin/pom.xml
+++ b/apm-agent-plugins/apm-kafka-plugin/apm-kafka-spring-plugin/pom.xml
@@ -13,7 +13,7 @@
     </properties>
 
     <artifactId>apm-kafka-spring-plugin</artifactId>
-
+    <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
         <module>apm-agent-benchmarks</module>
         <module>apm-agent-plugins</module>
         <module>apm-agent-api</module>
-        <module>apm-opentracing</module>
         <module>integration-tests</module>
         <module>apm-agent-attach</module>
         <module>apm-agent-plugin-sdk</module>
@@ -72,6 +71,17 @@
         <module>apm-agent-attach-cli</module>
         <module>apm-agent-common</module>
         <module>apm-agent-cached-lookup-key</module>
+        <module>apm-opentracing</module>
+        <!-- IMPORTANT:
+            For the nexus deployment to work correctly, the last project in the build order needs to have deployment
+            enabled (maven-deploy-plugin.skip must be false).
+            The reason is that for SNAPSHOT builds the upload is performed by the nexus-staging-maven-plugin
+            after the last project build and EVERYTHING is skipped if this project is not part of the deployment.
+            See the documentation (https://github.com/sonatype/nexus-maven-plugins/tree/main/staging/maven-plugin#plugin-flags)
+            and the related issue (https://issues.sonatype.org/browse/NEXUS-9138).
+
+            You can verify the build order by executing ./mvnw clean and looking for the "Reactor Build Order log".
+        -->
     </modules>
 
     <properties>
@@ -327,9 +337,16 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-deploy-plugin</artifactId>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <extensions>true</extensions>
                 <configuration>
-                    <skip>${maven-deploy-plugin.skip}</skip>
+                    <!-- The Base URL of Nexus instance where we want to stage -->
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <!-- The server "id" element from settings to use authentication from -->
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <skipNexusStagingDeployMojo>${maven-deploy-plugin.skip}</skipNexusStagingDeployMojo>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
             <!-- The shadowed source files of this module need to be included explicitly to create a javadoc artifact.-->
@@ -512,8 +529,9 @@
                     <version>1.6</version>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>2.8.2</version>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.13</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
## What does this PR do?

Switches from the `maven-deploy-plugin` to the `nexus-staging-maven-plugin` for nexus deployment.
This makes the manual steps in the Nexus UI from our release process obsolete: The plugin automatically closed, releases and drops the repository in nexus. It should automatically perform a cleanup in case of a failure aswell.

I have the hope that his maybe fixes #2855 aswell.

Unfortunately this change can hardly be tested manually, I'll trigger a SNAPSHOT build after this is on stable to see if at least the snapshot deployment works properly.
