### PR TITLE
add trace level logs for span compressed spans

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
@@ -571,6 +571,7 @@ public abstract class AbstractSpan<T extends AbstractSpan<T>> extends ElasticCon
                 try {
                     if (bufferedSpan.compareAndSet(buffered, null)) {
                         this.tracer.endSpan(buffered);
+                        logger.trace("span compression buffer was set to null and {} was ended", buffered);
                     }
                 } finally {
                     buffered.decrementReferences();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
@@ -280,6 +280,7 @@ public class Span extends AbstractSpan<Span> implements Recyclable, co.elastic.a
                         if (parentBuffered != null) {
                             if (parent.bufferedSpan.compareAndSet(parentBuffered, null)) {
                                 this.tracer.endSpan(parentBuffered);
+                                logger.trace("parent span compression buffer was set to null and {} was ended", parentBuffered);
                             }
                         }
                         this.tracer.endSpan(this);
@@ -292,6 +293,8 @@ public class Span extends AbstractSpan<Span> implements Recyclable, co.elastic.a
                             // but we're dropping the compression attempt to keep things simple and avoid looping so this stays wait-free
                             // this doesn't exactly diverge from the spec, but it can lead to non-optimal compression under high load
                             this.tracer.endSpan(this);
+                        } else {
+                            logger.trace("parent span compression buffer was set to {}", this);
                         }
                         return;
                     }
@@ -300,6 +303,7 @@ public class Span extends AbstractSpan<Span> implements Recyclable, co.elastic.a
                         // we couldn't compress so replace the buffer with this
                         if (parent.bufferedSpan.compareAndSet(parentBuffered, this)) {
                             this.tracer.endSpan(parentBuffered);
+                            logger.trace("parent span compression buffer was set to {} and {} was ended", this, parentBuffered);
                         } else {
                             // the failed update would ideally lead to a compression attempt with the new buffer,
                             // but we're dropping the compression attempt to keep things simple and avoid looping so this stays wait-free


### PR DESCRIPTION
## What does this PR do?
Add some trace log-level statements during span compression buffering

