### PR TITLE
Unnest exceptions before filtering

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ communication - {pull}2996[#2996]
 * Prevent potential connection leak on network failure - {pull}2869[#2869]
 * Fix for inferred spans where the parent id was also a child id - {pull}2686[#2686]
 * Fix context propagation for async 7.x and 8.x Elasticsearch clients - {pull}3015[#3015]
+* Fix exceptions filtering based on <<config-ignore-exceptions>> when those are <<config-unnest-exceptions, nested>> - {pull}3025[#3025]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -333,9 +333,14 @@ public class ElasticApmTracer implements Tracer {
 
     @Nullable
     private ErrorCapture captureException(long epochMicros, @Nullable Throwable e, @Nullable AbstractSpan<?> parent, @Nullable ClassLoader initiatingClassLoader) {
-        if (!isRunning()) {
+        if (!isRunning() || e == null) {
             return null;
         }
+
+        while (e != null && WildcardMatcher.anyMatch(coreConfiguration.getUnnestExceptions(), e.getClass().getName()) != null) {
+            e = e.getCause();
+        }
+
         // note: if we add inheritance support for exception filtering, caching would be required for performance
         if (e != null && !WildcardMatcher.isAnyMatch(coreConfiguration.getIgnoreExceptions(), e.getClass().getName())) {
             ErrorCapture error = errorPool.createInstance();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorCapture.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/ErrorCapture.java
@@ -18,7 +18,6 @@
  */
 package co.elastic.apm.agent.impl.error;
 
-import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.context.TransactionContext;
 import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
@@ -26,7 +25,6 @@ import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
-import co.elastic.apm.agent.common.util.WildcardMatcher;
 import co.elastic.apm.agent.objectpool.Recyclable;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
@@ -153,11 +151,7 @@ public class ErrorCapture implements Recyclable {
     }
 
     public void setException(Throwable e) {
-        if (WildcardMatcher.anyMatch(tracer.getConfig(CoreConfiguration.class).getUnnestExceptions(), e.getClass().getName()) != null) {
-            this.exception = e.getCause();
-        } else {
-            this.exception = e;
-        }
+        exception = e;
     }
 
     public StringBuilder getCulprit() {

--- a/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
+++ b/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
@@ -19,7 +19,8 @@
 package org.example.stacktrace;
 
 import co.elastic.apm.agent.MockTracer;
-import co.elastic.apm.agent.configuration.SpyConfiguration;
+import co.elastic.apm.agent.common.util.WildcardMatcher;
+import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.context.Request;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
@@ -27,7 +28,6 @@ import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import java.util.List;
 
@@ -36,14 +36,15 @@ import static org.mockito.Mockito.doReturn;
 
 class ErrorCaptureTest {
 
-    private StacktraceConfiguration stacktraceConfiguration;
     private ElasticApmTracer tracer;
+    private StacktraceConfiguration stacktraceConfiguration;
+    private CoreConfiguration coreConfiguration;
 
     @BeforeEach
     void setUp() {
-        final ConfigurationRegistry registry = SpyConfiguration.createSpyConfig();
-        tracer = MockTracer.create(registry);
-        stacktraceConfiguration = registry.getConfig(StacktraceConfiguration.class);
+        tracer = MockTracer.createRealTracer();
+        stacktraceConfiguration = tracer.getConfig(StacktraceConfiguration.class);
+        coreConfiguration = tracer.getConfig(CoreConfiguration.class);
     }
 
     @Test
@@ -65,11 +66,37 @@ class ErrorCaptureTest {
     }
 
     @Test
-    void testUnnestNestedExceptions() {
-        final ErrorCapture errorCapture = new ErrorCapture(tracer);
-        final NestedException nestedException = new NestedException(new Exception());
-        errorCapture.setException(nestedException);
+    void testUnnestNestedException() {
+        final NestedException nestedException = new NestedException(new CustomException());
+        ErrorCapture errorCapture = tracer.captureException(nestedException, null, null);
+        assertThat(errorCapture).isNotNull();
         assertThat(errorCapture.getException()).isNotInstanceOf(NestedException.class);
+        assertThat(errorCapture.getException()).isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void testUnnestDoublyNestedException() {
+        final NestedException nestedException = new NestedException(new NestedException(new CustomException()));
+        ErrorCapture errorCapture = tracer.captureException(nestedException, null, null);
+        assertThat(errorCapture).isNotNull();
+        assertThat(errorCapture.getException()).isNotInstanceOf(NestedException.class);
+        assertThat(errorCapture.getException()).isInstanceOf(CustomException.class);
+    }
+
+    @Test
+    void testIgnoredNestedException() {
+        doReturn(List.of(WildcardMatcher.valueOf("*CustomException"))).when(coreConfiguration).getIgnoreExceptions();
+        final NestedException nestedException = new NestedException(new CustomException());
+        ErrorCapture errorCapture = tracer.captureException(nestedException, null, null);
+        assertThat(errorCapture).isNull();
+    }
+
+    @Test
+    void testNonConfiguredNestedException() {
+        final WrapperException wrapperException = new WrapperException(new CustomException());
+        ErrorCapture errorCapture = tracer.captureException(wrapperException, null, null);
+        assertThat(errorCapture).isNotNull();
+        assertThat(errorCapture.getException()).isInstanceOf(WrapperException.class);
     }
 
     private static class NestedException extends Exception {
@@ -77,6 +104,14 @@ class ErrorCaptureTest {
             super(cause);
         }
     }
+
+    private static class WrapperException extends Exception {
+        public WrapperException(Throwable cause) {
+            super(cause);
+        }
+    }
+
+    private static class CustomException extends Exception {}
 
     @Test
     void testTransactionContextTransfer() {

--- a/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
+++ b/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
@@ -92,9 +92,17 @@ class ErrorCaptureTest {
     }
 
     @Test
-    void testNonConfiguredNestedException() {
+    void testNonConfiguredNestingException() {
         final WrapperException wrapperException = new WrapperException(new CustomException());
         ErrorCapture errorCapture = tracer.captureException(wrapperException, null, null);
+        assertThat(errorCapture).isNotNull();
+        assertThat(errorCapture.getException()).isInstanceOf(WrapperException.class);
+    }
+
+    @Test
+    void testNonConfiguredWrappingConfigured() {
+        final NestedException nestedException = new NestedException(new WrapperException(new NestedException(new Exception())));
+        ErrorCapture errorCapture = tracer.captureException(nestedException, null, null);
         assertThat(errorCapture).isNotNull();
         assertThat(errorCapture.getException()).isInstanceOf(WrapperException.class);
     }


### PR DESCRIPTION
## What does this PR do?
Fixes an issue reported in our [forum](https://discuss.elastic.co/t/apm-java-agent-ignore-error/325563)- when nested exceptions get [unnested](https://www.elastic.co/guide/en/apm/agent/java/current/config-core.html#config-unnest-exceptions), they will be reported even if they are of type that matches the configured [`ignore_exceptions`](https://www.elastic.co/guide/en/apm/agent/java/current/config-core.html#config-ignore-exceptions). 

## Checklist
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
