### PR TITLE
correlate service.environment for ecs-logging & ecs reformat 

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -27,6 +27,7 @@ endif::[]
 ===== Features
 * Added tests for Quarkus / RestEasy, adjusted vert.x router transaction name priority - {pull}1765[#1765]
 * Added support for Spring WebMVC 6.x and Spring Boot 3.x - {pull}3094[#3094]
+* Added `service.environment` to logs for service correlation - {pull}3115[#3115]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/EcsLoggingUtils.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/EcsLoggingUtils.java
@@ -36,6 +36,7 @@ public class EcsLoggingUtils {
 
     private static final WeakSet<Object> nameChecked = WeakConcurrent.buildSet();
     private static final WeakSet<Object> versionChecked = WeakConcurrent.buildSet();
+    private static final WeakSet<Object> environmentChecked = WeakConcurrent.buildSet();
 
     private static final ElasticApmTracer tracer = GlobalTracer.get().require(ElasticApmTracer.class);
 
@@ -52,6 +53,12 @@ public class EcsLoggingUtils {
         String configuredServiceVersion = tracer.getConfig(CoreConfiguration.class).getServiceVersion();
         return serviceInfo != null ? serviceInfo.getServiceVersion() : configuredServiceVersion;
     }
+
+    @Nullable
+    public static String getServiceEnvironment() {
+        return tracer.getConfig(CoreConfiguration.class).getEnvironment();
+    }
+
 
     private static void warnIfMisConfigured(String key, @Nullable String configuredValue, @Nullable String agentValue) {
         if (!Objects.equals(agentValue, configuredValue)) {
@@ -81,6 +88,19 @@ public class EcsLoggingUtils {
             return getServiceName();
         } else {
             warnIfMisConfigured("service.name", value, getServiceName());
+            return value;
+        }
+    }
+
+    @Nullable
+    public static String getOrWarnServiceEnvironment(Object target, @Nullable String value) {
+        if (!environmentChecked.add(target)) {
+            return value;
+        }
+        if (value == null) {
+            return getServiceEnvironment();
+        } else {
+            warnIfMisConfigured("environment", value, getServiceEnvironment());
             return value;
         }
     }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/jbosslogging/JbossEcsServiceInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/jbosslogging/JbossEcsServiceInstrumentation.java
@@ -87,4 +87,28 @@ public abstract class JbossEcsServiceInstrumentation extends EcsLoggingInstrumen
 
     }
 
+    public static class Environment extends JbossEcsServiceInstrumentation {
+
+        @Override
+        public ElementMatcher.Junction<? super TypeDescription> getTypeMatcher() {
+            return super.getTypeMatcher()
+                // setServiceEnvironment introduced in 1.5.0
+                .and(declaresMethod(named("setServiceEnvironment")));
+        }
+
+        public static class AdviceClass {
+
+            @Nullable
+            @Advice.AssignReturned.ToFields(@ToField(value = "serviceEnvironment", typing = Assigner.Typing.DYNAMIC))
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static String onEnter(@Advice.This Object formatter,
+                                         @Advice.FieldValue("serviceEnvironment") @Nullable String serviceEnvironment) {
+
+                return EcsLoggingUtils.getOrWarnServiceEnvironment(formatter, serviceEnvironment);
+            }
+        }
+
+    }
+
+
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/jbosslogging/JbossEcsServiceInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/jbosslogging/JbossEcsServiceInstrumentation.java
@@ -25,7 +25,6 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned.ToFields.ToField;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 
 import javax.annotation.Nullable;
@@ -53,7 +52,7 @@ public abstract class JbossEcsServiceInstrumentation extends EcsLoggingInstrumen
         public static class AdviceClass {
 
             @Nullable
-            @Advice.AssignReturned.ToFields(@ToField(value = "serviceName", typing = Assigner.Typing.DYNAMIC))
+            @Advice.AssignReturned.ToFields(@ToField(value = "serviceName"))
             @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
             public static String onEnter(@Advice.This Object formatter,
                                          @Advice.FieldValue("serviceName") @Nullable String serviceName) {
@@ -76,7 +75,7 @@ public abstract class JbossEcsServiceInstrumentation extends EcsLoggingInstrumen
         public static class AdviceClass {
 
             @Nullable
-            @Advice.AssignReturned.ToFields(@ToField(value = "serviceVersion", typing = Assigner.Typing.DYNAMIC))
+            @Advice.AssignReturned.ToFields(@ToField(value = "serviceVersion"))
             @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
             public static String onEnter(@Advice.This Object formatter,
                                          @Advice.FieldValue("serviceVersion") @Nullable String serviceVersion) {
@@ -99,7 +98,7 @@ public abstract class JbossEcsServiceInstrumentation extends EcsLoggingInstrumen
         public static class AdviceClass {
 
             @Nullable
-            @Advice.AssignReturned.ToFields(@ToField(value = "serviceEnvironment", typing = Assigner.Typing.DYNAMIC))
+            @Advice.AssignReturned.ToFields(@ToField(value = "serviceEnvironment"))
             @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
             public static String onEnter(@Advice.This Object formatter,
                                          @Advice.FieldValue("serviceEnvironment") @Nullable String serviceEnvironment) {

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/jul/JulEcsServiceInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/jul/JulEcsServiceInstrumentation.java
@@ -20,7 +20,6 @@ package co.elastic.apm.agent.ecs_logging.jul;
 
 import co.elastic.apm.agent.ecs_logging.EcsLoggingInstrumentation;
 import co.elastic.apm.agent.ecs_logging.EcsLoggingUtils;
-import co.elastic.logging.jul.EcsFormatter;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned.ToFields.ToField;
 import net.bytebuddy.description.method.MethodDescription;
@@ -83,6 +82,29 @@ public abstract class JulEcsServiceInstrumentation extends EcsLoggingInstrumenta
                                          @Advice.FieldValue("serviceVersion") @Nullable String serviceVersion) {
 
                 return EcsLoggingUtils.getOrWarnServiceVersion(formatter, serviceVersion);
+            }
+        }
+
+    }
+
+    public static class Environment extends JulEcsServiceInstrumentation {
+
+        @Override
+        public ElementMatcher.Junction<? super TypeDescription> getTypeMatcher() {
+            return super.getTypeMatcher()
+                // setServiceVersion introduced in 1.5.0
+                .and(declaresMethod(named("setServiceEnvironment")));
+        }
+
+        public static class AdviceClass {
+
+            @Nullable
+            @Advice.AssignReturned.ToFields(@ToField(value = "serviceEnvironment"))
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static String onEnter(@Advice.This Object formatter,
+                                         @Advice.FieldValue("serviceEnvironment") @Nullable String serviceEnvironment) {
+
+                return EcsLoggingUtils.getOrWarnServiceEnvironment(formatter, serviceEnvironment);
             }
         }
 

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/jul/JulEcsServiceInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/jul/JulEcsServiceInstrumentation.java
@@ -24,7 +24,6 @@ import net.bytebuddy.asm.Advice;
 import net.bytebuddy.asm.Advice.AssignReturned.ToFields.ToField;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
-import net.bytebuddy.implementation.bytecode.assign.Assigner;
 import net.bytebuddy.matcher.ElementMatcher;
 
 import javax.annotation.Nullable;
@@ -52,7 +51,7 @@ public abstract class JulEcsServiceInstrumentation extends EcsLoggingInstrumenta
         public static class AdviceClass {
 
             @Nullable
-            @Advice.AssignReturned.ToFields(@ToField(value = "serviceName", typing = Assigner.Typing.DYNAMIC))
+            @Advice.AssignReturned.ToFields(@ToField(value = "serviceName"))
             @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
             public static String onEnter(@Advice.This Object formatter,
                                          @Advice.FieldValue("serviceName") @Nullable String serviceName) {
@@ -76,7 +75,7 @@ public abstract class JulEcsServiceInstrumentation extends EcsLoggingInstrumenta
         public static class AdviceClass {
 
             @Nullable
-            @Advice.AssignReturned.ToFields(@ToField(value = "serviceVersion", typing = Assigner.Typing.DYNAMIC))
+            @Advice.AssignReturned.ToFields(@ToField(value = "serviceVersion"))
             @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
             public static String onEnter(@Advice.This Object formatter,
                                          @Advice.FieldValue("serviceVersion") @Nullable String serviceVersion) {

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/log4j1/Log4jEcsServiceInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/log4j1/Log4jEcsServiceInstrumentation.java
@@ -86,4 +86,27 @@ public abstract class Log4jEcsServiceInstrumentation extends EcsLoggingInstrumen
         }
 
     }
+
+    public static class Environment extends Log4jEcsServiceInstrumentation {
+
+        @Override
+        public ElementMatcher.Junction<? super TypeDescription> getTypeMatcher() {
+            return super.getTypeMatcher()
+                // setServiceEnvironment introduced in 1.5.0
+                .and(declaresMethod(named("setServiceEnvironment")));
+        }
+
+        public static class AdviceClass {
+
+            @Nullable
+            @Advice.AssignReturned.ToFields(@ToField("serviceEnvironment"))
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static String onEnter(@Advice.This Object layout,
+                                         @Advice.FieldValue("serviceEnvironment") @Nullable String serviceEnvironment) {
+
+                return EcsLoggingUtils.getOrWarnServiceEnvironment(layout, serviceEnvironment);
+            }
+        }
+
+    }
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/log4j2/Log4j2ServiceInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/log4j2/Log4j2ServiceInstrumentation.java
@@ -84,4 +84,27 @@ public abstract class Log4j2ServiceInstrumentation extends EcsLoggingInstrumenta
         }
     }
 
+    public static class Environment extends Log4j2ServiceInstrumentation {
+
+        @Override
+        public ElementMatcher.Junction<? super TypeDescription> getTypeMatcher() {
+            return named("co.elastic.logging.log4j2.EcsLayout$Builder")
+                // serviceEnvironment introduced in 1.5.0
+                .and(declaresField(named("serviceEnvironment")));
+        }
+
+        public static class AdviceClass {
+
+            @Nullable
+            @Advice.AssignReturned.ToFields(@ToField(value = "serviceEnvironment"))
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static String onEnter(@Advice.This Object formatter,
+                                         @Advice.FieldValue("serviceEnvironment") @Nullable String serviceEnvironment) {
+
+                return EcsLoggingUtils.getOrWarnServiceEnvironment(formatter, serviceEnvironment);
+            }
+        }
+
+    }
+
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/logback/LogBackServiceInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/logback/LogBackServiceInstrumentation.java
@@ -30,6 +30,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import javax.annotation.Nullable;
 
 import static net.bytebuddy.matcher.ElementMatchers.declaresField;
+import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.named;
 
 /**
@@ -80,6 +81,29 @@ public abstract class LogBackServiceInstrumentation extends EcsLoggingInstrument
                                         @Advice.FieldValue("serviceVersion") @Nullable String serviceVersion) {
 
                 return EcsLoggingUtils.getOrWarnServiceVersion(encoder, serviceVersion);
+            }
+        }
+
+    }
+
+    public static class Environment extends LogBackServiceInstrumentation {
+
+        @Override
+        public ElementMatcher.Junction<? super TypeDescription> getTypeMatcher() {
+            return super.getTypeMatcher()
+                // setServiceVersion introduced in 1.5.0
+                .and(declaresMethod(named("setServiceEnvironment")));
+        }
+
+        public static class AdviceClass {
+
+            @Nullable
+            @Advice.AssignReturned.ToFields(@ToField(value = "serviceEnvironment"))
+            @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
+            public static String onEnter(@Advice.This Object formatter,
+                                         @Advice.FieldValue("serviceEnvironment") @Nullable String serviceEnvironment) {
+
+                return EcsLoggingUtils.getOrWarnServiceEnvironment(formatter, serviceEnvironment);
             }
         }
 

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/logback/LogBackServiceInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/java/co/elastic/apm/agent/ecs_logging/logback/LogBackServiceInstrumentation.java
@@ -85,16 +85,4 @@ public abstract class LogBackServiceInstrumentation extends EcsLoggingInstrument
 
     }
 
-    public static class VersionAdvice {
-
-        @Nullable
-        @Advice.AssignReturned.ToFields(@ToField("serviceVersion"))
-        @Advice.OnMethodExit(suppress = Throwable.class, inline = false)
-        public static String onExit(@Advice.This Object encoder,
-                                    @Advice.FieldValue("serviceVersion") @Nullable String serviceVersion) {
-
-            return EcsLoggingUtils.getOrWarnServiceVersion(encoder, serviceVersion);
-        }
-    }
-
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -10,6 +10,7 @@ co.elastic.apm.agent.ecs_logging.log4j2.Log4j2ServiceInstrumentation$Version
 co.elastic.apm.agent.ecs_logging.jul.JulEcsMdcInstrumentation
 co.elastic.apm.agent.ecs_logging.jul.JulEcsServiceInstrumentation$Name
 co.elastic.apm.agent.ecs_logging.jul.JulEcsServiceInstrumentation$Version
+co.elastic.apm.agent.ecs_logging.jul.JulEcsServiceInstrumentation$Environment
 
 # Logback
 co.elastic.apm.agent.ecs_logging.logback.LogBackServiceInstrumentation$Name

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -5,6 +5,7 @@ co.elastic.apm.agent.ecs_logging.log4j1.Log4jEcsServiceInstrumentation$Version
 # log4j 2.x
 co.elastic.apm.agent.ecs_logging.log4j2.Log4j2ServiceInstrumentation$Name
 co.elastic.apm.agent.ecs_logging.log4j2.Log4j2ServiceInstrumentation$Version
+co.elastic.apm.agent.ecs_logging.log4j2.Log4j2ServiceInstrumentation$Environment
 
 # JUL
 co.elastic.apm.agent.ecs_logging.jul.JulEcsMdcInstrumentation
@@ -15,6 +16,7 @@ co.elastic.apm.agent.ecs_logging.jul.JulEcsServiceInstrumentation$Environment
 # Logback
 co.elastic.apm.agent.ecs_logging.logback.LogBackServiceInstrumentation$Name
 co.elastic.apm.agent.ecs_logging.logback.LogBackServiceInstrumentation$Version
+co.elastic.apm.agent.ecs_logging.logback.LogBackServiceInstrumentation$Environment
 
 # JBoss
 co.elastic.apm.agent.ecs_logging.jbosslogging.JbossEcsServiceInstrumentation$Name

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -18,3 +18,4 @@ co.elastic.apm.agent.ecs_logging.logback.LogBackServiceInstrumentation$Version
 # JBoss
 co.elastic.apm.agent.ecs_logging.jbosslogging.JbossEcsServiceInstrumentation$Name
 co.elastic.apm.agent.ecs_logging.jbosslogging.JbossEcsServiceInstrumentation$Version
+co.elastic.apm.agent.ecs_logging.jbosslogging.JbossEcsServiceInstrumentation$Environment

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -1,6 +1,7 @@
 # log4j 1.x
 co.elastic.apm.agent.ecs_logging.log4j1.Log4jEcsServiceInstrumentation$Name
 co.elastic.apm.agent.ecs_logging.log4j1.Log4jEcsServiceInstrumentation$Version
+co.elastic.apm.agent.ecs_logging.log4j1.Log4jEcsServiceInstrumentation$Environment
 
 # log4j 2.x
 co.elastic.apm.agent.ecs_logging.log4j2.Log4j2ServiceInstrumentation$Name

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/EcsServiceCorrelationIT.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/EcsServiceCorrelationIT.java
@@ -32,6 +32,8 @@ public abstract class EcsServiceCorrelationIT {
 
     protected abstract String getServiceVersionTestClass();
 
+    protected abstract String getServiceEnvironmentTestClass();
+
     @ParameterizedTest(name = "ecs-logging {0}, supports version = {1}, supports environment = {2}")
     @CsvSource(delimiter = '|', value = {
         "1.3.2 | false | false", // 1.3.2 only supports service name
@@ -44,6 +46,10 @@ public abstract class EcsServiceCorrelationIT {
 
         if (serviceVersionSupported) {
             new TestClassWithDependencyRunner(List.of(dependency), getServiceVersionTestClass()).run();
+        }
+
+        if (serviceEnvironmentSupported) {
+            new TestClassWithDependencyRunner(List.of(dependency), getServiceEnvironmentTestClass()).run();
         }
     }
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/EcsServiceEnvironmentTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/EcsServiceEnvironmentTest.java
@@ -35,7 +35,7 @@ public abstract class EcsServiceEnvironmentTest extends EcsLoggingTest {
     @Test
     public void testBuildWithNoServiceNameSet() {
         initFormatterWithoutServiceEnvironmentSet();
-        assertThat(getJson(createLogMsg(), "service.environment")).isEqualTo("test-env");
+        assertThat(getJson(createLogMsg(), "service.environment")).isEqualTo("test");
     }
 
     protected abstract void initFormatterWithoutServiceEnvironmentSet();

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/EcsServiceEnvironmentTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/EcsServiceEnvironmentTest.java
@@ -33,7 +33,7 @@ public abstract class EcsServiceEnvironmentTest extends EcsLoggingTest {
     }
 
     @Test
-    public void testBuildWithNoServiceNameSet() {
+    public void testBuildWithNoServiceEnvironmentSet() {
         initFormatterWithoutServiceEnvironmentSet();
         assertThat(getJson(createLogMsg(), "service.environment")).isEqualTo("test");
     }
@@ -41,7 +41,7 @@ public abstract class EcsServiceEnvironmentTest extends EcsLoggingTest {
     protected abstract void initFormatterWithoutServiceEnvironmentSet();
 
     @Test
-    public void testBuildWithServiceNameSet() {
+    public void testBuildWithServiceEnvironmentSet() {
         // this should also issue a warning as the value configured in ecs-logging differs from the agent
         initFormatterWithServiceEnvironment("prod");
         assertThat(getJson(createLogMsg(), "service.environment")).isEqualTo("prod");

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/EcsServiceEnvironmentTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/EcsServiceEnvironmentTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.ecs_logging;
+
+import co.elastic.apm.agent.configuration.CoreConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+public abstract class EcsServiceEnvironmentTest extends EcsLoggingTest {
+
+    @BeforeEach
+    public void setUp() {
+        doReturn("test").when(tracer.getConfig(CoreConfiguration.class)).getEnvironment();
+    }
+
+    @Test
+    public void testBuildWithNoServiceNameSet() {
+        initFormatterWithoutServiceEnvironmentSet();
+        assertThat(getJson(createLogMsg(), "service.environment")).isEqualTo("test-env");
+    }
+
+    protected abstract void initFormatterWithoutServiceEnvironmentSet();
+
+    @Test
+    public void testBuildWithServiceNameSet() {
+        // this should also issue a warning as the value configured in ecs-logging differs from the agent
+        initFormatterWithServiceEnvironment("prod");
+        assertThat(getJson(createLogMsg(), "service.environment")).isEqualTo("prod");
+    }
+
+    protected abstract void initFormatterWithServiceEnvironment(String environment);
+}

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jbosslogging/JbossServiceCorrelationIT.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jbosslogging/JbossServiceCorrelationIT.java
@@ -37,4 +37,8 @@ public class JbossServiceCorrelationIT extends EcsServiceCorrelationIT {
         return "co.elastic.apm.agent.ecs_logging.jbosslogging.JbossServiceVersionInstrumentationTest";
     }
 
+    @Override
+    protected String getServiceEnvironmentTestClass() {
+        return "co.elastic.apm.agent.ecs_logging.jbosslogging.JbossServiceEnvironmentInstrumentationTest";
+    }
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jbosslogging/JbossServiceEnvironmentInstrumentationTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jbosslogging/JbossServiceEnvironmentInstrumentationTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.ecs_logging.jbosslogging;
+
+import co.elastic.apm.agent.ecs_logging.EcsServiceEnvironmentTest;
+import co.elastic.apm.agent.testutils.TestClassWithDependencyRunner;
+import co.elastic.logging.jboss.logmanager.EcsFormatter;
+import org.jboss.logmanager.ExtLogRecord;
+import org.jboss.logmanager.Level;
+
+// must be tested in isolation, either used in agent or has side effects
+@TestClassWithDependencyRunner.DisableOutsideOfRunner
+public class JbossServiceEnvironmentInstrumentationTest extends EcsServiceEnvironmentTest {
+
+    EcsFormatter formatter;
+
+    @Override
+    protected String createLogMsg() {
+        ExtLogRecord record = new ExtLogRecord(Level.INFO, "Example Message", "ExampleLoggerClass");
+        return formatter.format(record);
+    }
+
+    @Override
+    protected void initFormatterWithoutServiceEnvironmentSet() {
+        formatter = new EcsFormatter();
+    }
+
+    @Override
+    protected void initFormatterWithServiceEnvironment(String environment) {
+        formatter = new EcsFormatter();
+        formatter.setServiceEnvironment(environment);
+    }
+}

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceCorrelationIT.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceCorrelationIT.java
@@ -36,4 +36,9 @@ public class JulServiceCorrelationIT extends EcsServiceCorrelationIT {
     protected String getServiceVersionTestClass() {
         return "co.elastic.apm.agent.ecs_logging.jul.JulServiceVersionInstrumentationTest";
     }
+
+    @Override
+    protected String getServiceEnvironmentTestClass() {
+        return "co.elastic.apm.agent.ecs_logging.jul.JulServiceEnvironmentInstrumentationTest";
+    }
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceEnvironmentInstrumentationTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceEnvironmentInstrumentationTest.java
@@ -41,12 +41,21 @@ public class JulServiceEnvironmentInstrumentationTest extends EcsServiceEnvironm
 
     @Override
     protected void initFormatterWithoutServiceEnvironmentSet() {
-        formatter = LogManagerTestInstrumentation.createFormatter(Collections.emptyMap());
+        formatter = createFormatter(Collections.emptyMap());
     }
 
     @Override
     protected void initFormatterWithServiceEnvironment(String environment) {
-        formatter = LogManagerTestInstrumentation.createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceEnvironment", environment));
+        formatter = createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceEnvironment", environment));
+    }
+
+    private static EcsFormatter createFormatter(Map<String, String> map) {
+        try {
+            LogManagerTestInstrumentation.JulProperties.override(map);
+            return new EcsFormatter();
+        } finally {
+            LogManagerTestInstrumentation.JulProperties.restore();
+        }
     }
 
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceEnvironmentInstrumentationTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceEnvironmentInstrumentationTest.java
@@ -18,7 +18,8 @@
  */
 package co.elastic.apm.agent.ecs_logging.jul;
 
-import co.elastic.apm.agent.ecs_logging.EcsServiceVersionTest;
+import co.elastic.apm.agent.ecs_logging.EcsServiceEnvironmentTest;
+import co.elastic.apm.agent.ecs_logging.EcsServiceNameTest;
 import co.elastic.apm.agent.testutils.TestClassWithDependencyRunner;
 import co.elastic.logging.jul.EcsFormatter;
 
@@ -29,7 +30,7 @@ import java.util.logging.LogRecord;
 
 // must be tested in isolation, either used in agent or has side effects
 @TestClassWithDependencyRunner.DisableOutsideOfRunner
-public class JulServiceVersionInstrumentationTest extends EcsServiceVersionTest {
+public class JulServiceEnvironmentInstrumentationTest extends EcsServiceEnvironmentTest {
 
     private EcsFormatter formatter;
 
@@ -39,12 +40,13 @@ public class JulServiceVersionInstrumentationTest extends EcsServiceVersionTest 
     }
 
     @Override
-    protected void initFormatterWithoutServiceVersionSet() {
+    protected void initFormatterWithoutServiceEnvironmentSet() {
         formatter = LogManagerTestInstrumentation.createFormatter(Collections.emptyMap());
     }
 
     @Override
-    protected void initFormatterWithServiceVersion(String version) {
-        formatter = LogManagerTestInstrumentation.createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceVersion", version));
+    protected void initFormatterWithServiceEnvironment(String environment) {
+        formatter = LogManagerTestInstrumentation.createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceEnvironment", environment));
     }
+
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceNameInstrumentationTest.java
@@ -40,13 +40,21 @@ public class JulServiceNameInstrumentationTest extends EcsServiceNameTest {
 
     @Override
     protected void initFormatterWithoutServiceNameSet() {
-        formatter = LogManagerTestInstrumentation.createFormatter(Collections.emptyMap());
+        formatter = createFormatter(Collections.emptyMap());
     }
 
     @Override
     protected void initFormatterWithServiceName(String name) {
-        formatter = LogManagerTestInstrumentation.createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceName", name));
+        formatter = createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceName", name));
     }
 
+    private static EcsFormatter createFormatter(Map<String, String> map) {
+        try {
+            LogManagerTestInstrumentation.JulProperties.override(map);
+            return new EcsFormatter();
+        } finally {
+            LogManagerTestInstrumentation.JulProperties.restore();
+        }
+    }
 
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceNameInstrumentationTest.java
@@ -40,21 +40,13 @@ public class JulServiceNameInstrumentationTest extends EcsServiceNameTest {
 
     @Override
     protected void initFormatterWithoutServiceNameSet() {
-        formatter = createFormatter(Collections.emptyMap());
+        formatter = LogManagerTestInstrumentation.createFormatter(Collections.emptyMap());
     }
 
     @Override
     protected void initFormatterWithServiceName(String name) {
-        formatter = createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceName", name));
+        formatter = LogManagerTestInstrumentation.createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceName", name));
     }
 
-    private static EcsFormatter createFormatter(Map<String, String> map) {
-        try {
-            LogManagerTestInstrumentation.JulProperties.override(map);
-            return new EcsFormatter();
-        } finally {
-            LogManagerTestInstrumentation.JulProperties.restore();
-        }
-    }
 
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceVersionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/JulServiceVersionInstrumentationTest.java
@@ -40,11 +40,20 @@ public class JulServiceVersionInstrumentationTest extends EcsServiceVersionTest 
 
     @Override
     protected void initFormatterWithoutServiceVersionSet() {
-        formatter = LogManagerTestInstrumentation.createFormatter(Collections.emptyMap());
+        formatter = createFormatter(Collections.emptyMap());
     }
 
     @Override
     protected void initFormatterWithServiceVersion(String version) {
-        formatter = LogManagerTestInstrumentation.createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceVersion", version));
+        formatter = createFormatter(Map.of("co.elastic.logging.jul.EcsFormatter.serviceVersion", version));
+    }
+
+    private static EcsFormatter createFormatter(Map<String, String> map) {
+        try {
+            LogManagerTestInstrumentation.JulProperties.override(map);
+            return new EcsFormatter();
+        } finally {
+            LogManagerTestInstrumentation.JulProperties.restore();
+        }
     }
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/LogManagerTestInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/LogManagerTestInstrumentation.java
@@ -20,12 +20,14 @@ package co.elastic.apm.agent.ecs_logging.jul;
 
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.sdk.state.GlobalState;
+import co.elastic.logging.jul.EcsFormatter;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 
+import javax.annotation.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
@@ -74,8 +76,9 @@ public class LogManagerTestInstrumentation extends ElasticApmInstrumentation {
     }
 
     @GlobalState
-    public static class JulProperties {
+    private static class JulProperties {
 
+        @Nullable
         public static Properties overridenProperties = null;
 
         public static void override(Map<String, String> map) {
@@ -85,6 +88,15 @@ public class LogManagerTestInstrumentation extends ElasticApmInstrumentation {
 
         public static void restore() {
             overridenProperties = null;
+        }
+    }
+
+    static EcsFormatter createFormatter(Map<String, String> map) {
+        try {
+            JulProperties.override(map);
+            return new EcsFormatter();
+        } finally {
+            JulProperties.restore();
         }
     }
 

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/LogManagerTestInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/LogManagerTestInstrumentation.java
@@ -91,13 +91,4 @@ public class LogManagerTestInstrumentation extends ElasticApmInstrumentation {
         }
     }
 
-    static EcsFormatter createFormatter(Map<String, String> map) {
-        try {
-            JulProperties.override(map);
-            return new EcsFormatter();
-        } finally {
-            JulProperties.restore();
-        }
-    }
-
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/LogManagerTestInstrumentation.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/jul/LogManagerTestInstrumentation.java
@@ -76,7 +76,7 @@ public class LogManagerTestInstrumentation extends ElasticApmInstrumentation {
     }
 
     @GlobalState
-    private static class JulProperties {
+    public static class JulProperties {
 
         @Nullable
         public static Properties overridenProperties = null;

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/log4j1/Log4jServiceCorrelationIT.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/log4j1/Log4jServiceCorrelationIT.java
@@ -37,4 +37,9 @@ public class Log4jServiceCorrelationIT extends EcsServiceCorrelationIT {
         return "co.elastic.apm.agent.ecs_logging.log4j1.Log4jServiceVersionInstrumentationTest";
     }
 
+    @Override
+    protected String getServiceEnvironmentTestClass() {
+        return "co.elastic.apm.agent.ecs_logging.log4j1.Log4jServiceEnvironmentInstrumentationTest";
+    }
+
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/log4j1/Log4jServiceEnvironmentInstrumentationTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/log4j1/Log4jServiceEnvironmentInstrumentationTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.ecs_logging.log4j1;
+
+import co.elastic.apm.agent.ecs_logging.EcsServiceEnvironmentTest;
+import co.elastic.apm.agent.testutils.TestClassWithDependencyRunner;
+import co.elastic.logging.log4j.EcsLayout;
+import org.apache.log4j.Category;
+import org.apache.log4j.Level;
+import org.apache.log4j.spi.LoggingEvent;
+import org.apache.log4j.spi.RootLogger;
+
+// must be tested in isolation, either used in agent or has side effects
+@TestClassWithDependencyRunner.DisableOutsideOfRunner
+public class Log4jServiceEnvironmentInstrumentationTest extends EcsServiceEnvironmentTest {
+
+    private EcsLayout ecsLayout;
+
+    @Override
+    protected void initFormatterWithoutServiceEnvironmentSet() {
+        ecsLayout = new EcsLayout();
+    }
+
+    @Override
+    protected void initFormatterWithServiceEnvironment(String environment) {
+        ecsLayout = new EcsLayout();
+        ecsLayout.setServiceEnvironment(environment);
+    }
+
+    @Override
+    protected String createLogMsg() {
+        Category logger = new RootLogger(Level.ALL);
+        LoggingEvent event = new LoggingEvent("", logger, System.currentTimeMillis(), Level.INFO, "msg", null);
+        return ecsLayout.format(event);
+    }
+
+}

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/log4j2/Log4j2ServiceCorrelationIT.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/log4j2/Log4j2ServiceCorrelationIT.java
@@ -37,4 +37,8 @@ public class Log4j2ServiceCorrelationIT extends EcsServiceCorrelationIT {
         return "co.elastic.apm.agent.ecs_logging.log4j2.Log4j2ServiceVersionInstrumentationTest";
     }
 
+    @Override
+    protected String getServiceEnvironmentTestClass() {
+        return "co.elastic.apm.agent.ecs_logging.log4j2.Log4j2ServiceEnvironmentInstrumentationTest";
+    }
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/log4j2/Log4j2ServiceEnvironmentInstrumentationTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/log4j2/Log4j2ServiceEnvironmentInstrumentationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.ecs_logging.log4j2;
+
+import co.elastic.apm.agent.ecs_logging.EcsServiceEnvironmentTest;
+import co.elastic.apm.agent.testutils.TestClassWithDependencyRunner;
+import co.elastic.logging.log4j2.EcsLayout;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
+
+// must be tested in isolation, either used in agent or has side effects
+@TestClassWithDependencyRunner.DisableOutsideOfRunner
+public class Log4j2ServiceEnvironmentInstrumentationTest extends EcsServiceEnvironmentTest {
+
+    private EcsLayout ecsLayout;
+
+    @Override
+    protected void initFormatterWithoutServiceEnvironmentSet() {
+        ecsLayout = EcsLayout.newBuilder().build();
+    }
+
+    @Override
+    protected void initFormatterWithServiceEnvironment(String environment) {
+        ecsLayout = EcsLayout.newBuilder().setServiceEnvironment(environment).build();
+    }
+
+    @Override
+    protected String createLogMsg() {
+        Log4jLogEvent event = new Log4jLogEvent("", null, "", null, new SimpleMessage(), null, null);
+        return ecsLayout.toSerializable(event);
+    }
+}

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/logback/LogbackServiceCorrelationIT.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/logback/LogbackServiceCorrelationIT.java
@@ -36,4 +36,9 @@ public class LogbackServiceCorrelationIT extends EcsServiceCorrelationIT {
     protected String getServiceVersionTestClass() {
         return "co.elastic.apm.agent.ecs_logging.logback.LogbackServiceVersionInstrumentationTest";
     }
+
+    @Override
+    protected String getServiceEnvironmentTestClass() {
+        return "co.elastic.apm.agent.ecs_logging.logback.LogbackServiceEnvironmentInstrumentationTest";
+    }
 }

--- a/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/logback/LogbackServiceEnvironmentInstrumentationTest.java
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/src/test/java/co/elastic/apm/agent/ecs_logging/logback/LogbackServiceEnvironmentInstrumentationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.ecs_logging.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.LoggingEvent;
+import co.elastic.apm.agent.ecs_logging.EcsServiceEnvironmentTest;
+import co.elastic.apm.agent.testutils.TestClassWithDependencyRunner;
+import co.elastic.logging.logback.EcsEncoder;
+
+// must be tested in isolation, either used in agent or has side effects
+@TestClassWithDependencyRunner.DisableOutsideOfRunner
+public class LogbackServiceEnvironmentInstrumentationTest extends EcsServiceEnvironmentTest {
+
+    private EcsEncoder ecsEncoder;
+
+    @Override
+    protected String createLogMsg() {
+        LoggerContext loggerContext = new LoggerContext();
+        Logger logger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME);
+        ILoggingEvent event = new LoggingEvent("co.elastic.apm.agent.ecs_logging.logback.LogbackServiceNameInstrumentationTest", logger, Level.INFO, "msg", null, null);
+        return new String(ecsEncoder.encode(event));
+    }
+
+    @Override
+    protected void initFormatterWithoutServiceEnvironmentSet() {
+        ecsEncoder = new EcsEncoder();
+        ecsEncoder.start();
+    }
+
+    @Override
+    protected void initFormatterWithServiceEnvironment(String environment) {
+        ecsEncoder = new EcsEncoder();
+        ecsEncoder.start();
+        ecsEncoder.setServiceEnvironment(environment);
+    }
+}

--- a/apm-agent-plugins/apm-logging-plugin/apm-jul-plugin/src/main/java/co/elastic/apm/agent/jul/reformatting/AbstractJulEcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-jul-plugin/src/main/java/co/elastic/apm/agent/jul/reformatting/AbstractJulEcsReformattingHelper.java
@@ -65,9 +65,14 @@ public abstract class AbstractJulEcsReformattingHelper<T extends Handler> extend
 
     @Nullable
     @Override
-    public Formatter createEcsFormatter(String eventDataset, @Nullable String serviceName, @Nullable String serviceVersion,
-                                        @Nullable String serviceNodeName, @Nullable Map<String, String> additionalFields,
-                                        Formatter originalFormatter) {
+    public Formatter createEcsFormatter(String eventDataset,
+                                        @Nullable String serviceName,
+                                        @Nullable String serviceVersion,
+                                        @Nullable String serviceEnvironment,
+                                        @Nullable String serviceNodeName,
+                                        @Nullable Map<String, String> additionalFields,
+                                        @Nullable Formatter originalFormatter) {
+
         EcsFormatter ecsFormatter = new EcsFormatter() {
             @Override
             protected Map<String, String> getMdcEntries() {

--- a/apm-agent-plugins/apm-logging-plugin/apm-jul-plugin/src/main/java/co/elastic/apm/agent/jul/reformatting/AbstractJulEcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-jul-plugin/src/main/java/co/elastic/apm/agent/jul/reformatting/AbstractJulEcsReformattingHelper.java
@@ -82,6 +82,7 @@ public abstract class AbstractJulEcsReformattingHelper<T extends Handler> extend
         };
         ecsFormatter.setServiceName(serviceName);
         ecsFormatter.setServiceVersion(serviceVersion);
+        ecsFormatter.setServiceEnvironment(serviceEnvironment);
         ecsFormatter.setServiceNodeName(serviceNodeName);
         ecsFormatter.setEventDataset(eventDataset);
         if (additionalFields != null && !additionalFields.isEmpty()) {

--- a/apm-agent-plugins/apm-logging-plugin/apm-log4j1-plugin/src/main/java/co/elastic/apm/agent/log4j1/reformatting/Log4J1EcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-log4j1-plugin/src/main/java/co/elastic/apm/agent/log4j1/reformatting/Log4J1EcsReformattingHelper.java
@@ -71,6 +71,7 @@ class Log4J1EcsReformattingHelper extends AbstractEcsReformattingHelper<WriterAp
         EcsLayout ecsLayout = new EcsLayout();
         ecsLayout.setServiceName(serviceName);
         ecsLayout.setServiceVersion(serviceVersion);
+        ecsLayout.setServiceEnvironment(serviceEnvironment);
         ecsLayout.setServiceNodeName(serviceNodeName);
         ecsLayout.setEventDataset(eventDataset);
         if (additionalFields != null) {

--- a/apm-agent-plugins/apm-logging-plugin/apm-log4j1-plugin/src/main/java/co/elastic/apm/agent/log4j1/reformatting/Log4J1EcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-log4j1-plugin/src/main/java/co/elastic/apm/agent/log4j1/reformatting/Log4J1EcsReformattingHelper.java
@@ -60,9 +60,14 @@ class Log4J1EcsReformattingHelper extends AbstractEcsReformattingHelper<WriterAp
     }
 
     @Override
-    protected Layout createEcsFormatter(String eventDataset, @Nullable String serviceName, @Nullable String serviceVersion,
-                                        @Nullable String serviceNodeName, @Nullable Map<String, String> additionalFields,
+    protected Layout createEcsFormatter(String eventDataset,
+                                        @Nullable String serviceName,
+                                        @Nullable String serviceVersion,
+                                        @Nullable String serviceEnvironment,
+                                        @Nullable String serviceNodeName,
+                                        @Nullable Map<String, String> additionalFields,
                                         @Nullable Layout originalFormatter) {
+
         EcsLayout ecsLayout = new EcsLayout();
         ecsLayout.setServiceName(serviceName);
         ecsLayout.setServiceVersion(serviceVersion);

--- a/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/main/java/co/elastic/apm/agent/log4j2/reformatting/Log4J2EcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/main/java/co/elastic/apm/agent/log4j2/reformatting/Log4J2EcsReformattingHelper.java
@@ -76,6 +76,7 @@ class Log4J2EcsReformattingHelper extends AbstractEcsReformattingHelper<Appender
         EcsLayout.Builder builder = EcsLayout.newBuilder()
             .setServiceName(serviceName)
             .setServiceVersion(serviceVersion)
+            .setServiceEnvironment(serviceEnvironment)
             .setServiceNodeName(serviceNodeName)
             .setEventDataset(eventDataset)
             .setIncludeMarkers(true)

--- a/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/main/java/co/elastic/apm/agent/log4j2/reformatting/Log4J2EcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/main/java/co/elastic/apm/agent/log4j2/reformatting/Log4J2EcsReformattingHelper.java
@@ -66,8 +66,12 @@ class Log4J2EcsReformattingHelper extends AbstractEcsReformattingHelper<Appender
     }
 
     @Override
-    protected Layout<? extends Serializable> createEcsFormatter(String eventDataset, @Nullable String serviceName, @Nullable String serviceVersion,
-                                                                @Nullable String serviceNodeName, @Nullable Map<String, String> additionalFields,
+    protected Layout<? extends Serializable> createEcsFormatter(String eventDataset,
+                                                                @Nullable String serviceName,
+                                                                @Nullable String serviceVersion,
+                                                                @Nullable String serviceEnvironment,
+                                                                @Nullable String serviceNodeName,
+                                                                @Nullable Map<String, String> additionalFields,
                                                                 @Nullable Layout<? extends Serializable> originalFormatter) {
         EcsLayout.Builder builder = EcsLayout.newBuilder()
             .setServiceName(serviceName)

--- a/apm-agent-plugins/apm-logging-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/reformatting/LogbackEcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/reformatting/LogbackEcsReformattingHelper.java
@@ -89,6 +89,7 @@ class LogbackEcsReformattingHelper extends AbstractEcsReformattingHelper<OutputS
         EcsEncoder ecsEncoder = new EcsEncoder();
         ecsEncoder.setServiceName(serviceName);
         ecsEncoder.setServiceVersion(serviceVersion);
+        ecsEncoder.setServiceEnvironment(serviceEnvironment);
         ecsEncoder.setServiceNodeName(serviceNodeName);
         ecsEncoder.setEventDataset(eventDataset);
         ecsEncoder.setIncludeMarkers(true);

--- a/apm-agent-plugins/apm-logging-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/reformatting/LogbackEcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-logback-plugin/apm-logback-plugin-impl/src/main/java/co/elastic/apm/agent/logback/reformatting/LogbackEcsReformattingHelper.java
@@ -79,7 +79,10 @@ class LogbackEcsReformattingHelper extends AbstractEcsReformattingHelper<OutputS
     }
 
     @Override
-    protected Encoder<ILoggingEvent> createEcsFormatter(String eventDataset, @Nullable String serviceName, @Nullable String serviceVersion,
+    protected Encoder<ILoggingEvent> createEcsFormatter(String eventDataset,
+                                                        @Nullable String serviceName,
+                                                        @Nullable String serviceVersion,
+                                                        @Nullable String serviceEnvironment,
                                                         @Nullable String serviceNodeName,
                                                         @Nullable Map<String, String> additionalFields,
                                                         @Nullable Encoder<ILoggingEvent> originalFormatter) {

--- a/apm-agent-plugins/apm-logging-plugin/apm-logging-plugin-common/src/main/java/co/elastic/apm/agent/loginstr/reformatting/AbstractEcsReformattingHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-logging-plugin-common/src/main/java/co/elastic/apm/agent/loginstr/reformatting/AbstractEcsReformattingHelper.java
@@ -165,6 +165,9 @@ public abstract class AbstractEcsReformattingHelper<A, B, F, L> {
     private final String configuredServiceNodeName;
 
     @Nullable
+    private final String environment;
+
+    @Nullable
     private final Map<String, String> additionalFields;
     private final Reporter reporter;
 
@@ -184,6 +187,7 @@ public abstract class AbstractEcsReformattingHelper<A, B, F, L> {
         } else {
             configuredServiceNodeName = null;
         }
+        environment = service.getEnvironment();
         reporter = tracer.require(ElasticApmTracer.class).getReporter();
     }
 
@@ -367,11 +371,17 @@ public abstract class AbstractEcsReformattingHelper<A, B, F, L> {
         }
     }
 
+    @Nullable
     private F createEcsFormatter(A originalAppender) {
         String serviceName = getServiceName();
         return createEcsFormatter(
-            getEventDataset(originalAppender, serviceName), serviceName, getServiceVersion(),
-            configuredServiceNodeName, additionalFields, getFormatterFrom(originalAppender)
+            getEventDataset(originalAppender, serviceName),
+            serviceName,
+            getServiceVersion(),
+            environment,
+            configuredServiceNodeName,
+            additionalFields,
+            getFormatterFrom(originalAppender)
         );
     }
 
@@ -466,8 +476,12 @@ public abstract class AbstractEcsReformattingHelper<A, B, F, L> {
     protected abstract A createAndStartEcsAppender(A originalAppender, String ecsAppenderName, F ecsFormatter);
 
     @Nullable
-    protected abstract F createEcsFormatter(String eventDataset, @Nullable String serviceName, @Nullable String serviceVersion,
-                                            @Nullable String serviceNodeName, @Nullable Map<String, String> additionalFields,
+    protected abstract F createEcsFormatter(String eventDataset,
+                                            @Nullable String serviceName,
+                                            @Nullable String serviceVersion,
+                                            @Nullable String serviceEnvironment,
+                                            @Nullable String serviceNodeName,
+                                            @Nullable Map<String, String> additionalFields,
                                             @Nullable F originalFormatter);
 
     /**

--- a/apm-agent-plugins/apm-logging-plugin/apm-logging-plugin-common/src/test/java/co/elastic/apm/agent/loginstr/LoggingInstrumentationTest.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-logging-plugin-common/src/test/java/co/elastic/apm/agent/loginstr/LoggingInstrumentationTest.java
@@ -68,6 +68,7 @@ public abstract class LoggingInstrumentationTest extends AbstractInstrumentation
 
     private static final String SERVICE_NODE_NAME = "my-service-node";
     private static final Map<String, String> ADDITIONAL_FIELDS = Map.of("some.field", "some-value", "another.field", "another-value");
+    private static final String ENVIRONMENT = "my-env";
 
     private final LoggerFacade logger;
     private final ObjectMapper objectMapper;
@@ -91,6 +92,7 @@ public abstract class LoggingInstrumentationTest extends AbstractInstrumentation
     @BeforeEach
     public void setup() throws Exception {
         doReturn(SERVICE_VERSION).when(config.getConfig(CoreConfiguration.class)).getServiceVersion();
+        doReturn(ENVIRONMENT).when(config.getConfig(CoreConfiguration.class)).getEnvironment();
         doReturn(SERVICE_NODE_NAME).when(config.getConfig(CoreConfiguration.class)).getServiceNodeName();
 
         loggingConfig = config.getConfig(LoggingConfiguration.class);
@@ -342,7 +344,8 @@ public abstract class LoggingInstrumentationTest extends AbstractInstrumentation
         assertThat(ecsLogLineTree.get("service.name").textValue()).isEqualTo(serviceName);
         assertThat(ecsLogLineTree.get("service.node.name").textValue()).isEqualTo(SERVICE_NODE_NAME);
         assertThat(ecsLogLineTree.get("event.dataset").textValue()).isEqualTo(serviceName + ".FILE");
-        assertThat(ecsLogLineTree.get("service.version").textValue()).isEqualTo("v42");
+        assertThat(ecsLogLineTree.get("service.version").textValue()).isEqualTo(SERVICE_VERSION);
+        assertThat(ecsLogLineTree.get("service.environment").textValue()).isEqualTo(ENVIRONMENT);
         assertThat(ecsLogLineTree.get("some.field").textValue()).isEqualTo("some-value");
         assertThat(ecsLogLineTree.get("another.field").textValue()).isEqualTo("another-value");
     }

--- a/docs/logs.asciidoc
+++ b/docs/logs.asciidoc
@@ -40,12 +40,13 @@ with <<log-reformatting, Log reformatting>>.
 For plain text logs, the pattern layout of your logging configuration needs to be modified to write the MDC values into
 log files. If you are using Logback or log4j, add `%X` to the format to log all MDC values or `%X{trace.id}` to only log the trace id.
 
-When using ECS-formatted logs, with `ecs-logging-java` library or <<log-reformatting, log reformatting>>, the agent
-also injects into ECS formatted logs the following identifiers for service-level correlation.
+When the application is logging in ECS format (by using `ecs-logging-java` or <<log-reformatting, log reformatting>>)
+ but does not provide the service fields, then the agent will automatically provide fallback values from its own configuration
+to provide service-level correlation:
 
-* {ecs-ref}/ecs-service.html[`service.name`]
-* {ecs-ref}/ecs-service.html[`service.version`]
-* {ecs-ref}/ecs-service.html[`service.environment`]
+- {ecs-ref}/ecs-service.html[`service.name`] value provided <<config-service-name, `service_name`>> in agent config.
+- {ecs-ref}/ecs-service.html[`service.version`] value provided by <<config-service-version, `service_version`>> in agent config.
+- {ecs-ref}/ecs-service.html[`service.environment`] value provided by <<config-environment, `environment`>> in agent config.
 
 [float]
 [[log-reformatting]]
@@ -56,6 +57,8 @@ logging configuration and making the application always use ECS log format. In s
 change to the application.
 
 Log reformatting is controlled by the <<config-log-ecs-reformatting, `log_ecs_reformatting`>> configuration option, and is disabled by default.
+
+The reformatted logs will include both the <<log-correlation-ids, trace and service correlation>> IDs.
 
 [float]
 [[log-error-capturing]]
@@ -77,13 +80,3 @@ As a result, when an exception is reported to the logger:
 
 The agent can automatically capture and send logs directly to APM Server, which allows to ingest log events without relying on filebeat.
 Log sending is controlled by the <<config-log-sending, `log_sending`>> configuration option and is disabled by default.
-
-[float]
-[[ecs-logging-service-fields]]
-=== ECS Logging Service fields
-
-When the application is using `ecs-logging-java` but does not provide the service fields, then the agent will
-automatically provide fallback values from its own configuration:
-
-- `service.name` value will be populated by <<config-service-name, `service_name`>> in agent config.
-- `service.version` value will be populated by <<config-service-version, `service_version`>> in agent config.

--- a/docs/logs.asciidoc
+++ b/docs/logs.asciidoc
@@ -26,7 +26,7 @@ NOTE: Starting in APM agent version 1.30.0, log correlation is enabled by defaul
 In previous versions, log correlation must be explicitly enabled by setting
 the `enable_log_correlation` configuration variable to `true`.
 
-In order to correlate logs from your application with transactions captured by the Elastic APM Java Agent,
+In order to correlate logs from your application with traces and errors captured by the Elastic APM Java Agent,
 the agent injects the following IDs into https://www.slf4j.org/api/org/slf4j/MDC.html[slf4j-MDC]-equivalents of
 <<supported-logging-frameworks, supported logging frameworks>>:
 
@@ -39,6 +39,13 @@ with <<log-reformatting, Log reformatting>>.
 
 For plain text logs, the pattern layout of your logging configuration needs to be modified to write the MDC values into
 log files. If you are using Logback or log4j, add `%X` to the format to log all MDC values or `%X{trace.id}` to only log the trace id.
+
+When using ECS-formatted logs, with `ecs-logging-java` library or <<log-reformatting, log reformatting>>, the agent
+also injects into ECS formatted logs the following identifiers for service-level correlation.
+
+* {ecs-ref}/ecs-service.html[`service.name`]
+* {ecs-ref}/ecs-service.html[`service.version`]
+* {ecs-ref}/ecs-service.html[`service.environment`]
 
 [float]
 [[log-reformatting]]

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -550,18 +550,16 @@ NOTE: only classes from the quartz-jobs dependency will be instrumented automati
 
 There are multiple log-related features in the agent and their support depend on the logging framework:
 
-- *<<log-correlation-ids, Log Correlation>>*:
+- *<<log-correlation-ids, Correlation>>*:
     The agent automatically injects `trace.id`, `transaction.id` and `error.id` into the MDC implementation (see below for framework specific MDC implementations used. MDC = Mapped Diagnostic Context, a standard way to enrich log messages with additional information).
+    For service correlation, the agent sets values for `service.name`, `service.version` and `service.environment`, using ECS log format is required (`ecs-logging-java` or reformatting).
 
-- *<<log-error-capturing, Log Error capturing>>*:
+- *<<log-error-capturing, Error capturing>>*:
     Automatically captures exceptions for calls like `logger.error("message", exception)`.
 
-- *<<config-log-ecs-reformatting,ECS reformatting>>*:
+- *<<config-log-ecs-reformatting,Reformatting>>*:
     When <<config-log-ecs-reformatting, `log_ecs_reformatting`>> is enabled, logs will be automatically reformatted into
     ECS-compatible format.
-
-- *<<ecs-logging-service-fields, ECS Logging service fields>>*: For users of `ecs-logging-java`, the agent sets the service name and version for the `EcsLayout` if not provided explicitly by the
-application.
 
 |===
 |Framework |Supported versions | Description | Since
@@ -572,31 +570,33 @@ application.
 |Error capturing - 1.10.0
 
 |log4j2
-|Trace correlation - 2.0+
+| Correlation - 2.0+
 
-ECS Reformatting - 2.6+
+Reformatting - 2.6+
 
 |https://logging.apache.org/log4j/2.x/manual/thread-context.html[`org.apache.logging.log4j.ThreadContext`] is used for correlation.
 
-|Trace correlation - 1.13.0
+|Correlation (traces) - 1.13.0
+
+Correlation (service) - 1.29.0
 
 Error capturing - 1.10.0
 
-ECS Service Name - 1.29.0
-
-ECS Reformatting - 1.22.0
+Reformatting - 1.22.0
 
 
 |log4j1
-|Trace correlation and error capture - 1.x
+|Correlation & error capture - 1.x
 
-ECS Reformatting - 1.2.17
+Reformatting - 1.2.17
 
 |https://logging.apache.org/log4j/1.2/apidocs/org/apache/log4j/MDC.html[`org.apache.log4j.MDC`] is used for correlation.
 
-|Trace correlation - 1.13.0
+|Correlation (traces) - 1.13.0
 
-ECS Reformatting - 1.22.0
+Correlation (service) - 1.38.0
+
+Reformatting - 1.22.0
 
 Error capturing - 1.30.0
 
@@ -604,36 +604,46 @@ Error capturing - 1.30.0
 |1.1.0+
 |https://www.slf4j.org/api/org/slf4j/MDC.html[`org.slf4j.MDC`] is used for correlation.
 
-|Trace correlation - 1.0.0
+|Correlation (traces) - 1.0.0
+
+Correlation (service) - 1.38.0
 
 ECS Reformatting - 1.22.0
 
 |JBoss Logging
 |3.0.0+
 | http://javadox.com/org.jboss.logging/jboss-logging/3.3.0.Final/org/jboss/logging/MDC.html[`org.jboss.logging.MDC`] is used for correlation.
-|Trace correlation - 1.23.0 (LogManager 1.30.0)
+|Correlation (traces) - 1.23.0 (LogManager 1.30.0)
+
+Correlation (service) - 1.38.0
+
+Reformatting - 1.31.0
 
 |JUL - `java.util.logging`
 |All supported Java versions
-|Trace correlation is only supported when used ECS logging library or with ECS Reformatting as JUL does
+|Correlation is only supported with ECS logging (library or reformatting) as JUL does
 not provide any MDC implementation.
-|Trace correlation - 1.35.0 (only when using ECS format as there is no MDC in JUL)
+|Correlation (traces) - 1.35.0 (requires ECS logging)
 
-ECS Reformatting - 1.31.0
+Correlation (service) - 1.38.0 (requires ECS logging)
+
+Reformatting - 1.31.0
 
 Error capturing - 1.31.0
 
 | Tomcat JULI
 | 7.0.0+
-|Trace correlation is only supported when used ECS logging library or with ECS Reformatting as JUL does
+|Trace correlation is only supported with ECS logging (library or reformatting) as JUL does
 not provide any MDC implementation.
 
 Tomcat access logs are not supported.
-|Trace correlation - 1.35.0 (only when using ECS format as there is no MDC in JUL)
+|Correlation (traces) - 1.35.0 (requires ECS logging)
 
-ECS Reformatting - 1.35.0
+Correlation (service) - 1.38.0 (requires ECS logging)
 
-Error capturing - 1.35.0 (through JUL)
+Reformatting - 1.35.0
+
+Error capturing - 1.35.0
 
 |===
 


### PR DESCRIPTION
## What does this PR do?

Fixes #3051 

Instruments ecs-logging library for Java and set the `service.environment` to match the agent configuration, hence providing correlation between agent data and logs produced by ecs-logging. It is a follow-up of #3064 .

In the case where the `ecs-logging` configuration for `service.environment` does not match the agent configuration, then a log warning is issued like with `service.name` and `service.version`.

I initially thought that the agent was already setting `service.environment` when using ECS reformatting, but it is not the case.
As a consequence this PR also has to cover this aspect.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] ~~Added an API method or config option? Document in which version this will be introduced~~ n/a
  - [x] I have made corresponding changes to the documentation
