### PR TITLE
captured span.sync attribute for ES restclient spans plugins

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Switched to OpenTelemetry compatible context propagation for Kafka - {pull}3300[#3300]
 * Changed `cloud.project.id` collected in Google Cloud (GCP) to be the `project-id` - {issues}3311[#3311]
 * Allow running the IntelliJ debug agent in parallel - {pull}3315[#3315]
+* Capture `span.sync` = `false` for ES restclient async spans plugins
 
 [float]
 ===== Bug fixes

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/src/main/java/co/elastic/apm/agent/esrestclient/v5_6/ElasticsearchClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/src/main/java/co/elastic/apm/agent/esrestclient/v5_6/ElasticsearchClientAsyncInstrumentation.java
@@ -75,7 +75,7 @@ public class ElasticsearchClientAsyncInstrumentation extends ElasticsearchRestCl
                                                @Advice.Argument(3) @Nullable HttpEntity entity,
                                                @Advice.Argument(5) ResponseListener responseListener) {
 
-            Span<?> span = helper.createClientSpan(method, endpoint, entity);
+            Span<?> span = helper.createClientSpan(method, endpoint, entity, false);
             if (span != null) {
                 Object[] ret = new Object[2];
                 ret[0] = span;

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/src/main/java/co/elastic/apm/agent/esrestclient/v5_6/ElasticsearchClientSyncInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-5_6/src/main/java/co/elastic/apm/agent/esrestclient/v5_6/ElasticsearchClientSyncInstrumentation.java
@@ -47,7 +47,7 @@ public class ElasticsearchClientSyncInstrumentation extends ElasticsearchRestCli
         public static Object onBeforeExecute(@Advice.Argument(0) String method,
                                             @Advice.Argument(1) String endpoint,
                                             @Advice.Argument(3) @Nullable HttpEntity entity) {
-            return helper.createClientSpan(method, endpoint, entity);
+            return helper.createClientSpan(method, endpoint, entity, true);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/esrestclient/v6_4/ElasticsearchClientAsyncInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/esrestclient/v6_4/ElasticsearchClientAsyncInstrumentation.java
@@ -66,7 +66,7 @@ public class ElasticsearchClientAsyncInstrumentation extends ElasticsearchRestCl
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object[] onBeforeExecute(@Advice.Argument(0) Request request,
                                                @Advice.Argument(1) ResponseListener responseListener) {
-            Span<?> span = helper.createClientSpan(request.getMethod(), request.getEndpoint(), request.getEntity());
+            Span<?> span = helper.createClientSpan(request.getMethod(), request.getEndpoint(), request.getEntity(), false);
             if (span != null) {
                 Object[] ret = new Object[2];
                 ret[0] = span;

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/esrestclient/v6_4/ElasticsearchClientSyncInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/esrestclient/v6_4/ElasticsearchClientSyncInstrumentation.java
@@ -60,7 +60,7 @@ public class ElasticsearchClientSyncInstrumentation extends ElasticsearchRestCli
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object onBeforeExecute(@Advice.Argument(0) Request request) {
-            return helper.createClientSpan(request.getMethod(), request.getEndpoint(), request.getEntity());
+            return helper.createClientSpan(request.getMethod(), request.getEndpoint(), request.getEntity(), false);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/esrestclient/v6_4/ElasticsearchClientSyncInstrumentation.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-6_4/src/main/java/co/elastic/apm/agent/esrestclient/v6_4/ElasticsearchClientSyncInstrumentation.java
@@ -60,7 +60,7 @@ public class ElasticsearchClientSyncInstrumentation extends ElasticsearchRestCli
         @Nullable
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object onBeforeExecute(@Advice.Argument(0) Request request) {
-            return helper.createClientSpan(request.getMethod(), request.getEndpoint(), request.getEntity(), false);
+            return helper.createClientSpan(request.getMethod(), request.getEndpoint(), request.getEntity(), true);
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_x/src/test/java/co/elastic/apm/agent/esrestclient/v7_x/ElasticsearchRestClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-7_x/src/test/java/co/elastic/apm/agent/esrestclient/v7_x/ElasticsearchRestClientInstrumentationIT.java
@@ -143,6 +143,7 @@ public class ElasticsearchRestClientInstrumentationIT extends AbstractEs6_4Clien
             .statusCode(-1)
             .disableHttpUrlCheck()
             .expectAnyStatement()
+            .expectAsync(true)
             .check();
 
         assertThat(searchSpan.getOutcome())

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-8_x/src/test/java/co/elastic/apm/agent/esrestclient/v8_x/Elasticsearch8JavaIT.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-8_x/src/test/java/co/elastic/apm/agent/esrestclient/v8_x/Elasticsearch8JavaIT.java
@@ -276,6 +276,7 @@ public class Elasticsearch8JavaIT extends AbstractEsClientInstrumentationTest {
                 .endpointName("delete")
                 .expectPathPart("index", INDEX)
                 .expectPathPart("id", DOC_ID)
+                .expectAsync(false) // delete is a sync operation
                 .check();
         }
     }

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchRestClientInstrumentationHelper.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/main/java/co/elastic/apm/agent/esrestclient/ElasticsearchRestClientInstrumentationHelper.java
@@ -86,7 +86,7 @@ public class ElasticsearchRestClientInstrumentationHelper {
     }
 
     @Nullable
-    public Span<?> createClientSpan(String method, String httpPath, @Nullable HttpEntity httpEntity) {
+    public Span<?> createClientSpan(String method, String httpPath, @Nullable HttpEntity httpEntity, boolean isSync) {
         ElasticsearchEndpointDefinition endpoint = currentRequestEndpoint.getAndRemove();
 
         Span<?> span = tracer.currentContext().createExitSpan();
@@ -98,7 +98,8 @@ public class ElasticsearchRestClientInstrumentationHelper {
 
         span.withType(SPAN_TYPE)
             .withSubtype(ELASTICSEARCH)
-            .withAction(SPAN_ACTION);
+            .withAction(SPAN_ACTION)
+            .withSync(isSync);
 
         StringBuilder name = span.getAndOverrideName(AbstractSpan.PRIORITY_HIGH_LEVEL_FRAMEWORK);
         if (endpoint != null) {

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/esrestclient/AbstractEsClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/esrestclient/AbstractEsClientInstrumentationTest.java
@@ -101,7 +101,7 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
     }
 
     protected EsSpanValidationBuilder validateSpan(Span spanToValidate) {
-        return new EsSpanValidationBuilder(spanToValidate);
+        return new EsSpanValidationBuilder(spanToValidate, async);
     }
 
     protected EsSpanValidationBuilder validateSpan() {
@@ -138,8 +138,11 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
         @Nullable
         private String expectedHttpUrl = "http://" + container.getHttpHostAddress();
 
-        public EsSpanValidationBuilder(Span spanToValidate) {
+        private boolean isAsyncRequest;
+
+        public EsSpanValidationBuilder(Span spanToValidate, boolean isAsyncRequest) {
             this.span = spanToValidate;
+            this.isAsyncRequest = isAsyncRequest;
         }
 
         public EsSpanValidationBuilder expectNoStatement() {
@@ -221,6 +224,9 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
             checkDbContext();
             checkPathPartAttributes();
             checkDestinationContext();
+            if (isAsyncRequest) {
+                assertThat(span).isAsync();
+            }
         }
 
 

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/esrestclient/AbstractEsClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/esrestclient/AbstractEsClientInstrumentationTest.java
@@ -157,6 +157,11 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
             return this;
         }
 
+        public EsSpanValidationBuilder expectAsync(boolean async) {
+            isAsyncRequest = async;
+            return this;
+        }
+
         public EsSpanValidationBuilder expectStatement(String statement) {
             try {
                 this.expectedStatement = jackson.readTree(statement);

--- a/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/esrestclient/AbstractEsClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-es-restclient-plugin/apm-es-restclient-plugin-common/src/test/java/co/elastic/apm/agent/esrestclient/AbstractEsClientInstrumentationTest.java
@@ -226,6 +226,8 @@ public abstract class AbstractEsClientInstrumentationTest extends AbstractInstru
             checkDestinationContext();
             if (isAsyncRequest) {
                 assertThat(span).isAsync();
+            } else {
+                assertThat(span).isSync();
             }
         }
 


### PR DESCRIPTION
partially covers #3168 

## What does this PR do?

Set the the span.sync = false for asynchronous spans of ES restclient plugins
## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] ~~Added an API method or config option? Document in which version this will be introduced~~
  - [x] ~~I have made corresponding changes to the documentation~~

