### PR TITLE
[ci] bypass integration tests for docs again

### DIFF
--- a/.github/workflows/main-docs.yml
+++ b/.github/workflows/main-docs.yml
@@ -17,11 +17,13 @@ jobs:
   # dummy steps that allow to bypass those mandatory checks for tests
   non-app-server-integration-tests:
     name: Non-Application Server integration tests
+    runs-on: ubuntu-latest
     steps:
       - run: 'echo "Not required for docs"'
 
   # dummy steps that allow to bypass those mandatory checks for tests
   app-server-integration-tests:
     name: Application Server integration tests
+    runs-on: ubuntu-latest
     steps:
       - run: 'echo "Not required for docs"'


### PR DESCRIPTION
## What does this PR do?

Fixes missing `runs-on` for dummy integration tests checks that are applied for docs PRs.

## Checklist

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
