### PR TITLE
Prevent NoSuchMethodErrors on pre Servlet-api 3.0 versions in spring instrumentation.

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,7 @@ endif::[]
 ===== Bug fixes
 * Fixed classloading for OpenTelemetry dependencies in external plugins - {pull}3154[#3154]
 * Handled an edge case where exceptions thrown by instrumentation code could escape into the application - {pull}3159[#3159]
+* Added guard to gracefully handle the presence of pre 3.0 Servlet API versions in the spring service name discovery mechanism - {pull}3172[#3172]
 
 
 [[release-notes-1.x]]

--- a/apm-agent-plugins/apm-servlet-plugin/pom.xml
+++ b/apm-agent-plugins/apm-servlet-plugin/pom.xml
@@ -53,6 +53,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
             <version>${version.okhttp}</version>

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
@@ -43,7 +43,17 @@ public class JavaxServletApiAdapter implements ServletApiAdapter<HttpServletRequ
 
     private static final JavaxServletApiAdapter INSTANCE = new JavaxServletApiAdapter();
 
+    private final boolean ServletContext_getClassLoader_available;
+
     private JavaxServletApiAdapter() {
+        boolean probeResult;
+        try {
+            ServletContext.class.getMethod("getClassLoader");
+            probeResult = true;
+        } catch (NoSuchMethodException e) {
+            probeResult = false;
+        }
+        ServletContext_getClassLoader_available = probeResult;
     }
 
     public static JavaxServletApiAdapter get() {
@@ -98,7 +108,11 @@ public class JavaxServletApiAdapter implements ServletApiAdapter<HttpServletRequ
         if (servletContext == null) {
             return null;
         }
-
+        if (!ServletContext_getClassLoader_available) {
+            // we are on a pre Servlet 3.0 version where ServletContext.getClassLoader does not exist.
+            // While we don't support such Servlet-API versions, we don't want our advices to throw NoSuchMethodErrors.
+            return null;
+        }
         // getClassloader might throw UnsupportedOperationException
         // see Section 4.4 of the Servlet 3.0 specification
         try {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
@@ -46,14 +46,16 @@ public class JavaxServletApiAdapter implements ServletApiAdapter<HttpServletRequ
     private final boolean ServletContext_getClassLoader_available;
 
     private JavaxServletApiAdapter() {
-        boolean probeResult;
+        ServletContext_getClassLoader_available = canCallServletContextGetClassLoader();
+    }
+
+    private static boolean canCallServletContextGetClassLoader() {
         try {
             ServletContext.class.getMethod("getClassLoader");
-            probeResult = true;
+            return true;
         } catch (NoSuchMethodException e) {
-            probeResult = false;
+            return false;
         }
-        ServletContext_getClassLoader_available = probeResult;
     }
 
     public static JavaxServletApiAdapter get() {

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/helper/AncientServletAPITest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/helper/AncientServletAPITest.java
@@ -1,0 +1,26 @@
+package co.elastic.apm.agent.servlet.helper;
+
+import co.elastic.apm.agent.servlet.adapter.JavaxServletApiAdapter;
+import co.elastic.apm.agent.testutils.TestClassWithDependencyRunner;
+import org.junit.jupiter.api.Test;
+
+import javax.servlet.ServletContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Invoked by {@link ServletApiAdapterTest#checkAncientServletApiVersionDoesNotThrowErrors()}
+ */
+@TestClassWithDependencyRunner.DisableOutsideOfRunner
+public class AncientServletAPITest {
+
+    @Test
+    public void checkGetClassloaderNotPresent() {
+        assertThatThrownBy(() -> ServletContext.class.getMethod("getClassLoader"))
+            .isInstanceOf(NoSuchMethodException.class);
+        ServletContext servletContext = mock(ServletContext.class);
+        assertThat(JavaxServletApiAdapter.get().getClassLoader(servletContext)).isNull();
+    }
+}

--- a/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/helper/ServletApiAdapterTest.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/test/java/co/elastic/apm/agent/servlet/helper/ServletApiAdapterTest.java
@@ -19,9 +19,11 @@
 package co.elastic.apm.agent.servlet.helper;
 
 import co.elastic.apm.agent.servlet.adapter.JavaxServletApiAdapter;
+import co.elastic.apm.agent.testutils.TestClassWithDependencyRunner;
 import org.junit.jupiter.api.Test;
 
 import javax.servlet.ServletContext;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -45,4 +47,14 @@ public class ServletApiAdapterTest {
         doReturn(cl).when(servletContext).getClassLoader();
         assertThat(adapter.getClassLoader(servletContext)).isSameAs(cl);
     }
+
+    @Test
+    void checkAncientServletApiVersionDoesNotThrowErrors() throws Exception {
+        new TestClassWithDependencyRunner(
+            List.of("javax.servlet:servlet-api:2.5"),
+            AncientServletAPITest.class.getName(),
+            JavaxServletApiAdapter.class.getName())
+            .run();
+    }
+
 }


### PR DESCRIPTION


## What does this PR do?

We had a user reporting that they are seeing the following error caused by our spring transaction-naming instrumentation:

```
[main] ERROR co.elastic.apm.agent.bci.IndyBootstrap - Advice threw an exception, this should never happen!
java.lang.NoSuchMethodError: javax.servlet.ServletContext.getClassLoader()Ljava/lang/ClassLoader;
```

While we only support Servlet-API versions 3.0+, the spring instrumentation does currently not guard against the presence older versions. This PR adds such a guard for this method to our servlet-api adapters.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
