### PR TITLE
ci: correct UI trigger and remove useless workflow_call trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: main
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       # enabled by default, required for merge through default GH check
       test_ci:
@@ -32,7 +32,6 @@ on:
         default: false
         required: false
         type: boolean
-  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
## What does this PR do?

* Remove useless [workflow_call](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_call) trigger.
* Use [workflow_dispatch](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch) instead of `workflow_call`.
* It allows triggering a workflow from the GitHub Actions UI.

## Screenshoot

<img width="356" alt="Screenshot 2023-03-24 at 12 21 44" src="https://user-images.githubusercontent.com/10237040/227508401-422ca5e2-0540-460c-9b94-e776aca15156.png">

