### PR TITLE
W3C Baggage propagation and tracer APIs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,13 +34,11 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Features
 * Capture `container.id` for cgroups v2 - {pull}3199[#3199]
+* Added W3C baggage propagation - {pull}3236[#3236]
 
 [float]
 ===== Bug fixes
 * fix jakarta.jms support (wasn't fully implemented) - {pull}3198[#3198]
-
-[float]
-===== Bug fixes
 * Fixed agent programmatic attach with immutable config - {pull}3170[#3170]
 * Prevent overriding `ELASTIC_APM_AWS_LAMBDA_HANDLER` in AWS lambda execution when explicitly set - {pull}3205[#3205]
 * Ignore gc allocation metrics when unsupported - {pull}3225[#3225]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
+[float]
+===== Features
+* Added W3C baggage propagation - {pull}3236[#3236]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 
@@ -40,7 +44,6 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Features
 * Capture `container.id` for cgroups v2 - {pull}3199[#3199]
-* Added W3C baggage propagation - {pull}3236[#3236]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/EmptyElasticContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/EmptyElasticContext.java
@@ -18,8 +18,10 @@
  */
 package co.elastic.apm.agent.impl;
 
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.ElasticContext;
+import co.elastic.apm.agent.impl.transaction.Span;
 
 import javax.annotation.Nullable;
 
@@ -32,6 +34,17 @@ class EmptyElasticContext extends ElasticContext<EmptyElasticContext> {
     @Nullable
     @Override
     public AbstractSpan<?> getSpan() {
+        return null;
+    }
+
+    @Override
+    public Baggage getBaggage() {
+        return Baggage.EMPTY;
+    }
+
+    @Nullable
+    @Override
+    public Span createSpan() {
         return null;
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/EmptyElasticContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/EmptyElasticContext.java
@@ -21,7 +21,6 @@ package co.elastic.apm.agent.impl;
 import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.ElasticContext;
-import co.elastic.apm.agent.impl.transaction.Span;
 
 import javax.annotation.Nullable;
 
@@ -40,12 +39,6 @@ class EmptyElasticContext extends ElasticContext<EmptyElasticContext> {
     @Override
     public Baggage getBaggage() {
         return Baggage.EMPTY;
-    }
-
-    @Nullable
-    @Override
-    public Span createSpan() {
-        return null;
     }
 
     @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.impl.baggage;
 
 import javax.annotation.Nullable;
@@ -9,7 +27,7 @@ import java.util.Set;
 
 public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
 
-    public static final Baggage EMPTY = new Baggage(Collections.emptyMap(), Collections.emptyMap());
+    public static final Baggage EMPTY = new Baggage(Collections.<String, String>emptyMap(), Collections.<String, String>emptyMap());
 
     private final Map<String, String> baggage;
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
@@ -92,17 +92,23 @@ public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
             this.parent = parent;
             this.baggage = parent.baggage;
             this.baggageMetadata = parent.baggageMetadata;
+            buildCalled = false;
         }
 
         private final Baggage parent;
         private Map<String, String> baggage;
         private Map<String, String> baggageMetadata;
 
+        private boolean buildCalled;
+
         public Builder put(String key, @Nullable String value) {
             return put(key, value, null);
         }
 
         public Builder put(String key, @Nullable String value, @Nullable String metadata) {
+            if (buildCalled) {
+                throw new IllegalStateException("build() was already called!");
+            }
             if (value == null) {
                 setBaggageValue(key, null);
                 setBaggageMetadata(key, null);
@@ -121,6 +127,7 @@ public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
          * @return a baggage resulting from this builder.
          */
         public Baggage build() {
+            buildCalled = true;
             boolean anyModifications = false;
             if (baggage != parent.baggage) {
                 anyModifications = true;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
@@ -1,0 +1,148 @@
+package co.elastic.apm.agent.impl.baggage;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
+
+    public static final Baggage EMPTY = new Baggage(Collections.emptyMap(), Collections.emptyMap());
+
+    private final Map<String, String> baggage;
+
+    /**
+     * W3C headers allow to add metadata key-value paris to baggage.
+     * We do currently not decode these key-value pairs, but propagate them in encoded form
+     * to ensure they are not lost.
+     * <p>
+     * Keys of this map are guaranteed to also be present as keys in #baggage
+     */
+    private final Map<String, String> baggageMetadata;
+
+    /**
+     * Baggage instances are immutable, therefore we can safely cache the serialized form.
+     */
+    private volatile String cachedSerializedW3CHeader = null;
+
+    private Baggage(Map<String, String> baggage, Map<String, String> baggageMetadata) {
+        this.baggage = baggage;
+        this.baggageMetadata = baggageMetadata;
+    }
+
+    public Set<String> keys() {
+        return baggage.keySet();
+    }
+
+    public @Nullable String get(String key) {
+        return baggage.get(key);
+    }
+
+    @Nullable
+    public String getMetadata(String key) {
+        return baggageMetadata.get(key);
+    }
+
+    public boolean isEmpty() {
+        return baggage.isEmpty();
+    }
+
+    public static Builder builder() {
+        return EMPTY.toBuilder();
+    }
+
+    /**
+     * @return a builder prepoluated with the contets of this baggage.
+     */
+    public Builder toBuilder() {
+        return new Builder(this);
+    }
+
+    void setCachedSerializedW3CHeader(String serialized) {
+        this.cachedSerializedW3CHeader = serialized;
+    }
+
+    String getCachedSerializedW3CHeader() {
+        return this.cachedSerializedW3CHeader;
+    }
+
+    public static class Builder {
+
+        public Builder(Baggage parent) {
+            this.parent = parent;
+            this.baggage = parent.baggage;
+            this.baggageMetadata = parent.baggageMetadata;
+        }
+
+        private Baggage parent;
+        private Map<String, String> baggage;
+        private Map<String, String> baggageMetadata;
+
+        public Builder put(String key, @Nullable String value) {
+            return put(key, value, null);
+        }
+
+        public Builder put(String key, @Nullable String value, @Nullable String metadata) {
+            if (value == null) {
+                setBaggageValue(key, null);
+                setBaggageMetadata(key, null);
+            } else {
+                setBaggageValue(key, value);
+                setBaggageMetadata(key, metadata);
+            }
+            return this;
+        }
+
+        /**
+         * Builds the resulting baggage.
+         * If no modifications were done, the returned instance might be the same as the parent baggage.
+         * The builder must not be used anymore after calling build.
+         *
+         * @return a baggage resulting from this builder.
+         */
+        public Baggage build() {
+            boolean anyModifications = false;
+            if (baggage != parent.baggage) {
+                anyModifications = true;
+                baggage = Collections.unmodifiableMap(baggage);
+            }
+            if (baggageMetadata != parent.baggageMetadata) {
+                anyModifications = true;
+                baggageMetadata = Collections.unmodifiableMap(baggageMetadata);
+            }
+            if (anyModifications) {
+                return new Baggage(baggage, baggageMetadata);
+            } else {
+                return parent;
+            }
+        }
+
+        private void setBaggageValue(String key, @Nullable String value) {
+            if (!Objects.equals(baggage.get(key), key)) {
+                if (baggage == parent.baggage) {
+                    baggage = new LinkedHashMap<>(baggage);
+                }
+                if (value == null) {
+                    baggage.remove(key);
+                } else {
+                    baggage.put(key, value);
+                }
+            }
+        }
+
+        private void setBaggageMetadata(String key, @Nullable String metadata) {
+            if (!Objects.equals(baggageMetadata.get(key), key)) {
+                if (baggageMetadata == parent.baggageMetadata) {
+                    baggageMetadata = new LinkedHashMap<>(baggageMetadata);
+                }
+                if (metadata == null) {
+                    baggageMetadata.remove(key);
+                } else {
+                    baggageMetadata.put(key, metadata);
+                }
+            }
+        }
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
@@ -32,7 +32,7 @@ public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
     private final Map<String, String> baggage;
 
     /**
-     * W3C headers allow to add metadata key-value paris to baggage.
+     * W3C headers allow to add metadata key-value pairs to baggage.
      * We do currently not decode these key-value pairs, but propagate them in encoded form
      * to ensure they are not lost.
      * <p>
@@ -72,7 +72,7 @@ public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
     }
 
     /**
-     * @return a builder prepoluated with the contets of this baggage.
+     * @return a builder pre-populated with the contents of this baggage.
      */
     public Builder toBuilder() {
         return new Builder(this);
@@ -94,7 +94,7 @@ public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
             this.baggageMetadata = parent.baggageMetadata;
         }
 
-        private Baggage parent;
+        private final Baggage parent;
         private Map<String, String> baggage;
         private Map<String, String> baggageMetadata;
 
@@ -138,7 +138,7 @@ public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
         }
 
         private void setBaggageValue(String key, @Nullable String value) {
-            if (!Objects.equals(baggage.get(key), key)) {
+            if (!Objects.equals(baggage.get(key), value)) {
                 if (baggage == parent.baggage) {
                     baggage = new LinkedHashMap<>(baggage);
                 }
@@ -151,7 +151,7 @@ public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
         }
 
         private void setBaggageMetadata(String key, @Nullable String metadata) {
-            if (!Objects.equals(baggageMetadata.get(key), key)) {
+            if (!Objects.equals(baggageMetadata.get(key), metadata)) {
                 if (baggageMetadata == parent.baggageMetadata) {
                     baggageMetadata = new LinkedHashMap<>(baggageMetadata);
                 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
@@ -1,9 +1,27 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.impl.baggage;
 
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.ElasticContext;
+import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.tracer.BaggageContextBuilder;
-import co.elastic.apm.agent.tracer.Scope;
 
 import javax.annotation.Nullable;
 
@@ -13,9 +31,9 @@ public class BaggageContext extends ElasticContext<BaggageContext> {
     private final AbstractSpan<?> span;
     private final Baggage baggage;
 
-    private BaggageContext(@Nullable AbstractSpan<?> span, Baggage baggage) {
-        super(tracer);
-        this.span = span;
+    private BaggageContext(ElasticContext<?> parent, Baggage baggage) {
+        super(parent.getTracer());
+        this.span = parent.getSpan();
         this.baggage = baggage;
     }
 
@@ -30,44 +48,41 @@ public class BaggageContext extends ElasticContext<BaggageContext> {
         return baggage;
     }
 
+    @Nullable
     @Override
-    public BaggageContext activate() {
-        return null;
-    }
-
-    @Override
-    public BaggageContext deactivate() {
-        return null;
-    }
-
-    @Override
-    public Scope activateInScope() {
+    public Span createSpan() {
+        if (span != null) {
+            return span.createSpan(baggage);
+        }
         return null;
     }
 
     @Override
     public void incrementReferences() {
-
+        if (span != null) {
+            span.incrementReferences();
+        }
     }
 
     @Override
     public void decrementReferences() {
-
+        if (span != null) {
+            span.decrementReferences();
+        }
     }
 
-    public static Baggage.Builder createBuilder(ElasticContext<?> parent) {
-        return new Builder()
+    public static BaggageContext.Builder createBuilder(ElasticContext<?> parent) {
+        return new Builder(parent);
     }
 
     public static class Builder implements BaggageContextBuilder {
 
-        private final AbstractSpan<?> span;
-
+        private final ElasticContext<?> parent;
         private final Baggage.Builder baggageBuilder;
 
-        public Builder(AbstractSpan<?> span, Baggage baseBaggage) {
-            this.span = span;
-            baggageBuilder = baseBaggage.toBuilder();
+        public Builder(ElasticContext<?> parent) {
+            this.parent = parent;
+            this.baggageBuilder = parent.getBaggage().toBuilder();
         }
 
         @Override
@@ -82,7 +97,7 @@ public class BaggageContext extends ElasticContext<BaggageContext> {
 
         @Override
         public BaggageContext buildContext() {
-            return new BaggageContext(span, baggageBuilder.build());
+            return new BaggageContext(parent, baggageBuilder.build());
         }
     }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
@@ -1,0 +1,88 @@
+package co.elastic.apm.agent.impl.baggage;
+
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.ElasticContext;
+import co.elastic.apm.agent.tracer.BaggageContextBuilder;
+import co.elastic.apm.agent.tracer.Scope;
+
+import javax.annotation.Nullable;
+
+public class BaggageContext extends ElasticContext<BaggageContext> {
+
+    @Nullable
+    private final AbstractSpan<?> span;
+    private final Baggage baggage;
+
+    private BaggageContext(@Nullable AbstractSpan<?> span, Baggage baggage) {
+        super(tracer);
+        this.span = span;
+        this.baggage = baggage;
+    }
+
+    @Nullable
+    @Override
+    public AbstractSpan<?> getSpan() {
+        return span;
+    }
+
+    @Override
+    public Baggage getBaggage() {
+        return baggage;
+    }
+
+    @Override
+    public BaggageContext activate() {
+        return null;
+    }
+
+    @Override
+    public BaggageContext deactivate() {
+        return null;
+    }
+
+    @Override
+    public Scope activateInScope() {
+        return null;
+    }
+
+    @Override
+    public void incrementReferences() {
+
+    }
+
+    @Override
+    public void decrementReferences() {
+
+    }
+
+    public static Baggage.Builder createBuilder(ElasticContext<?> parent) {
+        return new Builder()
+    }
+
+    public static class Builder implements BaggageContextBuilder {
+
+        private final AbstractSpan<?> span;
+
+        private final Baggage.Builder baggageBuilder;
+
+        public Builder(AbstractSpan<?> span, Baggage baseBaggage) {
+            this.span = span;
+            baggageBuilder = baseBaggage.toBuilder();
+        }
+
+        @Override
+        public void put(String key, @Nullable String value) {
+            baggageBuilder.put(key, value);
+        }
+
+        @Override
+        public void remove(String key) {
+            baggageBuilder.put(key, null);
+        }
+
+        @Override
+        public BaggageContext buildContext() {
+            return new BaggageContext(span, baggageBuilder.build());
+        }
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
@@ -20,7 +20,6 @@ package co.elastic.apm.agent.impl.baggage;
 
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.ElasticContext;
-import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.tracer.BaggageContextBuilder;
 
 import javax.annotation.Nullable;
@@ -46,15 +45,6 @@ public class BaggageContext extends ElasticContext<BaggageContext> {
     @Override
     public Baggage getBaggage() {
         return baggage;
-    }
-
-    @Nullable
-    @Override
-    public Span createSpan() {
-        if (span != null) {
-            return span.createSpan(baggage);
-        }
-        return null;
     }
 
     @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
@@ -86,13 +86,15 @@ public class BaggageContext extends ElasticContext<BaggageContext> {
         }
 
         @Override
-        public void put(String key, @Nullable String value) {
+        public Builder put(String key, @Nullable String value) {
             baggageBuilder.put(key, value);
+            return this;
         }
 
         @Override
-        public void remove(String key) {
+        public Builder remove(String key) {
             baggageBuilder.put(key, null);
+            return this;
         }
 
         @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/RecyclableCharArray.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/RecyclableCharArray.java
@@ -1,0 +1,49 @@
+package co.elastic.apm.agent.impl.baggage;
+
+import co.elastic.apm.agent.impl.baggage.otel.PercentEscaper;
+import co.elastic.apm.agent.objectpool.ObjectPool;
+import co.elastic.apm.agent.objectpool.Resetter;
+import co.elastic.apm.agent.objectpool.impl.QueueBasedObjectPool;
+import co.elastic.apm.agent.tracer.pooling.Allocator;
+import org.jctools.queues.atomic.MpmcAtomicArrayQueue;
+
+/**
+ * Loom-Friendly replacement for OTel "TemporaryBuffer" class used by the {@link PercentEscaper}.
+ */
+public class RecyclableCharArray implements AutoCloseable {
+
+    private static final int POOL_CAPACITY = 32;
+
+    private final char[] buffer = new char[1024];
+
+    private static final Allocator<RecyclableCharArray> ALLOCATOR = new Allocator<RecyclableCharArray>() {
+        @Override
+        public RecyclableCharArray createInstance() {
+            return new RecyclableCharArray();
+        }
+    };
+
+    private static final Resetter<RecyclableCharArray> RESETTER = new Resetter<RecyclableCharArray>() {
+        @Override
+        public void recycle(RecyclableCharArray object) {
+            //No need to clear array
+        }
+    };
+
+    private static ObjectPool<RecyclableCharArray> POOL = QueueBasedObjectPool.of(
+        new MpmcAtomicArrayQueue<RecyclableCharArray>((POOL_CAPACITY)), false, ALLOCATOR, RESETTER);
+
+    public static RecyclableCharArray acquire() {
+        return POOL.createInstance();
+    }
+
+    public char[] get() {
+        return buffer;
+    }
+
+    @Override
+    public void close() {
+        POOL.recycle(this);
+    }
+
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/RecyclableCharArray.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/RecyclableCharArray.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.impl.baggage;
 
 import co.elastic.apm.agent.impl.baggage.otel.PercentEscaper;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagation.java
@@ -1,0 +1,112 @@
+package co.elastic.apm.agent.impl.baggage;
+
+import co.elastic.apm.agent.impl.baggage.otel.Parser;
+import co.elastic.apm.agent.impl.baggage.otel.PercentEscaper;
+import co.elastic.apm.agent.tracer.dispatch.HeaderGetter;
+import co.elastic.apm.agent.tracer.dispatch.TextHeaderGetter;
+import co.elastic.apm.agent.tracer.dispatch.TextHeaderSetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+public class W3CBaggagePropagation {
+
+    private static final Logger logger = LoggerFactory.getLogger(W3CBaggagePropagation.class);
+
+    private static final PercentEscaper VALUE_ESCAPER = PercentEscaper.create();
+
+    public static final String BAGGAGE_HEADER_NAME = "baggage";
+
+    private static final HeaderGetter.HeaderConsumer<String, Baggage.Builder> PARSING_CONSUMER = new HeaderGetter.HeaderConsumer<String, Baggage.Builder>() {
+        @Override
+        public void accept(@Nullable String headerValue, Baggage.Builder state) {
+            if (headerValue != null) {
+                try {
+                    new Parser(headerValue).parseInto(state);
+                } catch (Exception e) {
+                    logger.error("Failed to parse baggage header: {}", headerValue, e);
+                }
+            }
+        }
+    };
+
+    public static <C> void parse(C carrier, TextHeaderGetter<C> headerGetter, Baggage.Builder into) {
+        headerGetter.forEach(BAGGAGE_HEADER_NAME, carrier, into, PARSING_CONSUMER);
+    }
+
+    public static <C> void propagate(Baggage baggage, C carrier, TextHeaderSetter<C> setter) {
+        if (baggage.isEmpty()) {
+            return;
+        }
+        String header = baggage.getCachedSerializedW3CHeader();
+        if (header == null) {
+            header = encodeToHeader(baggage);
+            baggage.setCachedSerializedW3CHeader(header);
+        }
+        if (!header.isEmpty()) {
+            setter.setHeader(BAGGAGE_HEADER_NAME, encodeToHeader(baggage), carrier);
+        }
+    }
+
+
+    private static String encodeToHeader(Baggage baggage) {
+        StringBuilder header = new StringBuilder();
+        for (String key : baggage.keys()) {
+            String value = baggage.get(key);
+            String metadata = baggage.getMetadata(key);
+            if (isEncodeableBaggage(key, value)) {
+                if (header.length() > 0) {
+                    header.append(",");
+                }
+                header.append(key).append('=').append(VALUE_ESCAPER.escape(value));
+                if (metadata != null && !metadata.isEmpty()) {
+                    header.append(';').append(metadata);
+                }
+            }
+        }
+        return header.toString();
+    }
+
+
+    private static boolean isEncodeableBaggage(String key, String value) {
+        if (key == null || key.isBlank()) {
+            return false;
+        }
+        if (value == null) {
+            return false;
+        }
+        for (int i = 0; i < key.length(); i++) {
+            char ch = key.charAt(i);
+            if (!isAllowedKeyChar(ch)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean isAllowedKeyChar(char ch) {
+        //Check for RFC tchar: https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6
+        switch (ch) {
+            case '!':
+            case '#':
+            case '$':
+            case '%':
+            case '&':
+            case '\'':
+            case '*':
+            case '+':
+            case '-':
+            case '.':
+            case '^':
+            case '_':
+            case '`':
+            case '|':
+            case '~':
+                return true;
+            default:
+                return (ch >= '0' && ch <= '9') || (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z');
+        }
+    }
+
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagation.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.impl.baggage;
 
 import co.elastic.apm.agent.impl.baggage.otel.Parser;
@@ -70,7 +88,7 @@ public class W3CBaggagePropagation {
 
 
     private static boolean isEncodeableBaggage(String key, String value) {
-        if (key == null || key.isBlank()) {
+        if (key == null || key.isEmpty()) {
             return false;
         }
         if (value == null) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagation.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagation.java
@@ -81,6 +81,8 @@ public class W3CBaggagePropagation {
                 if (metadata != null && !metadata.isEmpty()) {
                     header.append(';').append(metadata);
                 }
+            } else {
+                logger.debug("Skipping encoding of baggage {} because it is not encodeable!", key);
             }
         }
         return header.toString();

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/BaggageCodec.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/BaggageCodec.java
@@ -1,0 +1,93 @@
+/**
+ * This class has been copied from Otel release 1.27.0.
+ * We can't directly use it as it is compiled for Java 8 while we require java 7.
+ */
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package co.elastic.apm.agent.impl.baggage.otel;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Note: This class is based on code from Apache Commons Codec. It is comprised of code from these
+ * classes:
+ *
+ * <ul>
+ *   <li><a
+ *       href="https://github.com/apache/commons-codec/blob/482df6cabfb288acb6ab3e4a732fdb93aecfa7c2/src/main/java/org/apache/commons/codec/net/URLCodec.java">org.apache.commons.codec.net.URLCodec</a>
+ *   <li><a
+ *       href="https://github.com/apache/commons-codec/blob/482df6cabfb288acb6ab3e4a732fdb93aecfa7c2/src/main/java/org/apache/commons/codec/net/Utils.java">org.apache.commons.codec.net.Utils</a>
+ * </ul>
+ *
+ * <p>Implements baggage-octet decoding in accordance with th <a
+ * href="https://w3c.github.io/baggage/#definition">Baggage header content</a> specification. All
+ * US-ASCII characters excluding CTLs, whitespace, DQUOTE, comma, semicolon and backslash are
+ * encoded in `www-form-urlencoded` encoding scheme.
+ */
+class BaggageCodec {
+
+    private static final byte ESCAPE_CHAR = '%';
+    private static final int RADIX = 16;
+
+    private BaggageCodec() {
+    }
+
+    /**
+     * Decodes an array of URL safe 7-bit characters into an array of original bytes. Escaped
+     * characters are converted back to their original representation.
+     *
+     * @param bytes array of URL safe characters
+     * @return array of original bytes
+     */
+    private static byte[] decode(byte[] bytes) {
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+        for (int i = 0; i < bytes.length; i++) {
+            int b = bytes[i];
+            if (b == ESCAPE_CHAR) {
+                try {
+                    int u = digit16(bytes[++i]);
+                    int l = digit16(bytes[++i]);
+                    buffer.write((char) ((u << 4) + l));
+                } catch (ArrayIndexOutOfBoundsException e) { // FIXME
+                    throw new IllegalArgumentException("Invalid URL encoding: ", e);
+                }
+            } else {
+                buffer.write(b);
+            }
+        }
+        return buffer.toByteArray();
+    }
+
+    /**
+     * Decodes an array of URL safe 7-bit characters into an array of original bytes. Escaped
+     * characters are converted back to their original representation.
+     *
+     * @param value   string of URL safe characters
+     * @param charset encoding of given string
+     * @return decoded value
+     */
+    static String decode(String value, Charset charset) {
+        byte[] bytes = decode(value.getBytes(StandardCharsets.US_ASCII));
+        return new String(bytes, charset);
+    }
+
+    /**
+     * Returns the numeric value of the character {@code b} in radix 16.
+     *
+     * @param b The byte to be converted.
+     * @return The numeric value represented by the character in radix 16.
+     */
+    private static int digit16(byte b) {
+        int i = Character.digit((char) b, RADIX);
+        if (i == -1) {
+            throw new IllegalArgumentException( // FIXME
+                "Invalid URL encoding: not a valid digit (radix " + RADIX + "): " + b);
+        }
+        return i;
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/BaggageCodec.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/BaggageCodec.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /**
  * This class has been copied from Otel release 1.27.0.
  * We can't directly use it as it is compiled for Java 8 while we require java 7.

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Element.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Element.java
@@ -1,0 +1,137 @@
+/**
+ * This class has been copied from Otel v1.27.0 without any adjustments.
+ */
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package co.elastic.apm.agent.impl.baggage.otel;
+
+import javax.annotation.Nullable;
+import java.util.BitSet;
+
+/**
+ * Represents single element of a W3C baggage header (key or value). Allows tracking parsing of a
+ * header string, keeping the state and validating allowed characters. Parsing state can be reset
+ * with {@link #reset(int)} allowing instance re-use.
+ */
+class Element {
+
+    private static final BitSet EXCLUDED_KEY_CHARS = new BitSet(128);
+    private static final BitSet EXCLUDED_VALUE_CHARS = new BitSet(128);
+
+    static {
+        for (char c :
+            new char[]{
+                '(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=', '{', '}'
+            }) {
+            EXCLUDED_KEY_CHARS.set(c);
+        }
+        for (char c : new char[]{'"', ',', ';', '\\'}) {
+            EXCLUDED_VALUE_CHARS.set(c);
+        }
+    }
+
+    private final BitSet excluded;
+
+    private boolean leadingSpace;
+    private boolean readingValue;
+    private boolean trailingSpace;
+    private int start;
+    private int end;
+    @Nullable
+    private String value;
+
+    static Element createKeyElement() {
+        return new Element(EXCLUDED_KEY_CHARS);
+    }
+
+    static Element createValueElement() {
+        return new Element(EXCLUDED_VALUE_CHARS);
+    }
+
+    /**
+     * Constructs element instance.
+     *
+     * @param excluded characters that are not allowed for this type of an element
+     */
+    private Element(BitSet excluded) {
+        this.excluded = excluded;
+        reset(0);
+    }
+
+    @Nullable
+    String getValue() {
+        return value;
+    }
+
+    void reset(int start) {
+        this.start = start;
+        leadingSpace = true;
+        readingValue = false;
+        trailingSpace = false;
+        value = null;
+    }
+
+    boolean tryTerminating(int index, String header) {
+        if (this.readingValue) {
+            markEnd(index);
+        }
+        if (this.trailingSpace) {
+            setValue(header);
+            return true;
+        } else {
+            // leading spaces - no content, invalid
+            return false;
+        }
+    }
+
+    private void markEnd(int end) {
+        this.end = end;
+        this.readingValue = false;
+        trailingSpace = true;
+    }
+
+    private void setValue(String header) {
+        this.value = header.substring(this.start, this.end);
+    }
+
+    boolean tryNextChar(char character, int index) {
+        if (isWhitespace(character)) {
+            return tryNextWhitespace(index);
+        } else if (isExcluded(character)) {
+            return false;
+        } else {
+            return tryNextTokenChar(index);
+        }
+    }
+
+    private static boolean isWhitespace(char character) {
+        return character == ' ' || character == '\t';
+    }
+
+    private boolean tryNextWhitespace(int index) {
+        if (readingValue) {
+            markEnd(index);
+        }
+        return true;
+    }
+
+    private boolean isExcluded(char character) {
+        return (character <= 32 || character >= 127 || excluded.get(character));
+    }
+
+    private boolean tryNextTokenChar(int index) {
+        if (leadingSpace) {
+            markStart(index);
+        }
+        return !trailingSpace;
+    }
+
+    private void markStart(int start) {
+        this.start = start;
+        readingValue = true;
+        leadingSpace = false;
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Element.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Element.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /**
  * This class has been copied from Otel v1.27.0 without any adjustments.
  */

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Parser.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Parser.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 /**
- * This class has been copied from OTel release v1.27.0 and adjusted to use our itnernal baggage builder instead.
+ * This class has been copied from OTel release v1.27.0 and adjusted to use our internal baggage builder instead.
  */
 /*
  * Copyright The OpenTelemetry Authors

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Parser.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Parser.java
@@ -1,0 +1,165 @@
+/**
+ * This class has been copied from OTel release v1.27.0 and adjusted to use our itnernal baggage builder instead.
+ */
+/*
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package co.elastic.apm.agent.impl.baggage.otel;
+
+import co.elastic.apm.agent.impl.baggage.Baggage;
+
+import javax.annotation.Nullable;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Implements single-pass Baggage parsing in accordance with https://w3c.github.io/baggage/ Key /
+ * value are restricted in accordance with https://www.ietf.org/rfc/rfc2616.txt
+ *
+ * <p>Note: following aspects are not specified in RFC: - some invalid elements (key or value) -
+ * parser will include valid ones, disregard invalid - empty "value" is regarded as invalid - meta -
+ * anything besides element terminator (comma)
+ */
+public class Parser {
+
+    private enum State {
+        KEY,
+        VALUE,
+        META
+    }
+
+    private final String baggageHeader;
+
+    private final Element key = Element.createKeyElement();
+    private final Element value = Element.createValueElement();
+    private String meta;
+
+    private State state;
+    private int metaStart;
+
+    private boolean skipToNext;
+
+    public Parser(String baggageHeader) {
+        this.baggageHeader = baggageHeader;
+        reset(0);
+    }
+
+    public void parseInto(Baggage.Builder baggageBuilder) {
+        for (int i = 0, n = baggageHeader.length(); i < n; i++) {
+            char current = baggageHeader.charAt(i);
+
+            if (skipToNext) {
+                if (current == ',') {
+                    reset(i + 1);
+                }
+                continue;
+            }
+
+            switch (current) {
+                case '=': {
+                    if (state == State.KEY) {
+                        if (key.tryTerminating(i, baggageHeader)) {
+                            setState(State.VALUE, i + 1);
+                        } else {
+                            skipToNext = true;
+                        }
+                    } else if (state == State.VALUE) {
+                        skipToNext = !value.tryNextChar(current, i);
+                    }
+                    break;
+                }
+                case ';': {
+                    if (state == State.VALUE) {
+                        skipToNext = !value.tryTerminating(i, baggageHeader);
+                        setState(State.META, i + 1);
+                    }
+                    break;
+                }
+                case ',': {
+                    switch (state) {
+                        case VALUE:
+                            value.tryTerminating(i, baggageHeader);
+                            break;
+                        case META:
+                            meta = baggageHeader.substring(metaStart, i).trim();
+                            break;
+                        case KEY: // none
+                    }
+                    putBaggage(baggageBuilder, key.getValue(), value.getValue(), meta);
+                    reset(i + 1);
+                    break;
+                }
+                default: {
+                    switch (state) {
+                        case KEY:
+                            skipToNext = !key.tryNextChar(current, i);
+                            break;
+                        case VALUE:
+                            skipToNext = !value.tryNextChar(current, i);
+                            break;
+                        case META: // none
+                    }
+                }
+            }
+        }
+        // need to finish parsing if there was no list element termination comma
+        switch (state) {
+            case KEY:
+                break;
+            case META: {
+                String rest = baggageHeader.substring(metaStart).trim();
+                putBaggage(baggageBuilder, key.getValue(), value.getValue(), rest);
+                break;
+            }
+            case VALUE: {
+                if (!skipToNext) {
+                    value.tryTerminating(baggageHeader.length(), baggageHeader);
+                    putBaggage(baggageBuilder, key.getValue(), value.getValue(), null);
+                    break;
+                }
+            }
+        }
+    }
+
+    private static void putBaggage(
+        Baggage.Builder baggage,
+        @Nullable String key,
+        @Nullable String value,
+        @Nullable String metadataValue) {
+        String decodedValue = decodeValue(value);
+        if (key != null && decodedValue != null) {
+            baggage.put(key, decodedValue, metadataValue);
+        }
+    }
+
+    @Nullable
+    private static String decodeValue(@Nullable String value) {
+        if (value == null) {
+            return null;
+        }
+        return BaggageCodec.decode(value, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Resets parsing state, preparing to start a new list element (see spec).
+     *
+     * @param index index where parser should start new element scan
+     */
+    private void reset(int index) {
+        this.skipToNext = false;
+        this.state = State.KEY;
+        this.key.reset(index);
+        this.value.reset(index);
+        this.meta = "";
+        this.metaStart = 0;
+    }
+
+    /**
+     * Switches parser state (element of a list member).
+     */
+    private void setState(State state, int start) {
+        this.state = state;
+        this.metaStart = start;
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Parser.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/Parser.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 /**
  * This class has been copied from OTel release v1.27.0 and adjusted to use our itnernal baggage builder instead.
  */

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/PercentEscaper.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/PercentEscaper.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 
 /*
  * This class has been copied from Otel reelase v1.27.0.

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/PercentEscaper.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/otel/PercentEscaper.java
@@ -1,0 +1,395 @@
+
+/*
+ * This class has been copied from Otel reelase v1.27.0.
+ * We do embedd an OTel-API in our agent, unfortunately we can't directly use this class:
+ * OTel is compiled with Java 8, whereas our agent needs to be capable of running with Java 7.
+ *
+ * In addition the ThreadLocal buffer has been replaced with a recycling data structure (Loom support).
+ *
+ * Copyright The OpenTelemetry Authors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Includes work from:
+/*
+ * Copyright (C) 2008 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package co.elastic.apm.agent.impl.baggage.otel;
+
+
+import co.elastic.apm.agent.impl.baggage.RecyclableCharArray;
+
+import javax.annotation.CheckForNull;
+
+/**
+ * Note: This class is based on code from guava. It is comprised of code from three classes:
+ *
+ * <ul>
+ *   <li><a
+ *       href="https://github.com/google/guava/blob/46093e2517b4f49c019ecff6dbe90cc22e8003b5/guava/src/com/google/common/escape/Escaper.java">com.google.common.escape.Escaper</a>
+ *   <li><a
+ *       href="https://github.com/google/guava/blob/46093e2517b4f49c019ecff6dbe90cc22e8003b5/guava/src/com/google/common/escape/UnicodeEscaper.java">com.google.common.escape.UnicodeEscaper</a>
+ *   <li><a
+ *       href="https://github.com/google/guava/blob/46093e2517b4f49c019ecff6dbe90cc22e8003b5/guava/src/com/google/common/net/PercentEscaper.java">com.google.common.net.PercentEscaper</a>
+ * </ul>
+ *
+ * <p>Escapes some set of Java characters using a UTF-8 based percent encoding scheme. The set of
+ * safe characters (those which remain unescaped) can be specified on construction.
+ *
+ * <p>This class is primarily used for creating URI escapers in {@code UrlEscapers} but can be used
+ * directly if required. While URI escapers impose specific semantics on which characters are
+ * considered 'safe', this class has a minimal set of restrictions.
+ *
+ * <p>When escaping a String, the following rules apply:
+ *
+ * <ul>
+ *   <li>All specified safe characters remain unchanged.
+ *   <li>If {@code plusForSpace} was specified, the space character " " is converted into a plus
+ *       sign {@code "+"}.
+ *   <li>All other characters are converted into one or more bytes using UTF-8 encoding and each
+ *       byte is then represented by the 3-character string "%XX", where "XX" is the two-digit,
+ *       uppercase, hexadecimal representation of the byte value.
+ * </ul>
+ *
+ * <p>For performance reasons the only currently supported character encoding of this class is
+ * UTF-8.
+ *
+ * <p><b>Note:</b> This escaper produces <a
+ * href="https://url.spec.whatwg.org/#percent-encode">uppercase</a> hexadecimal sequences.
+ *
+ * <p>This class is internal and is hence not for public use. Its APIs are unstable and can change
+ * at any time.
+ *
+ * @author David Beaumont
+ * @since 15.0
+ */
+public final class PercentEscaper {
+
+    /**
+     * The amount of padding (chars) to use when growing the escape buffer.
+     */
+    private static final int DEST_PAD = 32;
+
+    private static final String SAFE_CHARS =
+        "-._~" // Unreserved characters.
+            + "!$'()*"
+            // + ",;=" // baggage delimiters, so let's escape them
+            + "&" // The subdelim characters.
+            + "@:" // The gendelim characters permitted in paths.
+            + "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+    // Percent escapers output upper case hex digits (uri escapers require this).
+    private static final char[] UPPER_HEX_DIGITS = "0123456789ABCDEF".toCharArray();
+
+    /**
+     * An array of flags where for any {@code char c} if {@code safeOctets[c]} is true then {@code c}
+     * should remain unmodified in the output. If {@code c >= safeOctets.length} then it should be
+     * escaped.
+     */
+    private static final boolean[] safeOctets = createSafeOctets(SAFE_CHARS);
+
+    /**
+     * The default {@link PercentEscaper} which will *not* replace spaces with plus signs.
+     */
+    public static PercentEscaper create() {
+        return new PercentEscaper();
+    }
+
+    /**
+     * Creates a boolean array with entries corresponding to the character values specified in
+     * safeChars set to true. The array is as small as is required to hold the given character
+     * information.
+     */
+    private static boolean[] createSafeOctets(String safeChars) {
+        int maxChar = -1;
+        char[] safeCharArray = safeChars.toCharArray();
+        for (char c : safeCharArray) {
+            maxChar = Math.max(c, maxChar);
+        }
+        boolean[] octets = new boolean[maxChar + 1];
+        for (char c : safeCharArray) {
+            octets[c] = true;
+        }
+        return octets;
+    }
+
+    /**
+     * Escape the provided String, using percent-style URL Encoding.
+     */
+    public String escape(String s) {
+        int slen = s.length();
+        for (int index = 0; index < slen; index++) {
+            char c = s.charAt(index);
+            if (c >= safeOctets.length || !safeOctets[c]) {
+                return escapeSlow(s, index);
+            }
+        }
+        return s;
+    }
+
+    /*
+     * Overridden for performance. For unescaped strings this improved the performance of the uri
+     * escaper from ~760ns to ~400ns as measured by {@link CharEscapersBenchmark}.
+     */
+
+    /**
+     * Returns the escaped form of a given literal string, starting at the given index. This method is
+     * called by the {@link #escape(String)} method when it discovers that escaping is required. It is
+     * protected to allow subclasses to override the fastpath escaping function to inline their
+     * escaping test.
+     *
+     * <p>This method is not reentrant and may only be invoked by the top level {@link
+     * #escape(String)} method.
+     *
+     * @param s     the literal string to be escaped
+     * @param index the index to start escaping from
+     * @return the escaped form of {@code string}
+     * @throws NullPointerException     if {@code string} is null
+     * @throws IllegalArgumentException if invalid surrogate characters are encountered
+     */
+    private static String escapeSlow(String s, int index) {
+        try (RecyclableCharArray recyclabe = RecyclableCharArray.acquire()) {
+            int end = s.length();
+            // Get a destination buffer and setup some loop variables.
+            char[] dest = recyclabe.get(); // 1024 from the original guava source
+            int destIndex = 0;
+            int unescapedChunkStart = 0;
+
+            while (index < end) {
+                int cp = codePointAt(s, index, end);
+                if (cp < 0) {
+                    throw new IllegalArgumentException("Trailing high surrogate at end of input");
+                }
+                // It is possible for this to return null because nextEscapeIndex() may
+                // (for performance reasons) yield some false positives but it must never
+                // give false negatives.
+                char[] escaped = escape(cp);
+                int nextIndex = index + (Character.isSupplementaryCodePoint(cp) ? 2 : 1);
+                if (escaped != null) {
+                    int charsSkipped = index - unescapedChunkStart;
+
+                    // This is the size needed to add the replacement, not the full
+                    // size needed by the string. We only regrow when we absolutely must.
+                    int sizeNeeded = destIndex + charsSkipped + escaped.length;
+                    if (dest.length < sizeNeeded) {
+                        int destLength = sizeNeeded + (end - index) + DEST_PAD;
+                        dest = growBuffer(dest, destIndex, destLength);
+                    }
+                    // If we have skipped any characters, we need to copy them now.
+                    if (charsSkipped > 0) {
+                        s.getChars(unescapedChunkStart, index, dest, destIndex);
+                        destIndex += charsSkipped;
+                    }
+                    if (escaped.length > 0) {
+                        System.arraycopy(escaped, 0, dest, destIndex, escaped.length);
+                        destIndex += escaped.length;
+                    }
+                    // If we dealt with an escaped character, reset the unescaped range.
+                    unescapedChunkStart = nextIndex;
+                }
+                index = nextEscapeIndex(s, nextIndex, end);
+            }
+
+            // Process trailing unescaped characters - no need to account for escaped
+            // length or padding the allocation.
+            int charsSkipped = end - unescapedChunkStart;
+            if (charsSkipped > 0) {
+                int endIndex = destIndex + charsSkipped;
+                if (dest.length < endIndex) {
+                    dest = growBuffer(dest, destIndex, endIndex);
+                }
+                s.getChars(unescapedChunkStart, end, dest, destIndex);
+                destIndex = endIndex;
+            }
+            return new String(dest, 0, destIndex);
+        }
+    }
+
+    private static int nextEscapeIndex(CharSequence csq, int index, int end) {
+        for (; index < end; index++) {
+            char c = csq.charAt(index);
+            if (c >= safeOctets.length || !safeOctets[c]) {
+                break;
+            }
+        }
+        return index;
+    }
+
+    /**
+     * Escapes the given Unicode code point in UTF-8.
+     */
+    @CheckForNull
+    @SuppressWarnings("UngroupedOverloads")
+    private static char[] escape(int cp) {
+        // We should never get negative values here but if we do it will throw an
+        // IndexOutOfBoundsException, so at least it will get spotted.
+        if (cp < safeOctets.length && safeOctets[cp]) {
+            return null;
+        } else if (cp <= 0x7F) {
+            // Single byte UTF-8 characters
+            // Start with "%--" and fill in the blanks
+            char[] dest = new char[3];
+            dest[0] = '%';
+            dest[2] = UPPER_HEX_DIGITS[cp & 0xF];
+            dest[1] = UPPER_HEX_DIGITS[cp >>> 4];
+            return dest;
+        } else if (cp <= 0x7ff) {
+            // Two byte UTF-8 characters [cp >= 0x80 && cp <= 0x7ff]
+            // Start with "%--%--" and fill in the blanks
+            char[] dest = new char[6];
+            dest[0] = '%';
+            dest[3] = '%';
+            dest[5] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[4] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[2] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[1] = UPPER_HEX_DIGITS[0xC | cp];
+            return dest;
+        } else if (cp <= 0xffff) {
+            // Three byte UTF-8 characters [cp >= 0x800 && cp <= 0xffff]
+            // Start with "%E-%--%--" and fill in the blanks
+            char[] dest = new char[9];
+            dest[0] = '%';
+            dest[1] = 'E';
+            dest[3] = '%';
+            dest[6] = '%';
+            dest[8] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[7] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[5] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[4] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[2] = UPPER_HEX_DIGITS[cp];
+            return dest;
+        } else if (cp <= 0x10ffff) {
+            char[] dest = new char[12];
+            // Four byte UTF-8 characters [cp >= 0xffff && cp <= 0x10ffff]
+            // Start with "%F-%--%--%--" and fill in the blanks
+            dest[0] = '%';
+            dest[1] = 'F';
+            dest[3] = '%';
+            dest[6] = '%';
+            dest[9] = '%';
+            dest[11] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[10] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[8] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[7] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[5] = UPPER_HEX_DIGITS[cp & 0xF];
+            cp >>>= 4;
+            dest[4] = UPPER_HEX_DIGITS[0x8 | (cp & 0x3)];
+            cp >>>= 2;
+            dest[2] = UPPER_HEX_DIGITS[cp & 0x7];
+            return dest;
+        } else {
+            // If this ever happens it is due to bug in UnicodeEscaper, not bad input.
+            throw new IllegalArgumentException("Invalid unicode character value " + cp);
+        }
+    }
+
+    /**
+     * Returns the Unicode code point of the character at the given index.
+     *
+     * <p>Unlike {@link Character#codePointAt(CharSequence, int)} or {@link String#codePointAt(int)}
+     * this method will never fail silently when encountering an invalid surrogate pair.
+     *
+     * <p>The behaviour of this method is as follows:
+     *
+     * <ol>
+     *   <li>If {@code index >= end}, {@link IndexOutOfBoundsException} is thrown.
+     *   <li><b>If the character at the specified index is not a surrogate, it is returned.</b>
+     *   <li>If the first character was a high surrogate value, then an attempt is made to read the
+     *       next character.
+     *       <ol>
+     *         <li><b>If the end of the sequence was reached, the negated value of the trailing high
+     *             surrogate is returned.</b>
+     *         <li><b>If the next character was a valid low surrogate, the code point value of the
+     *             high/low surrogate pair is returned.</b>
+     *         <li>If the next character was not a low surrogate value, then {@link
+     *             IllegalArgumentException} is thrown.
+     *       </ol>
+     *   <li>If the first character was a low surrogate value, {@link IllegalArgumentException} is
+     *       thrown.
+     * </ol>
+     *
+     * @param seq   the sequence of characters from which to decode the code point
+     * @param index the index of the first character to decode
+     * @param end   the index beyond the last valid character to decode
+     * @return the Unicode code point for the given index or the negated value of the trailing high
+     * surrogate character at the end of the sequence
+     */
+    private static int codePointAt(CharSequence seq, int index, int end) {
+        if (index < end) {
+            char c1 = seq.charAt(index++);
+            if (c1 < Character.MIN_HIGH_SURROGATE || c1 > Character.MAX_LOW_SURROGATE) {
+                // Fast path (first test is probably all we need to do)
+                return c1;
+            } else if (c1 <= Character.MAX_HIGH_SURROGATE) {
+                // If the high surrogate was the last character, return its inverse
+                if (index == end) {
+                    return -c1;
+                }
+                // Otherwise look for the low surrogate following it
+                char c2 = seq.charAt(index);
+                if (Character.isLowSurrogate(c2)) {
+                    return Character.toCodePoint(c1, c2);
+                }
+                throw new IllegalArgumentException(
+                    "Expected low surrogate but got char '"
+                        + c2
+                        + "' with value "
+                        + (int) c2
+                        + " at index "
+                        + index
+                        + " in '"
+                        + seq
+                        + "'");
+            } else {
+                throw new IllegalArgumentException(
+                    "Unexpected low surrogate character '"
+                        + c1
+                        + "' with value "
+                        + (int) c1
+                        + " at index "
+                        + (index - 1)
+                        + " in '"
+                        + seq
+                        + "'");
+            }
+        }
+        throw new IndexOutOfBoundsException("Index exceeds specified range");
+    }
+
+    /**
+     * Helper method to grow the character buffer as needed, this only happens once in a while so it's
+     * ok if it's in a method call. If the index passed in is 0 then no copying will be done.
+     */
+    private static char[] growBuffer(char[] dest, int index, int size) {
+        if (size < 0) { // overflow - should be OutOfMemoryError but GWT/j2cl don't support it
+            throw new AssertionError("Cannot increase internal buffer any further");
+        }
+        char[] copy = new char[size];
+        if (index > 0) {
+            System.arraycopy(dest, 0, copy, 0, index);
+        }
+        return copy;
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContext.java
@@ -19,6 +19,7 @@
 package co.elastic.apm.agent.impl.transaction;
 
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.tracer.Scope;
 import co.elastic.apm.agent.tracer.dispatch.BinaryHeaderSetter;
 import co.elastic.apm.agent.tracer.dispatch.HeaderUtils;
@@ -36,7 +37,11 @@ public abstract class ElasticContext<T extends ElasticContext<T>> implements co.
     }
 
     @Nullable
+    @Override
     public abstract AbstractSpan<?> getSpan();
+
+    @Override
+    public abstract Baggage getBaggage();
 
     /**
      * @return transaction associated to this context, {@literal null} if there is none
@@ -81,13 +86,9 @@ public abstract class ElasticContext<T extends ElasticContext<T>> implements co.
     }
 
     public boolean isEmpty() {
-        return getSpan() == null && !containsBaggage();
+        return getSpan() == null && getBaggage().isEmpty();
     }
 
-    //TODO: make abstract and implement correctly in subclasses
-    protected final boolean containsBaggage() {
-        return false;
-    }
 
     @Override
     public final <C> boolean propagateContext(C carrier, BinaryHeaderSetter<C> headerSetter) {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContext.java
@@ -85,7 +85,10 @@ public abstract class ElasticContext<T extends ElasticContext<T>> implements co.
 
     @Nullable
     @Override
-    public abstract co.elastic.apm.agent.impl.transaction.Span createSpan();
+    public co.elastic.apm.agent.impl.transaction.Span createSpan() {
+        AbstractSpan<?> currentSpan = getSpan();
+        return currentSpan == null ? null : currentSpan.createSpan(getBaggage());
+    }
 
     @Nullable
     @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContextWrapper.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContextWrapper.java
@@ -109,12 +109,6 @@ public class ElasticContextWrapper<T extends ElasticContext<T>> extends ElasticC
         throw activationNotSupported();
     }
 
-    @Nullable
-    @Override
-    public Span createSpan() {
-        throw new UnsupportedOperationException("span creation not expected on context wrapper");
-    }
-
     private static UnsupportedOperationException activationNotSupported() {
         // activation is not expected to happen on this wrapper but only on the wrapped context
         return new UnsupportedOperationException("activation not expected on context wrapper");

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContextWrapper.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContextWrapper.java
@@ -19,6 +19,7 @@
 package co.elastic.apm.agent.impl.transaction;
 
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.tracer.Scope;
 
 import javax.annotation.Nullable;
@@ -108,6 +109,12 @@ public class ElasticContextWrapper<T extends ElasticContext<T>> extends ElasticC
         throw activationNotSupported();
     }
 
+    @Nullable
+    @Override
+    public Span createSpan() {
+        throw new UnsupportedOperationException("span creation not expected on context wrapper");
+    }
+
     private static UnsupportedOperationException activationNotSupported() {
         // activation is not expected to happen on this wrapper but only on the wrapped context
         return new UnsupportedOperationException("activation not expected on context wrapper");
@@ -117,6 +124,11 @@ public class ElasticContextWrapper<T extends ElasticContext<T>> extends ElasticC
     @Nullable
     public AbstractSpan<?> getSpan() {
         return context.getSpan();
+    }
+
+    @Override
+    public Baggage getBaggage() {
+        throw new UnsupportedOperationException("Baggage should not be accessed on context wrapper");
     }
 
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Span.java
@@ -20,6 +20,7 @@ package co.elastic.apm.agent.impl.transaction;
 
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.context.Db;
 import co.elastic.apm.agent.impl.context.Message;
 import co.elastic.apm.agent.impl.context.ServiceTarget;
@@ -87,7 +88,8 @@ public class Span extends AbstractSpan<Span> implements Recyclable, co.elastic.a
         super(tracer);
     }
 
-    public <T> Span start(TraceContext.ChildContextCreator<T> childContextCreator, T parentContext, long epochMicros) {
+    public <T> Span start(TraceContext.ChildContextCreator<T> childContextCreator, T parentContext, Baggage parentBaggage, long epochMicros) {
+        this.baggage = parentBaggage;
         childContextCreator.asChildOf(traceContext, parentContext);
         if (parentContext instanceof Transaction) {
             this.transaction = (Transaction) parentContext;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -21,6 +21,7 @@ package co.elastic.apm.agent.impl.transaction;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.Tracer;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.sampling.Sampler;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
@@ -711,12 +712,15 @@ public class TraceContext implements Recyclable, co.elastic.apm.agent.tracer.Tra
         return serviceVersion;
     }
 
-    public Span createSpan() {
-        return tracer.startSpan(fromParentContext(), this);
-    }
 
+    /**
+     * Creates a child span from this trace context. The span will not have any baggage assigned.
+     *
+     * @param epochMicros the span start time
+     * @return the newly started span
+     */
     public Span createSpan(long epochMicros) {
-        return tracer.startSpan(fromParentContext(), this, epochMicros);
+        return tracer.startSpan(fromParentContext(), this, Baggage.EMPTY, epochMicros);
     }
 
     @Override

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -22,6 +22,8 @@ import co.elastic.apm.agent.common.util.WildcardMatcher;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.configuration.SpanConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.baggage.Baggage;
+import co.elastic.apm.agent.impl.baggage.W3CBaggagePropagation;
 import co.elastic.apm.agent.impl.context.Response;
 import co.elastic.apm.agent.impl.context.TransactionContext;
 import co.elastic.apm.agent.tracer.util.ResultUtil;
@@ -31,6 +33,7 @@ import co.elastic.apm.agent.metrics.MetricRegistry;
 import co.elastic.apm.agent.metrics.Timer;
 import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.tracer.dispatch.HeaderGetter;
+import co.elastic.apm.agent.tracer.dispatch.TextHeaderGetter;
 import co.elastic.apm.agent.util.KeyListConcurrentHashMap;
 import org.HdrHistogram.WriterReaderPhaser;
 
@@ -123,7 +126,8 @@ public class Transaction extends AbstractSpan<Transaction> implements co.elastic
         spanConfig = tracer.getConfig(SpanConfiguration.class);
     }
 
-    public <T> Transaction startRoot(long epochMicros, Sampler sampler) {
+    public <T> Transaction startRoot(long epochMicros, Sampler sampler, Baggage baggage) {
+        this.baggage = baggage;
         traceContext.asRootSpan(sampler);
         onTransactionStart(epochMicros);
         return this;
@@ -134,10 +138,18 @@ public class Transaction extends AbstractSpan<Transaction> implements co.elastic
         @Nullable C parent,
         HeaderGetter<H, C> headerGetter,
         long epochMicros,
-        Sampler sampler
+        Sampler sampler,
+        Baggage baseBaggage
     ) {
         if (parent == null) {
-            return startRoot(epochMicros, sampler);
+            return startRoot(epochMicros, sampler, baseBaggage);
+        }
+        if (headerGetter instanceof TextHeaderGetter) {
+            Baggage.Builder baggageBuilder = baggage.toBuilder();
+            W3CBaggagePropagation.parse(parent, (TextHeaderGetter<C>) headerGetter, baggageBuilder);
+            this.baggage = baggageBuilder.build();
+        } else {
+            this.baggage = baseBaggage;
         }
         CoreConfiguration.TraceContinuationStrategy traceContinuationStrategy = coreConfig.getTraceContinuationStrategy();
         boolean restartTrace = false;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -145,7 +145,7 @@ public class Transaction extends AbstractSpan<Transaction> implements co.elastic
             return startRoot(epochMicros, sampler, baseBaggage);
         }
         if (headerGetter instanceof TextHeaderGetter) {
-            Baggage.Builder baggageBuilder = baggage.toBuilder();
+            Baggage.Builder baggageBuilder = baseBaggage.toBuilder();
             W3CBaggagePropagation.parse(parent, (TextHeaderGetter<C>) headerGetter, baggageBuilder);
             this.baggage = baggageBuilder.build();
         } else {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/TransactionUtils.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/TransactionUtils.java
@@ -18,13 +18,14 @@
  */
 package co.elastic.apm.agent;
 
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.context.Request;
 import co.elastic.apm.agent.impl.context.TransactionContext;
 import co.elastic.apm.agent.impl.sampling.ConstantSampler;
-import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
+import co.elastic.apm.agent.tracer.Outcome;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,7 +33,7 @@ import java.util.List;
 public class TransactionUtils {
 
     public static void fillTransaction(Transaction t) {
-        t.startRoot((long) 0, ConstantSampler.of(true))
+        t.startRoot((long) 0, ConstantSampler.of(true), Baggage.EMPTY)
             .withName("GET /api/types")
             .withType("request")
             .withResult("success")
@@ -79,7 +80,7 @@ public class TransactionUtils {
     public static List<Span> getSpans(Transaction t) {
         List<Span> spans = new ArrayList<>();
         Span span = new Span(MockTracer.create())
-            .start(TraceContext.fromParent(), t, -1)
+            .start(TraceContext.fromParent(), t, Baggage.EMPTY, -1)
             .withName("SELECT FROM product_types")
             .withType("db")
             .withSubtype("postgresql")
@@ -95,20 +96,20 @@ public class TransactionUtils {
         spans.add(span);
 
         spans.add(new Span(MockTracer.create())
-            .start(TraceContext.fromParent(), t, -1)
+            .start(TraceContext.fromParent(), t, Baggage.EMPTY, -1)
             .withName("GET /api/types")
             .withType("request"));
         spans.add(new Span(MockTracer.create())
-            .start(TraceContext.fromParent(), t, -1)
+            .start(TraceContext.fromParent(), t, Baggage.EMPTY, -1)
             .withName("GET /api/types")
             .withType("request"));
         spans.add(new Span(MockTracer.create())
-            .start(TraceContext.fromParent(), t, -1)
+            .start(TraceContext.fromParent(), t, Baggage.EMPTY, -1)
             .withName("GET /api/types")
             .withType("request"));
 
         span = new Span(MockTracer.create())
-            .start(TraceContext.fromParent(), t, -1)
+            .start(TraceContext.fromParent(), t, Baggage.EMPTY, -1)
             .appendToName("GET ")
             .appendToName("test.elastic.co")
             .withType("ext")

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -24,6 +24,7 @@ import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.configuration.ServiceInfo;
 import co.elastic.apm.agent.configuration.SpyConfiguration;
 import co.elastic.apm.agent.configuration.source.ConfigSources;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.sampling.ConstantSampler;
 import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
@@ -513,7 +514,7 @@ class ElasticApmTracerTest {
 
         try (Scope transactionScope = transaction.activateInScope()) {
             assertThat(tracerImpl.getActive()).isEqualTo(transaction);
-            final Span span = tracerImpl.startSpan(TraceContext.fromActive(), tracerImpl);
+            final Span span = tracerImpl.startSpan(TraceContext.fromActive(), tracerImpl, Baggage.EMPTY);
             assertThat(span).isNotNull();
             try (Scope scope = span.activateInScope()) {
                 assertThat(tracerImpl.currentTransaction()).isNotNull();
@@ -739,6 +740,17 @@ class ElasticApmTracerTest {
         @Nullable
         @Override
         public AbstractSpan<?> getSpan() {
+            return null;
+        }
+
+        @Override
+        public Baggage getBaggage() {
+            return null;
+        }
+
+        @Nullable
+        @Override
+        public Span createSpan() {
             return null;
         }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -748,12 +748,6 @@ class ElasticApmTracerTest {
             return null;
         }
 
-        @Nullable
-        @Override
-        public Span createSpan() {
-            return null;
-        }
-
         @Override
         public void incrementReferences() {
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/baggage/BaggageBuilderTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/baggage/BaggageBuilderTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.impl.baggage;
+
+
+import org.junit.jupiter.api.Test;
+
+import static co.elastic.apm.agent.testutils.assertions.Assertions.assertThat;
+
+public class BaggageBuilderTest {
+
+    @Test
+    public void verifyBaggageReuseOnNoModification() {
+        Baggage base = Baggage.builder()
+            .put("foo", "bar")
+            .build();
+
+        Baggage newlyBuilt = base.toBuilder().build();
+
+        assertThat(newlyBuilt).isSameAs(base);
+    }
+
+    @Test
+    public void verifyBaggageBuilderPreserversOriginalBaggage() {
+        Baggage base = Baggage.builder()
+            .put("foo", "bar")
+            .put("bar", "baz")
+            .build();
+
+        Baggage newlyBuilt = base.toBuilder()
+            .put("foo", "not-bar")
+            .build();
+
+        assertThat(base)
+            .containsEntry("foo", "bar")
+            .containsEntry("bar", "baz");
+        assertThat(newlyBuilt)
+            .containsEntry("foo", "not-bar")
+            .containsEntry("bar", "baz");
+    }
+
+    @Test
+    public void testEntryRemoval() {
+        Baggage base = Baggage.builder()
+            .put("foo", "bar")
+            .put("bar", "baz")
+            .build();
+
+        Baggage newlyBuilt = base.toBuilder()
+            .put("foo", null)
+            .build();
+
+        assertThat(base)
+            .hasSize(2)
+            .containsEntry("foo", "bar")
+            .containsEntry("bar", "baz");
+        assertThat(newlyBuilt)
+            .hasSize(1)
+            .containsEntry("bar", "baz");
+    }
+
+    @Test
+    public void verifyMetadataPreserved() {
+        Baggage base = Baggage.builder()
+            .put("foo", "bar", "meta1")
+            .put("bar", "baz", "meta2")
+            .build();
+
+        Baggage newlyBuilt = base.toBuilder()
+            .put("foo", "not-bar")
+            .put("new", "newval", "new_meta")
+            .build();
+
+        assertThat(base)
+            .containsEntry("foo", "bar", "meta1")
+            .containsEntry("bar", "baz", "meta2");
+        assertThat(newlyBuilt)
+            .containsEntry("foo", "not-bar", null)
+            .containsEntry("bar", "baz", "meta2")
+            .containsEntry("new", "newval", "new_meta");
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagationTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.impl.baggage;
 
 import co.elastic.apm.agent.impl.TextHeaderMapAccessor;

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/baggage/W3CBaggagePropagationTest.java
@@ -1,0 +1,125 @@
+package co.elastic.apm.agent.impl.baggage;
+
+import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
+import co.elastic.apm.agent.tracer.dispatch.TextHeaderGetter;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static co.elastic.apm.agent.testutils.assertions.Assertions.assertThat;
+
+
+public class W3CBaggagePropagationTest {
+
+    @Nested
+    public class Propagation {
+
+        @Test
+        public void testComplexValue() {
+            Baggage baggage = Baggage.builder()
+                .put("foo", "bar")
+                .put("my_key!", "hello, world!?%ä=", "metadata=blub")
+                .build();
+
+            Map<String, String> resultHeaders = new HashMap<>();
+            W3CBaggagePropagation.propagate(baggage, resultHeaders, TextHeaderMapAccessor.INSTANCE);
+
+            assertThat(resultHeaders)
+                .hasSize(1)
+                .containsEntry("baggage", "foo=bar,my_key!=hello%2C%20world!%3F%25%C3%A4%3D;metadata=blub");
+        }
+
+        @Test
+        public void testEmptyBaggage() {
+            Baggage baggage = Baggage.builder().build();
+
+            Map<String, String> resultHeaders = new HashMap<>();
+            W3CBaggagePropagation.propagate(baggage, resultHeaders, TextHeaderMapAccessor.INSTANCE);
+
+            assertThat(resultHeaders).hasSize(0);
+        }
+
+        @Test
+        public void testInvalidKeysIgnored() {
+            Baggage baggage = Baggage.builder()
+                .put("foo", "bar")
+                .put("bad,key", "42")
+                .build();
+
+            Map<String, String> resultHeaders = new HashMap<>();
+            W3CBaggagePropagation.propagate(baggage, resultHeaders, TextHeaderMapAccessor.INSTANCE);
+
+            assertThat(resultHeaders)
+                .hasSize(1)
+                .containsEntry("baggage", "foo=bar");
+        }
+
+
+        @Test
+        public void testOnlyInvalidKeys() {
+            Baggage baggage = Baggage.builder()
+                .put("bad,key", "42")
+                .build();
+
+            Map<String, String> resultHeaders = new HashMap<>();
+            W3CBaggagePropagation.propagate(baggage, resultHeaders, TextHeaderMapAccessor.INSTANCE);
+
+            assertThat(resultHeaders).hasSize(0);
+        }
+    }
+
+
+    @Nested
+    public class Parsing {
+
+        @Test
+        public void testComplexValue() {
+            String[] baggageHeaders = {
+                "foo=bar,my_key!=hello%2C%20world!%3F%25%C3%A4%3D;metadata=blub,,bar=baz;override=me,foo=bar2;overridden=meta",
+                "bar=baz2"
+            };
+            TextHeaderGetter<String[]> headerGetter = new TextHeaderGetter<String[]>() {
+                @Nullable
+                @Override
+                public String getFirstHeader(String headerName, String[] baggageHeaders) {
+                    if (headerName.equals("baggage")) {
+                        return baggageHeaders[0];
+                    }
+                    return null;
+                }
+
+                @Override
+                public <S> void forEach(String headerName, String[] baggageHeaders, S state, HeaderConsumer<String, S> consumer) {
+                    if (headerName.equals("baggage")) {
+                        for (String val : baggageHeaders) {
+                            consumer.accept(val, state);
+                        }
+                    }
+                }
+            };
+
+            Baggage.Builder resultBuilder = Baggage.builder();
+            W3CBaggagePropagation.parse(baggageHeaders, headerGetter, resultBuilder);
+
+            assertThat(resultBuilder.build())
+                .hasSize(3)
+                .containsEntry("my_key!", "hello, world!?%ä=", "metadata=blub")
+                .containsEntry("bar", "baz2", null)
+                .containsEntry("foo", "bar2", "overridden=meta");
+        }
+
+        @Test
+        public void testNoValue() {
+            Baggage.Builder resultBuilder = Baggage.builder();
+            W3CBaggagePropagation.parse(Collections.emptyMap(), TextHeaderMapAccessor.INSTANCE, resultBuilder);
+
+            assertThat(resultBuilder.build()).hasSize(0);
+        }
+
+    }
+
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/BaggageTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/BaggageTest.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.impl.transaction;
+
+import co.elastic.apm.agent.MockReporter;
+import co.elastic.apm.agent.configuration.SpyConfiguration;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
+import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
+import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
+import co.elastic.apm.agent.tracer.ElasticContext;
+import co.elastic.apm.agent.tracer.Scope;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.stagemonitor.configuration.ConfigurationRegistry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static co.elastic.apm.agent.testutils.assertions.Assertions.assertThat;
+
+public class BaggageTest {
+
+    private ElasticApmTracer tracer;
+    private ConfigurationRegistry config;
+
+    @BeforeEach
+    public void setup() {
+        config = SpyConfiguration.createSpyConfig();
+        tracer = new ElasticApmTracerBuilder()
+            .configurationRegistry(config)
+            .reporter(new MockReporter())
+            .withObjectPoolFactory(new TestObjectPoolFactory())
+            .buildAndStart();
+    }
+
+    @Test
+    public void checkChildTransactionBaggageParsingWithTracestate() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("traceparent", "00-0af7651916cd43dd8448eb211c80319c-b9c7c989f97918e1-01");
+        headers.put("baggage", "key1=val1,key2=val2");
+
+        Transaction transaction = tracer.startChildTransaction(headers, TextHeaderMapAccessor.INSTANCE, null);
+        assertThat(transaction.getTraceContext())
+            .satisfies(tc -> assertThat(tc.getTraceId().toString()).isEqualTo("0af7651916cd43dd8448eb211c80319c"))
+            .satisfies(tc -> Assertions.assertThat(tc.getParentId().toString()).isEqualTo("b9c7c989f97918e1"));
+        assertThat(transaction)
+            .hasBaggageCount(2)
+            .hasBaggage("key1", "val1")
+            .hasBaggage("key2", "val2");
+    }
+
+    @Test
+    public void checkChildTransactionBaggageParsingWithoutTracestate() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("baggage", "key1=val1,key2=val2");
+
+        Transaction transaction = tracer.startChildTransaction(headers, TextHeaderMapAccessor.INSTANCE, null);
+        assertThat(transaction)
+            .hasBaggageCount(2)
+            .hasBaggage("key1", "val1")
+            .hasBaggage("key2", "val2");
+    }
+
+
+    @Test
+    public void checkChildTransactionOverridesCurrentBaggage() {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("baggage", "key1=val1");
+
+        ElasticContext<?> baggageContext = tracer.currentContext().withUpdatedBaggage()
+            .put("key1", "rootval1")
+            .put("key2", "rootval2")
+            .buildContext()
+            .activate();
+        Transaction transaction = tracer.startChildTransaction(headers, TextHeaderMapAccessor.INSTANCE, null);
+        baggageContext.deactivate();
+
+
+        assertThat(transaction)
+            .hasBaggageCount(2)
+            .hasBaggage("key1", "val1")
+            .hasBaggage("key2", "rootval2");
+    }
+
+    @Test
+    public void checkRootTransactionInheritsCurrentBaggage() {
+        ElasticContext<?> baggageContext = tracer.currentContext().withUpdatedBaggage()
+            .put("key1", "rootval1")
+            .put("key2", "rootval2")
+            .buildContext()
+            .activate();
+        Transaction transaction = tracer.startRootTransaction(null);
+        baggageContext.deactivate();
+
+        assertThat(transaction)
+            .hasBaggageCount(2)
+            .hasBaggage("key1", "rootval1")
+            .hasBaggage("key2", "rootval2");
+    }
+
+
+    @Test
+    public void checkSpanInheritsParentBaggage() {
+        Transaction transaction;
+        Span span1, span2, span3, span4;
+
+        ElasticContext<?> baggage1 = tracer.currentContext().withUpdatedBaggage()
+            .put("key1", "rootval1")
+            .put("key2", "rootval2")
+            .buildContext();
+        try (Scope sc1 = baggage1.activateInScope()) {
+            transaction = tracer.startRootTransaction(null);
+            try (Scope trSc = transaction.activateInScope()) {
+
+                span1 = tracer.currentContext().createSpan();
+
+                ElasticContext<?> baggage2 = tracer.currentContext().withUpdatedBaggage()
+                    .put("key1", "baggage2_override")
+                    .buildContext();
+                try (Scope sc2 = baggage2.activateInScope()) {
+
+                    span2 = tracer.currentContext().createSpan();
+
+                    try (Scope spanScope = span2.activateInScope()) {
+
+                        span3 = tracer.currentContext().createSpan();
+
+                        ElasticContext<?> baggage3 = tracer.currentContext().withUpdatedBaggage()
+                            .put("key3", "baggage3_override")
+                            .remove("key2")
+                            .buildContext();
+                        try (Scope sc3 = baggage3.activateInScope()) {
+                            span4 = tracer.currentContext().createSpan();
+                        }
+                    }
+
+                }
+            }
+        }
+
+        assertThat(span1)
+            .hasParent(transaction)
+            .hasBaggageCount(2)
+            .hasBaggage("key1", "rootval1")
+            .hasBaggage("key2", "rootval2");
+
+        assertThat(span2)
+            .hasParent(transaction)
+            .hasBaggageCount(2)
+            .hasBaggage("key1", "baggage2_override")
+            .hasBaggage("key2", "rootval2");
+
+        assertThat(span3)
+            .hasParent(span2)
+            .hasBaggageCount(2)
+            .hasBaggage("key1", "baggage2_override")
+            .hasBaggage("key2", "rootval2");
+
+        assertThat(span4)
+            .hasParent(span2)
+            .hasBaggageCount(2)
+            .hasBaggage("key1", "baggage2_override")
+            .hasBaggage("key3", "baggage3_override");
+    }
+
+
+    @Test
+    public void checkBaggagePropagationWithoutTrace() {
+        ElasticContext<?> baggage = tracer.currentContext().withUpdatedBaggage()
+            .put("key", "val")
+            .buildContext();
+
+        Map<String, String> headers = new HashMap<>();
+
+        assertThat(baggage.isPropagationRequired(headers, TextHeaderMapAccessor.INSTANCE)).isTrue();
+
+        baggage.propagateContext(headers, TextHeaderMapAccessor.INSTANCE, headers, TextHeaderMapAccessor.INSTANCE);
+        assertThat(headers)
+            .hasSize(1)
+            .containsEntry("baggage", "key=val");
+
+        //check handling of duplicate propagation
+        assertThat(baggage.isPropagationRequired(headers, TextHeaderMapAccessor.INSTANCE)).isFalse();
+        baggage.propagateContext(headers, TextHeaderMapAccessor.INSTANCE, headers, TextHeaderMapAccessor.INSTANCE);
+        assertThat(headers)
+            .hasSize(1)
+            .containsEntry("baggage", "key=val");
+    }
+
+    @Test
+    public void checkBaggagePropagationFromTransaction() {
+        ElasticContext<?> baggage = tracer.currentContext().withUpdatedBaggage()
+            .put("key", "val")
+            .buildContext()
+            .activate();
+
+        Transaction transaction = tracer.startRootTransaction(null);
+
+        baggage.deactivate();
+
+        Map<String, String> headers = new HashMap<>();
+
+        assertThat(transaction.isPropagationRequired(headers, TextHeaderMapAccessor.INSTANCE)).isTrue();
+
+        transaction.propagateContext(headers, TextHeaderMapAccessor.INSTANCE, headers, TextHeaderMapAccessor.INSTANCE);
+        assertThat(headers)
+            .containsEntry("baggage", "key=val")
+            .containsKey("traceparent");
+
+    }
+
+    @Test
+    public void checkBaggagePropagationFromSpan() {
+        ElasticContext<?> baggage = tracer.currentContext().withUpdatedBaggage()
+            .put("key", "val")
+            .buildContext()
+            .activate();
+
+        Transaction transaction = tracer.startRootTransaction(null);
+        Span span = transaction.createSpan();
+
+        baggage.deactivate();
+
+        Map<String, String> headers = new HashMap<>();
+
+        assertThat(span.isPropagationRequired(headers, TextHeaderMapAccessor.INSTANCE)).isTrue();
+
+        span.propagateContext(headers, TextHeaderMapAccessor.INSTANCE, headers, TextHeaderMapAccessor.INSTANCE);
+        assertThat(headers)
+            .containsEntry("baggage", "key=val")
+            .containsKey("traceparent");
+
+    }
+
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/SpanTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/SpanTest.java
@@ -22,6 +22,7 @@ import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.impl.BinaryHeaderMapAccessor;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.sampling.ConstantSampler;
 import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
 import co.elastic.apm.agent.tracer.Outcome;
@@ -101,10 +102,10 @@ public class SpanTest {
     void normalizeType(String type, String expectedType) {
 
         Transaction transaction = new Transaction(tracer);
-        transaction.startRoot(0, ConstantSampler.of(true));
+        transaction.startRoot(0, ConstantSampler.of(true), Baggage.EMPTY);
         try {
             Span span = new Span(tracer);
-            span.start(TraceContext.fromParent(), transaction, -1L);
+            span.start(TraceContext.fromParent(), transaction, Baggage.EMPTY, -1L);
             assertThat(span.getType())
                 .describedAs("span type should not be set by default")
                 .isNull();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/TransactionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/TransactionTest.java
@@ -22,6 +22,7 @@ import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.TransactionUtils;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.metadata.MetaDataMock;
 import co.elastic.apm.agent.impl.sampling.ConstantSampler;
 import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
@@ -106,7 +107,7 @@ public class TransactionTest {
     void normalizeType(String type, String expectedType) {
         Transaction transaction = new Transaction(MockTracer.createRealTracer());
 
-        transaction.startRoot(0, ConstantSampler.of(true));
+        transaction.startRoot(0, ConstantSampler.of(true), Baggage.EMPTY);
         assertThat(transaction.getType())
             .describedAs("transaction type should not be set by default")
             .isNull();

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -28,6 +28,7 @@ import co.elastic.apm.agent.impl.BinaryHeaderMapAccessor;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
 import co.elastic.apm.agent.impl.Tracer;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.context.AbstractContext;
 import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.context.Headers;
@@ -169,7 +170,7 @@ class DslJsonSerializerTest {
     @Test
     void testErrorSerialization() {
         Transaction transaction = new Transaction(tracer);
-        transaction.startRoot(-1, ConstantSampler.of(true));
+        transaction.startRoot(-1, ConstantSampler.of(true), Baggage.EMPTY);
         ErrorCapture error = new ErrorCapture(tracer).asChildOf(transaction).withTimestamp(5000);
         error.setTransactionSampled(true);
         error.setTransactionType("test-type");
@@ -217,7 +218,7 @@ class DslJsonSerializerTest {
     @Test
     void testErrorSerializationWithEmptyTraceId() {
         Transaction transaction = new Transaction(tracer);
-        transaction.startRoot(-1, ConstantSampler.of(true));
+        transaction.startRoot(-1, ConstantSampler.of(true), Baggage.EMPTY);
         transaction.getTraceContext().getTraceId().resetState();
         ErrorCapture error = new ErrorCapture(tracer).asChildOf(transaction).withTimestamp(5000);
 
@@ -1348,7 +1349,7 @@ class DslJsonSerializerTest {
 
     private Transaction createRootTransaction(Sampler sampler) {
         Transaction t = new Transaction(tracer);
-        t.startRoot(0, sampler);
+        t.startRoot(0, sampler, Baggage.EMPTY);
         t.withType("type");
         t.getContext().getRequest().withMethod("GET");
         t.getContext().getRequest().getUrl().withFull("http://localhost:8080/foo/bar");

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/AbstractSpanAssert.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/AbstractSpanAssert.java
@@ -25,7 +25,7 @@ import co.elastic.apm.agent.tracer.Outcome;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-public class AbstractSpanAssert<SELF extends AbstractSpanAssert<SELF, ACTUAL>, ACTUAL extends AbstractSpan<?>> extends BaseAssert<SELF, ACTUAL> {
+public class AbstractSpanAssert<SELF extends AbstractSpanAssert<SELF, ACTUAL>, ACTUAL extends AbstractSpan<?>> extends ElasticContextAssert<SELF, ACTUAL> {
 
     protected AbstractSpanAssert(ACTUAL actual, Class<SELF> selfType) {
         super(actual, selfType);

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/Assertions.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/Assertions.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.apm.agent.testutils.assertions;
 
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.context.Db;
 import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.context.ServiceTarget;
@@ -54,5 +55,9 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static MetricSetsAssert assertThatMetricSets(Collection<byte[]> metricsetsJson) {
         return new MetricSetsAssert(metricsetsJson);
+    }
+
+    public static BaggageAssert assertThat(Baggage baggage) {
+        return new BaggageAssert(baggage);
     }
 }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/Assertions.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/Assertions.java
@@ -23,6 +23,7 @@ import co.elastic.apm.agent.impl.context.Db;
 import co.elastic.apm.agent.impl.context.Destination;
 import co.elastic.apm.agent.impl.context.ServiceTarget;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.ElasticContext;
 import co.elastic.apm.agent.impl.transaction.Span;
 import co.elastic.apm.agent.testutils.assertions.metrics.MetricSetsAssert;
 
@@ -51,6 +52,10 @@ public class Assertions extends org.assertj.core.api.Assertions {
 
     public static AbstractSpanAssert<?, ?> assertThat(AbstractSpan<?> span) {
         return new AbstractSpanAssert<>(span, AbstractSpanAssert.class);
+    }
+
+    public static ElasticContextAssert<?, ?> assertThat(ElasticContext<?> span) {
+        return new ElasticContextAssert<>(span, ElasticContextAssert.class);
     }
 
     public static MetricSetsAssert assertThatMetricSets(Collection<byte[]> metricsetsJson) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/BaggageAssert.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/BaggageAssert.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.testutils.assertions;
+
+import co.elastic.apm.agent.impl.baggage.Baggage;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+public class BaggageAssert extends BaseAssert<BaggageAssert, Baggage> {
+
+    protected BaggageAssert(Baggage actual) {
+        super(actual, BaggageAssert.class);
+    }
+
+    public BaggageAssert hasSize(int expectedSize) {
+        isNotNull();
+        checkInt("Expected baggage to have size %d but %d", expectedSize, actual.keys().size());
+        return this;
+    }
+
+    public BaggageAssert containsEntry(String key, String value) {
+        isNotNull();
+        if (!actual.keys().contains(key)) {
+            failWithMessage("Expected baggage to contain key '%s' but did not. Contained keys are %s", key, actual.keys());
+        }
+        if (!value.equals(actual.get(key))) {
+            failWithMessage("Expected baggage to contain value '%s' for key '%s' but actual was '%s'", value, key, actual.get(key));
+        }
+        return this;
+    }
+
+    public BaggageAssert containsEntry(String key, String value, @Nullable String metadata) {
+        isNotNull();
+        containsEntry(key, value);
+        if (!Objects.equals(metadata, actual.getMetadata(key))) {
+            failWithMessage("Expected baggage to contain metadata '%s' for key '%s' but actual was '%s'", metadata, key, actual.getMetadata(key));
+        }
+        return this;
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/ElasticContextAssert.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/testutils/assertions/ElasticContextAssert.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.testutils.assertions;
+
+import co.elastic.apm.agent.impl.transaction.ElasticContext;
+
+public class ElasticContextAssert<SELF extends ElasticContextAssert<SELF, ACTUAL>, ACTUAL extends ElasticContext<?>> extends BaseAssert<SELF, ACTUAL> {
+
+    protected ElasticContextAssert(ACTUAL actual, Class<SELF> selfType) {
+        super(actual, selfType);
+    }
+
+    public SELF hasBaggageCount(int expectedCount) {
+        isNotNull();
+        new BaggageAssert(actual.getBaggage()).hasSize(expectedCount);
+        return thiz();
+    }
+
+    public SELF hasBaggage(String key, String value) {
+        isNotNull();
+        new BaggageAssert(actual.getBaggage()).containsEntry(key, value);
+        return thiz();
+    }
+
+    @SuppressWarnings("unchecked")
+    private SELF thiz() {
+        return (SELF) this;
+    }
+}

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -411,7 +411,7 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
             HttpHeaders headers = loggedRequest.getHeaders();
             if (headers != null) {
                 HttpHeader header = headers.getHeader(headerName);
-                if (header != null) {
+                if (header.isPresent()) {
                     List<String> values = header.values();
                     for (String value : values) {
                         consumer.accept(value, state);

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelBridgeContext.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelBridgeContext.java
@@ -116,13 +116,6 @@ public class OTelBridgeContext extends ElasticContext<OTelBridgeContext> impleme
         return currentSpan != null ? currentSpan.getBaggage() : Baggage.EMPTY;
     }
 
-    @Nullable
-    @Override
-    public co.elastic.apm.agent.impl.transaction.Span createSpan() {
-        AbstractSpan<?> currentSpan = getSpan();
-        return currentSpan == null ? null : currentSpan.createSpan(getBaggage());
-    }
-
 
     // OTel context implementation
 

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelBridgeContext.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelBridgeContext.java
@@ -19,6 +19,7 @@
 package co.elastic.apm.agent.opentelemetry.tracing;
 
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.ElasticContext;
 import io.opentelemetry.api.trace.Span;
@@ -106,6 +107,20 @@ public class OTelBridgeContext extends ElasticContext<OTelBridgeContext> impleme
             return ((OTelSpan) span).getInternalSpan();
         }
         return null;
+    }
+
+    @Override
+    public Baggage getBaggage() {
+        //TODO: correctly implement baggage
+        AbstractSpan<?> currentSpan = getSpan();
+        return currentSpan != null ? currentSpan.getBaggage() : Baggage.EMPTY;
+    }
+
+    @Nullable
+    @Override
+    public co.elastic.apm.agent.impl.transaction.Span createSpan() {
+        AbstractSpan<?> currentSpan = getSpan();
+        return currentSpan == null ? null : currentSpan.createSpan(getBaggage());
     }
 
 

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelSpanBuilder.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelSpanBuilder.java
@@ -155,7 +155,7 @@ class OTelSpanBuilder implements SpanBuilder {
             // when parent is not explicitly set, the currently active parent is used as fallback
             parent = elasticApmTracer.getActive();
         }
-
+        //TODO: correctly implement baggage: we need to use the baggage from the parent context instead of from the parent span
         if (remoteContext != null) {
             PotentiallyMultiValuedMap headers = new PotentiallyMultiValuedMap(2);
             W3CTraceContextPropagator.getInstance().inject(remoteContext, headers, PotentiallyMultiValuedMap::add);
@@ -163,7 +163,7 @@ class OTelSpanBuilder implements SpanBuilder {
         } else if (parent == null) {
             span = elasticApmTracer.startRootTransaction(PrivilegedActionUtils.getClassLoader(getClass()), epochMicros);
         } else {
-            span = elasticApmTracer.startSpan(parent, epochMicros);
+            span = elasticApmTracer.startSpan(parent, parent.getBaggage(), epochMicros);
         }
         if (span == null) {
             return Span.getInvalid();

--- a/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracingimpl/ApmSpanBuilderInstrumentation.java
+++ b/apm-agent-plugins/apm-opentracing-plugin/src/main/java/co/elastic/apm/agent/opentracingimpl/ApmSpanBuilderInstrumentation.java
@@ -95,9 +95,9 @@ public abstract class ApmSpanBuilderInstrumentation extends OpenTracingBridgeIns
                         result = createTransaction(tags, operationName, microseconds, baggage, tracer, applicationClassLoader);
                     } else {
                         if (microseconds >= 0) {
-                            result = tracer.startSpan(TraceContext.fromParent(), parentContext, microseconds);
+                            result = tracer.startSpan(TraceContext.fromParent(), parentContext, parentContext.getBaggage(), microseconds);
                         } else {
-                            result = tracer.startSpan(TraceContext.fromParent(), parentContext);
+                            result = tracer.startSpan(TraceContext.fromParent(), parentContext, parentContext.getBaggage());
                         }
                     }
                 }

--- a/apm-agent-plugins/apm-vertx/apm-vertx-common/src/test/java/co/elastic/apm/agent/vertx/webclient/AbstractVertxWebClientTest.java
+++ b/apm-agent-plugins/apm-vertx/apm-vertx-common/src/test/java/co/elastic/apm/agent/vertx/webclient/AbstractVertxWebClientTest.java
@@ -97,6 +97,11 @@ public abstract class AbstractVertxWebClientTest extends AbstractHttpClientInstr
         doVerifyFailedRequestHttpSpan("not-existing.com", "/error");
     }
 
+    @Override
+    public void testBaggagePropagatedWithoutTrace() {
+        //TODO: remove this NOOP override when vert-x context propagation (instead of span-propagation) is correctly implemented
+    }
+
     protected void doVerifyFailedRequestHttpSpan(String host, String path) {
         expectSpan(path)
             .withHost(host)

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/Baggage.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/Baggage.java
@@ -1,0 +1,12 @@
+package co.elastic.apm.agent.tracer;
+
+import javax.annotation.Nullable;
+import java.util.Set;
+
+public interface Baggage {
+
+    Set<String> keys();
+
+    @Nullable
+    String get(String key);
+}

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/Baggage.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/Baggage.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.tracer;
 
 import javax.annotation.Nullable;

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/BaggageContextBuilder.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/BaggageContextBuilder.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.tracer;
 
 import javax.annotation.Nullable;

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/BaggageContextBuilder.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/BaggageContextBuilder.java
@@ -29,14 +29,14 @@ public interface BaggageContextBuilder {
      * @param key   The key of the baggage to store
      * @param value the updated value. If null, any present value for the given key will be removed.
      */
-    void put(String key, @Nullable String value);
+    BaggageContextBuilder put(String key, @Nullable String value);
 
     /**
      * Same as invoking {@link #put(String, String)} with a null value.
      *
      * @param key
      */
-    void remove(String key);
+    BaggageContextBuilder remove(String key);
 
     /**
      * @return the created context with the baggage updates applied.

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/BaggageContextBuilder.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/BaggageContextBuilder.java
@@ -1,0 +1,27 @@
+package co.elastic.apm.agent.tracer;
+
+import javax.annotation.Nullable;
+
+/**
+ * Builder for creating a context with alteredBaggage.
+ */
+public interface BaggageContextBuilder {
+
+    /**
+     * @param key   The key of the baggage to store
+     * @param value the updated value. If null, any present value for the given key will be removed.
+     */
+    void put(String key, @Nullable String value);
+
+    /**
+     * Same as invoking {@link #put(String, String)} with a null value.
+     *
+     * @param key
+     */
+    void remove(String key);
+
+    /**
+     * @return the created context with the baggage updates applied.
+     */
+    ElasticContext<?> buildContext();
+}

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/ElasticContext.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/ElasticContext.java
@@ -39,6 +39,10 @@ public interface ElasticContext<T extends ElasticContext<T>> extends ReferenceCo
     @Nullable
     Transaction<?> getTransaction();
 
+    /**
+     * @return the baggage associated with this context
+     */
+    Baggage getBaggage();
 
     /**
      * Creates a child span of this context, if possible.
@@ -57,6 +61,8 @@ public interface ElasticContext<T extends ElasticContext<T>> extends ReferenceCo
      */
     @Nullable
     Span<?> createExitSpan();
+
+    BaggageContextBuilder withUpdatedBaggage();
 
     /**
      * If a context is empty, it does not need to be propagated (neither within the process, nor via external calls).

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/NoopElasticContext.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/NoopElasticContext.java
@@ -59,6 +59,11 @@ public class NoopElasticContext implements ElasticContext<NoopElasticContext> {
         return null;
     }
 
+    @Override
+    public Baggage getBaggage() {
+        throw new UnsupportedOperationException();
+    }
+
     @Nullable
     @Override
     public Span<?> createSpan() {
@@ -69,6 +74,11 @@ public class NoopElasticContext implements ElasticContext<NoopElasticContext> {
     @Override
     public Span<?> createExitSpan() {
         return null;
+    }
+
+    @Override
+    public BaggageContextBuilder withUpdatedBaggage() {
+        throw new UnsupportedOperationException();
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

Part of #3004. Implements W3C baggage propagation and parsing.
Adds tracer-API s for reading and updating baggage.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] ~Added an API method or config option? Document in which version this will be introduced~
  - [ ] ~I have made corresponding changes to the documentation~
