### PR TITLE
Spring6 webflux tests

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/Java17OnlyTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/Java17OnlyTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.springwebmvc;
+package co.elastic.apm.agent.testutils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledForJreRange;

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/pom.xml
@@ -20,6 +20,18 @@
         <animal.sniffer.skip>true</animal.sniffer.skip>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>2.7.10</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>co.elastic.apm</groupId>
@@ -29,13 +41,11 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
-            <version>${version.spring}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-webflux</artifactId>
-            <version>${version.spring}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -51,27 +61,29 @@
         <dependency>
             <groupId>io.projectreactor.netty</groupId>
             <artifactId>reactor-netty-http</artifactId>
-            <version>1.0.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver-dns-native-macos</artifactId>
+            <classifier>osx-aarch_64</classifier>
             <scope>test</scope>
         </dependency>
         <!-- alternative client implementation: jetty -->
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-reactive-httpclient</artifactId>
-            <version>1.1.11</version>
             <scope>test</scope>
         </dependency>
         <!-- alternative client implementation: apache async client -->
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5-reactive</artifactId>
-            <version>5.1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>2.7.10</version>
+                <version>${version.spring-boot-3}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -42,6 +42,18 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <!--
+                    jcl needs to be excluded because of the integration tests.
+                    jcl seems to provide apache commons logging classes, but compiled with java 17.
+                    Wiremock does some reflective lookup on these classes, which causes the tests to fail with Java 11.
+                    As a workaround, jcl has been excluded and commons-logging has been included as test dependency instead
+                    -->
+                    <groupId>org.springframework</groupId>
+                    <artifactId>spring-jcl</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -84,6 +96,17 @@
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5-reactive</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+            <version>1.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/test/java/co/elastic/apm/agent/springwebclient/WebClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/test/java/co/elastic/apm/agent/springwebclient/WebClientInstrumentationIT.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebclient;
+
+import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
+import co.elastic.apm.agent.testutils.JUnit4TestClassWithDependencyRunner;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class WebClientInstrumentationIT {
+
+
+    @ParameterizedTest
+    @ValueSource(strings = {"5.3.26"})
+    public void testNetty(String springVersion) throws Exception {
+        List<String> dependencies = Arrays.asList(
+            "org.springframework:spring-web:" + springVersion,
+            "org.springframework:spring-webflux:" + springVersion,
+            "org.springframework:spring-core:" + springVersion,
+            "org.springframework:spring-beans:" + springVersion
+        );
+        JUnit4TestClassWithDependencyRunner runner = new JUnit4TestClassWithDependencyRunner(dependencies, WebClientInstrumentationIT.class.getName() + "$TestImpl", WebClientInstrumentationIT.class.getName());
+        runner.run();
+    }
+
+    /**
+     * We don't test with all variations of {@link WebClientInstrumentationTest}
+     * but just with netty for integration test.
+     */
+    public static class TestImpl extends AbstractHttpClientInstrumentationTest {
+
+        private final WebClient webClient;
+
+
+        public TestImpl() {
+            HttpClient httpClient = HttpClient.create()
+                // followRedirect(boolean) only enables redirect for 30[1278], not 303
+                .followRedirect((req, res) -> res.status().code() == 303);
+
+            // crete netty reactor client
+            webClient = WebClient.builder()
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+        }
+
+        @Override
+        public boolean isRequireCheckErrorWhenCircularRedirect() {
+            // circular redirect does not trigger an error to capture with netty
+            return false;
+        }
+
+        @Override
+        public boolean isTestHttpCallWithUserInfoEnabled() {
+            // user info URI does not work with netty
+            return false;
+        }
+
+
+        @Override
+        protected void performGet(String path) throws Exception {
+            webClient.get().uri(path).exchangeToMono(response -> response.bodyToMono(String.class)).block();
+        }
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/pom.xml
@@ -21,9 +21,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-framework-bom</artifactId>
-                <version>6.0.1</version>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>3.0.5</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -36,6 +36,13 @@
             <artifactId>apm-spring-webflux-spring5</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-spring-webflux-testapp</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
@@ -44,7 +51,6 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>${version.reactor}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/pom.xml
@@ -23,7 +23,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.0.5</version>
+                <version>${version.spring-boot-3}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -38,6 +38,7 @@
         </dependency>
 
         <dependency>
+            <!-- through the spring-boot dependency management, the test app will be "updated" to spring boot 3 -->
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-spring-webflux-testapp</artifactId>
             <version>${project.version}</version>
@@ -56,6 +57,22 @@
         <dependency>
             <groupId>co.elastic.apm</groupId>
             <artifactId>apm-spring-webflux-spring5</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <!-- required for context-propagation during tests, but only at runtime -->
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-reactor-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-reactor-plugin</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
             <type>test-jar</type>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/pom.xml
@@ -47,6 +47,13 @@
             <version>${version.reactor}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-spring-webflux-spring5</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
     </dependencies>
 
 </project>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6HeaderGetterTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6HeaderGetterTest.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux;
+
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
+
+@EnabledForJreRange(min = JRE.JAVA_17)
+public class Spring6HeaderGetterTest extends HeaderGetterTest {
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6HeaderGetterTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6HeaderGetterTest.java
@@ -18,9 +18,18 @@
  */
 package co.elastic.apm.agent.springwebflux;
 
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 
 @EnabledForJreRange(min = JRE.JAVA_17)
-public class Spring6HeaderGetterTest extends HeaderGetterTest {
+public class Spring6HeaderGetterTest extends Java17OnlyTest {
+
+    public Spring6HeaderGetterTest() {
+        super(Impl.class);
+    }
+
+    public static class Impl extends HeaderGetterTest {
+
+    }
 }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6ServerAnnotatedInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6ServerAnnotatedInstrumentationTest.java
@@ -23,7 +23,7 @@ import co.elastic.apm.agent.testutils.Java17OnlyTest;
 public class Spring6ServerAnnotatedInstrumentationTest extends Java17OnlyTest {
 
     public Spring6ServerAnnotatedInstrumentationTest() {
-        super(Spring6ServerFunctionalInstrumentationTest.Impl.class);
+        super(Impl.class);
     }
 
     public static class Impl extends ServerAnnotatedInstrumentationTest {

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6ServerAnnotatedInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6ServerAnnotatedInstrumentationTest.java
@@ -16,16 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.springwebmvc.exception;
+package co.elastic.apm.agent.springwebflux;
 
 import co.elastic.apm.agent.testutils.Java17OnlyTest;
 
-public class Spring6ExceptionHandlerInstrumentationWithResponseStatusExceptionTest extends Java17OnlyTest {
+public class Spring6ServerAnnotatedInstrumentationTest extends Java17OnlyTest {
 
-    public Spring6ExceptionHandlerInstrumentationWithResponseStatusExceptionTest() {
-        super(Impl.class);
+    public Spring6ServerAnnotatedInstrumentationTest() {
+        super(Spring6ServerFunctionalInstrumentationTest.Impl.class);
     }
 
-    public static class Impl extends Spring5ExceptionHandlerInstrumentationWithResponseStatusExceptionTest {
+    public static class Impl extends ServerAnnotatedInstrumentationTest {
     }
 }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6ServerFunctionalInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6ServerFunctionalInstrumentationTest.java
@@ -16,16 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.springwebmvc.exception;
+package co.elastic.apm.agent.springwebflux;
 
 import co.elastic.apm.agent.testutils.Java17OnlyTest;
 
-public class Spring6ExceptionHandlerInstrumentationWithResponseStatusExceptionTest extends Java17OnlyTest {
+public class Spring6ServerFunctionalInstrumentationTest extends Java17OnlyTest {
 
-    public Spring6ExceptionHandlerInstrumentationWithResponseStatusExceptionTest() {
+    public Spring6ServerFunctionalInstrumentationTest() {
         super(Impl.class);
     }
 
-    public static class Impl extends Spring5ExceptionHandlerInstrumentationWithResponseStatusExceptionTest {
+    public static class Impl extends ServerFunctionalInstrumentationTest {
     }
 }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6ServletContainerTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6ServletContainerTest.java
@@ -16,16 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.springwebmvc.exception;
+package co.elastic.apm.agent.springwebflux;
 
-import co.elastic.apm.agent.testutils.Java17OnlyTest;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
-public class Spring6ExceptionHandlerInstrumentationWithResponseStatusExceptionTest extends Java17OnlyTest {
-
-    public Spring6ExceptionHandlerInstrumentationWithResponseStatusExceptionTest() {
-        super(Impl.class);
-    }
-
-    public static class Impl extends Spring5ExceptionHandlerInstrumentationWithResponseStatusExceptionTest {
-    }
+@EnabledForJreRange(min = JRE.JAVA_17)
+public class Spring6ServletContainerTest extends ServletContainerTest {
 }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6WebSocketServerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin/src/test/java/co/elastic/apm/agent/springwebflux/Spring6WebSocketServerInstrumentationTest.java
@@ -16,16 +16,11 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.springwebmvc.exception;
+package co.elastic.apm.agent.springwebflux;
 
-import co.elastic.apm.agent.testutils.Java17OnlyTest;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.JRE;
 
-public class Spring6ExceptionHandlerInstrumentationWithResponseStatusExceptionTest extends Java17OnlyTest {
-
-    public Spring6ExceptionHandlerInstrumentationWithResponseStatusExceptionTest() {
-        super(Impl.class);
-    }
-
-    public static class Impl extends Spring5ExceptionHandlerInstrumentationWithResponseStatusExceptionTest {
-    }
+@EnabledForJreRange(min = JRE.JAVA_17)
+public class Spring6WebSocketServerInstrumentationTest extends WebSocketServerInstrumentationTest {
 }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/pom.xml
@@ -94,5 +94,18 @@
         </dependency>
 
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/pom.xml
@@ -32,6 +32,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-httpserver-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-web</artifactId>
             <scope>provided</scope>
@@ -50,35 +56,6 @@
             <scope>test</scope>
         </dependency>
 
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apm-httpserver-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
-        <!-- required for context-propagation during tests, but only at runtime -->
-        <dependency>
-            <groupId>co.elastic.apm</groupId>
-            <artifactId>apm-reactor-plugin</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>co.elastic.apm</groupId>
-            <artifactId>apm-reactor-plugin</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-            <type>test-jar</type>
-        </dependency>
-
-        <!-- required to test integration with servlet instrumentation -->
-        <dependency>
-            <groupId>co.elastic.apm</groupId>
-            <artifactId>apm-servlet-plugin</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.springframework</groupId>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/pom.xml
@@ -21,9 +21,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.springframework</groupId>
-                <artifactId>spring-framework-bom</artifactId>
-                <version>5.3.25</version> <!-- NO MAJOR UPGRADE HERE -->
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${version.spring-boot-2}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -57,6 +57,22 @@
         </dependency>
 
 
+        <!-- required for context-propagation during tests, but only at runtime -->
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-reactor-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-reactor-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
@@ -66,7 +82,6 @@
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>${version.reactor}</version>
             <scope>test</scope>
         </dependency>
 

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/test/java/co/elastic/apm/agent/springwebflux/SpringWeb5UtilsTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/test/java/co/elastic/apm/agent/springwebflux/SpringWeb5UtilsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+class SpringWeb5UtilsTest {
+
+    @Test
+    void testGetStatusCode() throws Exception {
+        ServerHttpResponse mockResponse = mock(ServerHttpResponse.class);
+        doReturn(HttpStatus.IM_USED).when(mockResponse).getStatusCode();
+        assertThat(SpringWebVersionUtils.getStatusCode(mockResponse)).isEqualTo(226);
+    }
+
+    @Test
+    void testWrongResponseType() {
+        assertThatThrownBy(() -> SpringWebVersionUtils.getStatusCode(new Object())).isInstanceOf(ClassCastException.class);
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/pom.xml
@@ -29,14 +29,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>${version.spring-boot}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.fasterxml.jackson</groupId>
-                <artifactId>jackson-bom</artifactId>
-                <version>${version.jackson}</version>
+                <version>${version.spring-boot-2}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -76,46 +69,22 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <!-- we have to exclude junit from spring-boot to use the same as other agent modules
-                otherwise having multiple versions makes intellij issue a 'No test found' error -->
-                <exclusion>
-                    <groupId>org.junit.jupiter</groupId>
-                    <artifactId>junit-jupiter</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.junit.vintage</groupId>
-                    <artifactId>junit-vintage-engine</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <dependency>
             <groupId>io.projectreactor</groupId>
             <artifactId>reactor-test</artifactId>
-            <version>${version.reactor}</version>
             <scope>test</scope>
-        </dependency>
-
-        <!-- for an unknown reason, version 1.5.2 is resolved and breaks junit tests execution -->
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-commons</artifactId>
-            <version>1.7.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>${version.slf4j}</version>
         </dependency>
 
     </dependencies>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingHandler.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingHandler.java
@@ -37,7 +37,7 @@ import java.util.Optional;
 @Component
 public class GreetingHandler {
 
-    public static final Scheduler CHILDREN_SCHEDULER = Schedulers.newElastic("children");
+    public static final Scheduler CHILDREN_SCHEDULER = Schedulers.newBoundedElastic(16, 128, "children");
 
     public Mono<String> helloMessage(@Nullable String name) {
         return Mono.just(String.format("Hello, %s!", Optional.ofNullable(name).orElse("Spring")));

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingWebClient.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingWebClient.java
@@ -77,7 +77,7 @@ public class GreetingWebClient {
         this.useFunctionalEndpoint = useFunctionalEndpoint;
         this.headers = new HttpHeaders();
         this.cookies = new HttpHeaders();
-        this.clientScheduler = Schedulers.newElastic("webflux-client");
+        this.clientScheduler = Schedulers.newBoundedElastic(16, 128, "webflux-client");
         this.wsClient = new ReactorNettyWebSocketClient();
         this.logEnabled = logEnabled;
     }

--- a/apm-agent-plugins/apm-spring-webflux/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/pom.xml
@@ -33,4 +33,31 @@
         <module>apm-spring-webflux-testapp</module>
         <module>apm-spring-webflux-spring5</module>
     </modules>
+
+    <dependencies>
+
+        <!-- required for context-propagation during tests, but only at runtime -->
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-reactor-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-reactor-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <!-- required to test integration with servlet instrumentation -->
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-servlet-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 </project>

--- a/apm-agent-plugins/apm-spring-webflux/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/pom.xml
@@ -16,15 +16,9 @@
         <!-- for licence header plugin -->
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
 
-        <!-- spring boot version to use (for testing), needs to be kept in sync with spring version below -->
-        <version.spring-boot>2.5.3</version.spring-boot>
-
-        <!-- spring version & reactor our instrumentation will rely on -->
-        <version.spring>5.3.10</version.spring>
-        <version.reactor>3.4.18</version.reactor>
-
-        <!-- Jackson version should match the version found spring-boot dependencies, only for tests -->
-        <version.jackson>2.12.4</version.jackson>
+        <!-- spring boot version to use for dependency management & testing -->
+        <version.spring-boot-2>2.7.10</version.spring-boot-2>
+        <version.spring-boot-3>3.0.5</version.spring-boot-3>
     </properties>
 
     <modules>
@@ -35,22 +29,6 @@
     </modules>
 
     <dependencies>
-
-        <!-- required for context-propagation during tests, but only at runtime -->
-        <dependency>
-            <groupId>co.elastic.apm</groupId>
-            <artifactId>apm-reactor-plugin</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>co.elastic.apm</groupId>
-            <artifactId>apm-reactor-plugin</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-            <type>test-jar</type>
-        </dependency>
 
         <!-- required to test integration with servlet instrumentation -->
         <dependency>

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/Spring6TransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/Spring6TransactionNameInstrumentationTest.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.apm.agent.springwebmvc;
 
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/Spring6ExceptionHandlerInstrumentationWithExceptionHandlerTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/Spring6ExceptionHandlerInstrumentationWithExceptionHandlerTest.java
@@ -18,7 +18,7 @@
  */
 package co.elastic.apm.agent.springwebmvc.exception;
 
-import co.elastic.apm.agent.springwebmvc.Java17OnlyTest;
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 
 public class Spring6ExceptionHandlerInstrumentationWithExceptionHandlerTest extends Java17OnlyTest {
 

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/Spring6ExceptionHandlerInstrumentationWithExceptionResolverTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/Spring6ExceptionHandlerInstrumentationWithExceptionResolverTest.java
@@ -18,8 +18,8 @@
  */
 package co.elastic.apm.agent.springwebmvc.exception;
 
-import co.elastic.apm.agent.springwebmvc.Java17OnlyTest;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_resolver.AbstractRestResponseStatusExceptionResolver;
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.stereotype.Component;

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/Spring6ExceptionHandlerInstrumentationWithGlobalAdviceTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/exception/Spring6ExceptionHandlerInstrumentationWithGlobalAdviceTest.java
@@ -18,7 +18,7 @@
  */
 package co.elastic.apm.agent.springwebmvc.exception;
 
-import co.elastic.apm.agent.springwebmvc.Java17OnlyTest;
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 
 public class Spring6ExceptionHandlerInstrumentationWithGlobalAdviceTest extends Java17OnlyTest {
 

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6FreeMarkerViewTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6FreeMarkerViewTest.java
@@ -18,7 +18,7 @@
  */
 package co.elastic.apm.agent.springwebmvc.template;
 
-import co.elastic.apm.agent.springwebmvc.Java17OnlyTest;
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 
 public class Spring6FreeMarkerViewTest extends Java17OnlyTest {
     public Spring6FreeMarkerViewTest() {

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6GroovyTemplateTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6GroovyTemplateTest.java
@@ -18,7 +18,7 @@
  */
 package co.elastic.apm.agent.springwebmvc.template;
 
-import co.elastic.apm.agent.springwebmvc.Java17OnlyTest;
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 
 public class Spring6GroovyTemplateTest extends Java17OnlyTest {
 

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6Jackson2JsonViewTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6Jackson2JsonViewTest.java
@@ -18,7 +18,7 @@
  */
 package co.elastic.apm.agent.springwebmvc.template;
 
-import co.elastic.apm.agent.springwebmvc.Java17OnlyTest;
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 
 public class Spring6Jackson2JsonViewTest extends Java17OnlyTest {
 

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6JspViewTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6JspViewTest.java
@@ -18,7 +18,7 @@
  */
 package co.elastic.apm.agent.springwebmvc.template;
 
-import co.elastic.apm.agent.springwebmvc.Java17OnlyTest;
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 
 public class Spring6JspViewTest extends Java17OnlyTest {
 

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6ThymeleafTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/src/test/java/co/elastic/apm/agent/springwebmvc/template/Spring6ThymeleafTest.java
@@ -19,7 +19,7 @@
 package co.elastic.apm.agent.springwebmvc.template;
 
 
-import co.elastic.apm.agent.springwebmvc.Java17OnlyTest;
+import co.elastic.apm.agent.testutils.Java17OnlyTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;


### PR DESCRIPTION
## What does this PR do?

Part of #2942 .

 * Adds the missing tests for webflux with spring 6
 * Upgrades the webclient project to spring 6, added integration test to still also test with spring 5
 * Simplified dependency management: We only use now the spring-boot dependency management, which should simplify dependabot upgrades and avoid incompatibilities between dependencies

I won't update the changelog for this PR, as it only adds testing.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
