### PR TITLE
ci: migrate release to stable branch

### DIFF
--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -1,0 +1,26 @@
+name: Sync branches
+
+on:
+  push:
+    branches:
+      - feature/sync-branches
+
+jobs:
+  sync:
+    name: Sync branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Synchronize source to target branch
+        run: |
+          git checkout -f "${SOURCE_BRANCH}"
+          git checkout -f -b "${TARGET_BRANCH}"
+          git rebase "${SOURCE_BRANCH}"
+          git --no-pager log -n1 --pretty=oneline
+          git rev-parse --abbrev-ref HEAD
+          git push origin "${TARGET_BRANCH}"
+        env:
+          SOURCE_BRANCH: feature/sync-branches
+          TARGET_BRANCH: feature/sync-branches-test

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -3,7 +3,7 @@ name: Sync branches
 on:
   push:
     branches:
-      - feature/sync-branches
+      - main
 
 jobs:
   sync:
@@ -22,5 +22,5 @@ jobs:
           git rev-parse --abbrev-ref HEAD
           git push origin "${TARGET_BRANCH}"
         env:
-          SOURCE_BRANCH: feature/sync-branches
-          TARGET_BRANCH: feature/sync-branches-test
+          SOURCE_BRANCH: main
+          TARGET_BRANCH: stable

--- a/.github/workflows/sync-branches.yml
+++ b/.github/workflows/sync-branches.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+# Limit permissions
+permissions:
+  contents: write
+
 jobs:
   sync:
     name: Sync branches

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -150,34 +150,6 @@ pipeline {
         }
       }
     }
-    stage('Releases') {
-      when {
-        branch 'main'
-      }
-      stages {
-        stage('Stable') {
-          options { skipDefaultCheckout() }
-          when {
-            branch 'main'
-          }
-          steps {
-            deleteDir()
-            unstash 'source'
-            dir("${BASE_DIR}"){
-              setupAPMGitEmail(global: false)
-              sh(label: "checkout ${BRANCH_NAME} branch", script: "git checkout -f '${BRANCH_NAME}'")
-              sh(label: 'rebase stable', script: """
-                git checkout -f -b stable
-                git rebase '${BRANCH_NAME}'
-                git --no-pager log -n1 --pretty=oneline
-                git rev-parse --abbrev-ref HEAD
-              """)
-              gitPush()
-            }
-          }
-        }
-      }
-    }
   }
   post {
     cleanup {


### PR DESCRIPTION
## What does this PR do?

* Migration of the release stable branch to GitHub Actions.
* The sync between main and stable branch will be handled by the GitHub Actions.

## Validation

Ref: https://github.com/elastic/apm-agent-java/actions/runs/4502205643/jobs/7923696347