### PR TITLE
add missing 'histogram' type to micrometer

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,15 +35,12 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Bug fixes
 * Prevent bad serialization in edge cases for span compression - {pull}3293[#3293]
 * Allow overriding of transaction type for Servlet-API transactions - {pull}3226[#3226]
+* Fix micrometer histogram serialization - {pull}3290[#3290]
 
 [float]
 ===== Features
 * Add support for Elasticsearch client 8.9 - {pull}3283[#3283]
 * Added `baggage_to_attach` config option to allow automatic lifting of baggage into transaction, span and error attributes - {pull}3288[#3288], {pull}3289[#3289]
-
-[float]
-===== Bug fixes
-* Fix micrometer histogram serialization - {pull}3290[#3290]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Add support for Elasticsearch client 8.9 - {pull}3283[#3283]
 * Added `baggage_to_attach` config option to allow automatic lifting of baggage into transaction and span attributes - {pull}3288[#3288]
 
+[float]
+===== Bug fixes
+* Fix micrometer histogram serialization - {pull}3290[#3290]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
@@ -272,6 +272,10 @@ public class MicrometerMeterRegistrySerializer {
             }
         }
         jw.writeByte(JsonWriter.ARRAY_END);
+
+        jw.writeByte(JsonWriter.COMMA);
+        jw.writeAscii("\"type\":\"histogram\"");
+
         jw.writeByte(JsonWriter.OBJECT_END);
     }
 

--- a/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializerTest.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializerTest.java
@@ -318,6 +318,10 @@ public class MicrometerMeterRegistrySerializerTest {
             assertThat(histoNode2.get(0).asInt()).isEqualTo(under5Count);
             assertThat(histoNode2.get(1).asInt()).isEqualTo(from5To50Count);
             assertThat(histoNode2.get(2).asInt()).isEqualTo(from50to95Count);
+            path[3] = "type";
+            JsonNode histoType = getPathNode(jsonNode, path);
+            assertThat(histoType.isTextual()).isTrue();
+            assertThat(histoType.asText()).isEqualTo("histogram");
         }
     }
 


### PR DESCRIPTION
## What does this PR do?

Adds missing `"type": "histogram"` for micrometer json serialization.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
