### PR TITLE
Make most plugins depend on only the SDK and tracer dependencies.

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -23,7 +23,7 @@ import co.elastic.apm.agent.tracer.configuration.ListValueConverter;
 import co.elastic.apm.agent.tracer.configuration.RoundedDoubleConverter;
 import co.elastic.apm.agent.tracer.configuration.TimeDuration;
 import co.elastic.apm.agent.tracer.configuration.TimeDurationValueConverter;
-import co.elastic.apm.agent.configuration.validation.RegexValidator;
+import co.elastic.apm.agent.tracer.configuration.RegexValidator;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.matcher.MethodMatcher;
 import co.elastic.apm.agent.matcher.MethodMatcherValueConverter;
@@ -56,7 +56,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import static co.elastic.apm.agent.configuration.validation.RangeValidator.isInRange;
+import static co.elastic.apm.agent.tracer.configuration.RangeValidator.isInRange;
 import static co.elastic.apm.agent.logging.LoggingConfiguration.AGENT_HOME_PLACEHOLDER;
 
 public class CoreConfiguration extends ConfigurationOptionProvider implements co.elastic.apm.agent.tracer.configuration.CoreConfiguration {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -143,6 +143,7 @@ public class ElasticApmTracer implements Tracer {
         configs.put(co.elastic.apm.agent.tracer.configuration.MetricsConfiguration.class, MetricsConfiguration.class);
         configs.put(co.elastic.apm.agent.tracer.configuration.ReporterConfiguration.class, ReporterConfiguration.class);
         configs.put(co.elastic.apm.agent.tracer.configuration.ServerlessConfiguration.class, ServerlessConfiguration.class);
+        configs.put(co.elastic.apm.agent.tracer.configuration.StacktraceConfiguration.class, StacktraceConfiguration.class);
     }
 
     private static void checkClassloader() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/circuitbreaker/CircuitBreakerConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/circuitbreaker/CircuitBreakerConfiguration.java
@@ -23,8 +23,8 @@ import co.elastic.apm.agent.tracer.configuration.TimeDurationValueConverter;
 import org.stagemonitor.configuration.ConfigurationOption;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
 
-import static co.elastic.apm.agent.configuration.validation.RangeValidator.isInRange;
-import static co.elastic.apm.agent.configuration.validation.RangeValidator.isNotInRange;
+import static co.elastic.apm.agent.tracer.configuration.RangeValidator.isInRange;
+import static co.elastic.apm.agent.tracer.configuration.RangeValidator.isNotInRange;
 
 public class CircuitBreakerConfiguration extends ConfigurationOptionProvider {
     public static final String CIRCUIT_BREAKER_CATEGORY = "Circuit-Breaker";

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/stacktrace/StacktraceConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/stacktrace/StacktraceConfiguration.java
@@ -26,7 +26,7 @@ import org.stagemonitor.configuration.ConfigurationOptionProvider;
 import java.util.Collection;
 import java.util.Collections;
 
-public class StacktraceConfiguration extends ConfigurationOptionProvider {
+public class StacktraceConfiguration extends ConfigurationOptionProvider implements co.elastic.apm.agent.tracer.configuration.StacktraceConfiguration {
 
     private static final String STACKTRACE_CATEGORY = "Stacktrace";
     public static final String APPLICATION_PACKAGES = "application_packages";
@@ -95,6 +95,7 @@ public class StacktraceConfiguration extends ConfigurationOptionProvider {
         .dynamic(true)
         .buildWithDefault(TimeDuration.of("5ms"));
 
+    @Override
     public Collection<String> getApplicationPackages() {
         return applicationPackages.get();
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReporterConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReporterConfiguration.java
@@ -35,7 +35,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.List;
 
-import static co.elastic.apm.agent.configuration.validation.RangeValidator.isNotInRange;
+import static co.elastic.apm.agent.tracer.configuration.RangeValidator.isNotInRange;
 
 public class ReporterConfiguration extends ConfigurationOptionProvider implements co.elastic.apm.agent.tracer.configuration.ReporterConfiguration {
 

--- a/apm-agent-plugins/apm-api-plugin/pom.xml
+++ b/apm-agent-plugins/apm-api-plugin/pom.xml
@@ -16,6 +16,12 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-agent-api</artifactId>

--- a/apm-agent-plugins/apm-awslambda-plugin/pom.xml
+++ b/apm-agent-plugins/apm-awslambda-plugin/pom.xml
@@ -17,6 +17,12 @@
     </properties>
 
     <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-lambda-java-core</artifactId>

--- a/apm-agent-plugins/apm-cassandra/apm-cassandra3-plugin/src/main/java/co/elastic/apm/agent/cassandra3/Cassandra3Instrumentation.java
+++ b/apm-agent-plugins/apm-cassandra/apm-cassandra3-plugin/src/main/java/co/elastic/apm/agent/cassandra3/Cassandra3Instrumentation.java
@@ -19,7 +19,6 @@
 package co.elastic.apm.agent.cassandra3;
 
 import co.elastic.apm.agent.cassandra.CassandraHelper;
-import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers;
 import co.elastic.apm.agent.tracer.GlobalTracer;
@@ -204,7 +203,7 @@ public abstract class Cassandra3Instrumentation extends ElasticApmInstrumentatio
         }
 
         /**
-         * References the method {@link Destination#withSocketAddress(java.net.SocketAddress)} that has been introduced in 2.0.2
+         * References the method {@link co.elastic.apm.agent.tracer.metadata.Destination#withSocketAddress(java.net.SocketAddress)} that has been introduced in 2.0.2
          * We must not reference this class directly to avoid it being loaded which may cause a linkage error.
          */
         enum WithSocketAddress implements DestinationAddressSetter {

--- a/apm-agent-plugins/apm-ecs-logging-plugin/pom.xml
+++ b/apm-agent-plugins/apm-ecs-logging-plugin/pom.xml
@@ -16,6 +16,12 @@
     </properties>
 
     <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- log4j 1.x -->
         <dependency>

--- a/apm-agent-plugins/apm-jakarta-websocket-plugin/src/main/java/co/elastic/apm/agent/websocket/BaseServerEndpointInstrumentation.java
+++ b/apm-agent-plugins/apm-jakarta-websocket-plugin/src/main/java/co/elastic/apm/agent/websocket/BaseServerEndpointInstrumentation.java
@@ -18,12 +18,12 @@
  */
 package co.elastic.apm.agent.websocket;
 
-import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.tracer.Tracer;
 import co.elastic.apm.agent.tracer.Transaction;
+import co.elastic.apm.agent.tracer.configuration.StacktraceConfiguration;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;

--- a/apm-agent-plugins/apm-jaxrs-plugin/src/main/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-jaxrs-plugin/src/main/java/co/elastic/apm/agent/jaxrs/JaxRsTransactionNameInstrumentation.java
@@ -20,9 +20,9 @@ package co.elastic.apm.agent.jaxrs;
 
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.tracer.GlobalTracer;
-import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.tracer.Tracer;
 import co.elastic.apm.agent.tracer.Transaction;
+import co.elastic.apm.agent.tracer.configuration.StacktraceConfiguration;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;

--- a/apm-agent-plugins/apm-jaxws-plugin/src/main/java/co/elastic/apm/agent/jaxws/JaxWsTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-jaxws-plugin/src/main/java/co/elastic/apm/agent/jaxws/JaxWsTransactionNameInstrumentation.java
@@ -19,11 +19,11 @@
 package co.elastic.apm.agent.jaxws;
 
 import co.elastic.apm.agent.sdk.bytebuddy.SimpleMethodSignatureOffsetMappingFactory.SimpleMethodSignature;
-import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Tracer;
 import co.elastic.apm.agent.tracer.Transaction;
+import co.elastic.apm.agent.tracer.configuration.StacktraceConfiguration;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;

--- a/apm-agent-plugins/apm-jmx-plugin/pom.xml
+++ b/apm-agent-plugins/apm-jmx-plugin/pom.xml
@@ -15,4 +15,13 @@
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
 
+    <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-logging-plugin/pom.xml
+++ b/apm-agent-plugins/apm-logging-plugin/pom.xml
@@ -27,4 +27,13 @@
         <module>apm-jul-plugin</module>
     </modules>
 
+    <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-micrometer-plugin/pom.xml
+++ b/apm-agent-plugins/apm-micrometer-plugin/pom.xml
@@ -20,6 +20,12 @@
     </properties>
 
     <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>

--- a/apm-agent-plugins/apm-opentelemetry/pom.xml
+++ b/apm-agent-plugins/apm-opentelemetry/pom.xml
@@ -34,4 +34,13 @@
         <module>apm-opentelemetry-metrics-bridge-parent</module>
     </modules>
 
+    <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-opentracing-plugin/pom.xml
+++ b/apm-agent-plugins/apm-opentracing-plugin/pom.xml
@@ -15,4 +15,13 @@
         <apm-agent-parent.base.dir>${project.basedir}/../..</apm-agent-parent.base.dir>
     </properties>
 
+    <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
 </project>

--- a/apm-agent-plugins/apm-profiling-plugin/pom.xml
+++ b/apm-agent-plugins/apm-profiling-plugin/pom.xml
@@ -16,6 +16,12 @@
     </properties>
 
     <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.kohsuke</groupId>
             <artifactId>github-api</artifactId>

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -29,8 +29,8 @@ import org.stagemonitor.configuration.ConfigurationOptionProvider;
 import java.util.Arrays;
 import java.util.List;
 
-import static co.elastic.apm.agent.configuration.validation.RangeValidator.isInRange;
-import static co.elastic.apm.agent.configuration.validation.RangeValidator.min;
+import static co.elastic.apm.agent.tracer.configuration.RangeValidator.isInRange;
+import static co.elastic.apm.agent.tracer.configuration.RangeValidator.min;
 
 public class ProfilingConfiguration extends ConfigurationOptionProvider {
 

--- a/apm-agent-plugins/apm-quartz/apm-quartz-common/src/main/java/co/elastic/apm/agent/quartzjob/AbstractJobTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-quartz/apm-quartz-common/src/main/java/co/elastic/apm/agent/quartzjob/AbstractJobTransactionNameInstrumentation.java
@@ -18,7 +18,6 @@
  */
 package co.elastic.apm.agent.quartzjob;
 
-import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
@@ -29,6 +28,7 @@ import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.tracer.Tracer;
 import co.elastic.apm.agent.tracer.Transaction;
+import co.elastic.apm.agent.tracer.configuration.StacktraceConfiguration;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;

--- a/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/scheduled/ScheduledTransactionNameInstrumentation.java
+++ b/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/scheduled/ScheduledTransactionNameInstrumentation.java
@@ -19,7 +19,6 @@
 package co.elastic.apm.agent.scheduled;
 
 import co.elastic.apm.agent.sdk.bytebuddy.SimpleMethodSignatureOffsetMappingFactory.SimpleMethodSignature;
-import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
@@ -29,6 +28,7 @@ import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.tracer.Tracer;
 import co.elastic.apm.agent.tracer.Transaction;
+import co.elastic.apm.agent.tracer.configuration.StacktraceConfiguration;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;

--- a/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/scheduled/TimerTaskInstrumentation.java
+++ b/apm-agent-plugins/apm-scheduled-annotation-plugin/src/main/java/co/elastic/apm/agent/scheduled/TimerTaskInstrumentation.java
@@ -19,7 +19,6 @@
 package co.elastic.apm.agent.scheduled;
 
 import co.elastic.apm.agent.sdk.bytebuddy.SimpleMethodSignatureOffsetMappingFactory;
-import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
@@ -28,6 +27,7 @@ import co.elastic.apm.agent.tracer.AbstractSpan;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Tracer;
 import co.elastic.apm.agent.tracer.Transaction;
+import co.elastic.apm.agent.tracer.configuration.StacktraceConfiguration;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;

--- a/apm-agent-plugins/apm-servlet-plugin/pom.xml
+++ b/apm-agent-plugins/apm-servlet-plugin/pom.xml
@@ -16,6 +16,12 @@
     </properties>
 
     <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-java-concurrent-plugin</artifactId>

--- a/apm-agent-plugins/apm-spring-webflux/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/pom.xml
@@ -29,6 +29,11 @@
     </modules>
 
     <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <!-- required to test integration with servlet instrumentation -->
         <dependency>

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/pom.xml
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/pom.xml
@@ -33,6 +33,12 @@
 
 
     <dependencies>
+        <!-- This plugin requires further refactoring to avoid agent dependencies. -->
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -90,6 +90,12 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-agent-core</artifactId>
             <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
             <exclusions>

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -78,19 +78,13 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>apm-agent-core</artifactId>
+            <artifactId>apm-agent-plugin-sdk</artifactId>
             <version>${project.version}</version>
-            <exclusions>
-                <!--
-                Plugins shouldn't be aware of the logging implementation
-                In fact, plugins are disallowed to load log4j classes from the agent CL
-                so that they can instrument the log4j that comes with the application
-                -->
-                <exclusion>
-                    <groupId>org.apache.logging.log4j</groupId>
-                    <artifactId>*</artifactId>
-                </exclusion>
-            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-tracer</artifactId>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/RangeValidator.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/RangeValidator.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.configuration.validation;
+package co.elastic.apm.agent.tracer.configuration;
 
 import org.stagemonitor.configuration.ConfigurationOption;
 

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/RegexValidator.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/RegexValidator.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.configuration.validation;
+package co.elastic.apm.agent.tracer.configuration;
 
 import org.stagemonitor.configuration.ConfigurationOption;
 

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/StacktraceConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/StacktraceConfiguration.java
@@ -16,7 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-@NonnullApi
-package co.elastic.apm.agent.configuration.validation;
+package co.elastic.apm.agent.tracer.configuration;
 
-import co.elastic.apm.agent.sdk.NonnullApi;
+import java.util.Collection;
+
+public interface StacktraceConfiguration {
+    Collection<String> getApplicationPackages();
+}

--- a/apm-agent-tracer/src/test/java/co/elastic/apm/agent/tracer/configuration/RangeValidatorTest.java
+++ b/apm-agent-tracer/src/test/java/co/elastic/apm/agent/tracer/configuration/RangeValidatorTest.java
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.configuration.validation;
+package co.elastic.apm.agent.tracer.configuration;
 
+import co.elastic.apm.agent.tracer.configuration.RangeValidator;
 import co.elastic.apm.agent.tracer.configuration.TimeDuration;
 import org.junit.jupiter.api.Test;
 

--- a/apm-agent-tracer/src/test/java/co/elastic/apm/agent/tracer/configuration/RegexValidatorTest.java
+++ b/apm-agent-tracer/src/test/java/co/elastic/apm/agent/tracer/configuration/RegexValidatorTest.java
@@ -16,8 +16,9 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.configuration.validation;
+package co.elastic.apm.agent.tracer.configuration;
 
+import co.elastic.apm.agent.tracer.configuration.RegexValidator;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
Avoids that most plugins depend on apm-agent-core. To do so, some remaining classes are moved to more appropriate locations.