### PR TITLE
Fixed micrometer histograms to be non-cumulative

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Features
 * Added virtual thread support - {pull}#3239[#3239]
 
+[float]
+===== Bug fixes
+* Fixed Micrometer histograms to be correctly exported with non-cumulative bucket counts - {pull}3264[#3264]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-plugins/apm-micrometer-plugin/pom.xml
+++ b/apm-agent-plugins/apm-micrometer-plugin/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>io.micrometer</groupId>
             <artifactId>micrometer-core</artifactId>
-            <version>1.11.1</version>
+            <version>1.11.2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
@@ -19,12 +19,12 @@
 package co.elastic.apm.agent.micrometer;
 
 import co.elastic.apm.agent.report.serialize.DslJsonSerializer;
+import co.elastic.apm.agent.sdk.internal.util.PrivilegedActionUtils;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakConcurrent;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakSet;
 import co.elastic.apm.agent.tracer.configuration.MetricsConfiguration;
-import co.elastic.apm.agent.sdk.internal.util.PrivilegedActionUtils;
 import com.dslplatform.json.DslJson;
 import com.dslplatform.json.JsonWriter;
 import com.dslplatform.json.NumberConverter;
@@ -258,11 +258,16 @@ public class MicrometerMeterRegistrySerializer {
         jw.writeByte(JsonWriter.QUOTE);
         jw.writeByte(JsonWriter.SEMI);
         jw.writeByte(JsonWriter.ARRAY_START);
+        // Microemter bucket counts are cumulative: E.g. the count at bucket with upper boundary X is the total number of observations smaller than X
+        // including values which have already been counted for smaller buckets.
+        // Elastic however expects non-cumulative bucket counts
         if (bucket.length > 0) {
             NumberConverter.serialize((long) bucket[0].count(), jw);
+            double prevBucketCount = bucket[0].count();
             for (int i = 1; i < bucket.length; i++) {
                 jw.writeByte(JsonWriter.COMMA);
-                NumberConverter.serialize((long) bucket[i].count(), jw);
+                NumberConverter.serialize((long) (bucket[i].count() - prevBucketCount), jw);
+                prevBucketCount = bucket[i].count();
             }
         }
         jw.writeByte(JsonWriter.ARRAY_END);

--- a/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
@@ -258,7 +258,8 @@ public class MicrometerMeterRegistrySerializer {
         jw.writeByte(JsonWriter.QUOTE);
         jw.writeByte(JsonWriter.SEMI);
         jw.writeByte(JsonWriter.ARRAY_START);
-        // Microemter bucket counts are cumulative: E.g. the count at bucket with upper boundary X is the total number of observations smaller than X
+        // Micrometer bucket counts are cumulative: E.g. the count at bucket with upper
+        // boundary X is the total number of observations smaller than X
         // including values which have already been counted for smaller buckets.
         // Elastic however expects non-cumulative bucket counts
         if (bucket.length > 0) {

--- a/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializerTest.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializerTest.java
@@ -264,8 +264,8 @@ public class MicrometerMeterRegistrySerializerTest {
         int sum = 0;
         int count = 0;
         int under5Count = 0;
-        int under50Count = 0;
-        int under95Count = 0;
+        int from5To50Count = 0;
+        int from50to95Count = 0;
         int[] values = new int[]{22, 55, 66, 98};
 
         @Override
@@ -290,12 +290,10 @@ public class MicrometerMeterRegistrySerializerTest {
                 sum += val;
                 if (val < 5) {
                     under5Count++;
-                }
-                if (val < 50) {
-                    under50Count++;
-                }
-                if (val < 95) {
-                    under95Count++;
+                } else if (val < 50) {
+                    from5To50Count++;
+                } else if (val < 95) {
+                    from50to95Count++;
                 }
             }
         }
@@ -317,8 +315,8 @@ public class MicrometerMeterRegistrySerializerTest {
             assertThat(histoNode2.isArray()).isTrue();
             assertThat(histoNode2.size()).isEqualTo(3); //the 3 counts of samples under boundaries of the SLOs 5,50,95
             assertThat(histoNode2.get(0).asInt()).isEqualTo(under5Count);
-            assertThat(histoNode2.get(1).asInt()).isEqualTo(under50Count);
-            assertThat(histoNode2.get(2).asInt()).isEqualTo(under95Count);
+            assertThat(histoNode2.get(1).asInt()).isEqualTo(from5To50Count);
+            assertThat(histoNode2.get(2).asInt()).isEqualTo(from50to95Count);
         }
     }
 

--- a/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializerTest.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializerTest.java
@@ -278,7 +278,8 @@ public class MicrometerMeterRegistrySerializerTest {
             meter = DistributionSummary
                 .builder(metername())
                 .distributionStatisticBufferLength(20)
-                .serviceLevelObjectives(5,50,95)
+                .serviceLevelObjectives(5, 50, 95)
+                .publishPercentileHistogram()
                 .register(registry);
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes #3263 .
While touching the micrometer stuff, I decided to just include a fix for #3189.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
