### PR TITLE
Prevent overhead from excessive span creation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ endif::[]
 * Added tests for Quarkus / RestEasy, adjusted vert.x router transaction name priority - {pull}1765[#1765]
 * Added support for Spring WebMVC 6.x and Spring Boot 3.x - {pull}3094[#3094]
 * Added `service.environment` to logs for service correlation - {pull}3115[#3115]
+* Optimize agent overhead when an excessive number of spans is created with `trace_methods`, `@Traced` or `@CaptureSpan` - {pull}3151[#3151]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
@@ -497,6 +497,11 @@ public class Span extends AbstractSpan<Span> implements Recyclable, co.elastic.a
     }
 
     @Override
+    public boolean shouldSkipChildSpanCreation() {
+        return transaction != null && transaction.shouldSkipChildSpanCreation();
+    }
+
+    @Override
     protected void recycle() {
         tracer.recycle(this);
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -295,7 +295,20 @@ public class Transaction extends AbstractSpan<Transaction> implements co.elastic
         return droppedSpanStats;
     }
 
-    boolean isSpanLimitReached() {
+    @Override
+    public boolean shouldSkipChildSpanCreation() {
+        boolean drop = spanCount.isSpanLimitReached(maxSpans);
+        if (drop) {
+            // when dropping, the caller is expected to optimize and avoid span creation. As a consequence we have
+            // to artificially increase those counters to make it as if the span was actually created and dropped
+            // before reporting
+            spanCount.getTotal().incrementAndGet();
+            spanCount.getDropped().incrementAndGet();
+        }
+        return drop;
+    }
+
+     boolean isSpanLimitReached() {
         return getSpanCount().isSpanLimitReached(maxSpans);
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/tracemethods/TraceMethodInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/tracemethods/TraceMethodInstrumentation.java
@@ -22,6 +22,8 @@ import co.elastic.apm.agent.bci.TracerAwareInstrumentation;
 import co.elastic.apm.agent.bci.bytebuddy.SimpleMethodSignatureOffsetMappingFactory;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.Span;
@@ -126,6 +128,8 @@ public class TraceMethodInstrumentation extends TracerAwareInstrumentation {
 
     public static class TraceMethodAdvice {
 
+        public static final Logger logger = LoggerFactory.getLogger(TraceMethodAdvice.class);
+
         private static final ElasticApmTracer tracer = GlobalTracer.get().require(ElasticApmTracer.class);
         private static final long traceMethodThresholdMicros;
 
@@ -148,6 +152,7 @@ public class TraceMethodInstrumentation extends TracerAwareInstrumentation {
             } else if (parent.isSampled()) {
                 if (parent.shouldSkipChildSpanCreation()) {
                     // span limit reached means span will not be reported, thus we can optimize and skip creating one
+                    logger.debug("Not creating span for {} because span limit is reached.", signature);
                     return null;
                 }
                 span = parent.createSpan()

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/tracemethods/TraceMethodInstrumentation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/tracemethods/TraceMethodInstrumentation.java
@@ -146,6 +146,10 @@ public class TraceMethodInstrumentation extends TracerAwareInstrumentation {
                     span.withName(signature).activate();
                 }
             } else if (parent.isSampled()) {
+                if (parent.shouldSkipChildSpanCreation()) {
+                    // span limit reached means span will not be reported, thus we can optimize and skip creating one
+                    return null;
+                }
                 span = parent.createSpan()
                     .withName(signature)
                     .activate();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/collections/SpanConcurrentHashMapTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/collections/SpanConcurrentHashMapTest.java
@@ -217,6 +217,11 @@ class SpanConcurrentHashMapTest {
         protected TestSpan thiz() {
             return null;
         }
+
+        @Override
+        public boolean shouldSkipChildSpanCreation() {
+            return false;
+        }
     }
 
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/TransactionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/TransactionTest.java
@@ -20,11 +20,14 @@ package co.elastic.apm.agent.impl.transaction;
 
 import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.TransactionUtils;
+import co.elastic.apm.agent.configuration.CoreConfiguration;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.metadata.MetaDataMock;
 import co.elastic.apm.agent.impl.sampling.ConstantSampler;
 import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.report.ApmServerClient;
 import co.elastic.apm.agent.report.serialize.DslJsonSerializer;
+import co.elastic.apm.agent.report.serialize.SerializationConstants;
 import co.elastic.apm.agent.tracer.Outcome;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +39,7 @@ import java.util.Arrays;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 public class TransactionTest {
@@ -44,6 +48,9 @@ public class TransactionTest {
 
     @BeforeEach
     void setUp() {
+        CoreConfiguration coreConfig = MockTracer.createRealTracer().getConfig(CoreConfiguration.class);
+        SerializationConstants.init(coreConfig);
+
         jsonSerializer = new DslJsonSerializer(
             mock(StacktraceConfiguration.class),
             mock(ApmServerClient.class),

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/CaptureSpanInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/CaptureSpanInstrumentation.java
@@ -102,10 +102,10 @@ public class CaptureSpanInstrumentation extends ElasticApmInstrumentation {
             }
 
             span.withName(spanName.isEmpty() ? signature : spanName)
-                .withType(type)
-                .withSubtype(subtype)
-                .withAction(action)
                 .activate();
+
+            // using deprecated API to keep compatibility with existing behavior
+            ((co.elastic.apm.agent.impl.transaction.Span) span).setType(type, subtype, action);
 
             if (!discardable) {
                 span.setNonDiscardable();

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TracedInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TracedInstrumentation.java
@@ -90,6 +90,10 @@ public class TracedInstrumentation extends ElasticApmInstrumentation {
 
             final AbstractSpan<?> parent = tracer.getActive();
             if (parent != null) {
+                if (parent.shouldSkipChildSpanCreation()) {
+                    // span limit reached means span will not be reported, thus we can optimize and skip creating one
+                    return null;
+                }
                 Span<?> span = asExit ? parent.createExitSpan() : parent.createSpan();
                 if (span == null) {
                     return null;

--- a/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TracedInstrumentation.java
+++ b/apm-agent-plugins/apm-api-plugin/src/main/java/co/elastic/apm/agent/pluginapi/TracedInstrumentation.java
@@ -23,6 +23,8 @@ import co.elastic.apm.agent.bci.bytebuddy.SimpleMethodSignatureOffsetMappingFact
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.tracer.AbstractSpan;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Outcome;
@@ -46,10 +48,10 @@ import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.classLoad
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isInAnyPackage;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.isProxy;
 import static co.elastic.apm.agent.bci.bytebuddy.CustomElementMatchers.overridesOrImplementsMethodThat;
-import static co.elastic.apm.agent.tracer.AbstractSpan.PRIORITY_METHOD_SIGNATURE;
-import static co.elastic.apm.agent.tracer.AbstractSpan.PRIORITY_USER_SUPPLIED;
 import static co.elastic.apm.agent.pluginapi.ElasticApmApiInstrumentation.PUBLIC_API_INSTRUMENTATION_GROUP;
 import static co.elastic.apm.agent.pluginapi.Utils.FRAMEWORK_NAME;
+import static co.elastic.apm.agent.tracer.AbstractSpan.PRIORITY_METHOD_SIGNATURE;
+import static co.elastic.apm.agent.tracer.AbstractSpan.PRIORITY_USER_SUPPLIED;
 import static net.bytebuddy.matcher.ElementMatchers.declaresMethod;
 import static net.bytebuddy.matcher.ElementMatchers.isAnnotatedWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
@@ -58,6 +60,8 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 public class TracedInstrumentation extends ElasticApmInstrumentation {
 
     public static final Tracer tracer = GlobalTracer.get();
+
+    public static final Logger logger = LoggerFactory.getLogger(TracedInstrumentation.class);
 
     private final CoreConfiguration coreConfig;
     private final StacktraceConfiguration stacktraceConfig;
@@ -92,6 +96,7 @@ public class TracedInstrumentation extends ElasticApmInstrumentation {
             if (parent != null) {
                 if (parent.shouldSkipChildSpanCreation()) {
                     // span limit reached means span will not be reported, thus we can optimize and skip creating one
+                    logger.debug("Not creating span for {} because span limit is reached.", signature);
                     return null;
                 }
                 Span<?> span = asExit ? parent.createExitSpan() : parent.createSpan();

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/AbstractSpan.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/AbstractSpan.java
@@ -184,4 +184,11 @@ public interface AbstractSpan<T extends AbstractSpan<T>> extends ElasticContext<
     void incrementReferences();
 
     void decrementReferences();
+
+    /**
+     * @return {@literal true} when span limit is reached and the caller can optimize and not create a span. The caller
+     * is expected to call this method before every span creation operation for proper dropped spans accounting. If not
+     * called before attempting span creation, a span will be created and dropped before reporting.
+     */
+    boolean shouldSkipChildSpanCreation();
 }

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/AbstractSpan.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/AbstractSpan.java
@@ -189,6 +189,12 @@ public interface AbstractSpan<T extends AbstractSpan<T>> extends ElasticContext<
      * @return {@literal true} when span limit is reached and the caller can optimize and not create a span. The caller
      * is expected to call this method before every span creation operation for proper dropped spans accounting. If not
      * called before attempting span creation, a span will be created and dropped before reporting.
+     * <br/>
+     * Expected caller behavior depends on the returned value:
+     * <ul>
+     *     <li>{@literal true} returned means the caller is expected to NOT call {@link #createSpan()} or {@link #createExitSpan()}</li>
+     *     <li>{@literal false} returned means the caller MAY call {@link #createSpan()} or {@link #createExitSpan()}</li>
+     * </ul>
      */
     boolean shouldSkipChildSpanCreation();
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #2788 by skipping span creation when the max span limit is already reached within the active transaction.

This is applied to the following instrumentations:
- `trace_methods` set in configuration
- `@Traced` annotated methods
- `@CaptureSpan` annotated methods

While it does not prevent users from mis-using configuration or annotations, it removes most of the agent overhead by skipping the span creation.

The global number of dropped spans is captured in the transaction, however the dropped span metrics are not updated because they rely on the span being created (and are updated when the span ends).

As a consequence the dropped spans metrics might appear inconsistent, but I think it's safe to assume that inconsistency is a small price to pay here given it helps to lower the overhead in case of an agent mis-configuration.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] ~~Added an API method or config option? Document in which version this will be introduced~~ N/A
  - [x] ~~I have made corresponding changes to the documentation~~ N/A

### Performance improvements

10 millions very short spans created within a single transaction:
- the bottom half transactions with current version of the agent: transaction takes about ~7seconds
- the top half is with this change applied: transaction takes about 200~400ms

![Screenshot from 2023-05-26 16-23-32](https://github.com/elastic/apm-agent-java/assets/763082/b9733355-5e30-4ba8-8116-1fc9227b2fa1)
