### PR TITLE
Make maven_central_deploy job continue even if BK job fails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
       - prepare_release
     steps:
       - id: buildkite
+        continue-on-error: true
         name: Run Deploy
         uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
         with:


### PR DESCRIPTION
## What does this PR do?

The `maven_central_deploy` fails, even if it successfully publishes to maven central.

With this attribute, the job should continue as if it succeeded.

Since we are waiting for the package with the `await_artifact_on_maven_central` job, this workflow should still fail if the artifacts are not deployed correctly.


<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->