### PR TITLE
jdk update reminder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -309,7 +309,7 @@ jobs:
         with:
           test-java-version: ${{ matrix.version }}
           test-java-distribution: ${{ matrix.distribution }}
-          command: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true
+          command: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -Delastic.jdkCompatibilityTest=true
       - name: Run tests for ${{ matrix.version }}:${{ matrix.distribution }}
         run: ./mvnw test -Dtest_java_binary=${{ env.TEST_JAVA_BINARY }}
       - name: Store test results

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -309,9 +309,9 @@ jobs:
         with:
           test-java-version: ${{ matrix.version }}
           test-java-distribution: ${{ matrix.distribution }}
-          command: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -Delastic.jdkCompatibilityTest=true
+          command: ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true
       - name: Run tests for ${{ matrix.version }}:${{ matrix.distribution }}
-        run: ./mvnw test -Dtest_java_binary=${{ env.TEST_JAVA_BINARY }}
+        run: ./mvnw test -Delastic.jdkCompatibilityTest=true -Dtest_java_binary=${{ env.TEST_JAVA_BINARY }}
       - name: Store test results
         if: success() || failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -299,9 +299,9 @@ jobs:
             distribution: 'temurin'
           - version: 17
             distribution: 'temurin'
-          - version: 22-ea
-            distribution: 'temurin'
           - version: 21
