### PR TITLE
OpenTelemetry metrics exporter instrumentation breaks with instrument=false

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -47,6 +47,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Fix micrometer histogram serialization - {pull}3290[#3290], {pull}3304[#3304]
 * Fix transactions not being correctly handled in certain edge cases - {pull}3294[#3294]
 * Fixed JDBC instrumentation for DB2 - {pull}3313[#3313]
+* Fixed OpenTelemetry metrics export breaking when `instrument=false` is configured - {pull}3326[#3326]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/main/java/co/elastic/apm/agent/otelmetricsdk/SdkMeterProviderBuilderInstrumentation.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/main/java/co/elastic/apm/agent/otelmetricsdk/SdkMeterProviderBuilderInstrumentation.java
@@ -19,13 +19,13 @@
 package co.elastic.apm.agent.otelmetricsdk;
 
 import co.elastic.apm.agent.impl.ElasticApmTracer;
-import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
+import co.elastic.apm.agent.sdk.internal.util.LoggerUtils;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakConcurrent;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakSet;
-import co.elastic.apm.agent.sdk.internal.util.LoggerUtils;
+import co.elastic.apm.agent.tracer.GlobalTracer;
 import io.opentelemetry.sdk.metrics.SdkMeterProviderBuilder;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import net.bytebuddy.asm.Advice;
@@ -53,6 +53,11 @@ public class SdkMeterProviderBuilderInstrumentation extends ElasticApmInstrument
     public Collection<String> getInstrumentationGroupNames() {
         //These groups need to be kept in sync with the if-condition in ElasticOpenTelemetryWithMetrics
         return Arrays.asList("opentelemetry", "opentelemetry-metrics", "experimental");
+    }
+
+    @Override
+    public final boolean includeWhenInstrumentationIsDisabled() {
+        return true;
     }
 
     @Override


### PR DESCRIPTION

## What does this PR do?

We discovered that settings `instrument=false` "breaks" the opentelemetry metrics instrumentation:
* The `GlobalOpenTelemetry` instrumentation still works as expected
* `SdkMeterProviderBuilderInstrumentation` however gets disabled
* As a result no exporter is setup on the embedded metric SDK and therefore no metrics are exported.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->


- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
