### PR TITLE
Update maven search links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://apm-ci.elastic.co/buildStatus/icon?job=apm-agent-java%2Fapm-agent-java-mbp%2Fmain)](https://apm-ci.elastic.co/job/apm-agent-java/job/apm-agent-java-mbp/job/main/)
 [![codecov](https://codecov.io/gh/elastic/apm-agent-java/branch/main/graph/badge.svg)](https://codecov.io/gh/elastic/apm-agent-java)
-[![Maven Central](https://img.shields.io/maven-central/v/co.elastic.apm/apm-agent-api.svg)](https://search.maven.org/search?q=g:co.elastic.apm%20AND%20a:elastic-apm-agent)
+[![Maven Central](https://img.shields.io/maven-central/v/co.elastic.apm/apm-agent-api.svg)](https://central.sonatype.com/search?q=g%253Aco.elastic.apm%2520a%253Aelastic-apm-agent&sort=published)
 
 # apm-agent-java
 

--- a/docs/api-elastic.asciidoc
+++ b/docs/api-elastic.asciidoc
@@ -29,7 +29,7 @@ compile "co.elastic.apm:apm-agent-api:$elasticApmVersion"
 ----
 
 Replace the version placeholders with the
-link:https://search.maven.org/search?q=g:co.elastic.apm%20AND%20a:apm-agent-api[
+link:https://central.sonatype.com/search?q=g%253Aco.elastic.apm%20a%253Aapm-agent-api&sort=published[
 latest version from maven central]:
 image:https://img.shields.io/maven-central/v/co.elastic.apm/apm-agent-api.svg[Maven Central]
 

--- a/docs/api-opentracing.asciidoc
+++ b/docs/api-opentracing.asciidoc
@@ -42,8 +42,7 @@ compile "co.elastic.apm:apm-opentracing:$elasticApmVersion"
 ----
 
 Replace the version placeholders with the
-link:https://search.maven.org/search?q=g:co.elastic.apm%20AND%20a:apm-opentracing[
-latest version from maven central]:
+link:https://central.sonatype.com/search?q=g%253Aco.elastic.apm%2520a%253Aapm-opentracing&sort=published[latest version from maven central]:
 image:https://img.shields.io/maven-central/v/co.elastic.apm/apm-opentracing.svg[Maven Central]
 
 

--- a/docs/plugin-api.asciidoc
+++ b/docs/plugin-api.asciidoc
@@ -29,8 +29,7 @@ compile "co.elastic.apm:apm-agent-plugin-sdk:$elasticApmVersion"
 ----
 
 Replace the version placeholders with the
-link:https://search.maven.org/search?q=g:co.elastic.apm%20AND%20a:apm-agent-api[
-latest version from maven central]:
+link:https://central.sonatype.com/search?q=g%253Aco.elastic.apm%2520a%253Aapm-agent-api&sort=published[latest version from maven central]:
 image:https://img.shields.io/maven-central/v/co.elastic.apm/apm-agent-api.svg[Maven Central]
 
 An https://github.com/elastic/apm-agent-java-plugin-example[example repo] and an

--- a/docs/setup-attach-api.asciidoc
+++ b/docs/setup-attach-api.asciidoc
@@ -36,7 +36,7 @@ the application with a JDK. However, it will be required in the following cases:
 [[setup-attach-api-usage]]
 ==== Usage
 
-Declare a dependency to the link:https://search.maven.org/search?q=g:co.elastic.apm%20AND%20a:apm-agent-attach[`apm-agent-attach`] artifact.
+Declare a dependency to the link:https://central.sonatype.com/search?q=g%253Aco.elastic.apm%2520a%253Aapm-agent-attach&sort=published[`apm-agent-attach`] artifact.
 
 [source,xml]
 .pom.xml

--- a/docs/setup-attach-cli.asciidoc
+++ b/docs/setup-attach-cli.asciidoc
@@ -31,7 +31,7 @@ It's not possible to attach to a J9 VM from a HotSpot-based VM and vice-versa.
 ==== Download
 
 You can download the attach program from maven central:
-link:https://search.maven.org/search?q=g:co.elastic.apm%20AND%20a:apm-agent-attach-cli[maven central]
+link:https://central.sonatype.com/search?q=g%253Aco.elastic.apm%2520a%253Aapm-agent-attach-cli&sort=published[maven central]
 
 NOTE: In versions prior to 1.22.0, you will have to download the `standalone` jar of the `apm-agent-attach` artifact.
 

--- a/docs/setup/get-agent.asciidoc
+++ b/docs/setup/get-agent.asciidoc
@@ -2,7 +2,7 @@
 
 Java agent releases are published to https://repo.maven.apache.org/maven2/[Maven central], in order to get a copy you can either:
 
-- download manually from https://search.maven.org/artifact/co.elastic.apm/elastic-apm-agent[Maven central].
+- download manually from link:https://central.sonatype.com/search?q=g%253Aco.elastic.apm%2520a%253Aelastic-apm-agent&sort=published[Maven central].
 - download with `curl`:
 +
 [source,bash]

--- a/docs/upgrading.asciidoc
+++ b/docs/upgrading.asciidoc
@@ -15,7 +15,7 @@ Before upgrading the agent, be sure to review the:
 
 . Shut down the application.
 . Download the latest release of the agent jar file from
-https://search.maven.org/search?q=g:co.elastic.apm%20AND%20a:elastic-apm-agent[maven central].
+link:https://central.sonatype.com/search?q=g%253Aco.elastic.apm%2520a%253Aelastic-apm-agent&sort=published[maven central].
 . Optionally change JVM settings, e.g., if the path to the agent jar has changed due to a different file name.
 . Restart the application.
 


### PR DESCRIPTION
## What does this PR do?

Opening links to search.maven.org with a browser will show the a popup with the following message:

> On February 23, 2023, we started redirecting users from search.maven.org to central.sonatype.com. Launched in September of 2022, central.sonatype.com provides the main functionality of search.maven.org with enhanced search results, including security vulnerability and software quality information.

This PR updates all the links we have to `search.maven.org` to use `central.sonatype.com`.

## Checklist

- [x] This is something else
  - [x] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~ N/A
  - [ ] update `1.x` branch with this change.
