### PR TITLE
Update tests for Jedis 5

### DIFF
--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-4-plugin/src/test/java/co/elastic/apm/agent/jedis/Jedis4InstrumentationIT.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-4-plugin/src/test/java/co/elastic/apm/agent/jedis/Jedis4InstrumentationIT.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-class Jedis4InstrumentationIT extends Jedis1InstrumentationIT {
+public class Jedis4InstrumentationIT extends Jedis1InstrumentationIT {
     private JedisSharding shardedJedis;
     private UnifiedJedis binaryJedis;
 
@@ -50,6 +50,10 @@ class Jedis4InstrumentationIT extends Jedis1InstrumentationIT {
         shardedJedis.set("foo", "bar");
         assertThat(shardedJedis.get("foo".getBytes())).isEqualTo("bar".getBytes());
 
+        verifyShardedJedisSpan();
+    }
+
+    protected void verifyShardedJedisSpan() {
         assertTransactionWithRedisSpans("CLIENT", "CLIENT", "SET", "GET");
     }
 

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-5-tests/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-5-tests/pom.xml
@@ -8,7 +8,7 @@
         <version>1.43.1-SNAPSHOT</version>
     </parent>
 
-    <artifactId>apm-jedis-4-plugin</artifactId>
+    <artifactId>apm-jedis-5-tests</artifactId>
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
@@ -16,12 +16,6 @@
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>apm-jedis-plugin</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>apm-redis-common</artifactId>
@@ -37,25 +31,24 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-jedis-4-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-jedis-4-plugin</artifactId>
+            <type>test-jar</type>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>redis.clients</groupId>
             <artifactId>jedis</artifactId>
-            <version>4.4.3</version>
-            <scope>provided</scope>
+            <version>5.0.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-5-tests/src/test/java/jedis/Jedis5InstrumentationIT.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-5-tests/src/test/java/jedis/Jedis5InstrumentationIT.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package jedis;
+
+import co.elastic.apm.agent.jedis.Jedis4InstrumentationIT;
+
+public class Jedis5InstrumentationIT extends Jedis4InstrumentationIT {
+
+    @Override
+    protected void verifyShardedJedisSpan() {
+        assertTransactionWithRedisSpans("CLIENT", "CLIENT", "CLIENT", "CLIENT", "SET", "GET");
+    }
+
+    @Override
+    protected void verifyBasicJedisSpans() {
+        assertTransactionWithRedisSpans( "CLIENT", "CLIENT", "SET", "GET");
+    }
+}

--- a/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/test/java/co/elastic/apm/agent/jedis/Jedis1InstrumentationIT.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-jedis-plugin/src/test/java/co/elastic/apm/agent/jedis/Jedis1InstrumentationIT.java
@@ -55,6 +55,10 @@ class Jedis1InstrumentationIT extends AbstractRedisInstrumentationTest {
         jedis.set("foo", "bar");
         assertThat(jedis.get("foo".getBytes())).isEqualTo("bar".getBytes());
 
+        verifyBasicJedisSpans();
+    }
+
+    protected void verifyBasicJedisSpans() {
         assertTransactionWithRedisSpans("SET", "GET");
     }
 

--- a/apm-agent-plugins/apm-redis-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/pom.xml
@@ -20,6 +20,7 @@
         <module>apm-jedis-2-tests</module>
         <module>apm-jedis-3-tests</module>
         <module>apm-jedis-4-plugin</module>
+        <module>apm-jedis-5-tests</module>
         <module>apm-jedis-plugin</module>
         <module>apm-lettuce-3-tests</module>
         <module>apm-lettuce-plugin</module>

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -254,9 +254,9 @@ Other Servlet 3+ compliant servers will most likely work as well.
 |1.9.0
 
 |Redis Jedis
-|1.4.0-4.x
+|1.4.0-5.x
 |The agent creates spans for interactions with the Jedis client.
-|1.10.0, 4.x since 1.31.0
+|1.10.0, 4+ since 1.31.0
 
 |Redis Lettuce
 |3.4+


### PR DESCRIPTION
## What does this PR do?

 Similar to #3121 , jedis 5.0 added even more `CLIENT SETINFO` calls which our tests didn't take into account.
 I've updated the supported technologies page, but won't add a changelog because this PR just added tests and didn't change the instrumentation.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] ~Added an API method or config option? Document in which version this will be introduced~
  - [x] I have made corresponding changes to the documentation
