### PR TITLE
Fixed ActivationTypeIT flakyness

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -87,7 +87,6 @@ import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
 
 import static com.dslplatform.json.JsonWriter.ARRAY_END;
 import static com.dslplatform.json.JsonWriter.ARRAY_START;

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/ActivationTypeIT.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/configuration/ActivationTypeIT.java
@@ -404,19 +404,24 @@ public class ActivationTypeIT {
         private HttpHandler httpHandler() {
             return exchange -> {
 
-                InputStream requestBody = exchange.getRequestBody();
-                if (requestBody != null) {
-                    try (BufferedReader reader = new BufferedReader(new InputStreamReader(requestBody))) {
-                        String line = reader.readLine();
-                        if (!line.isEmpty()) {
-                            requestBodyLines.add(line);
+                String response;
+                if (exchange.getRequestURI().getPath().equals("/")) { // health check
+                    response = "{\"version\" : \"8.7.1\"}";
+                } else {
+                    InputStream requestBody = exchange.getRequestBody();
+                    if (requestBody != null) {
+                        try (BufferedReader reader = new BufferedReader(new InputStreamReader(requestBody))) {
+                            String line = reader.readLine();
+                            if (!line.isEmpty()) {
+                                requestBodyLines.add(line);
+                            }
                         }
                     }
+                    response = "{}";
                 }
-
-                String response = "{}";
                 exchange.sendResponseHeaders(200, response.getBytes().length);
                 exchange.getResponseBody().write(response.getBytes());
+                exchange.close();
             };
         }
 


### PR DESCRIPTION
## What does this PR do?

The agent does not sent the activation method when a APM server older than 8.7.1 is detected.
This caused some flakyness in the `AgentActivationIT`: If the health-check request finished before the metadata is generated, the agent assumed a pre-6.0 apm server and therefore did not send the activation method.
If the apm-server version is not known (the health-check request did not finish yet), the activation method is sent.