### PR TITLE
Add option elasticsearch capture body urls

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ communication - {pull}2996[#2996]
 * Add the <<config-long-field-max-length>> config to enable capturing larger values for specific fields - {pull}3027[#3027]
 * Provide fallback correlation when `ecs-logging-java` is used - {pull}3064[#3064]
 * Added separate Java 8 build with updated log4j2 - {pull}3076[#3076]
+* Add elasticsearch_capture_body_urls option to customize which Elasticsearch request bodies are captured - {pull}3091[#3091]
 
 [float]
 ===== Bug fixes

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,7 +41,7 @@ communication - {pull}2996[#2996]
 * Add the <<config-long-field-max-length>> config to enable capturing larger values for specific fields - {pull}3027[#3027]
 * Provide fallback correlation when `ecs-logging-java` is used - {pull}3064[#3064]
 * Added separate Java 8 build with updated log4j2 - {pull}3076[#3076]
-* Add elasticsearch_capture_body_urls option to customize which Elasticsearch request bodies are captured - {pull}3091[#3091]
+* Add <<config-elasticsearch-capture-body-urls, elasticsearch_capture_body_urls>> option to customize which Elasticsearch request bodies are captured - {pull}3091[#3091]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-builds/pom.xml
+++ b/apm-agent-builds/pom.xml
@@ -81,6 +81,11 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>apm-es-restclient-plugin-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>apm-es-restclient-plugin-5_6</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchConfiguration.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchConfiguration.java
@@ -32,7 +32,7 @@ public class ElasticsearchConfiguration extends ConfigurationOptionProvider {
         .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)
         .key("elasticsearch_capture_body_urls")
         .configurationCategory("Datastore")
-        .description("The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html[Elasticsearch REST APIs] making a search.\n" +
+        .description("The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for Elasticsearch REST APIs searches and counts.\n" +
             "\n" +
             "The captured request body (if any) is stored on the `span.db.statement` field. Captured request bodies are truncated to a maximum length defined by <<config-long-field-max-length>>." +
             "\n" +

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchConfiguration.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchConfiguration.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.mongodb;
+package co.elastic.apm.agent.esrestclient;
 
 import co.elastic.apm.agent.common.util.WildcardMatcher;
 import co.elastic.apm.agent.matcher.WildcardMatcherValueConverter;
@@ -27,28 +27,30 @@ import org.stagemonitor.configuration.converter.ListValueConverter;
 import java.util.Arrays;
 import java.util.List;
 
-public class MongoConfiguration extends ConfigurationOptionProvider {
-
-    private final ConfigurationOption<List<WildcardMatcher>> captureStatementCommands = ConfigurationOption
+public class ElasticsearchConfiguration extends ConfigurationOptionProvider {
+    private final ConfigurationOption<List<WildcardMatcher>> captureBodyUrls = ConfigurationOption
         .builder(new ListValueConverter<>(new WildcardMatcherValueConverter()), List.class)
-        .key("mongodb_capture_statement_commands")
+        .key("elasticsearch_capture_body_urls")
         .configurationCategory("Datastore")
-        .description("MongoDB command names for which the command document will be captured, limited to common read-only operations by default.\n" +
-            "Set to ` \"\"` (empty) to disable capture, and `\"*\"` to capture all (which is discouraged as it may lead to sensitive information capture).\n" +
+        .description("The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html[Elasticsearch REST APIs] making a search.\n" +
+            "\n" +
+            "The captured request body (if any) is stored on the `span.db.statement` field. Captured request bodies are truncated to a maximum length defined by <<config-long-field-max-length>>." +
             "\n" +
             WildcardMatcher.DOCUMENTATION
         )
         .dynamic(true)
         .buildWithDefault(Arrays.asList(
-            WildcardMatcher.valueOf("find"),
-            WildcardMatcher.valueOf("aggregate"),
-            WildcardMatcher.valueOf("count"),
-            WildcardMatcher.valueOf("distinct"),
-            WildcardMatcher.valueOf("mapReduce")
+            WildcardMatcher.valueOf("*_search"),
+            WildcardMatcher.valueOf("*_msearch"),
+            WildcardMatcher.valueOf("*_msearch/template"),
+            WildcardMatcher.valueOf("*_search/template"),
+            WildcardMatcher.valueOf("*_count"),
+            WildcardMatcher.valueOf("*_sql"),
+            WildcardMatcher.valueOf("*_eql/search"),
+            WildcardMatcher.valueOf("*_async_search")
         ));
 
-    public List<WildcardMatcher> getCaptureStatementCommands() {
-        return captureStatementCommands.get();
+    public List<WildcardMatcher> getCaptureBodyUrls() {
+        return captureBodyUrls.get();
     }
-
 }

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchConfiguration.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchConfiguration.java
@@ -38,6 +38,7 @@ public class ElasticsearchConfiguration extends ConfigurationOptionProvider {
             "\n" +
             WildcardMatcher.DOCUMENTATION
         )
+        .tags("added[1.37.0]")
         .dynamic(true)
         .buildWithDefault(Arrays.asList(
             WildcardMatcher.valueOf("*_search"),

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/resources/META-INF/services/org.stagemonitor.configuration.ConfigurationOptionProvider
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/resources/META-INF/services/org.stagemonitor.configuration.ConfigurationOptionProvider
@@ -1,0 +1,1 @@
+co.elastic.apm.agent.esrestclient.ElasticsearchConfiguration

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/esrestclient/ElasticsearchRestClientInstrumentationHelperTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/esrestclient/ElasticsearchRestClientInstrumentationHelperTest.java
@@ -19,19 +19,25 @@
 package co.elastic.apm.agent.esrestclient;
 
 import co.elastic.apm.agent.AbstractInstrumentationTest;
+import co.elastic.apm.agent.common.util.WildcardMatcher;
+import co.elastic.apm.agent.impl.context.Db;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.impl.transaction.TransactionTest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpVersion;
+import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.message.BasicStatusLine;
+import org.assertj.core.api.Assertions;
 import org.elasticsearch.client.Response;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Map;
 
+import static co.elastic.apm.agent.esrestclient.ElasticsearchRestClientInstrumentationHelper.ELASTICSEARCH;
 import static co.elastic.apm.agent.testutils.assertions.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -130,6 +136,47 @@ class ElasticsearchRestClientInstrumentationHelperTest extends AbstractInstrumen
                 .isNotNull();
         } finally {
             esSpan.deactivate().end();
+        }
+    }
+
+
+    @Test
+    public void testCaptureBodyUrls() throws Exception {
+        testCaptureBodyUrls(false);
+        testCaptureBodyUrls(true);
+    }
+
+    public void testCaptureBodyUrls(boolean captureEverything) throws Exception {
+        if (captureEverything) {
+            doReturn(List.of(WildcardMatcher.valueOf("*")))
+                .when(config.getConfig(ElasticsearchConfiguration.class))
+                .getCaptureBodyUrls();
+            assertThat(config.getConfig(ElasticsearchConfiguration.class).getCaptureBodyUrls()).hasSize(1);
+        } else {
+            assertThat(config.getConfig(ElasticsearchConfiguration.class).getCaptureBodyUrls()).hasSizeGreaterThan(5);
+        }
+
+        Span span = (Span) helper.createClientSpan("GET", "/_test",
+            new ByteArrayEntity(new byte[0]));
+        assertThat(span).isNotNull();
+        assertThat(tracer.getActive()).isEqualTo(span);
+
+        Response response = mockResponse(Map.of());
+        helper.finishClientSpan(response, span, null);
+        span.deactivate();
+
+        assertThat(tracer.getActive()).isEqualTo(transaction);
+        assertThat(span).hasType("db").hasSubType("elasticsearch");
+        assertThat(span.getContext().getServiceTarget())
+            .hasType("elasticsearch")
+            .hasNoName();
+
+        Db db = span.getContext().getDb();
+        Assertions.assertThat(db.getType()).isEqualTo(ELASTICSEARCH);
+        if (captureEverything) {
+            assertThat((CharSequence) db.getStatementBuffer()).isNotNull();
+        } else {
+            assertThat((CharSequence) db.getStatementBuffer()).isNull();
         }
     }
 }

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -136,6 +136,9 @@ Click on a key to get more information.
 ** <<config-enable-public-api-annotation-inheritance>>
 ** <<config-transaction-name-groups>>
 ** <<config-trace-continuation-strategy>>
+* <<config-datastore>>
+** <<config-elasticsearch-capture-body-urls>>
+** <<config-mongodb-capture-statement-commands>>
 * <<config-http>>
 ** <<config-capture-body-content-types>>
 ** <<config-transaction-ignore-urls>>
@@ -172,8 +175,6 @@ Click on a key to get more information.
 ** <<config-metric-set-limit>>
 ** <<config-agent-reporter-health-metrics>>
 ** <<config-agent-background-overhead-metrics>>
-* <<config-mongodb>>
-** <<config-mongodb-capture-statement-commands>>
 * <<config-profiling>>
 ** <<config-profiling-inferred-spans-enabled>>
 ** <<config-profiling-inferred-spans-logging-enabled>>
@@ -1547,6 +1548,71 @@ Valid options: `continue`, `restart`, `restart_external`
 | `elastic.apm.trace_continuation_strategy` | `trace_continuation_strategy` | `ELASTIC_APM_TRACE_CONTINUATION_STRATEGY`
 |============
 
+[[config-datastore]]
+=== Datastore configuration options
+
+++++
+<titleabbrev>Datastore</titleabbrev>
+++++
+
+// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
+[float]
+[[config-elasticsearch-capture-body-urls]]
+==== `elasticsearch_capture_body_urls`
+
+The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html[Elasticsearch REST APIs] making a search.
+
+The captured request body (if any) is stored on the `span.db.statement` field. Captured request bodies are truncated to a maximum length defined by <<config-long-field-max-length>>.
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive by default.
+Prepending an element with `(?-i)` makes the matching case sensitive.
+
+<<configuration-dynamic, image:./images/dynamic-config.svg[] >>
+
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `*_search, *_msearch, *_msearch/template, *_search/template, *_count, *_sql, *_eql/search, *_async_search` | List | true
+|============
+
+
+[options="header"]
+|============
+| Java System Properties      | Property file   | Environment
+| `elastic.apm.elasticsearch_capture_body_urls` | `elasticsearch_capture_body_urls` | `ELASTIC_APM_ELASTICSEARCH_CAPTURE_BODY_URLS`
+|============
+
+// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
+[float]
+[[config-mongodb-capture-statement-commands]]
+==== `mongodb_capture_statement_commands`
+
+MongoDB command names for which the command document will be captured, limited to common read-only operations by default.
+Set to ` ""` (empty) to disable capture, and `"*"` to capture all (which is discouraged as it may lead to sensitive information capture).
+
+This option supports the wildcard `*`, which matches zero or more characters.
+Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+Matching is case insensitive by default.
+Prepending an element with `(?-i)` makes the matching case sensitive.
+
+<<configuration-dynamic, image:./images/dynamic-config.svg[] >>
+
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `find, aggregate, count, distinct, mapReduce` | List | true
+|============
+
+
+[options="header"]
+|============
+| Java System Properties      | Property file   | Environment
+| `elastic.apm.mongodb_capture_statement_commands` | `mongodb_capture_statement_commands` | `ELASTIC_APM_MONGODB_CAPTURE_STATEMENT_COMMANDS`
+|============
+
 [[config-http]]
 === HTTP configuration options
 
@@ -2514,42 +2580,6 @@ Enables metrics which capture the resource consumption of agent background tasks
 |============
 | Java System Properties      | Property file   | Environment
 | `elastic.apm.agent_background_overhead_metrics` | `agent_background_overhead_metrics` | `ELASTIC_APM_AGENT_BACKGROUND_OVERHEAD_METRICS`
-|============
-
-[[config-mongodb]]
-=== MongoDB configuration options
-
-++++
-<titleabbrev>MongoDB</titleabbrev>
-++++
-
-// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
-[float]
-[[config-mongodb-capture-statement-commands]]
-==== `mongodb_capture_statement_commands`
-
-MongoDB command names for which the command document will be captured, limited to common read-only operations by default.
-Set to ` ""` (empty) to disable capture, and `"*"` to capture all (which is discouraged as it may lead to sensitive information capture).
-
-This option supports the wildcard `*`, which matches zero or more characters.
-Examples: `/foo/*/bar/*/baz*`, `*foo*`.
-Matching is case insensitive by default.
-Prepending an element with `(?-i)` makes the matching case sensitive.
-
-<<configuration-dynamic, image:./images/dynamic-config.svg[] >>
-
-
-[options="header"]
-|============
-| Default                          | Type                | Dynamic
-| `find, aggregate, count, distinct, mapReduce` | List | true
-|============
-
-
-[options="header"]
-|============
-| Java System Properties      | Property file   | Environment
-| `elastic.apm.mongodb_capture_statement_commands` | `mongodb_capture_statement_commands` | `ELASTIC_APM_MONGODB_CAPTURE_STATEMENT_COMMANDS`
 |============
 
 [[config-profiling]]
@@ -4005,6 +4035,38 @@ Example: `5ms`.
 # trace_continuation_strategy=CONTINUE
 
 ############################################
+# Datastore                                #
+############################################
+
+# The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html[Elasticsearch REST APIs] making a search.
+# 
+# The captured request body (if any) is stored on the `span.db.statement` field. Captured request bodies are truncated to a maximum length defined by <<config-long-field-max-length>>.
+# This option supports the wildcard `*`, which matches zero or more characters.
+# Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+# Matching is case insensitive by default.
+# Prepending an element with `(?-i)` makes the matching case sensitive.
+#
+# This setting can be changed at runtime
+# Type: comma separated list
+# Default value: *_search,*_msearch,*_msearch/template,*_search/template,*_count,*_sql,*_eql/search,*_async_search
+#
+# elasticsearch_capture_body_urls=*_search,*_msearch,*_msearch/template,*_search/template,*_count,*_sql,*_eql/search,*_async_search
+
+# MongoDB command names for which the command document will be captured, limited to common read-only operations by default.
+# Set to ` ""` (empty) to disable capture, and `"*"` to capture all (which is discouraged as it may lead to sensitive information capture).
+# 
+# This option supports the wildcard `*`, which matches zero or more characters.
+# Examples: `/foo/*/bar/*/baz*`, `*foo*`.
+# Matching is case insensitive by default.
+# Prepending an element with `(?-i)` makes the matching case sensitive.
+#
+# This setting can be changed at runtime
+# Type: comma separated list
+# Default value: find,aggregate,count,distinct,mapReduce
+#
+# mongodb_capture_statement_commands=find,aggregate,count,distinct,mapReduce
+
+############################################
 # HTTP                                     #
 ############################################
 
@@ -4503,24 +4565,6 @@ Example: `5ms`.
 # Default value: false
 #
 # agent_background_overhead_metrics=false
-
-############################################
-# MongoDB                                  #
-############################################
-
-# MongoDB command names for which the command document will be captured, limited to common read-only operations by default.
-# Set to ` ""` (empty) to disable capture, and `"*"` to capture all (which is discouraged as it may lead to sensitive information capture).
-# 
-# This option supports the wildcard `*`, which matches zero or more characters.
-# Examples: `/foo/*/bar/*/baz*`, `*foo*`.
-# Matching is case insensitive by default.
-# Prepending an element with `(?-i)` makes the matching case sensitive.
-#
-# This setting can be changed at runtime
-# Type: comma separated list
-# Default value: find,aggregate,count,distinct,mapReduce
-#
-# mongodb_capture_statement_commands=find,aggregate,count,distinct,mapReduce
 
 ############################################
 # Profiling                                #

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1560,7 +1560,7 @@ Valid options: `continue`, `restart`, `restart_external`
 [[config-elasticsearch-capture-body-urls]]
 ==== `elasticsearch_capture_body_urls` (added[1.37.0])
 
-The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html[Elasticsearch REST APIs] making a search.
+The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for Elasticsearch REST APIs searches and counts.
 
 The captured request body (if any) is stored on the `span.db.statement` field. Captured request bodies are truncated to a maximum length defined by <<config-long-field-max-length>>.
 This option supports the wildcard `*`, which matches zero or more characters.
@@ -4038,7 +4038,7 @@ Example: `5ms`.
 # Datastore                                #
 ############################################
 
-# The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html[Elasticsearch REST APIs] making a search.
+# The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for Elasticsearch REST APIs searches and counts.
 # 
 # The captured request body (if any) is stored on the `span.db.statement` field. Captured request bodies are truncated to a maximum length defined by <<config-long-field-max-length>>.
 # This option supports the wildcard `*`, which matches zero or more characters.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1558,7 +1558,7 @@ Valid options: `continue`, `restart`, `restart_external`
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-elasticsearch-capture-body-urls]]
-==== `elasticsearch_capture_body_urls`
+==== `elasticsearch_capture_body_urls` (added[1.37.0])
 
 The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for https://www.elastic.co/guide/en/elasticsearch/reference/current/rest-apis.html[Elasticsearch REST APIs] making a search.
 


### PR DESCRIPTION
## What does this PR do?
Per the spec this adds the elasticsearch_capture_body_urls option

Note that I've changed the category of the Mongo documentation from `MongoDB` to `Datastore` (which is also used for this ES option) following a team discussion that decided this was a better category. That means the existing MongoDB URL will no longer work and anything linking to it will get a 404. I decided this is better rather than making the MongoDB category a redirect page as it was a very niche option and we don't need the extra clutter for such a niche option


## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [x] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
