### PR TITLE
Update remaining projects to spring boot 3.2

### DIFF
--- a/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-plugin/pom.xml
@@ -22,7 +22,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.1.5</version> <!-- update IT in case of major upgrade -->
+                <version>3.2.0</version> <!-- update IT in case of major upgrade -->
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/pom.xml
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-plugin/pom.xml
@@ -22,7 +22,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.1.5</version> <!-- must be 3.X to correspond to spring 6 -->
+                <version>3.2.0</version> <!-- must be 3.X to correspond to spring 6 -->
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/apm-agent-plugins/apm-spring-webmvc/pom.xml
+++ b/apm-agent-plugins/apm-spring-webmvc/pom.xml
@@ -29,7 +29,7 @@
                 <!-- Import dependency management from Spring Boot -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.1.5</version> <!-- must be 3.X to correspond to spring 6 -->
+                <version>3.2.0</version> <!-- must be 3.X to correspond to spring 6 -->
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/integration-tests/spring-boot-2/spring-boot-2-base/src/test/java/co/elastic/apm/spring/boot/AbstractSpringBootTest.java
+++ b/integration-tests/spring-boot-2/spring-boot-2-base/src/test/java/co/elastic/apm/spring/boot/AbstractSpringBootTest.java
@@ -78,8 +78,8 @@ public abstract class AbstractSpringBootTest {
     public void setUp() {
         doReturn(true).when(config.getConfig(ReporterConfiguration.class)).isReportSynchronously();
         restTemplate = new TestRestTemplate(new RestTemplateBuilder()
-            .setConnectTimeout(Duration.ZERO)
-            .setReadTimeout(Duration.ZERO)
+            .setConnectTimeout(Duration.ofSeconds(10))
+            .setReadTimeout(Duration.ofSeconds(10))
             .basicAuthentication("username", "password"));
         reporter.reset();
     }

--- a/integration-tests/spring-boot-3/pom.xml
+++ b/integration-tests/spring-boot-3/pom.xml
@@ -30,7 +30,7 @@
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
-                <version>3.1.5</version>
+                <version>3.2.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/integration-tests/spring-boot-3/spring-boot-3-jetty/pom.xml
+++ b/integration-tests/spring-boot-3/spring-boot-3-jetty/pom.xml
@@ -17,11 +17,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakarta.servlet</groupId>
-            <artifactId>jakarta.servlet-api</artifactId>
-            <version>5.0.0</version> <!-- jetty doesn't support servlet API 6.x -->
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>spring-boot-2-base</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
## What does this PR do?

For some reason dependabot failed to upgrade tex existing spring boot `3.1.5` versions to `3.2.0`, so doing it manually now.

## Checklist

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
