### PR TITLE
OpenTelemetry Bridge Baggage support

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Features
 * Added W3C baggage propagation - {pull}3236[#3236]
+* Added support for baggage in OpenTelemetry bridge - {pull}3249[#3249]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -245,21 +245,32 @@ public class ElasticApmTracer implements Tracer {
     @Override
     @Nullable
     public Transaction startRootTransaction(@Nullable ClassLoader initiatingClassLoader) {
-        return startRootTransaction(sampler, -1, initiatingClassLoader);
+        return startRootTransaction(sampler, -1, currentContext().getBaggage(), initiatingClassLoader);
     }
 
     @Override
     @Nullable
     public Transaction startRootTransaction(@Nullable ClassLoader initiatingClassLoader, long epochMicro) {
-        return startRootTransaction(sampler, epochMicro, initiatingClassLoader);
+        return startRootTransaction(sampler, epochMicro, currentContext().getBaggage(), initiatingClassLoader);
+    }
+
+    @Nullable
+    @Override
+    public Transaction startRootTransaction(@Nullable ClassLoader initiatingClassLoader, Baggage baseBaggage, long epochMicro) {
+        return startRootTransaction(sampler, epochMicro, baseBaggage, initiatingClassLoader);
+    }
+
+
+    @Nullable
+    public Transaction startRootTransaction(Sampler sampler, long epochMicros, @Nullable ClassLoader initiatingClassLoader) {
+        return startRootTransaction(sampler, epochMicros, currentContext().getBaggage(), initiatingClassLoader);
     }
 
     @Override
     @Nullable
-    public Transaction startRootTransaction(Sampler sampler, long epochMicros, @Nullable ClassLoader initiatingClassLoader) {
+    public Transaction startRootTransaction(Sampler sampler, long epochMicros, Baggage baseBaggage, @Nullable ClassLoader initiatingClassLoader) {
         Transaction transaction = null;
         if (isRunning()) {
-            Baggage baseBaggage = currentContext().getBaggage();
             transaction = createTransaction().startRoot(epochMicros, sampler, baseBaggage);
             afterTransactionStart(initiatingClassLoader, transaction);
         }
@@ -274,7 +285,7 @@ public class ElasticApmTracer implements Tracer {
 
     @Override
     @Nullable
-    public <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, @Nullable ClassLoader initiatingClassLoader, long epochMicros) {
+    public <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, @Nullable ClassLoader initiatingClassLoader, Baggage baseBaggage, long epochMicros) {
         return startChildTransaction(headerCarrier, textHeadersGetter, sampler, epochMicros, initiatingClassLoader);
     }
 
@@ -282,9 +293,13 @@ public class ElasticApmTracer implements Tracer {
     @Nullable
     public <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, Sampler sampler,
                                                  long epochMicros, @Nullable ClassLoader initiatingClassLoader) {
+        return startChildTransaction(headerCarrier, textHeadersGetter, sampler, epochMicros, currentContext().getBaggage(), initiatingClassLoader);
+    }
+
+    private <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, Sampler sampler,
+                                                  long epochMicros, Baggage baseBaggage, @Nullable ClassLoader initiatingClassLoader) {
         Transaction transaction = null;
         if (isRunning()) {
-            Baggage baseBaggage = currentContext().getBaggage();
             transaction = createTransaction().start(TraceContext.<C>getFromTraceContextTextHeaders(), headerCarrier,
                 textHeadersGetter, epochMicros, sampler, baseBaggage);
             afterTransactionStart(initiatingClassLoader, transaction);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Tracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Tracer.java
@@ -19,6 +19,7 @@
 package co.elastic.apm.agent.impl;
 
 import co.elastic.apm.agent.configuration.ServiceInfo;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.impl.sampling.Sampler;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
@@ -40,6 +41,9 @@ public interface Tracer extends co.elastic.apm.agent.tracer.Tracer {
     @Nullable
     Transaction startRootTransaction(@Nullable ClassLoader initiatingClassLoader, long epochMicro);
 
+    @Nullable
+    Transaction startRootTransaction(@Nullable ClassLoader initiatingClassLoader, Baggage baseBaggage, long epochMicro);
+
     /**
      * Starts a trace-root transaction with a specified sampler and start timestamp
      *
@@ -51,14 +55,14 @@ public interface Tracer extends co.elastic.apm.agent.tracer.Tracer {
      * @return a transaction that will be the root of the current trace if the agent is currently RUNNING; null otherwise
      */
     @Nullable
-    Transaction startRootTransaction(Sampler sampler, long epochMicros, @Nullable ClassLoader initiatingClassLoader);
+    Transaction startRootTransaction(Sampler sampler, long epochMicros, Baggage baseBaggage, @Nullable ClassLoader initiatingClassLoader);
 
     @Override
     @Nullable
     <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, @Nullable ClassLoader initiatingClassLoader);
 
     @Nullable
-    <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, @Nullable ClassLoader initiatingClassLoader, long epochMicros);
+    <C> Transaction startChildTransaction(@Nullable C headerCarrier, TextHeaderGetter<C> textHeadersGetter, @Nullable ClassLoader initiatingClassLoader, Baggage baseBaggage, long epochMicros);
 
     /**
      * Starts a transaction as a child of the context headers obtained through the provided {@link HeaderGetter}.

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/BaggageContext.java
@@ -81,6 +81,11 @@ public class BaggageContext extends ElasticContext<BaggageContext> {
             return this;
         }
 
+        public Builder put(String key, @Nullable String value, @Nullable String metadata) {
+            baggageBuilder.put(key, value, metadata);
+            return this;
+        }
+
         @Override
         public Builder remove(String key) {
             baggageBuilder.put(key, null);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/ElasticContext.java
@@ -22,7 +22,6 @@ import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.baggage.BaggageContext;
 import co.elastic.apm.agent.impl.baggage.W3CBaggagePropagation;
-import co.elastic.apm.agent.tracer.BaggageContextBuilder;
 import co.elastic.apm.agent.tracer.Scope;
 import co.elastic.apm.agent.tracer.dispatch.BinaryHeaderSetter;
 import co.elastic.apm.agent.tracer.dispatch.HeaderUtils;
@@ -79,7 +78,7 @@ public abstract class ElasticContext<T extends ElasticContext<T>> implements co.
     }
 
     @Override
-    public BaggageContextBuilder withUpdatedBaggage() {
+    public BaggageContext.Builder withUpdatedBaggage() {
         return BaggageContext.createBuilder(this);
     }
 

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/baggage/OtelBaggage.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/baggage/OtelBaggage.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.opentelemetry.baggage;
 
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakConcurrent;

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/baggage/OtelBaggage.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/baggage/OtelBaggage.java
@@ -1,0 +1,40 @@
+package co.elastic.apm.agent.opentelemetry.baggage;
+
+import co.elastic.apm.agent.sdk.weakconcurrent.WeakConcurrent;
+import co.elastic.apm.agent.sdk.weakconcurrent.WeakMap;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageBuilder;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
+
+public class OtelBaggage {
+
+    private static final WeakMap<Baggage, co.elastic.apm.agent.impl.baggage.Baggage> translationCache = WeakConcurrent.buildMap();
+
+    public static Baggage fromElasticBaggage(co.elastic.apm.agent.impl.baggage.Baggage elasticBaggage) {
+        BaggageBuilder builder = Baggage.builder();
+        for (String key : elasticBaggage.keys()) {
+            builder.put(key, elasticBaggage.get(key), BaggageEntryMetadata.create(elasticBaggage.getMetadata(key)));
+        }
+        Baggage result = builder.build();
+        // remember the translation for future toElasticBaggage calls
+        translationCache.put(result, elasticBaggage);
+        return result;
+    }
+
+    public static co.elastic.apm.agent.impl.baggage.Baggage toElasticBaggage(Baggage otelBaggage) {
+        if (otelBaggage == null || otelBaggage.isEmpty()) {
+            return co.elastic.apm.agent.impl.baggage.Baggage.EMPTY;
+        }
+        co.elastic.apm.agent.impl.baggage.Baggage translated = translationCache.get(otelBaggage);
+        if (translated == null) {
+            co.elastic.apm.agent.impl.baggage.Baggage.Builder builder = co.elastic.apm.agent.impl.baggage.Baggage.builder();
+            otelBaggage.forEach((key, value) -> {
+                String metadata = value.getMetadata().getValue();
+                builder.put(key, value.getValue(), metadata.isEmpty() ? null : metadata);
+            });
+            translated = builder.build();
+            translationCache.put(otelBaggage, translated);
+        }
+        return translated;
+    }
+}

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/context/OTelContextStorage.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/context/OTelContextStorage.java
@@ -19,7 +19,6 @@
 package co.elastic.apm.agent.opentelemetry.context;
 
 import co.elastic.apm.agent.impl.ElasticApmTracer;
-import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.ElasticContext;
 import co.elastic.apm.agent.opentelemetry.tracing.OTelBridgeContext;
 import co.elastic.apm.agent.sdk.logging.Logger;
@@ -77,12 +76,6 @@ public class OTelContextStorage implements ContextStorage {
             return (Context) current;
         }
 
-        AbstractSpan<?> currentSpan = current.getSpan();
-        if (currentSpan == null) {
-            // OTel context without an active span is not supported yet
-            return null;
-        }
-
         // Ensure that root context is being accessed at least once to capture the original root
         // OTel 1.0 directly calls ArrayBasedContext.root() which is not publicly accessible, later versions delegate
         // to ContextStorage.root() which we can't call from here either.
@@ -91,6 +84,6 @@ public class OTelContextStorage implements ContextStorage {
         // Current context hasn't been created with this OTel instance, but with another OTel plugin instance
         // (one per external plugin) or is an Elastic context (span or transaction), thus needs wrapping to make it visible
         // to this OTel context.
-        return tracer.wrapActiveContextIfRequired(OTelBridgeContext.class, () -> OTelBridgeContext.wrapElasticActiveSpan(tracer, currentSpan));
+        return tracer.wrapActiveContextIfRequired(OTelBridgeContext.class, () -> OTelBridgeContext.wrapElasticActiveSpan(tracer, current));
     }
 }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelSpanBuilder.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelSpanBuilder.java
@@ -19,12 +19,14 @@
 package co.elastic.apm.agent.opentelemetry.tracing;
 
 import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.MultiValueMapAccessor;
 import co.elastic.apm.agent.impl.transaction.OTelSpanKind;
 import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
+import co.elastic.apm.agent.opentelemetry.baggage.OtelBaggage;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.sdk.internal.util.LoggerUtils;
@@ -58,9 +60,7 @@ class OTelSpanBuilder implements SpanBuilder {
     private final Map<AttributeKey<?>, Object> attributes = new HashMap<>();
     private long epochMicros = -1;
     @Nullable
-    private AbstractSpan<?> parent;
-    @Nullable
-    private Context remoteContext;
+    private Context parent;
 
     private List<SpanContext> links = new ArrayList<>();
 
@@ -74,19 +74,13 @@ class OTelSpanBuilder implements SpanBuilder {
 
     @Override
     public SpanBuilder setParent(Context context) {
-        Span span = Span.fromContext(context);
-        if (span.getSpanContext().isRemote()) {
-            remoteContext = context;
-        } else if (span instanceof OTelSpan) {
-            parent = ((OTelSpan) span).getInternalSpan();
-        }
+        parent = context;
         return this;
     }
 
     @Override
     public SpanBuilder setNoParent() {
         parent = null;
-        remoteContext = null;
         return this;
     }
 
@@ -151,19 +145,32 @@ class OTelSpanBuilder implements SpanBuilder {
     public Span startSpan() {
         AbstractSpan<?> span;
 
-        if (parent == null) {
+        Baggage parentBaggage;
+        AbstractSpan<?> parentSpan = null;
+        Context remoteContext = null;
+
+        if (parent != null) {
+            Span parentOtelSpan = Span.fromContext(parent);
+            if (parentOtelSpan.getSpanContext().isRemote()) {
+                remoteContext = parent;
+            } else if (parentOtelSpan instanceof OTelSpan) {
+                parentSpan = ((OTelSpan) parentOtelSpan).getInternalSpan();
+            }
+            parentBaggage = OtelBaggage.toElasticBaggage(io.opentelemetry.api.baggage.Baggage.fromContext(parent));
+        } else {
             // when parent is not explicitly set, the currently active parent is used as fallback
-            parent = elasticApmTracer.getActive();
+            parentSpan = elasticApmTracer.currentContext().getSpan();
+            parentBaggage = elasticApmTracer.currentContext().getBaggage();
         }
-        //TODO: correctly implement baggage: we need to use the baggage from the parent context instead of from the parent span
+
         if (remoteContext != null) {
             PotentiallyMultiValuedMap headers = new PotentiallyMultiValuedMap(2);
             W3CTraceContextPropagator.getInstance().inject(remoteContext, headers, PotentiallyMultiValuedMap::add);
-            span = elasticApmTracer.startChildTransaction(headers, MultiValueMapAccessor.INSTANCE, PrivilegedActionUtils.getClassLoader(getClass()), epochMicros);
-        } else if (parent == null) {
-            span = elasticApmTracer.startRootTransaction(PrivilegedActionUtils.getClassLoader(getClass()), epochMicros);
+            span = elasticApmTracer.startChildTransaction(headers, MultiValueMapAccessor.INSTANCE, PrivilegedActionUtils.getClassLoader(getClass()), parentBaggage, epochMicros);
+        } else if (parentSpan == null) {
+            span = elasticApmTracer.startRootTransaction(PrivilegedActionUtils.getClassLoader(getClass()), parentBaggage, epochMicros);
         } else {
-            span = elasticApmTracer.startSpan(parent, parent.getBaggage(), epochMicros);
+            span = elasticApmTracer.startSpan(parentSpan, parentBaggage, epochMicros);
         }
         if (span == null) {
             return Span.getInvalid();

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/test/java/co/elastic/apm/agent/opentelemetry/tracing/ElasticOpenTelemetryTest.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/test/java/co/elastic/apm/agent/opentelemetry/tracing/ElasticOpenTelemetryTest.java
@@ -23,6 +23,8 @@ import co.elastic.apm.agent.impl.transaction.ElasticContext;
 import co.elastic.apm.agent.impl.transaction.OTelSpanKind;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.tracer.Outcome;
+import io.opentelemetry.api.baggage.Baggage;
+import io.opentelemetry.api.baggage.BaggageEntryMetadata;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
@@ -59,12 +61,19 @@ public class ElasticOpenTelemetryTest extends AbstractOpenTelemetryTest {
 
     @Test
     public void testTransaction() {
-        otelTracer.spanBuilder("transaction")
-            .startSpan()
-            .end();
+
+        try (Scope sc = Baggage.builder().put("foo", "bar").build().makeCurrent()) {
+            otelTracer.spanBuilder("transaction")
+                .startSpan()
+                .end();
+        }
+
         assertThat(reporter.getTransactions()).hasSize(1);
         Transaction transaction = reporter.getFirstTransaction();
         assertThat(transaction.getNameAsString()).isEqualTo("transaction");
+        assertThat(transaction.getBaggage())
+            .hasSize(1)
+            .containsEntry("foo", "bar");
 
         assertThat(transaction.getOtelKind())
             .describedAs("default span kind should be internal when not set explicitly")
@@ -90,12 +99,43 @@ public class ElasticOpenTelemetryTest extends AbstractOpenTelemetryTest {
         assertThat(transaction.getOtelAttributes().get("string")).isEqualTo("hello");
     }
 
+
+    @Test
+    public void testBaggageInteroperability() {
+        ElasticContext<?> elasticContext = tracer.currentContext().withUpdatedBaggage()
+            .put("foo", "elastic")
+            .put("bar", "el2", "metadata")
+            .buildContext()
+            .activate();
+
+        assertThat(Baggage.current().size()).isEqualTo(2);
+        assertThat(Baggage.current().getEntryValue("foo")).isEqualTo("elastic");
+        assertThat(Baggage.current().asMap().get("foo").getMetadata().getValue()).isEqualTo("");
+        assertThat(Baggage.current().getEntryValue("bar")).isEqualTo("el2");
+        assertThat(Baggage.current().asMap().get("bar").getMetadata().getValue()).isEqualTo("metadata");
+
+        elasticContext.deactivate();
+
+        Baggage otelBaggage = Baggage.builder()
+            .put("foo", "otel")
+            .put("bar", "otel2", BaggageEntryMetadata.create("otel-meta"))
+            .build();
+        try (Scope scope = otelBaggage.makeCurrent()) {
+            assertThat(tracer.currentContext().getBaggage())
+                .hasSize(2)
+                .containsEntry("foo", "otel", null)
+                .containsEntry("bar", "otel2", "otel-meta");
+        }
+
+    }
+
     @Test
     public void testTransactionWithSpanManualPropagation() {
         Span transaction = otelTracer.spanBuilder("transaction")
             .startSpan();
+        Baggage baggage = Baggage.builder().put("foo", "bar").build();
         otelTracer.spanBuilder("span")
-            .setParent(Context.root().with(transaction))
+            .setParent(Context.root().with(transaction).with(baggage))
             .startSpan()
             .end();
         transaction.end();
@@ -106,6 +146,7 @@ public class ElasticOpenTelemetryTest extends AbstractOpenTelemetryTest {
         assertThat(reportedTransaction.getNameAsString()).isEqualTo("transaction");
 
         assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("span");
+        assertThat(reporter.getFirstSpan()).hasBaggage("foo", "bar");
         assertThat(reporter.getFirstSpan().isChildOf(reporter.getFirstTransaction())).isTrue();
     }
 
@@ -126,6 +167,25 @@ public class ElasticOpenTelemetryTest extends AbstractOpenTelemetryTest {
         assertThat(reporter.getFirstTransaction().getNameAsString()).isEqualTo("transaction");
         assertThat(reporter.getFirstSpan().getNameAsString()).isEqualTo("span");
         assertThat(reporter.getFirstSpan().isChildOf(reporter.getFirstTransaction())).isTrue();
+    }
+
+
+    @Test
+    public void testOtelBaggageOnElasticSpan() {
+
+        Baggage baggage = Baggage.builder().put("foo", "bar").build();
+        try (Scope scope = baggage.makeCurrent()) {
+            Transaction tr = tracer.startRootTransaction(null).activate();
+            assertThat(tr).hasBaggage("foo", "bar");
+            Baggage baggage2 = Baggage.builder().put("foo2", "bar2").build();
+            try (Scope scope2 = baggage2.makeCurrent()) {
+                co.elastic.apm.agent.impl.transaction.Span elasticSpan = tracer.currentContext().createSpan();
+                assertThat(elasticSpan)
+                    .hasBaggage("foo2", "bar2")
+                    .hasBaggageCount(1);
+            }
+            tr.deactivate();
+        }
     }
 
     @Test

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -250,8 +250,7 @@ Spans can only have a single parent (`SpanBuilder#setParent`)
 [float]
 [[otel-baggage]]
 ===== Baggage
-Propagating baggage within or outside the process is not supported.
-Baggage items are silently dropped.
+Baggage support has been added in version `1.41.0`.
 
 [float]
 [[otel-events]]


### PR DESCRIPTION
## What does this PR do?

Adds baggage interoperability between OpenTelemetry baggage and our internal Baggage data structure.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] ~Added an API method or config option? Document in which version this will be introduced~
  - [x] I have made corresponding changes to the documentation

