### PR TITLE
[ci] enhance CI build artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -82,6 +82,21 @@ jobs:
         with:
           name: elastic-apm-agent-java8
           path: ./elastic-apm-agent-java8/target/elastic-apm-agent-java8-*.jar
+      - name: Upload agent attach CLI artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: apm-agent-attach-cli
+          path: ./apm-agent-attach-cli/target/apm-agent-attach-cli-*.jar
+      - name: Upload agent attach artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: apm-agent-attach
+          path: ./apm-agent-attach/target/apm-agent-attach-*.jar
+      - name: Upload agent API artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: apm-agent-api
+          path: ./apm-agent-api/target/apm-agent-api-*.jar
 
   license:
     name: License

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
           path: |
             ./apm-agent-attach-cli/target/apm-agent-attach-cli-*.jar
             !./**/*-sources.jar
+            !./**/*-tests.jar
       - name: Upload agent attach artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,15 @@ jobs:
           path: |
             ./apm-agent-api/target/apm-agent-api-*.jar
             !./**/*-sources.jar
+      - name: Upload agent plugin SDK artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: apm-agent-plugin-sdk
+          path: |
+            ./apm-agent-plugin-sdk/target/apm-agent-plugin-sdk-*.jar
+            !./**/*-sources.jar
+
+
 
   license:
     name: License

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,31 +72,42 @@ jobs:
         with:
           name: build
           path: ${{ github.workspace }}
+
       - name: Upload agent binaries as artifacts
         uses: actions/upload-artifact@v3
         with:
           name: elastic-apm-agent
-          path: ./elastic-apm-agent/target/elastic-apm-agent-*.jar
+          path: |
+            ./elastic-apm-agent/target/elastic-apm-agent-*.jar
+            !./**/*-sources.jar
       - name: Upload agent java 8 binaries as artifacts
         uses: actions/upload-artifact@v3
         with:
           name: elastic-apm-agent-java8
-          path: ./elastic-apm-agent-java8/target/elastic-apm-agent-java8-*.jar
+          path: |
+            ./elastic-apm-agent-java8/target/elastic-apm-agent-java8-*.jar
+            !./**/*-sources.jar
       - name: Upload agent attach CLI artifacts
         uses: actions/upload-artifact@v3
         with:
           name: apm-agent-attach-cli
-          path: ./apm-agent-attach-cli/target/apm-agent-attach-cli-*.jar
+          path: |
+            ./apm-agent-attach-cli/target/apm-agent-attach-cli-*.jar
+            !./**/*-sources.jar
       - name: Upload agent attach artifacts
         uses: actions/upload-artifact@v3
         with:
           name: apm-agent-attach
-          path: ./apm-agent-attach/target/apm-agent-attach-*.jar
+          path: |
+            ./apm-agent-attach/target/apm-agent-attach-*.jar
+            !./**/*-sources.jar
       - name: Upload agent API artifacts
         uses: actions/upload-artifact@v3
         with:
           name: apm-agent-api
-          path: ./apm-agent-api/target/apm-agent-api-*.jar
+          path: |
+            ./apm-agent-api/target/apm-agent-api-*.jar
+            !./**/*-sources.jar
 
   license:
     name: License


### PR DESCRIPTION
## What does this PR do?

Publish other agent artifacts in github workflow to have a ready-to-download link for each PR build.
For now it's one zip file per artifact, but we may switch to a single archive later.


## Checklist

- [x] decide on single zip or many zip files
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
