### PR TITLE
Fix invalid SQSHelper usage in AWS async client instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,12 +32,14 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 === Unreleased
 
 [float]
-===== Features
-* Added virtual thread support - {pull}#3239[#3239]
-
-[float]
 ===== Bug fixes
 * Fixed Micrometer histograms to be correctly exported with non-cumulative bucket counts - {pull}3264[#3264]
+* Fixed SQS NoClassDefFoundError in AWS SDK instrumentation for async clients - {pull}3266[#3266]
+
+[float]
+===== Refactorings
+* Replaced thread-local IO buffers with pooled ones for virtual thread friendliness - {pull}#3239[#3239]
+
 
 [[release-notes-1.x]]
 === Java Agent version 1.x


### PR DESCRIPTION
## What does this PR do?

Fixes the same issue as #3254, but for the async-client. Looks like I forgot about the async client in the previous bugfix.
This time I double-checked: The Async and Sync clients are the only references to the problematic `SQSHelper`-class.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
