### PR TITLE
Docs clarification that additional log fields are unsupported for log sending.

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
@@ -19,12 +19,12 @@
 package co.elastic.apm.agent.logging;
 
 import co.elastic.apm.agent.common.util.SystemStandardOutputLogger;
+import co.elastic.apm.agent.common.util.WildcardMatcher;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.tracer.configuration.ByteValue;
 import co.elastic.apm.agent.tracer.configuration.ByteValueConverter;
-import co.elastic.apm.agent.common.util.WildcardMatcher;
 import co.elastic.apm.agent.tracer.configuration.LogEcsReformatting;
 import co.elastic.apm.agent.tracer.configuration.WildcardMatcherValueConverter;
-import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
@@ -193,7 +193,8 @@ public class LoggingConfiguration extends ConfigurationOptionProvider implements
         .configurationCategory(LOGGING_CATEGORY)
         .description("A comma-separated list of key-value pairs that will be added as additional fields to all log events.\n " +
             "Takes the format `key=value[,key=value[,...]]`, for example: `key1=value1,key2=value2`.\n " +
-            "Only relevant if <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.\n")
+            "Only relevant if <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.\n" +
+            "Additional fields are currently not supported for direct log sending through the agent.\n")
         .dynamic(false)
         .buildWithDefault(Collections.<String, String>emptyMap());
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -2195,6 +2195,7 @@ Valid options: `OFF`, `SHADE`, `REPLACE`, `OVERRIDE`
 A comma-separated list of key-value pairs that will be added as additional fields to all log events.
  Takes the format `key=value[,key=value[,...]]`, for example: `key1=value1,key2=value2`.
  Only relevant if <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.
+Additional fields are currently not supported for direct log sending through the agent.
 
 
 
@@ -4398,6 +4399,7 @@ Example: `5ms`.
 # A comma-separated list of key-value pairs that will be added as additional fields to all log events.
 #  Takes the format `key=value[,key=value[,...]]`, for example: `key1=value1,key2=value2`.
 #  Only relevant if <<config-log-ecs-reformatting,`log_ecs_reformatting`>> is set to any option other than `OFF`.
+# Additional fields are currently not supported for direct log sending through the agent.
 # 
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.


### PR DESCRIPTION
There have been user reports that they were confused that the `log_ecs_reformatting_additional_fields` setting has no effect for direct log sending. This PR tries to make this limitation explicit.
