### PR TITLE
Bypass proxy for cloud metadata

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,10 @@ endif::[]
 ===== Features
 * Added tests for Quarkus / RestEasy, adjusted vert.x router transaction name priority - {pull}1765[#1765]
 
+[float]
+===== Bug fixes
+* Do not use proxy to retrieve cloud metadata - {pull}3108[#3108]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/CloudMetadataProvider.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/CloudMetadataProvider.java
@@ -416,7 +416,7 @@ public class CloudMetadataProvider {
     }
 
     private static String executeRequest(String url, String method, @Nullable Map<String, String> headers, int queryTimeoutMs) throws IOException {
-        HttpURLConnection urlConnection = (HttpURLConnection) UrlConnectionUtils.openUrlConnectionThreadSafely(new URL(url));
+        HttpURLConnection urlConnection = (HttpURLConnection) UrlConnectionUtils.openUrlConnectionThreadSafely(new URL(url), false);
         if (headers != null) {
             for (String header : headers.keySet()) {
                 urlConnection.setRequestProperty(header, headers.get(header));

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerClient.java
@@ -142,7 +142,7 @@ public class ApmServerClient {
 
     @Nonnull
     private HttpURLConnection startRequestToUrl(URL url) throws IOException {
-        final URLConnection connection = UrlConnectionUtils.openUrlConnectionThreadSafely(url);
+        final URLConnection connection = UrlConnectionUtils.openUrlConnectionThreadSafely(url, true);
 
         // change SSL socket factory to support both TLS fallback and disabling certificate validation
         if (connection instanceof HttpsURLConnection) {


### PR DESCRIPTION
## What does this PR do?

Do not use proxy when querying cloud metadata

Relates to https://github.com/elastic/apm/pull/785

## Checklist

- [x] manually testing with `-Dhttp.proxyHost=` and `-Dhttp.proxyPort`
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix