### PR TITLE
Disable instrumentation for ES client versions with native instrumentation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -33,8 +33,6 @@ updates:
       - dependency-name: "com.datastax.oss:java-driver-core"
       - dependency-name: "io.micrometer:*"
       - dependency-name: "redis.clients:*"
-      - dependency-name: "org.elasticsearch.client:*"
-      - dependency-name: "co.elastic.clients:*"
       - dependency-name: "io.vertx:*"
       - dependency-name: "org.apache.logging.log4j:*"
       - dependency-name: "org.springframework.boot:*"

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -42,6 +42,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Features
 * Add support for Elasticsearch client 8.9 - {pull}3283[#3283]
 * Added `baggage_to_attach` config option to allow automatic lifting of baggage into transaction, span and error attributes - {pull}3288[#3288], {pull}3289[#3289]
+* Exclude elasticsearch 8.10 and newer clients from instrumentation because they natively support OpenTelemetry  - {pull}3303[#3303]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchRestClientInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchRestClientInstrumentation.java
@@ -23,11 +23,11 @@ import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Tracer;
 import net.bytebuddy.matcher.ElementMatcher;
 
-import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
-import static net.bytebuddy.matcher.ElementMatchers.not;
-
 import java.util.Collection;
 import java.util.Collections;
+
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 
 public abstract class ElasticsearchRestClientInstrumentation extends ElasticApmInstrumentation {
@@ -41,7 +41,7 @@ public abstract class ElasticsearchRestClientInstrumentation extends ElasticApmI
 
     @Override
     public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
-        // ensure only ES client versions without native instrumentation are instrumented
+        // ensure only ES client versions without native instrumentation are instrumented (8.9 and older)
         return not(classLoaderCanLoadClass("co.elastic.clients.transport.instrumentation.Instrumentation"));
     }
 

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchRestClientInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchRestClientInstrumentation.java
@@ -21,6 +21,10 @@ package co.elastic.apm.agent.esrestclient;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Tracer;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
+import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -33,6 +37,12 @@ public abstract class ElasticsearchRestClientInstrumentation extends ElasticApmI
     @Override
     public Collection<String> getInstrumentationGroupNames() {
         return Collections.singleton("elasticsearch-restclient");
+    }
+
+    @Override
+    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
+        // ensure only ES client versions without native instrumentation are instrumented
+        return not(classLoaderCanLoadClass("co.elastic.clients.transport.instrumentation.Instrumentation"));
     }
 
 }


### PR DESCRIPTION
Fixes #3235


https://github.com/elastic/elasticsearch-java/pull/652 introduced native instrumentation into the ES client.
We need to disable agent instrumentation for versions with native instrumentation.

The native instrumentation introduced the class  `co.elastic.clients.transport.instrumentation.Instrumentation` in the ES client. This PR adds a check for the presence of that class.