### PR TITLE
github-action: cleanup unused tools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,16 @@ jobs:
         with:
           name: build
           path: ${{ github.workspace }}
+      # As long as there are some space issues with the CI runners.
+      - name: Free Disk Space
+        uses: jlumbroso/free-disk-space@d96838abfe1ae26692c13803f935e10083748040
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          swap-storage: true
+          tool-cache: false
       - uses: ./.github/workflows/maven-goal
         with:
           command: ./mvnw -q -P ci-application-server-integration-tests verify

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -205,12 +205,13 @@ jobs:
           path: ${{ github.workspace }}
       # As long as there are some space issues with the CI runners.
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@d96838abfe1ae26692c13803f935e10083748040
+        uses: jlumbroso/free-disk-space@0add001504c51b93b35ac8e81d252bdd47e4ef07
         with:
           android: true
           dotnet: true
           haskell: true
           large-packages: true
+          docker-images: true
           swap-storage: true
           tool-cache: false
       - uses: ./.github/workflows/maven-goal


### PR DESCRIPTION
## What does this PR do?

Use https://github.com/jlumbroso/free-disk-space/commit/0add001504c51b93b35ac8e81d252bdd47e4ef07 so it can free up some space when running the `Application Server integration tests` job.

See https://github.com/actions/runner-images/issues/2875#issuecomment-1163363045

## Caveats

It adds about 2 more minutes:

<img width="1261" alt="image" src="https://github.com/elastic/apm-agent-java/assets/2871786/f04fdca5-838a-42e7-b90d-ca8ff18f1330">


And it's able to save 29gb of space

<img width="857" alt="image" src="https://github.com/elastic/apm-agent-java/assets/2871786/82185c28-e67c-47b8-8853-bd8181be3794">

See https://github.com/elastic/apm-agent-java/actions/runs/5787763529/job/15685585403?pr=3268#step:4:1940

## Checklist

- [ ] ~~This is an enhancement of existing features, or a new feature in existing plugins~~
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
  - [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
  - [ ] ~~Added an API method or config option? Document in which version this will be introduced~~
  - [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~This is a bugfix~~
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
  - [ ] ~~I have added tests that would fail without this fix~~
- [ ] ~~This is a new plugin~~
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
  - [ ] ~~My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)~~
  - [ ] ~~I have made corresponding changes to the documentation~~
  - [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
  - [ ] ~~New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes~~
  - [ ] ~~I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)~~
  - [ ] ~~Added an API method or config option? Document in which version this will be introduced~~
  - [ ] ~~Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.~~
- [x] This is something else
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
