### PR TITLE
fix empty histograms from micrometer being sent to the server

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,7 +35,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Bug fixes
 * Prevent bad serialization in edge cases for span compression - {pull}3293[#3293]
 * Allow overriding of transaction type for Servlet-API transactions - {pull}3226[#3226]
-* Fix micrometer histogram serialization - {pull}3290[#3290]
+* Fix micrometer histogram serialization - {pull}3290[#3290], {pull}3304[#3304]
 * Fix transactions not being correctly handled in certain edge cases - {pull}3294[#3294]
 
 [float]

--- a/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/main/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializer.java
@@ -201,7 +201,7 @@ public class MicrometerMeterRegistrySerializer {
             serializeValue(id, ".count", count, jw, replaceBuilder, dedotMetricName);
             jw.writeByte(JsonWriter.COMMA);
             serializeValue(id, ".sum.us", totalTime, jw, replaceBuilder, dedotMetricName);
-            if (histogramSnapshot != null) {
+            if (histogramSnapshot != null && histogramSnapshot.histogramCounts().length > 0) {
                 jw.writeByte(JsonWriter.COMMA);
                 serializeHistogram(id, histogramSnapshot, jw, replaceBuilder, dedotMetricName);
             }
@@ -229,8 +229,10 @@ public class MicrometerMeterRegistrySerializer {
             serializeValue(id, ".count", count, jw, replaceBuilder, dedotMetricName);
             jw.writeByte(JsonWriter.COMMA);
             serializeValue(id, ".sum", totalAmount, jw, replaceBuilder, dedotMetricName);
-            jw.writeByte(JsonWriter.COMMA);
-            serializeHistogram(id, histogramSnapshot, jw, replaceBuilder, dedotMetricName);
+            if (histogramSnapshot != null && histogramSnapshot.histogramCounts().length > 0) {
+                jw.writeByte(JsonWriter.COMMA);
+                serializeHistogram(id, histogramSnapshot, jw, replaceBuilder, dedotMetricName);
+            }
             return true;
         }
         return hasValue;

--- a/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializerTest.java
+++ b/apm-agent-plugins/apm-micrometer-plugin/src/test/java/co/elastic/apm/agent/micrometer/MicrometerMeterRegistrySerializerTest.java
@@ -81,6 +81,11 @@ public class MicrometerMeterRegistrySerializerTest {
     }
 
     @Test
+    void serializeDistributionSummaryWithNoValues() {
+        serializeOneMeter(new TestSummary(false));
+    }
+
+    @Test
     void serializeGauge() {
         serializeOneMeter(new TestGauge());
     }
@@ -201,9 +206,18 @@ public class MicrometerMeterRegistrySerializerTest {
         }
 
         protected static JsonNode getPathNode(JsonNode jsonNode, String[] path) {
+            return getPathNode(jsonNode, path, false);
+        }
+        protected static JsonNode getPathNode(JsonNode jsonNode, String[] path, boolean isNull) {
             assertThat(jsonNode).isNotNull();
-            for (String element: path) {
-                jsonNode = jsonNode.get(element);
+            for (int i = 0; i < path.length-1; i++) {
+                jsonNode = jsonNode.get(path[i]);
+                assertThat(jsonNode).isNotNull();
+            }
+            jsonNode = jsonNode.get(path[path.length-1]);
+            if (isNull) {
+                assertThat(jsonNode).isNull();
+            } else {
                 assertThat(jsonNode).isNotNull();
             }
             return jsonNode;
@@ -261,6 +275,7 @@ public class MicrometerMeterRegistrySerializerTest {
     }
 
     static class TestSummary extends TestMeter {
+        private final boolean setSLOs;
         int sum = 0;
         int count = 0;
         int under5Count = 0;
@@ -268,6 +283,13 @@ public class MicrometerMeterRegistrySerializerTest {
         int from50to95Count = 0;
         int[] values = new int[]{22, 55, 66, 98};
 
+        public TestSummary () {
+            this(true);
+        }
+        public TestSummary (boolean setSLOs) {
+            super();
+            this.setSLOs = setSLOs;
+        }
         @Override
         String meternameExtension() {
             return ".count";
@@ -275,12 +297,20 @@ public class MicrometerMeterRegistrySerializerTest {
 
         @Override
         public void addToMeterRegistry(MeterRegistry registry) {
-            meter = DistributionSummary
-                .builder(metername())
-                .distributionStatisticBufferLength(20)
-                .serviceLevelObjectives(5, 50, 95)
-                .publishPercentileHistogram()
-                .register(registry);
+            if (setSLOs) {
+                meter = DistributionSummary
+                    .builder(metername())
+                    .distributionStatisticBufferLength(20)
+                    .serviceLevelObjectives(5, 50, 95)
+                    .publishPercentileHistogram()
+                    .register(registry);
+            } else {
+                meter = DistributionSummary
+                    .builder(metername())
+                    .distributionStatisticBufferLength(20)
+                    .publishPercentileHistogram()
+                    .register(registry);
+            }
         }
 
         @Override
@@ -303,9 +333,20 @@ public class MicrometerMeterRegistrySerializerTest {
         public void checkSerialization(JsonNode jsonNode) {
             checkPathHasValue(jsonNode, path(), count);
             checkPathHasValue(jsonNode, path(".sum"), sum);
-            String[] path = path(".histogram");
-            path[3] = "values";
-            JsonNode histoNode1 = getPathNode(jsonNode, path);
+            String[] temppath = path(".histogram");
+            String[] path;
+            if (!setSLOs) {
+                path = new String[temppath.length-1];
+                System.arraycopy(temppath, 0, path, 0, path.length);
+            } else {
+                path = temppath;
+                path[3] = "values";
+            }
+            JsonNode histoNode1 = getPathNode(jsonNode, path, !setSLOs);
+            if(!setSLOs) {
+                assertThat(histoNode1).isNull();
+                return;
+            }
             assertThat(histoNode1.isArray()).isTrue();
             assertThat(histoNode1.size()).isEqualTo(3); //the 3 bucket boundaries of the SLOs 5,50,95
             assertThat(histoNode1.get(0).asDouble()).isEqualTo(5.0);


### PR DESCRIPTION
## What does this PR do?
Empty histograms are produced by the micrometer plugin, but these are not valid for the APM server so need to be discarded. Note for the reviewer, the Otel metrics serialization doesn't need changing, the Otel metrics doesn't produce any histogram if the histogram is empty

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
