### PR TITLE
Fix invalid SQS propagation introduced with #3206

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Added W3C baggage propagation - {pull}3236[#3236]
 * Added support for baggage in OpenTelemetry bridge - {pull}3249[#3249]
 
+[float]
+===== Bug fixes
+* Fixed SQS NoClassDefFoundError in AWS SDK instrumentation - {pull}3254[#3254]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 


### PR DESCRIPTION
## What does this PR do?

Fixes a `ClassDefNotFoundError` reported in this [discussion forums thread](https://discuss.elastic.co/t/bug-apm-java-springboot-v1-39-0-no-jvm-metrics-found/339104).

The invocation of the `SQSHelper` was moved behind the span activation to ensure that even if no span is created, baggage propagation still occurs.

This however caused the `SQSHelper` to be invoked for all aws services, including non-sqs ones.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix

