### PR TITLE
Fix JVM memory metrics regression

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
+[float]
+===== Bug fixes
+* Fix JVM memory usage capture - {pull}3279[#3279]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/JvmMemoryMetricsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/metrics/builtin/JvmMemoryMetricsTest.java
@@ -66,7 +66,8 @@ class JvmMemoryMetricsTest {
                     .isNotNaN()
                     .isNotNegative());
         }
-    }
+
+     }
 
     private AbstractDoubleAssert<?> assertMetric(MetricRegistry registry, String name, Labels labels) {
         return assertThat(registry.getGaugeValue(name, labels))


### PR DESCRIPTION
## What does this PR do?

Reported in [our forum](https://discuss.elastic.co/t/java-apm1-41-0-jvm-used-is-zero/).

Fixes a regression in JVM memory metrics capture introduced in 1.39.0.

The problem was introduced when refactoring as the `MemoryUsage` instance was kept, hence making the memory usage artificially making captured memory usage static.



## Checklist

- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
