### PR TITLE
Fix invalid currentTransaction() logic

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Bug fixes
 * Prevent bad serialization in edge cases for span compression - {pull}3293[#3293]
 * Allow overriding of transaction type for Servlet-API transactions - {pull}3226[#3226]
+* Fix transactions not being correctly handled in certain edge cases - {pull}3294[#3294]
 
 [float]
 ===== Features

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActiveStack.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActiveStack.java
@@ -21,7 +21,6 @@ package co.elastic.apm.agent.impl;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.ElasticContext;
 import co.elastic.apm.agent.impl.transaction.ElasticContextWrapper;
-import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 
@@ -65,12 +64,6 @@ class ActiveStack {
         this.emptyContext = emptyContextForTracer;
     }
 
-    @Nullable
-    Transaction currentTransaction() {
-        final ElasticContext<?> bottomOfStack = activeContextStack.peekLast();
-        return bottomOfStack != null ? bottomOfStack.getTransaction() : null;
-    }
-
     /**
      * @return the current context, potentially empty when no span, transaction or baggage is currently active.
      */
@@ -94,7 +87,7 @@ class ActiveStack {
         if (activeContextStack.size() == stackMaxDepth) {
             if (overflowCounter == 0) {
                 logger.error(String.format("Activation stack depth reached its maximum - %s. This is likely related to activation" +
-                        " leak. Current transaction: %s", stackMaxDepth, currentTransaction()),
+                        " leak. Current transaction: %s", stackMaxDepth, currentContext().getTransaction()),
                     new Throwable("Stack of threshold-crossing activation: ")
                 );
             }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -355,7 +355,7 @@ public class ElasticApmTracer implements Tracer {
     @Override
     @Nullable
     public Transaction currentTransaction() {
-        return activeStack.get().currentTransaction();
+        return currentContext().getTransaction();
     }
 
     /**

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/TraceContext.java
@@ -20,7 +20,6 @@ package co.elastic.apm.agent.impl.transaction;
 
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
-import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.sampling.Sampler;
 import co.elastic.apm.agent.sdk.logging.Logger;
@@ -177,17 +176,7 @@ public class TraceContext implements Recyclable, co.elastic.apm.agent.tracer.Tra
                 return false;
             }
         };
-    private static final ChildContextCreator<Tracer> FROM_ACTIVE = new ChildContextCreator<Tracer>() {
-        @Override
-        public boolean asChildOf(TraceContext child, Tracer tracer) {
-            final AbstractSpan<?> active = tracer.getActive();
-            if (active != null) {
-                return fromParent().asChildOf(child, active);
 
-            }
-            return false;
-        }
-    };
     private static final ChildContextCreator<Object> AS_ROOT = new ChildContextCreator<Object>() {
         @Override
         public boolean asChildOf(TraceContext child, Object ignore) {
@@ -290,10 +279,6 @@ public class TraceContext implements Recyclable, co.elastic.apm.agent.tracer.Tra
     @SuppressWarnings("unchecked")
     public static <C> HeaderChildContextCreator<byte[], C> getFromTraceContextBinaryHeaders() {
         return (HeaderChildContextCreator<byte[], C>) FROM_TRACE_CONTEXT_BINARY_HEADERS;
-    }
-
-    public static ChildContextCreator<Tracer> fromActive() {
-        return FROM_ACTIVE;
     }
 
     public static ChildContextCreator<TraceContext> fromParentContext() {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -514,7 +514,7 @@ class ElasticApmTracerTest {
 
         try (Scope transactionScope = transaction.activateInScope()) {
             assertThat(tracerImpl.getActive()).isEqualTo(transaction);
-            final Span span = tracerImpl.startSpan(TraceContext.fromActive(), tracerImpl, Baggage.EMPTY);
+            final Span span = tracerImpl.startSpan(transaction, Baggage.EMPTY, -1);
             assertThat(span).isNotNull();
             try (Scope scope = span.activateInScope()) {
                 assertThat(tracerImpl.currentTransaction()).isNotNull();


### PR DESCRIPTION
## What does this PR do?

While enhancing the kafka tests I noticed a strange behaviour: The kafka instrumentation would stop correctly ending transaction if the initial context is baggage without a span / transaction.

This was due to the implementation of `ActiveStak.currentTransaction()` which relies on the transaction being the first element on the stack.

This is not always true in case of baggage, but also was wrong prior to the baggage addition in cases where a nested transaction shadows the original one.

The tests (except for the one fixed in this pr) remain green, therefor I assume there should be no bad side effects.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
