### PR TITLE
Add ability to change Naming Mode for spring-rabbit-plugin

### DIFF
--- a/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-plugin/src/main/java/co/elastic/apm/agent/rabbitmq/AbstractBaseInstrumentation.java
+++ b/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-plugin/src/main/java/co/elastic/apm/agent/rabbitmq/AbstractBaseInstrumentation.java
@@ -52,6 +52,10 @@ public abstract class AbstractBaseInstrumentation extends ElasticApmInstrumentat
         return !WildcardMatcher.isAnyMatch(coreConfiguration.getSanitizeFieldNames(), key);
     }
 
+    protected static MessagingConfiguration.RabbitMQNamingMode getRabbitMQNamingMode() {
+        return messagingConfiguration.getRabbitMQNamingMode();
+    }
+
     /**
      * Captures queue name and optional timestamp
      *

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
@@ -19,7 +19,6 @@
 package co.elastic.apm.agent.tracer.configuration;
 
 import co.elastic.apm.agent.common.util.WildcardMatcher;
-import co.elastic.apm.agent.tracer.configuration.WildcardMatcherValueConverter;
 import org.stagemonitor.configuration.ConfigurationOption;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
 import org.stagemonitor.configuration.converter.ListValueConverter;
@@ -33,7 +32,7 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
     private static final String MESSAGE_POLLING_TRANSACTION_STRATEGY = "message_polling_transaction_strategy";
     private static final String MESSAGE_BATCH_STRATEGY = "message_batch_strategy";
 
-    private ConfigurationOption<JmsStrategy> messagePollingTransactionStrategy = ConfigurationOption.enumOption(JmsStrategy.class)
+    private final ConfigurationOption<JmsStrategy> messagePollingTransactionStrategy = ConfigurationOption.enumOption(JmsStrategy.class)
         .key(MESSAGE_POLLING_TRANSACTION_STRATEGY)
         .configurationCategory(MESSAGING_CATEGORY)
         .tags("internal")
@@ -45,7 +44,7 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
         .dynamic(true)
         .buildWithDefault(JmsStrategy.HANDLING);
 
-    private ConfigurationOption<BatchStrategy> messageBatchStrategy = ConfigurationOption.enumOption(BatchStrategy.class)
+    private final ConfigurationOption<BatchStrategy> messageBatchStrategy = ConfigurationOption.enumOption(BatchStrategy.class)
         .key(MESSAGE_BATCH_STRATEGY)
         .configurationCategory(MESSAGING_CATEGORY)
         .tags("internal")
@@ -57,7 +56,7 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
         .dynamic(true)
         .buildWithDefault(BatchStrategy.BATCH_HANDLING);
 
-    private ConfigurationOption<Boolean> collectQueueAddress = ConfigurationOption.booleanOption()
+    private final ConfigurationOption<Boolean> collectQueueAddress = ConfigurationOption.booleanOption()
         .key("collect_queue_address")
         .configurationCategory(MESSAGING_CATEGORY)
         .tags("internal")
@@ -77,7 +76,7 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
             "\n" +
             WildcardMatcher.DOCUMENTATION)
         .dynamic(true)
-        .buildWithDefault(Collections.<WildcardMatcher>emptyList());
+        .buildWithDefault(Collections.emptyList());
 
     private final ConfigurationOption<Boolean> endMessagingTransactionOnPoll = ConfigurationOption.booleanOption()
         .key("end_messaging_transaction_on_poll")
@@ -107,7 +106,14 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
             "Starting from version 1.43.0, the classes that are part of the 'application_packages' option are also included in the list of classes considered."
         )
         .dynamic(false)
-        .buildWithDefault(Collections.<String>emptyList());
+        .buildWithDefault(Collections.emptyList());
+
+    private final ConfigurationOption<RabbitMQNamingMode> rabbitMQNamingMode = ConfigurationOption.enumOption(RabbitMQNamingMode.class)
+        .key("rabbitmq_naming_mode")
+        .configurationCategory(MESSAGING_CATEGORY)
+        .description("Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions.")
+        .dynamic(true)
+        .buildWithDefault(RabbitMQNamingMode.EXCHANGE);
 
     public JmsStrategy getMessagePollingTransactionStrategy() {
         return messagePollingTransactionStrategy.get();
@@ -131,6 +137,10 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
 
     public Collection<String> getJmsListenerPackages() {
         return jmsListenerPackages.get();
+    }
+
+    public RabbitMQNamingMode getRabbitMQNamingMode() {
+        return rabbitMQNamingMode.get();
     }
 
     public enum JmsStrategy {
@@ -163,5 +173,16 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
          * Create a single transaction encapsulating the entire message/record batch-processing.
          */
         BATCH_HANDLING
+    }
+
+    public enum RabbitMQNamingMode {
+        /**
+         * Use exchange in transaction names
+         */
+        EXCHANGE,
+        /**
+         * Use queue in transaction names
+         */
+        QUEUE,
     }
 }

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
@@ -76,7 +76,7 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
             "\n" +
             WildcardMatcher.DOCUMENTATION)
         .dynamic(true)
-        .buildWithDefault(Collections.emptyList());
+        .buildWithDefault(Collections.<WildcardMatcher>emptyList());
 
     private final ConfigurationOption<Boolean> endMessagingTransactionOnPoll = ConfigurationOption.booleanOption()
         .key("end_messaging_transaction_on_poll")
@@ -106,7 +106,7 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
             "Starting from version 1.43.0, the classes that are part of the 'application_packages' option are also included in the list of classes considered."
         )
         .dynamic(false)
-        .buildWithDefault(Collections.emptyList());
+        .buildWithDefault(Collections.<String>emptyList());
 
     private final ConfigurationOption<RabbitMQNamingMode> rabbitMQNamingMode = ConfigurationOption.enumOption(RabbitMQNamingMode.class)
         .key("rabbitmq_naming_mode")


### PR DESCRIPTION
## What does this PR do?
This PR adds the ability to change the Naming Mode for the spring-rabbit plugin. It offers 2 naming modes as a configuration option: EXCHANGE and QUEUE. EXCHANGE ist the default and does not change the plugins current behaviour. If one chooses QUEUE, then the names of the rabbit transactions contain the queue names instead of the exchange names.
See Issue #3421 

## Checklist
- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
