### PR TITLE
Pin jackson version to prevent accidental usage of release candidates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <!-- -dependencies versions -->
         <version.error_prone>2.2.0</version.error_prone>
         <version.h2>1.4.196</version.h2>
-        <version.jackson>[2.10.0,)</version.jackson>
+        <version.jackson>2.14.2</version.jackson>
         <version.junit>5.9.1</version.junit>
         <version.junit.vintage>4.13.2</version.junit.vintage>
         <version.logback>1.2.3</version.logback>


### PR DESCRIPTION
## What does this PR do?

Our tests are currently failing due to a problem with the jackson dependency.
We currently always use the latest jackson version based on a maven version range, which however includes jackson release candidates.

This PR pins the jackson version, we should rely on dependabot for upgrades instead.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
