### PR TITLE
Fix lambda layer publish script

### DIFF
--- a/.ci/create-arn-table.sh
+++ b/.ci/create-arn-table.sh
@@ -4,11 +4,10 @@ set -o pipefail
 #
 # Create the AWS ARN table given the below environment variables:
 #
-#   - AWS_FOLDER      - that's the location of the publish-layer-version output for each region
-#	- SUFFIX_ARN_FILE - that's the output file.
-#
+#  AWS_FOLDER - that's the location of the publish-layer-version output for each region
 
-ARN_FILE=${SUFFIX_ARN_FILE}
+AWS_FOLDER=${AWS_FOLDER?:No aws folder provided}
+ARN_FILE=".ci/.arn-file.md"
 
 {
 	echo "### ARNs of the APM Java Agent's AWS Lambda Layer"
@@ -19,7 +18,7 @@ ARN_FILE=${SUFFIX_ARN_FILE}
 
 for f in $(ls "${AWS_FOLDER}"); do
 	LAYER_VERSION_ARN=$(grep '"LayerVersionArn"' "$AWS_FOLDER/${f}" | cut -d":" -f2- | sed 's/ //g' | sed 's/"//g' | cut -d"," -f1)
-	echo "INFO: create-arn-table ARN(${LAYER_VERSION_ARN}):region(${f}))"
+	echo "INFO: create-arn-table ARN(${LAYER_VERSION_ARN}):region(${f})"
 	echo "|${f}|${LAYER_VERSION_ARN}|" >> "${ARN_FILE}"
 done
 

--- a/.ci/publish-aws.sh
+++ b/.ci/publish-aws.sh
@@ -21,20 +21,6 @@ ALL_AWS_REGIONS=$(aws ec2 describe-regions --output json --no-cli-pager | jq -r 
 rm -rf "${AWS_FOLDER}"
 mkdir -p "${AWS_FOLDER}"
 
-# Delete previous layers
-for region in $ALL_AWS_REGIONS; do
-  layer_versions=$(aws lambda list-layer-versions --region="${region}" --layer-name="${ELASTIC_LAYER_NAME}" | jq '.LayerVersions[].Version')
-  echo "Found layer versions for ${FULL_LAYER_NAME} in ${region}: ${layer_versions:-none}"
-  for version_number in $layer_versions; do
-    echo "- Deleting ${FULL_LAYER_NAME}:${version_number} in ${region}"
-    aws lambda delete-layer-version \
-        --region="${region}" \
-        --layer-name="${FULL_LAYER_NAME}" \
-        --version-number="${version_number}"
-  done
-done
-
-
 zip_file="./elastic-apm-agent/target/elastic-apm-java-ver-1-39-0.zip"
 
 for region in $ALL_AWS_REGIONS; do

--- a/.ci/publish-aws.sh
+++ b/.ci/publish-aws.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+#
+# Publishes the created artifacts from ./dev-utils/make-distribution.sh to AWS as AWS Lambda Layers in every region.
+# Finalized by generating an ARN table which will be used in the release notes.
+#
+# AWS_FOLDER is used for temporary output of publishing layers used to create the arn table. (Optional)
+# ELASTIC_LAYER_NAME is the name of the lambda layer e.g. elastic-apm-python-ver-3-44-1 for the git tag v3.44.1 (Required)
+
+
+# This needs to be set in GH actions
+# https://dotjoeblog.wordpress.com/2021/03/14/github-actions-aws-error-exit-code-255/
+# eu-west-1 is just a random region
+export AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-eu-west-1}
+
+export AWS_FOLDER=${AWS_FOLDER:-.ci/.aws}
+FULL_LAYER_NAME=${ELASTIC_LAYER_NAME:?layer name not provided}
+ALL_AWS_REGIONS=$(aws ec2 describe-regions --output json --no-cli-pager | jq -r '.Regions[].RegionName')
+
+rm -rf "${AWS_FOLDER}"
+mkdir -p "${AWS_FOLDER}"
+
+# Delete previous layers
+for region in $ALL_AWS_REGIONS; do
+  layer_versions=$(aws lambda list-layer-versions --region="${region}" --layer-name="${ELASTIC_LAYER_NAME}" | jq '.LayerVersions[].Version')
+  echo "Found layer versions for ${FULL_LAYER_NAME} in ${region}: ${layer_versions:-none}"
+  for version_number in $layer_versions; do
+    echo "- Deleting ${FULL_LAYER_NAME}:${version_number} in ${region}"
+    aws lambda delete-layer-version \
+        --region="${region}" \
+        --layer-name="${FULL_LAYER_NAME}" \
+        --version-number="${version_number}"
+  done
+done
+
+
+zip_file="./elastic-apm-agent/target/elastic-apm-java-ver-1-39-0.zip"
+
+for region in $ALL_AWS_REGIONS; do
+  echo "Publish ${FULL_LAYER_NAME} in ${region}"
+  publish_output=$(aws lambda \
+    --output json \
+    publish-layer-version \
+    --region="${region}" \
+    --layer-name="${FULL_LAYER_NAME}" \
+    --description="AWS Lambda Extension Layer for the Elastic APM Java Agent" \
+    --license-info="Apache-2.0" \
+    --compatible-runtimes java8.al2 java11 \
+    --zip-file="fileb://${zip_file}")
+  echo "${publish_output}" > "${AWS_FOLDER}/${region}"
+  layer_version=$(echo "${publish_output}" | jq '.Version')
+  echo "Grant public layer access ${FULL_LAYER_NAME}:${layer_version} in ${region}"
+  grant_access_output=$(aws lambda \
+  		--output json \
+  		add-layer-version-permission \
+  		--region="${region}" \
+  		--layer-name="${FULL_LAYER_NAME}" \
+  		--action="lambda:GetLayerVersion" \
+  		--principal='*' \
+  		--statement-id="${FULL_LAYER_NAME}" \
+  		--version-number="${layer_version}")
+  echo "${grant_access_output}" > "${AWS_FOLDER}/.${region}-public"
+done
+
+sh -c "./.ci/create-arn-table.sh"

--- a/.ci/publish-aws.sh
+++ b/.ci/publish-aws.sh
@@ -2,11 +2,11 @@
 set -euo pipefail
 
 #
-# Publishes the created artifacts from ./dev-utils/make-distribution.sh to AWS as AWS Lambda Layers in every region.
+# Publishes the created lambda layer zip to AWS as AWS Lambda Layers in every region.
 # Finalized by generating an ARN table which will be used in the release notes.
 #
 # AWS_FOLDER is used for temporary output of publishing layers used to create the arn table. (Optional)
-# ELASTIC_LAYER_NAME is the name of the lambda layer e.g. elastic-apm-python-ver-3-44-1 for the git tag v3.44.1 (Required)
+# ELASTIC_LAYER_NAME is the name of the lambda layer e.g. elastic-apm-java-ver-3-44-1 for the git tag v3.44.1 (Required)
 
 
 # This needs to be set in GH actions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -234,18 +234,21 @@ jobs:
             secret/observability-team/ci/service-account/apm-aws-lambda access_key_id | AWS_ACCESS_KEY_ID ;
             secret/observability-team/ci/service-account/apm-aws-lambda secret_access_key | AWS_SECRET_ACCESS_KEY
       - name: Publish
-        run: make -C .ci publish-in-all-aws-regions
-      - name: Create ARN file
-        run: make -C .ci create-arn-file
+        run: |
+          # Convert v1.2.3 to ver-1-2-3
+          VERSION=${TAG_NAME/v/ver-}
+          VERSION=${VERSION//./-}
+          
+          ELASTIC_LAYER_NAME="elastic-apm-java-${VERSION}" .ci/publish-aws.sh
       - uses: actions/upload-artifact@v3
         with:
           name: arn-file
-          path: .ci/arn-file.md
+          path: .ci/.arn-file.md
       - name: Add ARN file to output
         id: arn_output
         run: |
           echo 'arn_content<<ARN_CONTENT_EOF' >> $GITHUB_OUTPUT
-          cat .ci/arn-file.md >> $GITHUB_OUTPUT
+          cat .ci/.arn-file.md >> $GITHUB_OUTPUT
           echo 'ARN_CONTENT_EOF' >> $GITHUB_OUTPUT
 
 


### PR DESCRIPTION
## What does this PR do?

The lambda layer publish script did not work as expected locally and presumably in GH actions and created 20+ lambda layer versions in eu-west-1 instead of 1 version in every region. (Assumption: maybe due to Jenkins compatibility)

The script added by this PR proved to work in a GH Actions workflow in https://github.com/elastic/apm-agent-python and https://github.com/elastic/apm-aws-lambda.