### PR TITLE
GH Actions: Fix maven deploy step being skipped if preparation is skipped

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
 
   maven_central_deploy:
     name: "Deploy to Maven Central (Buildkite)"
-    if: ${{ ! inputs.skip_maven_deploy }}
+    if: ${{ ! inputs.skip_maven_deploy && ( inputs.skip_preparation || success() ) }}
     runs-on: ubuntu-latest
     needs:
       - prepare_release


### PR DESCRIPTION
## What does this PR do?

It is currently not possible to trigger the BuildKite release without the preparation step (e.g. version bump & tag):
The GH Actions release script skips the BuildKite step because it depends on the preparation step.
This PR attempts to fix this.
