### PR TITLE
buildkite: add permissions to observablt-robots-automation

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -28,7 +28,7 @@ spec:
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots-automation:
-          access_level: MANAGE_BUILD_AND_READ
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -62,7 +62,7 @@ spec:
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots-automation:
-          access_level: MANAGE_BUILD_AND_READ
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -96,7 +96,7 @@ spec:
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots-automation:
-          access_level: MANAGE_BUILD_AND_READ
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -131,7 +131,7 @@ spec:
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots-automation:
-          access_level: MANAGE_BUILD_AND_READ
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
       schedules:

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -27,6 +27,8 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ
+        observablt-robots-automation:
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -58,6 +60,8 @@ spec:
         apm-agent-java:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots:
+          access_level: MANAGE_BUILD_AND_READ
+        observablt-robots-automation:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
@@ -91,6 +95,8 @@ spec:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots:
           access_level: MANAGE_BUILD_AND_READ
+        observablt-robots-automation:
+          access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY
 
@@ -123,6 +129,8 @@ spec:
         apm-agent-java:
           access_level: MANAGE_BUILD_AND_READ
         observablt-robots:
+          access_level: MANAGE_BUILD_AND_READ
+        observablt-robots-automation:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
## What does this PR do?

Use a machine account which it's member of https://github.com/orgs/elastic/teams/observablt-robots-automation

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
