### PR TITLE
Ignore gc alloc metrics when unsupported

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Bug fixes
 * Fixed agent programmatic attach with immutable config - {pull}3170[#3170]
 * Prevent overriding `ELASTIC_APM_AWS_LAMBDA_HANDLER` in AWS lambda execution when explicitly set - {pull}3205[#3205]
+* Ignore gc allocation metrics when unsupported - {pull}3225[#3225]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/JvmGcMetrics.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/metrics/builtin/JvmGcMetrics.java
@@ -62,11 +62,17 @@ public class JvmGcMetrics extends AbstractLifecycleListener {
             // J9 does contain com.sun.management.ThreadMXBean in classpath
             // but the actual MBean it uses (com.ibm.lang.management.internal.ExtendedThreadMXBeanImpl) does not implement it
             if (sunBeanClass.isInstance(ManagementFactory.getThreadMXBean())) {
+
+                DoubleSupplier supplier = (DoubleSupplier) Class.forName(getClass().getName() + "$HotspotAllocationSupplier").getEnumConstants()[0];
+
+                // attempt to read it at least once before registering
+                supplier.get();
+
                 // in reference to JMH's GC profiler (gc.alloc.rate)
-                registry.add("jvm.gc.alloc", Labels.EMPTY,
-                    (DoubleSupplier) Class.forName(getClass().getName() + "$HotspotAllocationSupplier").getEnumConstants()[0]);
+                registry.add("jvm.gc.alloc", Labels.EMPTY, supplier);
             }
         } catch (ClassNotFoundException ignore) {
+        } catch (UnsupportedOperationException ignore){
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #3224

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
  - [x] manually tested with the docker image provided in the issue.
