### PR TITLE
[mergify] fix mergify config again

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,8 @@
 queue_rules:
   - name: default
-  # branch protection rules are automatically included, no extra rule needed for now
+  # merge method needs to be set to 'squash' to match the repository config
     merge_method: squash
+  # branch protection rules are automatically included, no extra rule needed for now
 
 pull_request_rules:
   - name: Automatic squash and merge on approval with success checks and ready-to-merge label

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -11,3 +11,4 @@ pull_request_rules:
       - base=main
     actions:
       queue:
+        name: default

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,7 @@
 queue_rules:
   - name: default
   # branch protection rules are automatically included, no extra rule needed for now
+    merge_method: squash
 
 pull_request_rules:
   - name: Automatic squash and merge on approval with success checks and ready-to-merge label
@@ -9,5 +10,3 @@ pull_request_rules:
       - base=main
     actions:
       queue:
-        merge_method: squash
-        name: default


### PR DESCRIPTION
## What does this PR do?

The default merge queue strategy is `merge` and that is not compatible with our branch protection rules (we require a linear history), as a consequence we need to explicitly set `merge_method` on the queue (and not the pull-request like I did previously).

## Checklist

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
