### PR TITLE
 Enhance/document msg listener heuristic

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Features
 * Virtual thread support - {pull}3244[#3244], {pull}3286[#3286]
+* Include `application_packages` in JMS listener naming heuristic - {pull}3299[#3299]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/co/elastic/apm/agent/jms/jakarta/JmsMessageListenerTest.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/co/elastic/apm/agent/jms/jakarta/JmsMessageListenerTest.java
@@ -22,6 +22,7 @@ import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.bci.ElasticApmAgent;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.Tracer;
+import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.jms.jakarta.test.TestMessageConsumer;
 import co.elastic.apm.agent.jms.jakarta.test.TestMessageListener;
@@ -37,6 +38,7 @@ import org.stagemonitor.configuration.ConfigurationRegistry;
 import jakarta.jms.Message;
 import jakarta.jms.MessageListener;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static co.elastic.apm.agent.testutils.assertions.Assertions.assertThat;
@@ -70,9 +72,11 @@ public class JmsMessageListenerTest {
 
     @Test
     public void testJmsMessageListenerPackage_defaultConfig() throws Exception {
+        // default configuration
+        doReturn(Collections.emptyList()).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
+
         startAgent();
 
-        // default configuration
         testJmsMessageListenerPackage(true, JmsMessageListenerVariant.MATCHING_NAME_CONVENTION);
         testJmsMessageListenerPackage(true, JmsMessageListenerVariant.INNER_CLASS);
         testJmsMessageListenerPackage(true, JmsMessageListenerVariant.LAMBDA);
@@ -81,7 +85,20 @@ public class JmsMessageListenerTest {
 
     @Test
     public void testJmsMessageListenerPackage_customValue() throws Exception {
+        doReturn(Collections.emptyList()).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
         doReturn(Arrays.asList("co.elastic.apm.agent.jms.jakarta.test")).when(config.getConfig(MessagingConfiguration.class)).getJmsListenerPackages();
+
+        startAgent();
+
+        testJmsMessageListenerPackage(true, JmsMessageListenerVariant.MATCHING_NAME_CONVENTION);
+        testJmsMessageListenerPackage(true, JmsMessageListenerVariant.INNER_CLASS);
+        testJmsMessageListenerPackage(true, JmsMessageListenerVariant.LAMBDA);
+        testJmsMessageListenerPackage(true, JmsMessageListenerVariant.NOT_MATCHING_NAME_CONVENTION);
+    }
+
+    @Test
+    public void testJmsMessageListenerPackage_applicationPackages() throws Exception {
+        doReturn(Arrays.asList("co.elastic.apm.agent.jms.jakarta.test")).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
 
         startAgent();
 

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/co/elastic/apm/agent/jms/jakarta/JmsMessageListenerTest.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/co/elastic/apm/agent/jms/jakarta/JmsMessageListenerTest.java
@@ -24,15 +24,13 @@ import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.impl.transaction.Transaction;
-import co.elastic.apm.agent.jms.jakarta.test.TestMessageConsumer;
-import co.elastic.apm.agent.jms.jakarta.test.TestMessageListener;
-import co.elastic.apm.agent.jms.jakarta.test.TestMsgHandler;
+import testapp.TestMessageConsumer;
+import testapp.TestMessageListener;
+import testapp.TestMsgHandler;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.configuration.MessagingConfiguration;
 import net.bytebuddy.agent.ByteBuddyAgent;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import jakarta.jms.Message;
@@ -86,7 +84,7 @@ public class JmsMessageListenerTest {
     @Test
     public void testJmsMessageListenerPackage_customValue() throws Exception {
         doReturn(Collections.emptyList()).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
-        doReturn(Arrays.asList("co.elastic.apm.agent.jms.jakarta.test")).when(config.getConfig(MessagingConfiguration.class)).getJmsListenerPackages();
+        doReturn(Arrays.asList("testapp")).when(config.getConfig(MessagingConfiguration.class)).getJmsListenerPackages();
 
         startAgent();
 
@@ -98,7 +96,7 @@ public class JmsMessageListenerTest {
 
     @Test
     public void testJmsMessageListenerPackage_applicationPackages() throws Exception {
-        doReturn(Arrays.asList("co.elastic.apm.agent.jms.jakarta.test")).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
+        doReturn(Arrays.asList("testapp")).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
 
         startAgent();
 

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/testapp/TestMessageConsumer.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/testapp/TestMessageConsumer.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.jms.javax.test;
+package testapp;
 
-import javax.jms.JMSException;
-import javax.jms.Message;
-import javax.jms.MessageConsumer;
-import javax.jms.MessageListener;
+import jakarta.jms.JMSException;
+import jakarta.jms.Message;
+import jakarta.jms.MessageConsumer;
+import jakarta.jms.MessageListener;
 
 // no-op implementation that is required only for testing registration of lambda message listeners
 public class TestMessageConsumer implements MessageConsumer {

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/testapp/TestMessageListener.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/testapp/TestMessageListener.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.jms.jakarta.test;
+package testapp;
 
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.impl.transaction.Transaction;

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/testapp/TestMsgHandler.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-jakarta/src/test/java/testapp/TestMsgHandler.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.jms.jakarta.test;
+package testapp;
 
 
 import co.elastic.apm.agent.impl.Tracer;

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/main/java/co/elastic/apm/agent/jms/javax/JmsMessageListenerInstrumentation.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/main/java/co/elastic/apm/agent/jms/javax/JmsMessageListenerInstrumentation.java
@@ -39,9 +39,6 @@ import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 
 public class JmsMessageListenerInstrumentation extends BaseJmsInstrumentation {
 
-    @SuppressWarnings("WeakerAccess")
-    public static final Logger logger = LoggerFactory.getLogger(JmsMessageListenerInstrumentation.class);
-
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
         return getMessageListenerTypeMatcherPreFilter();

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/co/elastic/apm/agent/jms/javax/JmsMessageListenerTest.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/co/elastic/apm/agent/jms/javax/JmsMessageListenerTest.java
@@ -20,6 +20,7 @@ package co.elastic.apm.agent.jms.javax;
 
 import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.bci.ElasticApmAgent;
+import co.elastic.apm.agent.impl.stacktrace.StacktraceConfiguration;
 import co.elastic.apm.agent.tracer.configuration.MessagingConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.Tracer;
@@ -37,6 +38,7 @@ import org.stagemonitor.configuration.ConfigurationRegistry;
 import javax.jms.Message;
 import javax.jms.MessageListener;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static co.elastic.apm.agent.testutils.assertions.Assertions.assertThat;
@@ -70,9 +72,11 @@ public class JmsMessageListenerTest {
 
     @Test
     public void testJmsMessageListenerPackage_defaultConfig() throws Exception {
+        // default configuration
+        doReturn(Collections.emptyList()).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
+
         startAgent();
 
-        // default configuration
         testJmsMessageListenerPackage(true, JmsMessageListenerVariant.MATCHING_NAME_CONVENTION);
         testJmsMessageListenerPackage(true, JmsMessageListenerVariant.INNER_CLASS);
         testJmsMessageListenerPackage(true, JmsMessageListenerVariant.LAMBDA);
@@ -81,7 +85,20 @@ public class JmsMessageListenerTest {
 
     @Test
     public void testJmsMessageListenerPackage_customValue() throws Exception {
-        doReturn(Arrays.asList("co.elastic.apm.agent.jms.javax.test")).when(config.getConfig(MessagingConfiguration.class)).getJmsListenerPackages();
+        doReturn(Collections.emptyList()).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
+        doReturn(Arrays.asList("co.elastic.apm.agent.jms.jakarta.test")).when(config.getConfig(MessagingConfiguration.class)).getJmsListenerPackages();
+
+        startAgent();
+
+        testJmsMessageListenerPackage(true, JmsMessageListenerVariant.MATCHING_NAME_CONVENTION);
+        testJmsMessageListenerPackage(true, JmsMessageListenerVariant.INNER_CLASS);
+        testJmsMessageListenerPackage(true, JmsMessageListenerVariant.LAMBDA);
+        testJmsMessageListenerPackage(true, JmsMessageListenerVariant.NOT_MATCHING_NAME_CONVENTION);
+    }
+
+    @Test
+    public void testJmsMessageListenerPackage_applicationPackages() throws Exception {
+        doReturn(Arrays.asList("co.elastic.apm.agent.jms.jakarta.test")).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
 
         startAgent();
 

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/co/elastic/apm/agent/jms/javax/JmsMessageListenerTest.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/co/elastic/apm/agent/jms/javax/JmsMessageListenerTest.java
@@ -26,9 +26,9 @@ import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.impl.transaction.Transaction;
-import co.elastic.apm.agent.jms.javax.test.TestMessageConsumer;
-import co.elastic.apm.agent.jms.javax.test.TestMessageListener;
-import co.elastic.apm.agent.jms.javax.test.TestMsgHandler;
+import testapp.TestMessageConsumer;
+import testapp.TestMessageListener;
+import testapp.TestMsgHandler;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,7 +86,7 @@ public class JmsMessageListenerTest {
     @Test
     public void testJmsMessageListenerPackage_customValue() throws Exception {
         doReturn(Collections.emptyList()).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
-        doReturn(Arrays.asList("co.elastic.apm.agent.jms.javax.test")).when(config.getConfig(MessagingConfiguration.class)).getJmsListenerPackages();
+        doReturn(Arrays.asList("testapp")).when(config.getConfig(MessagingConfiguration.class)).getJmsListenerPackages();
 
         startAgent();
 
@@ -98,7 +98,7 @@ public class JmsMessageListenerTest {
 
     @Test
     public void testJmsMessageListenerPackage_applicationPackages() throws Exception {
-        doReturn(Arrays.asList("co.elastic.apm.agent.jms.javax.test")).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
+        doReturn(Arrays.asList("testapp")).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
 
         startAgent();
 

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/co/elastic/apm/agent/jms/javax/JmsMessageListenerTest.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/co/elastic/apm/agent/jms/javax/JmsMessageListenerTest.java
@@ -86,7 +86,7 @@ public class JmsMessageListenerTest {
     @Test
     public void testJmsMessageListenerPackage_customValue() throws Exception {
         doReturn(Collections.emptyList()).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
-        doReturn(Arrays.asList("co.elastic.apm.agent.jms.jakarta.test")).when(config.getConfig(MessagingConfiguration.class)).getJmsListenerPackages();
+        doReturn(Arrays.asList("co.elastic.apm.agent.jms.javax.test")).when(config.getConfig(MessagingConfiguration.class)).getJmsListenerPackages();
 
         startAgent();
 
@@ -98,7 +98,7 @@ public class JmsMessageListenerTest {
 
     @Test
     public void testJmsMessageListenerPackage_applicationPackages() throws Exception {
-        doReturn(Arrays.asList("co.elastic.apm.agent.jms.jakarta.test")).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
+        doReturn(Arrays.asList("co.elastic.apm.agent.jms.javax.test")).when(config.getConfig(StacktraceConfiguration.class)).getApplicationPackages();
 
         startAgent();
 

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/testapp/TestMessageConsumer.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/testapp/TestMessageConsumer.java
@@ -16,12 +16,12 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.jms.jakarta.test;
+package testapp;
 
-import jakarta.jms.JMSException;
-import jakarta.jms.Message;
-import jakarta.jms.MessageConsumer;
-import jakarta.jms.MessageListener;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageListener;
 
 // no-op implementation that is required only for testing registration of lambda message listeners
 public class TestMessageConsumer implements MessageConsumer {

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/testapp/TestMessageListener.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/testapp/TestMessageListener.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.jms.javax.test;
+package testapp;
 
 import co.elastic.apm.agent.impl.Tracer;
 import co.elastic.apm.agent.tracer.GlobalTracer;

--- a/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/testapp/TestMsgHandler.java
+++ b/apm-agent-plugins/apm-jms-plugin/apm-jms-javax/src/test/java/testapp/TestMsgHandler.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.jms.javax.test;
+package testapp;
 
 
 import co.elastic.apm.agent.impl.Tracer;

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
@@ -100,7 +100,7 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
         .configurationCategory(MESSAGING_CATEGORY)
         .description("Defines which packages contain JMS MessageListener implementations for instrumentation." +
             "\n" +
-            "When empty (default), only the inner-classes or that have 'Listener' or 'Message' in their names are considered.\n"+
+            "When empty (default), all inner-classes or any classes that have 'Listener' or 'Message' in their names are considered.\n"+
             "\n" +
             "This configuration option helps to make MessageListener type matching faster and improve application startup performance.\n" +
             "\n" +

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
@@ -100,8 +100,11 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
         .configurationCategory(MESSAGING_CATEGORY)
         .description("Defines which packages contain JMS MessageListener implementations for instrumentation." +
             "\n" +
-            "When set to a non-empty value, only the classes matching configuration will be instrumented.\n" +
-            "This configuration option helps to make MessageListener type matching faster and improve application startup performance."
+            "When empty (default), only the inner-classes or that have 'Listener' or 'Message' in their names are considered.\n"+
+            "\n" +
+            "This configuration option helps to make MessageListener type matching faster and improve application startup performance.\n" +
+            "\n" +
+            "Starting from version 1.43.0, the classes that are part of the 'application_packages' option are also included."
         )
         .dynamic(false)
         .buildWithDefault(Collections.<String>emptyList());

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
@@ -104,7 +104,7 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
             "\n" +
             "This configuration option helps to make MessageListener type matching faster and improve application startup performance.\n" +
             "\n" +
-            "Starting from version 1.43.0, the classes that are part of the 'application_packages' option are also included."
+            "Starting from version 1.43.0, the classes that are part of the 'application_packages' option are also included in the list of classes considered."
         )
         .dynamic(false)
         .buildWithDefault(Collections.<String>emptyList());

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -2430,8 +2430,11 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 ==== `jms_listener_packages` (performance added[1.36.0])
 
 Defines which packages contain JMS MessageListener implementations for instrumentation.
-When set to a non-empty value, only the classes matching configuration will be instrumented.
+When empty (default), only the inner-classes or that have 'Listener' or 'Message' in their names are considered.
+
 This configuration option helps to make MessageListener type matching faster and improve application startup performance.
+
+Starting from version 1.43.0, the classes that are part of the 'application_packages' option are also included.
 
 
 
@@ -4514,8 +4517,11 @@ Example: `5ms`.
 # ignore_message_queues=
 
 # Defines which packages contain JMS MessageListener implementations for instrumentation.
-# When set to a non-empty value, only the classes matching configuration will be instrumented.
+# When empty (default), only the inner-classes or that have 'Listener' or 'Message' in their names are considered.
+# 
 # This configuration option helps to make MessageListener type matching faster and improve application startup performance.
+# 
+# Starting from version 1.43.0, the classes that are part of the 'application_packages' option are also included.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: comma separated list

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -134,6 +134,22 @@ Here, we will refer to the agent log file as `/tmp/agent.log`, but any other loc
 . copy the `/tmp/agent.log` file and send it back for investigation
 
 [float]
+[[trouble-shooting-matching-heuristics]]
+=== Agent matching heuristics
+
+The agent relies on heuristics to define which classes needs to be instrumented or not efficiently to prevent instrumentation
+overhead.
+
+Those heuristics are based on the packages and class names and are influenced by `application_packages` and
+`jms_listener_packages` configurations. However, if instrumentation is not applied as expected or to enable creating configuration
+without proper knowledge of the application internals, it could be relevant to disable those heuristics for investigation:
+
+1. disable name heuristics by setting `enable_type_matching_name_pre_filtering=false` and enable the <<trouble-shooting-logging-procedure, agent logs>>.
+2. restart the application, which will be slower than usual due to the extra overhead
+3. analyze the agent logs to identify which classes/methods are instrumented by filtering lines with `Method match` string.
+4. properly configure `application_packages` or `jms_listener_packages` with values that apply
+
+[float]
 [[trouble-shooting-debugging]]
 === Debugging
 Sometimes reading the logs is just not enough to debug a problem.

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -141,7 +141,7 @@ The agent relies on heuristics to define which classes needs to be instrumented 
 overhead.
 
 Those heuristics are based on the packages and class names and are influenced by `application_packages` and
-`jms_listener_packages` configurations. However, if instrumentation is not applied as expected or to enable creating configuration
+`jms_listener_packages` configurations. However, if instrumentation is not applied as expected or if you want to investigate creating configurations
 without proper knowledge of the application internals, it could be relevant to disable those heuristics for investigation:
 
 1. disable name heuristics by setting `enable_type_matching_name_pre_filtering=false` and enable the <<trouble-shooting-logging-procedure, agent logs>>.


### PR DESCRIPTION

## What does this PR do?

Fixes #3135 
Relates to #3259 

I had to move the test JMS classes to a package outside of `co.elastic.apm` as `co.elastic.apm` is already covered by the test configuration which is automatically loaded from classpath.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [x] I have made corresponding changes to the documentation