+            distribution: 'temurin'
+          - version: 22-ea
             distribution: 'temurin'
     steps:
       - uses: actions/checkout@v4

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.util;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.provider.Arguments;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class JdkVersionTest {
+
+    private static List<Arguments> releaseSchedule() {
+        // from https://www.oracle.com/java/technologies/java-se-support-roadmap.html
+        return List.of(
+            Arguments.of(22, LocalDate.parse("2024-03-01")),
+            Arguments.of(23, LocalDate.parse("2024-09-01")),
+            Arguments.of(24, LocalDate.parse("2025-03-01")),
+            Arguments.of(25, LocalDate.parse("2025-09-01"))
+        );
+    }
+
+    @Test
+    void jdkReleaseScheduleReminder() {
+        if (!Boolean.getBoolean("elastic.jdkCompatibilityTest")) {
+            return;
+        }
+        // not using @MethodSource and directly the arguments stream to ensure at least one is in the future
+        jdkReleaseScheduleReminder(releaseSchedule(), LocalDate.now());
+    }
+
+    void jdkReleaseScheduleReminder(List<Arguments> args, LocalDate now) {
+        assertThat(args).isNotEmpty();
+        LocalDate lastGaDate = args.stream().map(a -> (LocalDate) (a.get()[1]))
+            .sorted()
+            .reduce((d1, d2) -> d2)
+            .get();
+
+        assertThat(now)
+            .describedAs("at least one GA date must be in the future")
+            .isBefore(lastGaDate);
+
+        args.forEach(a -> jdkReleaseScheduleReminder((int) a.get()[0], (LocalDate) a.get()[1], now));
+    }
+
+    void jdkReleaseScheduleReminder(int version, LocalDate gaDate, LocalDate now) {
+        if (now.isBefore(gaDate)) {
+            return;
+        }
+        assertThat(false)
+            .describedAs("This test fails to remind you that JDK %d is about to be released, updating release schedule in this test and test matrix in CI is required", version)
+            .isTrue();
+
+    }
+
+    @Test
+    void selfTest() {
+        // verify that the test will fail in the future when we need to get reminded to update
+
+        LocalDate now = LocalDate.now();
+
+        assertThatThrownBy(() -> jdkReleaseScheduleReminder(List.of(), now))
+            .isExactlyInstanceOf(AssertionError.class);
+
+        assertThatThrownBy(() -> jdkReleaseScheduleReminder(List.of(Arguments.of(42, now)), now))
+            .isExactlyInstanceOf(AssertionError.class);
+
+        // should not trigger until the release day
+        jdkReleaseScheduleReminder(List.of(Arguments.of(42, now.plusDays(1))), now);
+
+    }
+}

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
@@ -32,6 +32,7 @@ public class JdkVersionTest {
     private static List<Arguments> releaseSchedule() {
         // from https://www.oracle.com/java/technologies/java-se-support-roadmap.html
         return List.of(
+            Arguments.of(21, LocalDate.parse("2024-09-01")),
             Arguments.of(22, LocalDate.parse("2024-03-01")),
             Arguments.of(23, LocalDate.parse("2024-09-01")),
             Arguments.of(24, LocalDate.parse("2025-03-01")),

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
@@ -64,7 +64,7 @@ public class JdkVersionTest {
                 "This test fails to remind you that JDK %d is about or already released,\n\n" +
                     "please update the following:\n" +
                     "\n" +
-                    "- .github/workflows/main.yml in 'jdk-compatibility-tests' : replace early-access with released GA version\n" +
+                    "- .github/workflows/main.yml in 'jdk-compatibility-tests' : replace early-access with released GA version and add the new early-access version\n" +
                     "- in this test: remove released version in the release schedule\n" +
                     "- in this test: update release schedule if needed\n"
                 , version)

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
@@ -33,7 +33,6 @@ public class JdkVersionTest {
     private static List<Arguments> releaseSchedule() {
         // from https://www.oracle.com/java/technologies/java-se-support-roadmap.html
         return List.of(
-            Arguments.of(21, LocalDate.parse("2022-09-01")),
             Arguments.of(22, LocalDate.parse("2024-03-01")),
             Arguments.of(23, LocalDate.parse("2024-09-01")),
             Arguments.of(24, LocalDate.parse("2025-03-01")),

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
@@ -33,6 +33,7 @@ public class JdkVersionTest {
     private static List<Arguments> releaseSchedule() {
         // from https://www.oracle.com/java/technologies/java-se-support-roadmap.html
         return List.of(
+            Arguments.of(21, LocalDate.parse("2022-09-01")),
             Arguments.of(22, LocalDate.parse("2024-03-01")),
             Arguments.of(23, LocalDate.parse("2024-09-01")),
             Arguments.of(24, LocalDate.parse("2025-03-01")),

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/JdkVersionTest.java
@@ -33,11 +33,10 @@ public class JdkVersionTest {
     private static List<Arguments> releaseSchedule() {
         // from https://www.oracle.com/java/technologies/java-se-support-roadmap.html
         return List.of(
-            Arguments.of(21, LocalDate.parse("2022-09-01")),
-            Arguments.of(22, LocalDate.parse("2024-03-01")),
-            Arguments.of(23, LocalDate.parse("2024-09-01")),
-            Arguments.of(24, LocalDate.parse("2025-03-01")),
-            Arguments.of(25, LocalDate.parse("2025-09-01"))
+            Arguments.of(22, LocalDate.parse("2024-04-01")),
+            Arguments.of(23, LocalDate.parse("2024-10-01")),
+            Arguments.of(24, LocalDate.parse("2025-04-01")),
+            Arguments.of(25, LocalDate.parse("2025-10-01"))
         );
     }
 


### PR DESCRIPTION
Whenever there is a new JDK release GA, we need to update our JDK integration tests.
The main problem is that it's quite easy to forget about this over time as they are expected only twice a year.

## What does this PR do?
- provides a simple release schedule that will fail in CI whenever a new JDK GA is available:
```
This test fails to remind you that JDK 21 is about or already released,

please update the following:

- .github/workflows/main.yml in 'jdk-compatibility-tests' : replace early-access with released GA version
- in this test: remove released version in the release schedule
- in this test: update release schedule if needed
```
- disabled by default, enabled only in CI through system property to prevent noise outside of CI and in unrelated pull-requests.

While it does not ensures that we properly update the tests in CI, which could require parsing the github workflow YAML, at least it allows us to avoid forgetting about doing so, which should be fine given it only happens twice a year.


## Checklist

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] manually tested with settings for JDK 21: `Arguments.of(21, LocalDate.parse("2023-09-01"))`, result when it fails: https://github.com/elastic/apm-agent-java/actions/runs/6773390429
