### PR TITLE
Fix DB2 jdbc connection instrumentation

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Allow overriding of transaction type for Servlet-API transactions - {pull}3226[#3226]
 * Fix micrometer histogram serialization - {pull}3290[#3290], {pull}3304[#3304]
 * Fix transactions not being correctly handled in certain edge cases - {pull}3294[#3294]
+* Fixed JDBC instrumentation for DB2 - {pull}3313[#3313]
 
 [float]
 ===== Features

--- a/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/ConnectionInstrumentation.java
+++ b/apm-agent-plugins/apm-jdbc-plugin/src/main/java/co/elastic/apm/agent/jdbc/ConnectionInstrumentation.java
@@ -57,7 +57,7 @@ public class ConnectionInstrumentation extends JdbcInstrumentation {
 
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameContains("Connection");
+        return nameContains("Connection").or(nameStartsWith("com.ibm.db2.jcc")); //db2 doesn't have Connection in the name
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

It seems like DB2 JDBC-connection classes are sometimes obfuscated and therefor do not contain "Connection" in their name. Our JDBC instrumentation does not trace statemented if the SQL is not available, which is only available if the connection was also instrumented.

## Checklist


- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] ~I have added tests that would fail without this fix~
