### PR TITLE
Temporary buildkite action usage fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,11 @@ jobs:
           artifactName: lambda-zip
           artifactPath: "elastic-apm-agent/target/elastic-apm-java-aws-lambda-layer-*.zip"
           artifactIfNoFilesFound: error
+          # The action fails with .github/actions/buildkite/run.sh: line 24: 3: parameter missing.
+          # Which is an unexpected bug.
+          # Adding a random buildEnvVar to circumvent the behaviour.
+          buildEnvVars: |
+            something_something: true
 
 
   await_artifact_on_maven_central:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           # Which is an unexpected bug.
           # Adding a random buildEnvVar to circumvent the behaviour.
           buildEnvVars: |
-            something_something: true
+            something_something=true
 
 
   await_artifact_on_maven_central:


### PR DESCRIPTION
## What does this PR do?

The buildkite action unexpectedly fails with a missing parameter.

This PR adds a random buildEnvVar to temporarily circumvent the error.

A proper fix will be done in a follow-up.