### PR TITLE
Update spring dependencies managed via spring boot via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,7 @@ updates:
       - dependency-name: "co.elastic.clients:*"
       - dependency-name: "io.vertx:*"
       - dependency-name: "org.apache.logging.log4j:*"
+      - dependency-name: "org.springframework.boot:*"
     ignore:
       - dependency-name: "net.bytebuddy:byte-buddy-agent"
         # We deliberately want to keep this older version of Byte Buddy for our runtime attach test
@@ -50,6 +51,8 @@ updates:
       # Prevent dependabot from attempting to upgrade vertx from version 3 to 4, but still perform minor & patch updates
       - dependency-name: "io.vertx:*"
         update-types: [ "version-update:semver-major" ]
+      - dependency-name: "org.springframework.boot:*"
+        update-types: [ "version-update:semver-patch" ] # ignore spring patch updates to prevent PR spam
       # Since these AWS dependencies are heavy and are being released very frequently, we ignore in the weekly update and update monthly
       - dependency-name: "com.amazonaws:aws-java-sdk-s3"
       - dependency-name: "com.amazonaws:aws-java-sdk-dynamodb"


### PR DESCRIPTION
## What does this PR do?

We use spring boot for dependency management in most of our spring-related plugins. This PR ensures that we don't miss updates in the future by enabling dependabot for major and minor spring updates (no patch updates).

## Checklist
- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
