### PR TITLE
ci: remove notification and leftovers Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,6 +46,15 @@ pipeline {
   }
   stages {
     stage('Checkout') {
+      when {
+        beforeAgent true
+        anyOf {
+          branch 'main'
+          expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
+          expression { matchesPrLabel(label: 'ci:benchmarks') }
+          expression { return params.bench_ci }
+        }
+      }
       options { skipDefaultCheckout() }
       steps {
         pipelineManager([ cancelPreviousRunningBuilds: [ when: 'PR' ] ])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,18 +119,6 @@ pipeline {
             NO_BUILD = "true"
             PATH = "${env.JAVA_HOME}/bin:${env.PATH}"
           }
-          when {
-            beforeAgent true
-            allOf {
-              expression { return env.ONLY_DOCS == "false" }
-              anyOf {
-                branch 'main'
-                expression { return env.GITHUB_COMMENT?.contains('benchmark tests') }
-                expression { matchesPrLabel(label: 'ci:benchmarks') }
-                expression { return params.bench_ci }
-              }
-            }
-          }
           steps {
             withGithubNotify(context: "${STAGE_NAME}", tab: 'artifacts') {
               deleteDir()


### PR DESCRIPTION
## What does this PR do?

Remove GitHub build message in Jenkins. CI has been migrated to GH actions, but the micro-benchmarking and release, that will happen eventually.

GH build message might be re-done to support GitHub actions, but for now the GH command is not accurate. Hence it's removed.