### PR TITLE
HttpURLConnection (#2976) - fix getResponseCode handled exceptions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ communication - {pull}2996[#2996]
 * Prevent potential connection leak on network failure - {pull}2869[#2869]
 * Fix for inferred spans where the parent id was also a child id - {pull}2686[#2686]
 * Fix context propagation for async 7.x and 8.x Elasticsearch clients - {pull}3015[#3015]
+* Fix for `HttpUrlConnection` throwing exception for responseCode >= 400 (OTel inspired way to fix) - {pull}3024[#3024]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,7 +38,7 @@ communication - {pull}2996[#2996]
 * Fix for inferred spans where the parent id was also a child id - {pull}2686[#2686]
 * Fix context propagation for async 7.x and 8.x Elasticsearch clients - {pull}3015[#3015]
 * Fix exceptions filtering based on <<config-ignore-exceptions>> when those are <<config-unnest-exceptions, nested>> - {pull}3025[#3025]
-* Fix for `HttpUrlConnection.getResponseCode` capturing an exception, also internally already handled - {pull}3024[#3024]
+* Fix usage of `HttpUrlConnection.getResponseCode()` causing an error event due to exception capturing, even when it is internally handled - {pull}3024[#3024]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,7 +36,7 @@ communication - {pull}2996[#2996]
 * Prevent potential connection leak on network failure - {pull}2869[#2869]
 * Fix for inferred spans where the parent id was also a child id - {pull}2686[#2686]
 * Fix context propagation for async 7.x and 8.x Elasticsearch clients - {pull}3015[#3015]
-* Fix for `HttpUrlConnection` throwing exception for responseCode >= 400 (OTel inspired way to fix) - {pull}3024[#3024]
+* Fix for `HttpUrlConnection.getResponseCode` capturing an exception, also internally already handled - {pull}3024[#3024]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
@@ -121,7 +121,8 @@ public abstract class HttpUrlConnectionInstrumentation extends TracerAwareInstru
                         // checking if "finished" to avoid multiple endings on nested calls
                         if (!span.isFinished()) {
                             span.getContext().getHttp().withStatusCode(responseCode);
-                            span.captureException(t).end();
+                            // https://github.com/elastic/apm-agent-java/issues/2976
+                            span.captureException(responseCode >= 400 ? null : t).end();
                         }
                     } else if (t != null) {
                         inFlightSpans.remove(thiz);

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/main/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentation.java
@@ -121,8 +121,7 @@ public abstract class HttpUrlConnectionInstrumentation extends TracerAwareInstru
                         // checking if "finished" to avoid multiple endings on nested calls
                         if (!span.isFinished()) {
                             span.getContext().getHttp().withStatusCode(responseCode);
-                            // https://github.com/elastic/apm-agent-java/issues/2976
-                            span.captureException(responseCode >= 400 ? null : t).end();
+                            span.captureException(t).end();
                         }
                     } else if (t != null) {
                         inFlightSpans.remove(thiz);
@@ -150,7 +149,8 @@ public abstract class HttpUrlConnectionInstrumentation extends TracerAwareInstru
         public ElementMatcher<? super MethodDescription> getMethodMatcher() {
             return named("connect").and(takesArguments(0))
                 .or(named("getOutputStream").and(takesArguments(0)))
-                .or(named("getInputStream").and(takesArguments(0)));
+                .or(named("getInputStream").and(takesArguments(0)))
+                .or(named("getResponseCode").and(takesArguments(0)));
         }
     }
 

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
@@ -122,7 +122,7 @@ public class HttpUrlConnectionInstrumentationTest extends AbstractHttpClientInst
     }
 
     @Test
-    public void testGetResponseCodeWithUnknownHost() {
+    public void testGetResponseCodeWithUnhandledException() {
         try {
             performGet("http://unknown");
         } catch (Exception e) {

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
@@ -124,7 +124,9 @@ public class HttpUrlConnectionInstrumentationTest extends AbstractHttpClientInst
     @Test
     public void testGetResponseCodeWithUnhandledException() {
         try {
-            performGet("http://unknown");
+            final HttpURLConnection urlConnection = (HttpURLConnection) new URL("http://unknown").openConnection();
+            urlConnection.getResponseCode();
+            urlConnection.disconnect();
         } catch (Exception e) {
             // intentionally ignored
         }

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
@@ -20,7 +20,9 @@ package co.elastic.apm.agent.urlconnection;
 
 import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
 import co.elastic.apm.agent.impl.Scope;
+import co.elastic.apm.agent.impl.context.Http;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Span;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -132,6 +134,16 @@ public class HttpUrlConnectionInstrumentationTest extends AbstractHttpClientInst
         }
 
         assertThat(reporter.getErrors()).hasSize(1);
+        
+        assertThat(reporter.getFirstSpan(500)).isNotNull();
+        assertThat(reporter.getSpans()).hasSize(1);
+
+        Span span = reporter.getSpans().get(0);
+        assertThat(span.getNameAsString()).isEqualTo("GET unknown");
+
+        Http http = span.getContext().getHttp();
+        assertThat(http.getStatusCode()).isEqualTo(0);
+        assertThat(http.getUrl().toString()).isEqualTo("http://unknown");
     }
 
     @Test

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
@@ -122,10 +122,23 @@ public class HttpUrlConnectionInstrumentationTest extends AbstractHttpClientInst
     }
 
     @Test
-    public void testCapturesNoException() {
-        String path = "/non-existent";
-        performGetWithinTransaction(path);
+    public void testGetResponseCodeWithUnknownHost() {
+        try {
+            performGet("http://unknown");
+        } catch (Exception e) {
+            // intentionally ignored
+        }
 
+        assertThat(reporter.getErrors()).hasSize(1);
+    }
+
+    @Test
+    public void testGetResponseWithHandledException() throws Exception {
+        final HttpURLConnection urlConnection = (HttpURLConnection) new URL(getBaseUrl() + "/non-existent").openConnection();
+        urlConnection.getResponseCode();
+        urlConnection.disconnect();
+
+        verifyHttpSpan("localhost", "/non-existent", 404);
         assertThat(reporter.getErrors()).isEmpty();
     }
 

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
@@ -121,4 +121,12 @@ public class HttpUrlConnectionInstrumentationTest extends AbstractHttpClientInst
         verifyHttpSpan("/");
     }
 
+    @Test
+    public void testCapturesNoException() {
+        String path = "/non-existent";
+        performGetWithinTransaction(path);
+
+        assertThat(reporter.getErrors()).isEmpty();
+    }
+
 }

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
@@ -144,4 +144,13 @@ public class HttpUrlConnectionInstrumentationTest extends AbstractHttpClientInst
         assertThat(reporter.getErrors()).isEmpty();
     }
 
+    @Test
+    public void testGetInstrumentationWithErrorEvent() {
+        String path = "/non-existing";
+        performGetWithinTransaction(path);
+
+        verifyHttpSpan("localhost", path, 404);
+        assertThat(reporter.getErrors()).hasSize(1);
+    }
+
 }


### PR DESCRIPTION
## What does this PR do?
Fixes #2976 same way OTel has implemented its instrumentation of `HttpURLConnection`

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
