### PR TITLE
Wildlfy test upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -69,3 +69,14 @@ updates:
       - dependency-name: "com.amazonaws:aws-java-sdk-s3"
       - dependency-name: "com.amazonaws:aws-java-sdk-dynamodb"
       - dependency-name: "software.amazon.awssdk:*"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 3
+    reviewers:
+      - "@elastic/apm-agent-java"
+    ignore:
+      # We are only interested in major updates
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-minor", "version-update:semver-patch" ]

--- a/apm-agent-common/src/test/java/co/elastic/apm/agent/test/DockerfileReader.java
+++ b/apm-agent-common/src/test/java/co/elastic/apm/agent/test/DockerfileReader.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+public class DockerfileReader {
+
+    public static String getFrom(String resourcePath) {
+        try (InputStream content = DockerfileReader.class.getResourceAsStream(resourcePath)) {
+            String dockerfile = new String(content.readAllBytes(), StandardCharsets.UTF_8);
+            return Stream.of(dockerfile.split("\n"))
+                .filter(line -> line.startsWith("FROM"))
+                .map(line -> line.substring("FROM".length()).trim())
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("Failed to find FROM-clause in Dockerfile"));
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/apm-agent-common/src/test/java/co/elastic/apm/agent/test/DockerfileReaderTest.java
+++ b/apm-agent-common/src/test/java/co/elastic/apm/agent/test/DockerfileReaderTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.test;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class DockerfileReaderTest {
+
+    @Test
+    public void checkValidDockerfile() {
+        assertThat(DockerfileReader.getFrom("/test-dockfile.txt")).isEqualTo("foobar");
+    }
+
+    @Test
+    public void checkInvalidDockerfile() {
+        assertThatThrownBy(() -> DockerfileReader.getFrom("/test-dockfile-invalid.txt"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+}

--- a/apm-agent-common/src/test/resources/test-dockfile-invalid.txt
+++ b/apm-agent-common/src/test/resources/test-dockfile-invalid.txt
@@ -1,0 +1,5 @@
+#this is a dummy dockerfile to text the image extraction from the "FROM" clause
+
+NOFROM foobar
+
+

--- a/apm-agent-common/src/test/resources/test-dockfile.txt
+++ b/apm-agent-common/src/test/resources/test-dockfile.txt
@@ -1,0 +1,5 @@
+#this is a dummy dockerfile to text the image extraction from the "FROM" clause
+
+FROM foobar
+
+

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -201,7 +201,7 @@ Other Servlet 3+ compliant servers will most likely work as well.
 |7.x, 8.5.x, 9.x, 10.x
 
 |<<setup-jboss-wildfly,WildFly>>
-|8-16
+|8+
 
 |<<setup-jboss-wildfly,JBoss EAP>>
 |6.4, 7.0, 7.1, 7.2

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JakartaeeWildFlyIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/JakartaeeWildFlyIT.java
@@ -19,11 +19,11 @@
 package co.elastic.apm.servlet;
 
 import co.elastic.apm.agent.test.AgentTestContainer;
-import co.elastic.apm.servlet.tests.CdiApplicationServerTestApp;
-import co.elastic.apm.servlet.tests.JBossServletApiTestApp;
-import co.elastic.apm.servlet.tests.JavaxExternalPluginTestApp;
-import co.elastic.apm.servlet.tests.JsfApplicationServerTestApp;
-import co.elastic.apm.servlet.tests.SoapTestApp;
+import co.elastic.apm.agent.test.DockerfileReader;
+import co.elastic.apm.servlet.tests.CdiJakartaeeApplicationServerTestApp;
+import co.elastic.apm.servlet.tests.JBossJakartaServletApiTestApp;
+import co.elastic.apm.servlet.tests.JakartaExternalPluginTestApp;
+import co.elastic.apm.servlet.tests.JakartaeeJsfApplicationServerTestApp;
 import co.elastic.apm.servlet.tests.TestApp;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -31,10 +31,10 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 
 @RunWith(Parameterized.class)
-public class WildFlyIT extends AbstractServletContainerIntegrationTest {
+public class JakartaeeWildFlyIT extends AbstractServletContainerIntegrationTest {
 
-    public WildFlyIT(final String wildFlyVersion) {
-        super(AgentTestContainer.appServer("jboss/wildfly:" + wildFlyVersion)
+    public JakartaeeWildFlyIT(final String wildFlyImage) {
+        super(AgentTestContainer.appServer(wildFlyImage)
                 .withContainerName("wildfly")
                 .withHttpPort(8080)
                 .withJvmArgumentsVariable("JAVA_OPTS") // using JAVA_OPTS to provide JVM arguments
@@ -48,23 +48,17 @@ public class WildFlyIT extends AbstractServletContainerIntegrationTest {
     @Parameterized.Parameters(name = "Wildfly {0}")
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {"8.2.1.Final"},
-            {"9.0.0.Final"},
-            {"11.0.0.Final"},
-            {"13.0.0.Final"},
-            {"15.0.0.Final"},
-            {"25.0.0.Final"}
+            {DockerfileReader.getFrom("/Dockerfile-wildfly-latest")},
         });
     }
 
     @Override
     protected Iterable<Class<? extends TestApp>> getTestClasses() {
         return Arrays.asList(
-            JBossServletApiTestApp.class,
-            JsfApplicationServerTestApp.class,
-            SoapTestApp.class,
-            CdiApplicationServerTestApp.class,
-            JavaxExternalPluginTestApp.class
+            JBossJakartaServletApiTestApp.class,
+            JakartaeeJsfApplicationServerTestApp.class,
+            CdiJakartaeeApplicationServerTestApp.class,
+            JakartaExternalPluginTestApp.class
         );
     }
 }

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/JBossJakartaServletApiTestApp.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/tests/JBossJakartaServletApiTestApp.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.servlet.tests;
+
+import co.elastic.apm.servlet.AbstractServletContainerIntegrationTest;
+
+import java.util.Map;
+
+public class JBossJakartaServletApiTestApp extends JakartaeeServletApiTestApp {
+
+    @Override
+    public void test(AbstractServletContainerIntegrationTest test) throws Exception {
+        super.test(test);
+        test.executeAndValidateRequest("/jakartaee-simple-webapp/jboss-mbeans", "Found jboss.as:* MBeans", 200, Map.of());
+    }
+}

--- a/integration-tests/application-server-integration-tests/src/test/resources/Dockerfile-wildfly-latest
+++ b/integration-tests/application-server-integration-tests/src/test/resources/Dockerfile-wildfly-latest
@@ -1,0 +1,4 @@
+FROM quay.io/wildfly/wildfly:27.0.0.Final-jdk17
+# This is a dummy dockerfile which is just there to receive dependabot updates
+# The FROM clause at the top is parsed by our integration tests to use the latest but fixed version
+# This has the benefit over using docker :latest tags in tests that the tests should remain stable


### PR DESCRIPTION
## What does this PR do?

Upgrades the wildfly integration tests and the docs regarding supported versions.
In addition this contains an experiment for how to receive dependabot updates for our integration tests: A dummy dockerfile was added, which should be scanned by dependabot. Our integration tests read the image to use from that Dockerfile.

## Checklist

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
