### PR TITLE
Fixes ByteBuddy AbstractMethodError which could occur when running tests from IDE

### DIFF
--- a/apm-agent-attach-cli/pom.xml
+++ b/apm-agent-attach-cli/pom.xml
@@ -56,6 +56,13 @@
             <version>${version.bouncy-castle.bc-fips}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <!-- required for the inherited assertJ and Mockito dependencies-->
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-dep</artifactId>
+            <version>${version.byte-buddy}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-5_x/pom.xml
@@ -26,6 +26,12 @@
             <artifactId>hibernate-search-orm</artifactId>
             <version>5.11.1.Final</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId> <!-- conflicts with byte-buddy-dep -->
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
+++ b/apm-agent-plugins/apm-hibernate-search-plugin/apm-hibernate-search-plugin-6_x/pom.xml
@@ -28,6 +28,12 @@
             <artifactId>hibernate-search-mapper-orm</artifactId>
             <version>${version.hibernate.search}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId> <!-- conflicts with byte-buddy-dep -->
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/apm-agent-tracer/pom.xml
+++ b/apm-agent-tracer/pom.xml
@@ -24,6 +24,13 @@
             <artifactId>apm-agent-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <!-- required for the inherited assertJ and Mockito dependencies-->
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-dep</artifactId>
+            <version>${version.byte-buddy}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/elastic-apm-agent-premain/pom.xml
+++ b/elastic-apm-agent-premain/pom.xml
@@ -21,6 +21,13 @@
             <artifactId>apm-agent-common</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <!-- required for the inherited assertJ and Mockito dependencies-->
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-dep</artifactId>
+            <version>${version.byte-buddy}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -652,6 +652,11 @@
             <!-- ensures that we always rely on a single bytebuddy version -->
             <dependency>
                 <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>${version.byte-buddy}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy-agent</artifactId>
                 <version>${version.byte-buddy}</version>
             </dependency>
@@ -734,13 +739,6 @@
                     <artifactId>byte-buddy</artifactId> <!-- conflicts with byte-buddy-dep -->
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <!-- explicitly include byte-buddy-dep to replace byte-buddy dependency in tests for mockito and assertj-->
-            <groupId>net.bytebuddy</groupId>
-            <artifactId>byte-buddy-dep</artifactId>
-            <version>${version.byte-buddy}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <!-- adding this to classpath allows to keep default behavior of mockito 4.x where mock subclassing is used.  -->

--- a/pom.xml
+++ b/pom.xml
@@ -652,11 +652,6 @@
             <!-- ensures that we always rely on a single bytebuddy version -->
             <dependency>
                 <groupId>net.bytebuddy</groupId>
-                <artifactId>byte-buddy</artifactId>
-                <version>${version.byte-buddy}</version>
-            </dependency>
-            <dependency>
-                <groupId>net.bytebuddy</groupId>
                 <artifactId>byte-buddy-agent</artifactId>
                 <version>${version.byte-buddy}</version>
             </dependency>
@@ -739,6 +734,13 @@
                     <artifactId>byte-buddy</artifactId> <!-- conflicts with byte-buddy-dep -->
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <!-- explicitly include byte-buddy-dep to replace byte-buddy dependency in tests for mockito and assertj-->
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy-dep</artifactId>
+            <version>${version.byte-buddy}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <!-- adding this to classpath allows to keep default behavior of mockito 4.x where mock subclassing is used.  -->

--- a/pom.xml
+++ b/pom.xml
@@ -721,12 +721,24 @@
             <artifactId>assertj-core</artifactId>
             <version>3.24.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId> <!-- conflicts with byte-buddy-dep -->
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${version.mockito}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId> <!-- conflicts with byte-buddy-dep -->
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <!-- adding this to classpath allows to keep default behavior of mockito 4.x where mock subclassing is used.  -->
@@ -756,7 +768,7 @@
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
-            <version>2.37.0</version>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
We have now had for a time the strange behaviour that certain tests would fail when run from the IDE with the following error:

```
java.lang.AbstractMethodError: Receiver class co.elastic.apm.agent.bci.bytebuddy.MinimumClassFileVersionValidator does not define or inherit an implementation of the resolved method 'abstract net.bytebuddy.jar.asm.ClassVisitor wrap(net.bytebuddy.description.type.TypeDescription, net.bytebuddy.jar.asm.ClassVisitor, net.bytebuddy.implementation.Implementation$Context, net.bytebuddy.pool.TypePool, net.bytebuddy.description.field.FieldList, net.bytebuddy.description.method.MethodList, int, int)' of interface net.bytebuddy.asm.AsmVisitorWrapper.
	at net.bytebuddy.asm.AsmVisitorWrapper$Compound.wrap(AsmVisitorWrapper.java:746) ~[byte-buddy-1.14.8.jar:?]
```

I've been able to find the root cause of the issue and fix it with this PR.

Our `MinimumClassFileVersionValidator` implements `AsmVisitorWrapper` from `byte-buddy-dep`, which means it uses the **unshaded** `org.objectweb.asm.ClassVisitor` as parameter type.
The error message shows that at runtime the `AsmVisitorWrapper` interface is picked up from `byte-buddy` instead, which expects the shaded `net.bytebuddy.jar.asm.ClassVisitor`.

I assume that when the tests are run from maven the classpath order is slightly different, so that `byte-buddy-dep` wins over `byte-buddy`. In the IDE the order seems to be the other way around, causing the failure.

I've fixed it by excluding `byte-buddy` from the dependencies which pull it in transitively: `assertJ` and `mockito`.

## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
