### PR TITLE
Updated changelog for 1.38.0 release

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -20,8 +20,11 @@ endif::[]
 
 === Unreleased
 
+[[release-notes-1.x]]
+=== Java Agent version 1.x
+
 [[release-notes-1.38.0]]
-==== 1.38.0 - YYYY/MM/DD
+==== 1.38.0 - 2023/05/04
 
 [float]
 ===== Features
@@ -32,9 +35,6 @@ endif::[]
 [float]
 ===== Bug fixes
 * Do not use proxy to retrieve cloud metadata - {pull}3108[#3108]
-
-[[release-notes-1.x]]
-=== Java Agent version 1.x
 
 [[release-notes-1.37.0]]
 ==== 1.37.0 - 2023/04/11


### PR DESCRIPTION
## What does this PR do?

Prepares changelog for 1.38.0 release.
