### PR TITLE
Add baggage as labels to error captures

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -849,7 +849,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
         .tags("added[1.43.0]")
         .configurationCategory(CORE_CATEGORY)
         .description("If any baggage key matches any of the patterns provided via this config option," +
-            " the corresponding baggage key and value will be automatically stored on the corresponding transactions and spans." +
+            " the corresponding baggage key and value will be automatically stored on the corresponding transactions, spans and errors." +
             " The baggage keys will be prefixed with \"baggage.\" on storage.")
         .dynamic(true)
         .buildWithDefault(Arrays.asList(WildcardMatcher.valueOf("*")));

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -470,6 +470,8 @@ public class ElasticApmTracer implements Tracer {
                     error.getTraceContext().setServiceInfo(serviceInfo.getServiceName(), serviceInfo.getServiceVersion());
                 }
             }
+            parentContext.getBaggage()
+                .storeBaggageInContext(error.getContext(), getConfig(CoreConfiguration.class).getBaggageToAttach());
             return error;
         }
         return null;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -47,6 +47,8 @@ import co.elastic.apm.agent.objectpool.ObjectPoolFactory;
 import co.elastic.apm.agent.report.ApmServerClient;
 import co.elastic.apm.agent.report.Reporter;
 import co.elastic.apm.agent.report.ReporterConfiguration;
+import co.elastic.apm.agent.sdk.internal.util.PrivilegedActionUtils;
+import co.elastic.apm.agent.sdk.internal.util.VersionUtils;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakConcurrent;
@@ -59,11 +61,6 @@ import co.elastic.apm.agent.tracer.reference.ReferenceCounted;
 import co.elastic.apm.agent.tracer.reference.ReferenceCountedMap;
 import co.elastic.apm.agent.util.DependencyInjectingServiceLoader;
 import co.elastic.apm.agent.util.ExecutorUtils;
-import co.elastic.apm.agent.tracer.Scope;
-import co.elastic.apm.agent.tracer.dispatch.BinaryHeaderGetter;
-import co.elastic.apm.agent.tracer.dispatch.TextHeaderGetter;
-import co.elastic.apm.agent.sdk.internal.util.PrivilegedActionUtils;
-import co.elastic.apm.agent.sdk.internal.util.VersionUtils;
 import org.stagemonitor.configuration.ConfigurationOption;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
 import org.stagemonitor.configuration.ConfigurationRegistry;
