### PR TITLE
prevent overriding aws elastic handler when set

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Bug fixes
 * Fixed agent programmatic attach with immutable config - {pull}3170[#3170]
+* Prevent overriding `ELASTIC_APM_AWS_LAMBDA_HANDLER` in AWS lambda execution when explicitly set - {pull}3205[#3205]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/elastic-apm-agent/src/main/assembly/elastic-apm-handler
+++ b/elastic-apm-agent/src/main/assembly/elastic-apm-handler
@@ -2,11 +2,15 @@
 
 export JAVA_TOOL_OPTIONS="-javaagent:/opt/elastic-apm-agent.jar ${JAVA_TOOL_OPTIONS}"
 
-export ELASTIC_APM_AWS_LAMBDA_HANDLER="${_HANDLER}"
+# if ELASTIC_APM_AWS_LAMBDA_HANDLER is explicitly set its value has priority
+export ELASTIC_APM_AWS_LAMBDA_HANDLER="${ELASTIC_APM_AWS_LAMBDA_HANDLER:-${_HANDLER}}"
+
 export ELASTIC_APM_METRICS_INTERVAL="0s"
 export ELASTIC_APM_CENTRAL_CONFIG="false"
 export ELASTIC_APM_CLOUD_PROVIDER="none"
 export ELASTIC_APM_ACTIVATION_METHOD="AWS_LAMBDA_LAYER"
 
+# removing class file sharing as it prevents bytecode instrumentation
 CMD="$(echo "$@" | sed 's/-Xshare:on/-Xshare:auto/g')"
+
 exec $CMD


### PR DESCRIPTION
## What does this PR do?

Fixes #2969 by not overriding the ELASTIC_APM_AWS_LAMBDA_HANDLER environment variable.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
