### PR TITLE
[mergify] fix merge method

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,5 +9,5 @@ pull_request_rules:
       - base=main
     actions:
       queue:
-        method: squash
+        merge_method: squash
         name: default


### PR DESCRIPTION
## What does this PR do?

Changes from `merge` to `merge_method` in the mergify config, this argument was renamed and thus might not work as we'd expect with the old name ([docs](https://docs.mergify.com/workflow/actions/queue/))

## Checklist

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
