### PR TITLE
Fix multiple spans being created for HTTPUrlConnection HEAD requests

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
+[float]
+===== Bug fixes
+* Fixed too many spans being created for `HTTPUrlConnection` requests with method `HEAD` - {pull}3353[#3353]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
+++ b/apm-agent-plugins/apm-urlconnection-plugin/src/test/java/co/elastic/apm/agent/urlconnection/HttpUrlConnectionInstrumentationTest.java
@@ -82,6 +82,16 @@ public class HttpUrlConnectionInstrumentationTest extends AbstractHttpClientInst
     }
 
     @Test
+    public void testMultipleGetResponseCodeWithHead() throws Exception {
+        final HttpURLConnection urlConnection = (HttpURLConnection) new URL(getBaseUrl() + "/").openConnection();
+        urlConnection.setRequestMethod("HEAD");
+        //Call twice to make sure we don't create two spans
+        urlConnection.getResponseCode();
+        urlConnection.getResponseCode();
+        expectSpan("/").verify();
+    }
+
+    @Test
     public void testGetOutputStream() throws Exception {
         final HttpURLConnection urlConnection = (HttpURLConnection) new URL(getBaseUrl() + "/").openConnection();
         urlConnection.setDoOutput(true);


### PR DESCRIPTION
## What does this PR do?

While testing with a local spring-boot app I noticed that out instrumentation created 14 spans per single RestTemplate request.

This issue occured because I instructed the `RestTemplate` to ignore the response body by setting the expected type to `Void.class`. This causes spring to send `HEAD` requests instead. And as it turns out, our `HTTPUrlConnection` instrumentation doesn't deal well with those:

The internal `connected` field is not switched to `true` for `HEAD` requests, causing multiple spans to be created when invoking `getResponseCode` multiple times.

This PR fixes this by also checking the `responseCode` field to infer whether the `HTTPUrlConnection` has already connected or not.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix