### PR TITLE
Upload agent binaries as artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,11 @@ jobs:
         with:
           name: build
           path: ${{ github.workspace }}
+      - name: Upload agent binaries as artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: elastic-apm-agent
+          path: ./elastic-apm-agent/target/elastic-apm-agent-*.jar
 
   license:
     name: License


### PR DESCRIPTION
## What does this PR do?

With jenkins a common workflow regarding support cases was to create a draft PR and provide the link to the resulting agent snapshot build artifact from jenkins to users.

Our current GH actions workflow does not upload the agent binaries as separate artifacts, this is fixed by this PR.
Tested on my fork of this repo.

## Checklist
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
