### PR TITLE
Make disable_send dynamic, exclude health & config requests.

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/ApmServerConfigurationSource.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/ApmServerConfigurationSource.java
@@ -165,7 +165,7 @@ public class ApmServerConfigurationSource extends AbstractConfigurationSource im
         }
         try {
             payloadSerializer.blockUntilReady();
-            return apmServerClient.execute("/config/v1/agents", new ApmServerClient.ConnectionHandler<String>() {
+            return apmServerClient.forceExecute("/config/v1/agents", new ApmServerClient.ConnectionHandler<String>() {
                 @Override
                 public String withConnection(HttpURLConnection connection) throws IOException {
                     try {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
@@ -64,7 +64,7 @@ public class ApmServerHealthChecker implements Callable<Version> {
     @Nullable
     @Override
     public Version call() {
-        List<Version> versions = apmServerClient.executeForAllUrls("/", new ApmServerClient.ConnectionHandler<Version>() {
+        List<Version> versions = apmServerClient.forceExecuteForAllUrls("/", new ApmServerClient.ConnectionHandler<Version>() {
             @Override
             public Version withConnection(HttpURLConnection connection) {
                 try {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReporterConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ReporterConfiguration.java
@@ -240,9 +240,6 @@ public class ReporterConfiguration extends ConfigurationOptionProvider implement
      * @return a list of APM Server URLs resulting from the combination of {@code server_url} and {@code server_urls}
      */
     public List<URL> getServerUrls() {
-        if (disableSend.get()) {
-            return Collections.emptyList();
-        }
         List<URL> calculatedUrlList;
         URL singleUrl = serverUrl.get();
         List<URL> urlList = serverUrls.get();
@@ -265,6 +262,10 @@ public class ReporterConfiguration extends ConfigurationOptionProvider implement
             calculatedUrlList = urlList;
         }
         return calculatedUrlList;
+    }
+
+    public boolean isSendDisabled() {
+        return disableSend.get();
     }
 
     public TimeDuration getServerTimeout() {

--- a/apm-agent-core/src/test/java/specs/MockServerStepDefinitions.java
+++ b/apm-agent-core/src/test/java/specs/MockServerStepDefinitions.java
@@ -97,7 +97,7 @@ public class MockServerStepDefinitions {
         ApmServerClient apmServerClient = new ApmServerClient(config);
         apmServerClient.start();
         try {
-            apmServerClient.execute("/", new ApmServerClient.ConnectionHandler<>() {
+            apmServerClient.forceExecute("/", new ApmServerClient.ConnectionHandler<>() {
                 @Nullable
                 @Override
                 public Object withConnection(HttpURLConnection connection) throws IOException {


### PR DESCRIPTION
## What does this PR do?


## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation