### PR TITLE
Fixing slim attacher CLI with requested agent version for download

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -53,6 +53,7 @@ communication - {pull}2996[#2996]
 * Fix usage of `HttpUrlConnection.getResponseCode()` causing an error event due to exception capturing, even when it is internally handled - {pull}3024[#3024]
 * Fix source code jar to contain apm-agent sources - {pull}3063[#3063]
 * Fix security exception when security manager is used with `log_level=debug` - {pull}3077[#3077]
+* Fix slim attacher when downloading agent version - {pull}3096[#3096]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/AgentAttacher.java
+++ b/apm-agent-attach-cli/src/main/java/co/elastic/apm/attach/AgentAttacher.java
@@ -380,7 +380,8 @@ public class AgentAttacher {
                 if (!agentJar.canRead()) {
                     throw new IllegalArgumentException(String.format("Agent jar %s is not readable", agentJarString));
                 }
-            } else {
+            } else if (downloadAgentVersion == null) {
+                // this would fail if using the slim attacher CLI jar without providing either --agent-jar or --download-agent-version
                 this.agentJar = ElasticApmAttacher.getBundledAgentJarFile();
             }
             if (!config.isEmpty() && argsProvider != null) {

--- a/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
+++ b/apm-agent-attach/src/main/java/co/elastic/apm/attach/ElasticApmAttacher.java
@@ -213,7 +213,7 @@ public class ElasticApmAttacher {
 
             // Running attacher without proper packaging is quite common when running it from the IDE without having
             // it packaged from CLI beforehand
-            throw new IllegalStateException("unable to get packaged agent within attacher jar, make sure to execute 'mvn clean package' first.");
+            throw new IllegalStateException("unable to get packaged agent within attacher jar.");
         }
     }
 


### PR DESCRIPTION
There seems to be a regression that is specifically related to running the slim attacher CLI jar with a requested `--download-agent-version` and without `--agent-jar`. 
In order to reproduce, change manually the [statically specified download version](https://github.com/elastic/apm-agent-java/blob/be3870b03e33e670edaaae35ba0f3584ff3984f2/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java#L106) to anything other than `null` (e.g. `latest`) and run one of the cli-supporting integration tests, like Tomcat. As long as this field is set to `null`, these integration tests run with a [specified `--agent-jar`](https://github.com/elastic/apm-agent-java/blob/be3870b03e33e670edaaae35ba0f3584ff3984f2/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java#L222-L226), which works around the issue.

The error is:
```
Exception in thread "main" java.lang.ExceptionInInitializerError
	at co.elastic.apm.attach.ElasticApmAttacher.getBundledAgentJarFile(ElasticApmAttacher.java:199)
	at co.elastic.apm.attach.AgentAttacher$Arguments.<init>(AgentAttacher.java:384)
	at co.elastic.apm.attach.AgentAttacher$Arguments.parse(AgentAttacher.java:510)
	at co.elastic.apm.attach.AgentAttacher.main(AgentAttacher.java:108)
Caused by: java.lang.IllegalStateException: unable to get packaged agent within attacher jar, make sure to execute 'mvn clean package' first.
	at co.elastic.apm.attach.ElasticApmAttacher$AgentJarFileHolder.getAgentJarFile(ElasticApmAttacher.java:216)
	at co.elastic.apm.attach.ElasticApmAttacher$AgentJarFileHolder.<init>(ElasticApmAttacher.java:206)
	at co.elastic.apm.attach.ElasticApmAttacher$AgentJarFileHolder.<clinit>(ElasticApmAttacher.java:203)
	... 4 more
```

Consider changing the error message - `make sure to execute 'mvn clean package' first`, which is irrelevant to attacher users.