### PR TITLE
[release] Fix release notification step

### DIFF
--- a/.ci/create-arn-table.sh
+++ b/.ci/create-arn-table.sh
@@ -10,7 +10,7 @@ AWS_FOLDER=${AWS_FOLDER?:No aws folder provided}
 ARN_FILE=".ci/.arn-file.md"
 
 {
-	echo "### ARNs of the APM Java Agent's AWS Lambda Layer"
+	echo "### ARNs of the APM Java Agent AWS Lambda Layer"
 	echo ''
 	echo '|Region|ARN|'
 	echo '|------|---|'


### PR DESCRIPTION
## What does this PR do?

Removes extra quote that prevents notification step execution when release is completed.

triggered in https://github.com/elastic/apm-agent-java/actions/runs/5784840545/job/15678612540
copy-pasting the shell script output locally helps to identify that there is an un-escaped `'`.

This PR just removes the extra quote

## Checklist

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
