### PR TITLE
action: avoid github-action bot with write permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,6 @@ concurrency:
 
 jobs:
   prepare_release:
-    permissions:
-      contents: write
     name: "Changelog and Version Bump"
     if: ${{ ! inputs.skip_preparation }}
     runs-on: ubuntu-latest
@@ -130,8 +128,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - await_artifact_on_maven_central
-    permissions:
-      contents: write
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
         with:
@@ -155,8 +151,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - await_artifact_on_maven_central
-    permissions:
-      contents: write
     steps:
       - uses: elastic/apm-pipeline-library/.github/actions/github-token@current
         with:
@@ -260,6 +254,7 @@ jobs:
       - publish_aws_lambda
       - update_major_branch
     runs-on: ubuntu-latest
+    # github-actions [bot] is the one creating the GitHub releases
     permissions:
       contents: write
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
           git commit -m "Prepare changelog for release ${{ inputs.version }}" CHANGELOG.asciidoc
       - name: Bump version and add git tag
         run: ./mvnw release:prepare -B -DpushChanges=false "-Darguments=-DskipTests -Dmaven.javadoc.skip=true" -DreleaseVersion=${{ inputs.version }}
+      - run: git --no-pager log -n 1
       - run: git push --atomic origin ${{ inputs.branch }} ${{ env.TAG_NAME }}
 
 
@@ -144,6 +145,7 @@ jobs:
           ref: ${{ env.TAG_NAME }}
           token: ${{ env.GITHUB_TOKEN }}
       - run: .ci/release/update_major_branch.sh ${{ inputs.version }}
+      - run: git --no-pager log -n 1
       - run: git push -f origin "$(echo '${{ inputs.version }}' | sed -E 's/\..+/.x/')"
 
   update_cloudfoundry:
@@ -169,6 +171,7 @@ jobs:
       - name: "Update Cloudfoundry index.yml file"
         shell: bash
         run: .ci/release/update_cloudfoundry.sh ${{ inputs.version }}
+      - run: git --no-pager log -n 1
       - run: git push origin ${{ inputs.branch }}
 
 


### PR DESCRIPTION
## What does this PR do?

Ensure `github-action [bot]` does not have write permissions.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
