### PR TITLE
Change 'cloud.project.id' for GCP metadata to be the 'project-id'

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -44,6 +44,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Added `baggage_to_attach` config option to allow automatic lifting of baggage into transaction, span and error attributes - {pull}3288[#3288], {pull}3289[#3289]
 * Exclude elasticsearch 8.10 and newer clients from instrumentation because they natively support OpenTelemetry  - {pull}3303[#3303]
 * Switched to OpenTelemetry compatible context propagation for Kafka - {pull}3300[#3300]
+* Changed `cloud.project.id` collected in Google Cloud (GCP) to be the `project-id` - {issues}3311[#3311]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/CloudMetadataProvider.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/CloudMetadataProvider.java
@@ -343,8 +343,7 @@ public class CloudMetadataProvider {
         if (projectData instanceof Map) {
             @SuppressWarnings("unchecked") Map<String, Object> projectMap = (Map<String, Object>) projectData;
             String projectId = projectMap.get("projectId") instanceof String ? (String) projectMap.get("projectId") : null;
-            Long numericProjectId = projectMap.get("numericProjectId") instanceof Long ? (Long) projectMap.get("numericProjectId") : null;
-            cloudProviderInfo.setProject(new NameAndIdField(projectId, numericProjectId));
+            cloudProviderInfo.setProject(new NameAndIdField(null, projectId));
         } else {
             logger.warn("Error while parsing GCP metadata - expecting the value of the 'project' entry to be a map but it is not");
         }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/metadata/CloudMetadataProviderTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/metadata/CloudMetadataProviderTest.java
@@ -41,8 +41,8 @@ class CloudMetadataProviderTest {
         assertThat(gcpMetadata.getInstance().getId()).isEqualTo("4306570268266786072");
         assertThat(gcpMetadata.getInstance().getName()).isEqualTo("basepi-test");
         assertThat(gcpMetadata.getAccount()).isNull();
-        assertThat(gcpMetadata.getProject().getId()).isEqualTo("513326162531");
-        assertThat(gcpMetadata.getProject().getName()).isEqualTo("elastic-apm");
+        assertThat(gcpMetadata.getProject().getId()).isEqualTo("elastic-apm");
+        assertThat(gcpMetadata.getProject().getName()).isNull();
         assertThat(gcpMetadata.getMachine().getType()).isEqualTo("n1-standard-1");
     }
 


### PR DESCRIPTION
Closes: https://github.com/elastic/apm-agent-java/issues/3311
