### PR TITLE
Add warning for snapshot version

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/StartupInfo.java
@@ -70,6 +70,10 @@ public class StartupInfo extends AbstractLifecycleListener {
             serviceNameAndVersion.append(" (").append(serviceVersion).append(")");
         }
 
+        if (elasticApmVersion.contains("-SNAPSHOT")) {
+            logger.warn("This is a pre-release snapshot version, usage in production is not recommended unless instructed otherwise.");
+        }
+
         logger.info("Starting Elastic APM {} as {} on {}",
             elasticApmVersion,
             serviceNameAndVersion,


### PR DESCRIPTION
## What does this PR do?

Fixes #2905 by adding a warning when agent version is not a release.

This simple change allows to make the agent provide the right "logging preamble" as [specified here](https://github.com/elastic/apm/blob/edc5e1b4352da026004f55735a18f868723c33c2/specs/agents/logging.md#logging-preamble).

The low-level architecture and/or OS parts are less relevant in Java as they are indirectly provided (and also abstracted) by the JVM.

## Checklist

- [x] tested manually
