### PR TITLE
fix metadata parsing for gardener

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -41,6 +41,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Bug fixes
 * Fixed too many spans being created for `HTTPUrlConnection` requests with method `HEAD` - {pull}3353[#3353]
+* Enhance k8s container/pod and host name detection heuristics - {pull}3418[#3418]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
@@ -133,9 +133,7 @@ public class SystemInfo {
             systemInfo = new SystemInfo(osArch, configuredHostname, detectedHostname, osName);
         }
         // this call reads and parses files
-        systemInfo.findContainerDetails();
-        return systemInfo;
-
+        return systemInfo.findContainerDetails();
     }
 
     static boolean isWindows(String osName) {
@@ -361,7 +359,7 @@ public class SystemInfo {
 
                 // Legacy, e.g.: /system.slice/docker-<CID>.scope
                 if (idPart.endsWith(".scope")) {
-                    idPart = idPart.substring(0, idPart.length() - ".scope".length()).substring(idPart.indexOf("-") + 1);
+                    idPart = idPart.substring(0, idPart.length() - ".scope".length()).substring(idPart.lastIndexOf("-") + 1);
                 }
 
                 // Looking for kubernetes info

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
@@ -25,12 +25,14 @@ import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
@@ -51,7 +53,7 @@ public class SystemInfo {
     private static final String AWS_FARGATE_UID_REGEX = "^[0-9a-fA-F]{32}\\-[0-9]{10}$";
     private static final String POD_REGEX = "(?:^/kubepods[\\S]*/pod([^/]+)$)|(?:kubepods[^/]*-pod([^/]+)\\.slice)";
 
-    private static final String CGROUPV2_HOSTNAME_FILE = "/etc/hostname";
+    private static final String HOST_FILE = "/etc/hostname";
     private static final Pattern CGROUPV2_CONTAINER_PATTERN = Pattern.compile("^.*(" + CONTAINER_REGEX_64 + ").*$");
 
     private static final String SELF_CGROUP = "/proc/self/cgroup";
@@ -168,7 +170,15 @@ public class SystemInfo {
             try {
                 hostname = InetAddress.getLocalHost().getHostName();
             } catch (Exception e) {
-                logger.warn("Last fallback for hostname discovery of localhost failed", e);
+                logger.debug("Network fallback for hostname discovery of localhost failed", e);
+            }
+        }
+        if (hostname == null || hostname.isEmpty() && !isWindows) {
+            try (FileReader fileReader = new FileReader(HOST_FILE);
+                 BufferedReader reader = new BufferedReader(fileReader)) {
+                hostname = reader.readLine().trim();
+            } catch (IOException e) {
+                logger.debug(HOST_FILE + " fallback for hostname discovery of localhost failed", e);
             }
         }
         return hostname;
@@ -209,7 +219,7 @@ public class SystemInfo {
             logger.info("Failed to execute command {} with exit code {}", cmdAsString(cmd), commandOutput.getExitCode());
             logger.debug("Command execution error", commandOutput.getExceptionThrown());
         }
-        if(hostname != null) {
+        if (hostname != null) {
             hostname = hostname.toLowerCase(Locale.ROOT);
         }
         return hostname;
@@ -306,7 +316,7 @@ public class SystemInfo {
 
     @Nullable
     private void parseCgroupsFile(Path path) {
-        if(!Files.isRegularFile(path)){
+        if (!Files.isRegularFile(path)) {
             logger.debug("Could not parse container ID from '{}'", path);
             return;
         }
@@ -405,7 +415,7 @@ public class SystemInfo {
      */
     SystemInfo parseCgroupsV2ContainerId(List<String> lines) {
         for (String line : lines) {
-            int index = line.indexOf(CGROUPV2_HOSTNAME_FILE);
+            int index = line.indexOf(HOST_FILE);
             if (index > 0) {
                 String[] parts = line.split(" ");
                 if (parts.length > 3) {
@@ -416,9 +426,6 @@ public class SystemInfo {
                 }
             }
         }
-
-
-
 
         return this;
     }

--- a/apm-agent-core/src/test/resources/json-specs/container_metadata_discovery.json
+++ b/apm-agent-core/src/test/resources/json-specs/container_metadata_discovery.json
@@ -60,6 +60,41 @@
     },
     "containerId": "6548c6863fb748e72d1e2a4f824fde92f720952d062dede1318c2d6219a672d6",
     "podId": null
+  },
+  "gardener": {
+    "files": {
+      "/proc/self/mountinfo": [
+        "10112 5519 0:864 / / ro,relatime master:1972 - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/35235/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/27346/fs:/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/27345/fs:/var/lib/containerd/io.containerd.snapsh",
+        "10113 10112 0:884 / /proc rw,nosuid,nodev,noexec,relatime - proc proc rw",
+        "10301 10112 0:926 / /dev rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64",
+        "10302 10301 0:930 / /dev/pts rw,nosuid,noexec,relatime - devpts devpts rw,gid=5,mode=620,ptmxmode=666",
+        "10519 10301 0:820 / /dev/mqueue rw,nosuid,nodev,noexec,relatime - mqueue mqueue rw",
+        "10520 10112 0:839 / /sys ro,nosuid,nodev,noexec,relatime - sysfs sysfs ro",
+        "10716 10520 0:26 /kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod121157b5_c67d_4c3e_9052_cb27bbb711fb.slice/cri-containerd-1cd3449e930b8a28c7595240fa32ba20c84f36d059e5fbe63104ad40057992d1.scope /sys/fs/cgroup ro,nosuid,nodev,noexec,relatime - cgroup2 cgroup rw",
+        "10736 10112 8:3 /var/lib/kubelet/pods/121157b5-c67d-4c3e-9052-cb27bbb711fb/volumes/kubernetes.io~empty-dir/tmpdir /tmp rw,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10737 10112 0:786 / /vault/tls ro,relatime - tmpfs tmpfs rw,size=4194304k,inode64",
+        "10738 10112 8:3 /var/lib/kubelet/pods/121157b5-c67d-4c3e-9052-cb27bbb711fb/etc-hosts /etc/hosts rw,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10739 10301 8:3 /var/lib/kubelet/pods/121157b5-c67d-4c3e-9052-cb27bbb711fb/containers/application-search-indexer/9bf2b38c /dev/termination-log rw,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10740 10112 8:3 /var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/26a006f558da58874bc37863efe9d2b5d715afc54453d95b22a7809a4e65566c/hostname /etc/hostname ro,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10741 10112 8:3 /var/lib/containerd/io.containerd.grpc.v1.cri/sandboxes/26a006f558da58874bc37863efe9d2b5d715afc54453d95b22a7809a4e65566c/resolv.conf /etc/resolv.conf ro,relatime - ext4 /dev/sda3 rw,discard,prjquota,errors=remount-ro",
+        "10761 10301 0:788 / /dev/shm rw,nosuid,nodev,noexec,relatime - tmpfs shm rw,size=65536k,inode64",
+        "10762 10112 0:787 / /var/run/secrets/kubernetes.io/serviceaccount ro,relatime - tmpfs tmpfs rw,size=4194304k,inode64",
+        "5630 10113 0:884 /bus /proc/bus ro,nosuid,nodev,noexec,relatime - proc proc rw",
+        "5631 10113 0:884 /fs /proc/fs ro,nosuid,nodev,noexec,relatime - proc proc rw",
+        "5632 10113 0:884 /irq /proc/irq ro,nosuid,nodev,noexec,relatime - proc proc rw",
+        "5633 10113 0:884 /sys /proc/sys ro,nosuid,nodev,noexec,relatime - proc proc rw",
+        "5634 10113 0:931 / /proc/acpi ro,relatime - tmpfs tmpfs ro,inode64",
+        "5635 10113 0:926 /null /proc/kcore rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64",
+        "5636 10113 0:926 /null /proc/keys rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64",
+        "5637 10113 0:926 /null /proc/timer_list rw,nosuid - tmpfs tmpfs rw,size=65536k,mode=755,inode64",
+        "5639 10520 0:932 / /sys/firmware ro,relatime - tmpfs tmpfs ro,inode64"
+      ],
+      "/proc/self/cgroup": [
+        "0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod121157b5_c67d_4c3e_9052_cb27bbb711fb.slice/cri-containerd-1cd3449e930b8a28c7595240fa32ba20c84f36d059e5fbe63104ad40057992d1.scope"
+      ]
+    },
+    "containerId": "1cd3449e930b8a28c7595240fa32ba20c84f36d059e5fbe63104ad40057992d1",
+    "podId": "121157b5-c67d-4c3e-9052-cb27bbb711fb"
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

This fixes parsing of Gardener k8s metadata parsing: https://github.com/elastic/apm/pull/837

Adds an extra fallback heuristic for host name with the content of `/etc/hostname`: https://github.com/elastic/apm/pull/838

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
