### PR TITLE
Fix off-by-one error in tests which effectively disabled recycling validation

### DIFF
--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/MockTracer.java
@@ -26,6 +26,7 @@ import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
 import co.elastic.apm.agent.report.ApmServerClient;
 import co.elastic.apm.agent.report.Reporter;
 import co.elastic.apm.agent.common.util.Version;
+import org.mockito.CheckReturnValue;
 import org.stagemonitor.configuration.ConfigurationRegistry;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -51,11 +52,15 @@ public class MockTracer {
         return createRealTracer(reporter, SpyConfiguration.createSpyConfig());
     }
 
+    public static ElasticApmTracer createRealTracer(Reporter reporter, ConfigurationRegistry config) {
+        return createRealTracer(reporter, config, true);
+    }
+
     /**
      * Creates a real tracer with a given reporter and a mock configuration which returns default values which can be customized by mocking
      * the configuration.
      */
-    public static ElasticApmTracer createRealTracer(Reporter reporter, ConfigurationRegistry config) {
+    public static ElasticApmTracer createRealTracer(Reporter reporter, ConfigurationRegistry config, boolean checkRecycling) {
 
         // use an object pool that does bookkeeping to allow for extra usage checks
         TestObjectPoolFactory objectPoolFactory = new TestObjectPoolFactory();
@@ -72,8 +77,10 @@ public class MockTracer {
                     ((MockReporter) reporter).assertRecycledAfterDecrementingReferences();
                 }
 
-                // checking proper object pool usage using tracer lifecycle events
-                objectPoolFactory.checkAllPooledObjectsHaveBeenRecycled();
+                if (checkRecycling) {
+                    // checking proper object pool usage using tracer lifecycle events
+                    objectPoolFactory.checkAllPooledObjectsHaveBeenRecycled();
+                }
             }))
             .build();
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/TestObjectPoolFactory.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/objectpool/TestObjectPoolFactory.java
@@ -79,7 +79,7 @@ public class TestObjectPoolFactory extends ObjectPoolFactory {
                     // silently ignored
                 }
             }
-        } while (retry-- > 0 && hasSomethingLeft);
+        } while (--retry > 0 && hasSomethingLeft);
 
         if (retry == 0 && hasSomethingLeft) {
             for (BookkeeperObjectPool<?> pool : createdPools) {

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/PartialTransactionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/PartialTransactionTest.java
@@ -88,8 +88,8 @@ public class PartialTransactionTest {
 
     @AfterEach
     public void cleanup() {
+        reporter.reset();
         objectPoolFactory.checkAllPooledObjectsHaveBeenRecycled();
-        reporter.resetWithoutRecycling();
         objectPoolFactory.reset();
     }
 

--- a/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationInheritanceTest.java
+++ b/apm-agent-plugins/apm-api-plugin/src/test/java/co/elastic/apm/api/AnnotationInheritanceTest.java
@@ -22,6 +22,7 @@ import co.elastic.apm.agent.MockReporter;
 import co.elastic.apm.agent.MockTracer;
 import co.elastic.apm.agent.bci.ElasticApmAgent;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
+import co.elastic.apm.agent.configuration.SpyConfiguration;
 import co.elastic.apm.agent.impl.ElasticApmTracer;
 import net.bytebuddy.agent.ByteBuddyAgent;
 import org.junit.jupiter.api.AfterAll;
@@ -49,7 +50,7 @@ class AnnotationInheritanceTest {
     }
 
     private void init(boolean annotationInheritanceEnabled) {
-        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup();
+        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup(SpyConfiguration.createSpyConfig(), false);
         tracer = mockInstrumentationSetup.getTracer();
         doReturn(annotationInheritanceEnabled).when(tracer.getConfig(CoreConfiguration.class)).isEnablePublicApiAnnotationInheritance();
         reporter = mockInstrumentationSetup.getReporter();

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -401,6 +401,7 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
             assertThat(transaction).isNotNull();
             assertThat(transaction.getTraceContext().getTraceId()).isEqualTo(span.getTraceContext().getTraceId());
             assertThat(transaction.getTraceContext().getParentId()).isEqualTo(span.getTraceContext().getId());
+            transaction.decrementReferences(); //recycle transaction without reporting
         });
     }
 

--- a/apm-agent-plugins/apm-logging-plugin/apm-logging-plugin-common/src/test/java/co/elastic/apm/agent/loginstr/correlation/CorrelationIdMapAdapterTest.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-logging-plugin-common/src/test/java/co/elastic/apm/agent/loginstr/correlation/CorrelationIdMapAdapterTest.java
@@ -57,7 +57,7 @@ public class CorrelationIdMapAdapterTest {
         try (Scope scope = transaction.activateInScope()) {
             assertThat(CorrelationIdMapAdapter.get()).containsOnlyKeys("trace.id", "transaction.id");
         } finally {
-            transaction.end();
+            transaction.decrementReferences(); //recycle without reporting
         }
         assertThat(CorrelationIdMapAdapter.get()).isEmpty();
     }
@@ -70,8 +70,9 @@ public class CorrelationIdMapAdapterTest {
             assertThat(CorrelationIdMapAdapter.get()).containsOnlyKeys("trace.id", "transaction.id");
         } finally {
             span.end();
+            span.decrementReferences();
         }
-        transaction.end();
+        transaction.decrementReferences();
         assertThat(CorrelationIdMapAdapter.get()).isEmpty();
     }
 

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/CallTreeSpanifyTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/CallTreeSpanifyTest.java
@@ -53,8 +53,7 @@ class CallTreeSpanifyTest {
         ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
         // disable scheduled profiling to not interfere with this test
         doReturn(false).when(config.getConfig(ProfilingConfiguration.class)).isProfilingEnabled();
-        tracer = MockTracer.createRealTracer(reporter, config);
-        tracer = MockTracer.createRealTracer(reporter);
+        tracer = MockTracer.createRealTracer(reporter, config, false);
     }
 
     @AfterEach

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/CallTreeTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/CallTreeTest.java
@@ -73,7 +73,7 @@ class CallTreeTest {
         // disable scheduled profiling to not interfere with this test
         profilerConfig = config.getConfig(ProfilingConfiguration.class);
         doReturn(true).when(profilerConfig).isProfilingEnabled();
-        tracer = MockTracer.createRealTracer(reporter, config);
+        tracer = MockTracer.createRealTracer(reporter, config, false);
     }
 
     @AfterEach


### PR DESCRIPTION
## What does this PR do?

While working on #3356 I discovered that our tests did not catch leaked objects in all cases.
Turns out that this was caused by an off-by-one error in `TestObjectPoolFactory`.

After fixing the error, it uncovered a few missing recyclings in our tests, but the production code is fine.
For that reason I won't add a changelog, as it is tests-only.

## Checklist

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
