### PR TITLE
Add guard against invalid end timestamps

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpan.java
@@ -559,6 +559,13 @@ public abstract class AbstractSpan<T extends AbstractSpan<T>> extends ElasticCon
 
     public final void end(long epochMicros) {
         if (!finished) {
+
+            long startTime = timestamp.get();
+            if(epochMicros < startTime) {
+                logger.warn("End called on {} with a timestamp before start! Using start timestamp as end instead.", this);
+                epochMicros = startTime;
+            }
+
             this.endTimestamp.set(epochMicros);
             childDurations.onSpanEnd(epochMicros);
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -506,6 +506,20 @@ class ElasticApmTracerTest {
     }
 
     @Test
+    void testTimestampSanitization() {
+        final Transaction transaction = tracerImpl.startChildTransaction(new HashMap<>(), TextHeaderMapAccessor.INSTANCE, ConstantSampler.of(true), 10, null);
+        final Span span = transaction.createSpan(20);
+        span.end(10);
+
+        transaction.end(5);
+
+        assertThat(transaction.getTimestamp()).isEqualTo(10);
+        assertThat(transaction.getDuration()).isEqualTo(0);
+        assertThat(span.getTimestamp()).isEqualTo(20);
+        assertThat(span.getDuration()).isEqualTo(0);
+    }
+
+    @Test
     void testStartSpanAfterTransactionHasEnded() {
         final Transaction transaction = startTestRootTransaction();
         assertThat(transaction).isNotNull();


### PR DESCRIPTION
## What does this PR do?

Recently our windows tests have been failing:
```
2023-10-17T06:17:03.0410452Z 2023-10-17 06:16:57,817 [main] ERROR co.elastic.apm.agent.bci.IndyBootstrap - Advice threw an exception, this should never happen!
2023-10-17T06:17:03.0410818Z java.lang.AssertionError: [$.duration: must have a minimum value of 0]
2023-10-17T06:17:03.0411159Z JSON schema path = /apm-server-schema/current/transaction.json
2023-10-17T06:17:03.0411173Z 
2023-10-17T06:17:03.0411256Z {
2023-10-17T06:17:03.0411382Z   "timestamp" : 1697523417814567,
2023-10-17T06:17:03.0411487Z   "name" : "unnamed",
2023-10-17T06:17:03.0411602Z   "id" : "ddba5acdad68e7ab",
2023-10-17T06:17:03.0411791Z   "trace_id" : "054914ce0a91fb98a7e41a5ee516a021",
2023-10-17T06:17:03.0411943Z   "type" : "custom",
2023-10-17T06:17:03.0412102Z   "duration" : -5.49,
2023-10-17T06:17:03.0412207Z   "outcome" : "success",
2023-10-17T06:17:03.0412302Z   "context" : {
2023-10-17T06:17:03.0412465Z     "service" : {
2023-10-17T06:17:03.0412568Z       "framework" : {
2023-10-17T06:17:03.0412675Z         "name" : "API"
2023-10-17T06:17:03.0412761Z       },
2023-10-17T06:17:03.0412867Z       "version" : null
2023-10-17T06:17:03.0412952Z     },
2023-10-17T06:17:03.0413046Z     "tags" : { }
2023-10-17T06:17:03.0413134Z   },
2023-10-17T06:17:03.0413231Z   "span_count" : {
2023-10-17T06:17:03.0413337Z     "dropped" : 0,
2023-10-17T06:17:03.0413429Z     "started" : 0
2023-10-17T06:17:03.0413508Z   },
2023-10-17T06:17:03.0413637Z   "dropped_spans_stats" : [ ],
2023-10-17T06:17:03.0413738Z   "sample_rate" : 1.0,
2023-10-17T06:17:03.0413843Z   "sampled" : true
2023-10-17T06:17:03.0413923Z }
2023-10-17T06:17:03.0414510Z 	at co.elastic.apm.agent.MockReporter.verifyJsonSchema(MockReporter.java:406) ~[test-classes/:?]
2023-10-17T06:17:03.0415099Z 	at co.elastic.apm.agent.MockReporter.verifyJsonSchemas(MockReporter.java:398) ~[test-classes/:?]
2023-10-17T06:17:03.0415732Z 	at co.elastic.apm.agent.MockReporter.verifyTransactionSchema(MockReporter.java:338) ~[test-classes/:?]
2023-10-17T06:17:03.0416228Z 	at co.elastic.apm.agent.MockReporter.report(MockReporter.java:230) ~[test-classes/:?]
2023-10-17T06:17:03.0416769Z 	at co.elastic.apm.agent.impl.ElasticApmTracer.endTransaction(ElasticApmTracer.java:514) ~[classes/:?]
2023-10-17T06:17:03.0417282Z 	at co.elastic.apm.agent.impl.transaction.Transaction.afterEnd(Transaction.java:285) ~[classes/:?]
2023-10-17T06:17:03.0417763Z 	at co.elastic.apm.agent.impl.transaction.AbstractSpan.end(AbstractSpan.java:580) ~[classes/:?]
2023-10-17T06:17:03.0418251Z 	at co.elastic.apm.agent.impl.transaction.AbstractSpan.end(AbstractSpan.java:557) ~[classes/:?]
2023-10-17T06:17:03.0419074Z 	at co.elastic.apm.agent.pluginapi.AbstractSpanInstrumentation$EndInstrumentation$AdviceClass.end(AbstractSpanInstrumentation.java:223) ~[classes/:?]
2023-10-17T06:17:03.0419479Z 	at co.elastic.apm.api.AbstractSpanImpl.end(AbstractSpanImpl.java:126) ~[classes/:?]
2023-10-17T06:17:03.0420454Z 	at co.elastic.apm.api.BlockingQueueContextPropagationTest.testAsyncSpanDelegation(BlockingQueueContextPropagationTest.java:118) ~[test-classes/:?]
```

The problematic test manually sets the start-timestamp, but uses the agent built-in clock via `end()` for the end timestamp. Because those two methods could use two different "bases" for converting `System.nanoTime()` to micros, this potentially causes an end-timestamp which is lower than the start timestamp.

I assume we only observed this issue on windows because the precision of *nix `System.currentTimeMillis()` is higher and therefore makes this issue much less likely.

This PR adds a sanitization to the end-timestamp, as it is possible via manual instrumentation to give invalid timestamps.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] ~Added an API method or config option? Document in which version this will be introduced~
  - [ ] ~I have made corresponding changes to the documentation~
