### PR TITLE
Remove IntelliJ debugging agent detection

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Added `baggage_to_attach` config option to allow automatic lifting of baggage into transaction, span and error attributes - {pull}3288[#3288], {pull}3289[#3289]
 * Exclude elasticsearch 8.10 and newer clients from instrumentation because they natively support OpenTelemetry  - {pull}3303[#3303]
 * Switched to OpenTelemetry compatible context propagation for Kafka - {pull}3300[#3300]
+* Allow running the IntelliJ debug agent in parallel - {pull}3315[#3315]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ForkJoinTaskInstrumentation.java
+++ b/apm-agent-plugins/apm-java-concurrent-plugin/src/main/java/co/elastic/apm/agent/concurrent/ForkJoinTaskInstrumentation.java
@@ -42,17 +42,6 @@ public class ForkJoinTaskInstrumentation extends ElasticApmInstrumentation {
 
     private static final Tracer tracer = GlobalTracer.get();
 
-    static {
-        if (Boolean.parseBoolean(System.getProperty("intellij.debug.agent"))) {
-            // IntelliJ debugger also instrument some java.util.concurrent classes and changes the class structure.
-            // However, the changes are not re-applied when re-transforming already loaded classes, which makes our
-            // agent unable to see those structural changes and try to load classes with their original bytecode
-            //
-            // Go to the following to enable/disable: File | Settings | Build, Execution, Deployment | Debugger | Async Stack Traces
-            throw new IllegalStateException("IntelliJ debug agent detected, disable it to prevent unexpected instrumentation errors. See https://github.com/elastic/apm-agent-java/issues/1673");
-        }
-    }
-
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
         return is(ForkJoinTask.class);


### PR DESCRIPTION
## What does this PR do?

Removes the detection of IntelliJ Debug agent introduced in #1689 .
Closes #3314.

## Checklist

- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
