### PR TITLE
updatecli: fix title since it caused errors

### DIFF
--- a/.ci/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli.d/update-gherkin-specs.yml
@@ -1,5 +1,6 @@
 name: update-gherkin-specs
 pipelineid: update-gherkin-specs
+title: synchronize gherkin specs
 
 scms:
   default:
@@ -52,15 +53,15 @@ actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
+    title: '[Automation] Update Gherkin specs'
     spec:
-      title: Update Gherkin specs
       automerge: false
       draft: false
       labels:
         - "automation"
       description: |-
         ### What
-        APM agent specs automatic sync
+        APM agent Gherkin specs automatic sync
         ### Why
         *Changeset*
         * https://github.com/elastic/apm/commit/{{ source "sha" }}

--- a/.ci/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli.d/update-json-specs.yml
@@ -1,5 +1,6 @@
-name: update-jsons-specs
-pipelineid: update-jsons-specs
+name: update-json-specs
+pipelineid: update-json-specs
+title: synchronize json specs
 
 scms:
   default:
@@ -55,8 +56,8 @@ actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
+    title: '[Automation] Update JSON specs'
     spec:
-      title: Update JSON specs
       automerge: false
       draft: false
       labels:

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -1,5 +1,5 @@
 name: update-specs
-
+pipelineid: update-schema-specs
 title: synchronize schema specs
 
 scms:
@@ -49,6 +49,7 @@ actions:
     kind: "github/pullrequest"
     scmid: default
     sourceid: sha
+    title: '[Automation] Update JSON schema specs'
     spec:
       automerge: false
       draft: false


### PR DESCRIPTION
### What

Updatecli pipelines were misconfigured hence the automation failed with

```

ACTIONS
========

WARNING: **Fallback** Please add a title to you configuration using the field 'title: <your pipeline>'
Pipeline "update-jsons-specs" failed
Skipping due to:
	action stage:	"Title is too long (maximum is 256 characters)"

```

I also changed the PR title to be within the kind definition rather than within the specs.
