### PR TITLE
added MDC limitation to log sending docs

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/logging/LoggingConfiguration.java
@@ -276,7 +276,9 @@ public class LoggingConfiguration extends ConfigurationOptionProvider implements
             "or if Elasticsearch can't index the logs fast enough.\n" +
             "\n" +
             "For better delivery guarantees, it's recommended to ship ECS JSON log files with Filebeat\n" +
-            "See also <<config-log-ecs-reformatting,`log_ecs_reformatting`>>.")
+            "See also <<config-log-ecs-reformatting,`log_ecs_reformatting`>>.\n" +
+            "Log sending does currently not support custom MDC fields," +
+            " `log_ecs_reformatting` and shipping the logs with Filebeat must be used if custom MDC fields are required.")
         .dynamic(true)
         .tags("added[1.36.0]", "experimental")
         .buildWithDefault(false);

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -2368,6 +2368,7 @@ or if Elasticsearch can't index the logs fast enough.
 
 For better delivery guarantees, it's recommended to ship ECS JSON log files with Filebeat
 See also <<config-log-ecs-reformatting,`log_ecs_reformatting`>>.
+Log sending does currently not support custom MDC fields, `log_ecs_reformatting` and shipping the logs with Filebeat must be used if custom MDC fields are required.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
 
@@ -4482,6 +4483,7 @@ Example: `5ms`.
 # 
 # For better delivery guarantees, it's recommended to ship ECS JSON log files with Filebeat
 # See also <<config-log-ecs-reformatting,`log_ecs_reformatting`>>.
+# Log sending does currently not support custom MDC fields, `log_ecs_reformatting` and shipping the logs with Filebeat must be used if custom MDC fields are required.
 #
 # This setting can be changed at runtime
 # Type: Boolean


### PR DESCRIPTION
## What does this PR do?

Sending custom MDC fields via log sending is currently not supported due to an APM server restriction.
This PR adds this limitation to the docs.

## Checklist

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