@@ -410,7 +407,7 @@ public class ElasticApmTracer implements Tracer {
 
     @Override
     public void captureAndReportException(@Nullable Throwable e, ClassLoader initiatingClassLoader) {
-        ErrorCapture errorCapture = captureException(System.currentTimeMillis() * 1000, e, getActive(), initiatingClassLoader);
+        ErrorCapture errorCapture = captureException(System.currentTimeMillis() * 1000, e, currentContext(), initiatingClassLoader);
         if (errorCapture != null) {
             errorCapture.end();
         }
@@ -418,9 +415,9 @@ public class ElasticApmTracer implements Tracer {
 
     @Override
     @Nullable
-    public String captureAndReportException(long epochMicros, @Nullable Throwable e, @Nullable AbstractSpan<?> parent) {
+    public String captureAndReportException(long epochMicros, @Nullable Throwable e, ElasticContext<?> parentContext) {
         String id = null;
-        ErrorCapture errorCapture = captureException(epochMicros, e, parent, null);
+        ErrorCapture errorCapture = captureException(epochMicros, e, parentContext, null);
         if (errorCapture != null) {
             id = errorCapture.getTraceContext().getId().toString();
             errorCapture.end();
@@ -430,12 +427,12 @@ public class ElasticApmTracer implements Tracer {
 
     @Override
     @Nullable
-    public ErrorCapture captureException(@Nullable Throwable e, @Nullable AbstractSpan<?> parent, @Nullable ClassLoader initiatingClassLoader) {
-        return captureException(System.currentTimeMillis() * 1000, e, parent, initiatingClassLoader);
+    public ErrorCapture captureException(@Nullable Throwable e, @Nullable ElasticContext<?> parentContext, @Nullable ClassLoader initiatingClassLoader) {
+        return captureException(System.currentTimeMillis() * 1000, e, parentContext, initiatingClassLoader);
     }
 
     @Nullable
-    private ErrorCapture captureException(long epochMicros, @Nullable Throwable e, @Nullable AbstractSpan<?> parent, @Nullable ClassLoader initiatingClassLoader) {
+    private ErrorCapture captureException(long epochMicros, @Nullable Throwable e, ElasticContext<?> parentContext, @Nullable ClassLoader initiatingClassLoader) {
         if (!isRunning() || e == null) {
             return null;
         }
@@ -461,6 +458,7 @@ public class ElasticApmTracer implements Tracer {
                 error.setTransactionType(currentTransaction.getType());
                 error.setTransactionSampled(currentTransaction.isSampled());
             }
+            AbstractSpan<?> parent = parentContext.getSpan();
             if (parent != null) {
                 error.asChildOf(parent);
                 // don't discard spans leading up to an error, otherwise they'd point to an invalid parent

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Tracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/Tracer.java
@@ -125,10 +125,10 @@ public interface Tracer extends co.elastic.apm.agent.tracer.Tracer {
     void captureAndReportException(@Nullable Throwable e, ClassLoader initiatingClassLoader);
 
     @Nullable
-    String captureAndReportException(long epochMicros, @Nullable Throwable e, @Nullable AbstractSpan<?> parent);
+    String captureAndReportException(long epochMicros, @Nullable Throwable e, ElasticContext<?> parentContext);
 
     @Nullable
-    ErrorCapture captureException(@Nullable Throwable e, @Nullable AbstractSpan<?> parent, @Nullable ClassLoader initiatingClassLoader);
+    ErrorCapture captureException(@Nullable Throwable e, ElasticContext<?> parentContext, @Nullable ClassLoader initiatingClassLoader);
 
     TracerState getState();
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/baggage/Baggage.java
@@ -19,6 +19,7 @@
 package co.elastic.apm.agent.impl.baggage;
 
 import co.elastic.apm.agent.common.util.WildcardMatcher;
+import co.elastic.apm.agent.impl.context.AbstractContext;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 
 import javax.annotation.Nullable;
@@ -111,6 +112,20 @@ public class Baggage implements co.elastic.apm.agent.tracer.Baggage {
                 String keyWithPrefix = getKeyWithAttributePrefix(key);
                 String value = baggage.get(key);
                 span.withOtelAttribute(keyWithPrefix, value);
+            }
+        }
+    }
+
+    public void storeBaggageInContext(AbstractContext context, List<WildcardMatcher> keyFilter) {
+        if (baggage.isEmpty() || keyFilter.isEmpty()) {
+            // early out to prevent unnecessarily allocating an iterator
+            return;
+        }
+        for (String key : baggage.keySet()) {
+            if (WildcardMatcher.anyMatch(keyFilter, key) != null) {
+                String keyWithPrefix = getKeyWithAttributePrefix(key);
+                String value = baggage.get(key);
+                context.addLabel(keyWithPrefix, value);
             }
         }
     }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/LifecycleTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/LifecycleTest.java
@@ -132,7 +132,7 @@ public class LifecycleTest {
             .buildAndStart();
         assertThat(tracer.isRunning()).isFalse();
         assertThat(tracer.startRootTransaction(null)).isNull();
-        assertThat(tracer.captureException(new Exception(), null, null)).isNull();
+        assertThat(tracer.captureException(new Exception(), tracer.currentContext(), null)).isNull();
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/BaggageTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/transaction/BaggageTest.java
@@ -25,6 +25,9 @@ import co.elastic.apm.agent.configuration.SpyConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.ElasticApmTracerBuilder;
 import co.elastic.apm.agent.impl.TextHeaderMapAccessor;
+import co.elastic.apm.agent.impl.baggage.BaggageContext;
+import co.elastic.apm.agent.impl.context.TransactionContext;
+import co.elastic.apm.agent.impl.error.ErrorCapture;
 import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
 import co.elastic.apm.agent.tracer.ElasticContext;
 import co.elastic.apm.agent.tracer.Scope;
@@ -45,12 +48,15 @@ public class BaggageTest {
     private ElasticApmTracer tracer;
     private ConfigurationRegistry config;
 
+    private MockReporter mockReporter;
+
     @BeforeEach
     public void setup() {
+        mockReporter = new MockReporter();
         config = SpyConfiguration.createSpyConfig();
         tracer = new ElasticApmTracerBuilder()
             .configurationRegistry(config)
-            .reporter(new MockReporter())
+            .reporter(mockReporter)
             .withObjectPoolFactory(new TestObjectPoolFactory())
             .buildAndStart();
     }
@@ -287,6 +293,46 @@ public class BaggageTest {
             .containsEntry("baggage.bar.key", "bar_val")
             .doesNotContainKey("baggage.ignore");
 
+    }
+
+    @Test
+    void testStandaloneExceptionCapturesBaggage() {
+        doReturn(List.of(WildcardMatcher.valueOf("foo*"), WildcardMatcher.valueOf("bar*")))
+            .when(config.getConfig(CoreConfiguration.class)).getBaggageToAttach();
+
+        BaggageContext parentCtx = tracer.currentContext().withUpdatedBaggage()
+            .put("foo.bar", "foo_val")
+            .put("ignoreme", "ignore")
+            .buildContext();
+
+        ErrorCapture errorCapture = tracer.captureException(new RuntimeException(), parentCtx, null);
+
+        TransactionContext ctx = errorCapture.getContext();
+        Assertions.assertThat(ctx.getLabel("baggage.foo.bar")).isEqualTo("foo_val");
+        Assertions.assertThat(ctx.getLabel("baggage.ignoreme")).isNull();
+    }
+
+
+    @Test
+    void testExceptionInheritsBaggageFromParentSpan() {
+        doReturn(List.of(WildcardMatcher.valueOf("foo*"), WildcardMatcher.valueOf("bar*")))
+            .when(config.getConfig(CoreConfiguration.class)).getBaggageToAttach();
+
+        Span parentSpan = tracer.startRootTransaction(null)
+            .withUpdatedBaggage()
+            .put("foo.bar", "foo_val")
+            .put("ignoreme", "ignore")
+            .buildContext()
+            .createSpan();
+
+        parentSpan.captureException(new RuntimeException());
+
+        assertThat(mockReporter.getErrors()).hasSize(1);
+        ErrorCapture errorCapture = mockReporter.getErrors().get(0);
+
+        TransactionContext ctx = errorCapture.getContext();
+        Assertions.assertThat(ctx.getLabel("baggage.foo.bar")).isEqualTo("foo_val");
+        Assertions.assertThat(ctx.getLabel("baggage.ignoreme")).isNull();
     }
 
 }

--- a/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
+++ b/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
@@ -68,7 +68,7 @@ class ErrorCaptureTest {
     @Test
     void testUnnestNestedException() {
         final NestedException nestedException = new NestedException(new CustomException());
-        ErrorCapture errorCapture = tracer.captureException(nestedException, null, null);
+        ErrorCapture errorCapture = tracer.captureException(nestedException, tracer.currentContext(), null);
         assertThat(errorCapture).isNotNull();
         assertThat(errorCapture.getException()).isNotInstanceOf(NestedException.class);
         assertThat(errorCapture.getException()).isInstanceOf(CustomException.class);
@@ -77,7 +77,7 @@ class ErrorCaptureTest {
     @Test
     void testUnnestDoublyNestedException() {
         final NestedException nestedException = new NestedException(new NestedException(new CustomException()));
-        ErrorCapture errorCapture = tracer.captureException(nestedException, null, null);
+        ErrorCapture errorCapture = tracer.captureException(nestedException, tracer.currentContext(), null);
         assertThat(errorCapture).isNotNull();
         assertThat(errorCapture.getException()).isNotInstanceOf(NestedException.class);
         assertThat(errorCapture.getException()).isInstanceOf(CustomException.class);
@@ -87,14 +87,14 @@ class ErrorCaptureTest {
     void testIgnoredNestedException() {
         doReturn(List.of(WildcardMatcher.valueOf("*CustomException"))).when(coreConfiguration).getIgnoreExceptions();
         final NestedException nestedException = new NestedException(new CustomException());
-        ErrorCapture errorCapture = tracer.captureException(nestedException, null, null);
+        ErrorCapture errorCapture = tracer.captureException(nestedException, tracer.currentContext(), null);
         assertThat(errorCapture).isNull();
     }
 
     @Test
     void testNonConfiguredNestingException() {
         final WrapperException wrapperException = new WrapperException(new CustomException());
-        ErrorCapture errorCapture = tracer.captureException(wrapperException, null, null);
+        ErrorCapture errorCapture = tracer.captureException(wrapperException, tracer.currentContext(), null);
         assertThat(errorCapture).isNotNull();
         assertThat(errorCapture.getException()).isInstanceOf(WrapperException.class);
     }
@@ -102,7 +102,7 @@ class ErrorCaptureTest {
     @Test
     void testNonConfiguredWrappingConfigured() {
         final NestedException nestedException = new NestedException(new WrapperException(new NestedException(new Exception())));
-        ErrorCapture errorCapture = tracer.captureException(nestedException, null, null);
+        ErrorCapture errorCapture = tracer.captureException(nestedException, tracer.currentContext(), null);
         assertThat(errorCapture).isNotNull();
         assertThat(errorCapture.getException()).isInstanceOf(WrapperException.class);
     }

--- a/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
+++ b/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
@@ -161,4 +161,6 @@ class ErrorCaptureTest {
         errorCapture.deactivate().end();
         assertThat(ErrorCapture.getActive()).isNull();
     }
+
+
 }

--- a/apm-agent-plugins/apm-logging-plugin/apm-logging-plugin-common/src/main/java/co/elastic/apm/agent/loginstr/error/LoggerErrorHelper.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-logging-plugin-common/src/main/java/co/elastic/apm/agent/loginstr/error/LoggerErrorHelper.java
@@ -19,9 +19,9 @@
 package co.elastic.apm.agent.loginstr.error;
 
 import co.elastic.apm.agent.impl.error.ErrorCapture;
+import co.elastic.apm.agent.sdk.internal.util.PrivilegedActionUtils;
 import co.elastic.apm.agent.sdk.state.CallDepth;
 import co.elastic.apm.agent.tracer.Tracer;
-import co.elastic.apm.agent.sdk.internal.util.PrivilegedActionUtils;
 
 import javax.annotation.Nullable;
 
@@ -47,7 +47,7 @@ public class LoggerErrorHelper {
         if (!callDepth.isNestedCallAndIncrement()) {
             if (exception != null) {
                 co.elastic.apm.agent.impl.Tracer required = tracer.require(co.elastic.apm.agent.impl.Tracer.class);
-                ErrorCapture error = required.captureException(exception, required.getActive(), PrivilegedActionUtils.getClassLoader(originClass));
+                ErrorCapture error = required.captureException(exception, required.currentContext(), PrivilegedActionUtils.getClassLoader(originClass));
                 if (error != null) {
                     error.activate();
                 }

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -251,7 +251,7 @@ Spans can only have a single parent (`SpanBuilder#setParent`)
 [[otel-baggage]]
 ===== Baggage
 Baggage support has been added in version `1.41.0`.
-Since `1.43.0` you can automatically attach baggage as span and transaction attributes via the <<config-baggage-to-attach, `baggage_to_attach`>> configuration option.
+Since `1.43.0` you can automatically attach baggage as span, transaction and error attributes via the <<config-baggage-to-attach, `baggage_to_attach`>> configuration option.
 
 [float]
 [[otel-events]]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1554,7 +1554,7 @@ Valid options: `continue`, `restart`, `restart_external`
 [[config-baggage-to-attach]]
 ==== `baggage_to_attach` (added[1.43.0])
 
-If any baggage key matches any of the patterns provided via this config option, the corresponding baggage key and value will be automatically stored on the corresponding transactions and spans. The baggage keys will be prefixed with "baggage." on storage.
+If any baggage key matches any of the patterns provided via this config option, the corresponding baggage key and value will be automatically stored on the corresponding transactions, spans and errors. The baggage keys will be prefixed with "baggage." on storage.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
 
@@ -4064,7 +4064,7 @@ Example: `5ms`.
 #
 # trace_continuation_strategy=CONTINUE
 
-# If any baggage key matches any of the patterns provided via this config option, the corresponding baggage key and value will be automatically stored on the corresponding transactions and spans. The baggage keys will be prefixed with "baggage." on storage.
+# If any baggage key matches any of the patterns provided via this config option, the corresponding baggage key and value will be automatically stored on the corresponding transactions, spans and errors. The baggage keys will be prefixed with "baggage." on storage.
 #
 # This setting can be changed at runtime
 # Type: comma separated list


### PR DESCRIPTION
## What does this PR do?

Adds support for the `baggage_to_attach` option for errors.
Closes #3004 .

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [x] I have made corresponding changes to the documentation
