### PR TITLE
fix java 11 and java 21 test failures

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -296,7 +296,7 @@ jobs:
             distribution: 'temurin'
           - version: 20
             distribution: 'temurin'
-          - version: 21-ea
+          - version: 21
             distribution: 'zulu'
     steps:
       - uses: actions/checkout@v3

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,9 @@
 
         <version.testcontainers>1.16.3</version.testcontainers>
 
+        <!-- latest version compiled for java 11 -->
+        <version.jsonunit>2.38.0</version.jsonunit>
+
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -768,7 +771,7 @@
         <dependency>
             <groupId>net.javacrumbs.json-unit</groupId>
             <artifactId>json-unit-assertj</artifactId>
-            <version>3.2.2</version>
+            <version>${version.jsonunit}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## What does this PR do?

- Keep tests compatible with java 11, json-unit is now relying on JDK 17 as minimum requirement for version 3.x
- use zulu JDk 21 GA instead of the early-access (EA) version that was used in our tests.

## Checklist

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
