### PR TITLE
Upgrade to OpenTelemetry 1.32.0, add support for bucket boundaries metrics API

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -37,6 +37,13 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Only automatically apply redacted exceptions for Corretto JVM 17-20. Outside that, user should use capture_exception_details=false to workaround the JVM race-condition bug if it gets triggered: {pull}3438[#3438]
 * Added support for Spring 6.1 / Spring-Boot 3.2 - {pull}3440[#3440]
 
+[float]
+===== Potentially breaking changes
+* Added support for OpenTelemetry 1.32.0. As a result, `custom_metrics_histogram_boundaries` will not
+work when you bring your own `MeterProvider` from an SDK with version `1.32.0` or newer. As a workaround,
+you should manually register a corresponding View in your `MeterProvider`. Note that this change will not
+affect you, if you are using the OpenTelemetry API only and not the SDK. - {pull}3447[#3447]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,7 +39,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 [float]
 ===== Potentially breaking changes
-* Added support for OpenTelemetry 1.32.0. As a result, `custom_metrics_histogram_boundaries` will not
+* Added support for OpenTelemetry `1.32.0`. As a result, `custom_metrics_histogram_boundaries` will not
 work when you bring your own `MeterProvider` from an SDK with version `1.32.0` or newer. As a workaround,
 you should manually register a corresponding View in your `MeterProvider`. Note that this change will not
 affect you, if you are using the OpenTelemetry API only and not the SDK. - {pull}3447[#3447]

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/MetricsConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/MetricsConfiguration.java
@@ -48,7 +48,10 @@ public class MetricsConfiguration extends ConfigurationOptionProvider implements
     private final ConfigurationOption<List<Double>> customMetricsHistogramBoundaries = ConfigurationOption.builder(new ListValueConverter<>(DoubleValueConverter.INSTANCE), List.class)
         .key("custom_metrics_histogram_boundaries")
         .configurationCategory(METRICS_CATEGORY)
-        .description("Defines the default bucket boundaries to use for OpenTelemetry histograms.")
+        .description("Defines the default bucket boundaries to use for OpenTelemetry histograms.\n" +
+            "\n" +
+            "Note that for OpenTelemetry 1.32.0 or newer this setting will only work when using API only. " +
+            "The default buckets will not be applied when bringing your own SDK.")
         .dynamic(false)
         .tags("added[1.37.0]", "experimental")
         .addValidator(new ConfigurationOption.Validator<List<Double>>() {

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-embedded-metrics-sdk/src/main/java/co/elastic/apm/agent/embeddedotel/proxy/ProxyDoubleHistogramBuilder.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-embedded-metrics-sdk/src/main/java/co/elastic/apm/agent/embeddedotel/proxy/ProxyDoubleHistogramBuilder.java
@@ -22,6 +22,8 @@ import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongHistogramBuilder;
 
+import java.util.List;
+
 public class ProxyDoubleHistogramBuilder {
 
     private final DoubleHistogramBuilder delegate;
@@ -52,4 +54,8 @@ public class ProxyDoubleHistogramBuilder {
         return this;
     }
 
+    public ProxyDoubleHistogramBuilder setExplicitBucketBoundariesAdvice(List<Double> bucketBoundaries) {
+        delegate.setExplicitBucketBoundariesAdvice(bucketBoundaries);
+        return this;
+    }
 }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-embedded-metrics-sdk/src/main/java/co/elastic/apm/agent/embeddedotel/proxy/ProxyDoubleHistogramBuilder.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-embedded-metrics-sdk/src/main/java/co/elastic/apm/agent/embeddedotel/proxy/ProxyDoubleHistogramBuilder.java
@@ -18,9 +18,9 @@
  */
 package co.elastic.apm.agent.embeddedotel.proxy;
 
-import io.opentelemetry.api.metrics.DoubleHistogram;
+import co.elastic.apm.agent.configuration.MetricsConfiguration;
+import co.elastic.apm.agent.tracer.GlobalTracer;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
-import io.opentelemetry.api.metrics.LongHistogramBuilder;
 
 import java.util.List;
 
@@ -30,6 +30,9 @@ public class ProxyDoubleHistogramBuilder {
 
     public ProxyDoubleHistogramBuilder(DoubleHistogramBuilder delegate) {
         this.delegate = delegate;
+        //apply default bucket boundaries
+        List<Double> boundaries = GlobalTracer.get().getConfig(MetricsConfiguration.class).getCustomMetricsHistogramBoundaries();
+        delegate.setExplicitBucketBoundariesAdvice(boundaries);
     }
 
     public DoubleHistogramBuilder getDelegate() {

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-embedded-metrics-sdk/src/main/java/co/elastic/apm/agent/embeddedotel/proxy/ProxyLongHistogramBuilder.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-embedded-metrics-sdk/src/main/java/co/elastic/apm/agent/embeddedotel/proxy/ProxyLongHistogramBuilder.java
@@ -31,7 +31,7 @@ public class ProxyLongHistogramBuilder {
 
     public ProxyLongHistogramBuilder(LongHistogramBuilder delegate) {
         this.delegate = delegate;
-        //apply default bucket boundaries
+        //apply default bucket boundaries, they are guaranteed to be ordered
         List<Double> boundaries = GlobalTracer.get().getConfig(MetricsConfiguration.class).getCustomMetricsHistogramBoundaries();
         delegate.setExplicitBucketBoundariesAdvice(convertToLongBoundaries(boundaries));
     }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-latest/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/BridgeFactoryLatest.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-latest/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/BridgeFactoryLatest.java
@@ -21,25 +21,31 @@ package co.elastic.apm.agent.opentelemetry.metrics.bridge;
 import co.elastic.apm.agent.embeddedotel.proxy.ProxyBatchCallback;
 import co.elastic.apm.agent.embeddedotel.proxy.ProxyDoubleCounterBuilder;
 import co.elastic.apm.agent.embeddedotel.proxy.ProxyDoubleGaugeBuilder;
+import co.elastic.apm.agent.embeddedotel.proxy.ProxyDoubleHistogramBuilder;
 import co.elastic.apm.agent.embeddedotel.proxy.ProxyDoubleUpDownCounterBuilder;
 import co.elastic.apm.agent.embeddedotel.proxy.ProxyLongCounterBuilder;
 import co.elastic.apm.agent.embeddedotel.proxy.ProxyLongGaugeBuilder;
+import co.elastic.apm.agent.embeddedotel.proxy.ProxyLongHistogramBuilder;
 import co.elastic.apm.agent.embeddedotel.proxy.ProxyLongUpDownCounterBuilder;
 import co.elastic.apm.agent.embeddedotel.proxy.ProxyMeter;
 import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeBatchCallback;
 import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeDoubleCounterBuilder;
 import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeDoubleGaugeBuilder;
+import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeDoubleHistogramBuilder;
 import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeDoubleUpDownCounterBuilder;
 import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeLongCounterBuilder;
 import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeLongGaugeBuilder;
+import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeLongHistogramBuilder;
 import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeLongUpDownCounterBuilder;
 import co.elastic.apm.agent.opentelemetry.metrics.bridge.latest.BridgeMeter;
 import io.opentelemetry.api.metrics.BatchCallback;
 import io.opentelemetry.api.metrics.DoubleCounterBuilder;
 import io.opentelemetry.api.metrics.DoubleGaugeBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.DoubleUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.LongCounterBuilder;
 import io.opentelemetry.api.metrics.LongGaugeBuilder;
+import io.opentelemetry.api.metrics.LongHistogramBuilder;
 import io.opentelemetry.api.metrics.LongUpDownCounterBuilder;
 import io.opentelemetry.api.metrics.Meter;
 
@@ -98,5 +104,15 @@ public class BridgeFactoryLatest extends BridgeFactoryV1_14 {
 
     public BatchCallback bridgeBatchCallback(ProxyBatchCallback delegate) {
         return new BridgeBatchCallback(delegate);
+    }
+
+    @Override
+    public DoubleHistogramBuilder bridgeDoubleHistogramBuilder(ProxyDoubleHistogramBuilder delegate) {
+        return new BridgeDoubleHistogramBuilder(delegate);
+    }
+
+    @Override
+    public LongHistogramBuilder bridgeLongHistogramBuilder(ProxyLongHistogramBuilder delegate) {
+        return new BridgeLongHistogramBuilder(delegate);
     }
 }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-latest/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/latest/BridgeDoubleHistogramBuilder.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-latest/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/latest/BridgeDoubleHistogramBuilder.java
@@ -16,40 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.embeddedotel.proxy;
+package co.elastic.apm.agent.opentelemetry.metrics.bridge.latest;
 
-import io.opentelemetry.api.metrics.LongHistogram;
-import io.opentelemetry.api.metrics.LongHistogramBuilder;
+import co.elastic.apm.agent.embeddedotel.proxy.ProxyDoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 
 import java.util.List;
 
-public class ProxyLongHistogramBuilder {
-
-    private final LongHistogramBuilder delegate;
-
-    public ProxyLongHistogramBuilder(LongHistogramBuilder delegate) {
-        this.delegate = delegate;
+public class BridgeDoubleHistogramBuilder extends co.elastic.apm.agent.opentelemetry.metrics.bridge.v1_14.BridgeDoubleHistogramBuilder {
+    public BridgeDoubleHistogramBuilder(ProxyDoubleHistogramBuilder delegate) {
+        super(delegate);
     }
 
-    public LongHistogramBuilder getDelegate() {
-        return delegate;
-    }
-
-    public ProxyLongHistogram build() {
-        return new ProxyLongHistogram(delegate.build());
-    }
-
-    public ProxyLongHistogramBuilder setUnit(String arg0) {
-        delegate.setUnit(arg0);
-        return this;
-    }
-
-    public ProxyLongHistogramBuilder setDescription(String arg0) {
-        delegate.setDescription(arg0);
-        return this;
-    }
-
-    public ProxyLongHistogramBuilder setExplicitBucketBoundariesAdvice(List<Long> bucketBoundaries) {
+    /**
+     * This method was added in 1.32.0, but is safe to have even if the provided API is older.
+     * This is safe because it doesn't reference any newly added API types.
+     */
+    @Override
+    public DoubleHistogramBuilder setExplicitBucketBoundariesAdvice(List<Double> bucketBoundaries) {
         delegate.setExplicitBucketBoundariesAdvice(bucketBoundaries);
         return this;
     }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-latest/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/latest/BridgeLongHistogramBuilder.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-latest/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/latest/BridgeLongHistogramBuilder.java
@@ -16,40 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.embeddedotel.proxy;
+package co.elastic.apm.agent.opentelemetry.metrics.bridge.latest;
 
-import io.opentelemetry.api.metrics.LongHistogram;
+import co.elastic.apm.agent.embeddedotel.proxy.ProxyDoubleHistogramBuilder;
+import co.elastic.apm.agent.embeddedotel.proxy.ProxyLongHistogramBuilder;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.LongHistogramBuilder;
 
 import java.util.List;
 
-public class ProxyLongHistogramBuilder {
-
-    private final LongHistogramBuilder delegate;
-
-    public ProxyLongHistogramBuilder(LongHistogramBuilder delegate) {
-        this.delegate = delegate;
+public class BridgeLongHistogramBuilder extends co.elastic.apm.agent.opentelemetry.metrics.bridge.v1_14.BridgeLongHistogramBuilder {
+    public BridgeLongHistogramBuilder(ProxyLongHistogramBuilder delegate) {
+        super(delegate);
     }
 
-    public LongHistogramBuilder getDelegate() {
-        return delegate;
-    }
-
-    public ProxyLongHistogram build() {
-        return new ProxyLongHistogram(delegate.build());
-    }
-
-    public ProxyLongHistogramBuilder setUnit(String arg0) {
-        delegate.setUnit(arg0);
-        return this;
-    }
-
-    public ProxyLongHistogramBuilder setDescription(String arg0) {
-        delegate.setDescription(arg0);
-        return this;
-    }
-
-    public ProxyLongHistogramBuilder setExplicitBucketBoundariesAdvice(List<Long> bucketBoundaries) {
+    /**
+     * This method was added in 1.32.0, but is safe to have even if the provided API is older.
+     * This is safe because it doesn't reference any newly added API types.
+     */
+    @Override
+    public LongHistogramBuilder setExplicitBucketBoundariesAdvice(List<Long> bucketBoundaries) {
         delegate.setExplicitBucketBoundariesAdvice(bucketBoundaries);
         return this;
     }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/main/java/co/elastic/apm/agent/otelmetricsdk/ElasticOtelMetricsExporter.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/main/java/co/elastic/apm/agent/otelmetricsdk/ElasticOtelMetricsExporter.java
@@ -121,7 +121,7 @@ public class ElasticOtelMetricsExporter implements MetricExporter {
         try {
             DoubleHistogramBuilder.class.getMethod("setExplicitBucketBoundariesAdvice", List.class);
             return true;
-        } catch (NoSuchMethodException e) {
+        } catch (NoSuchMethodException | SecurityException e) {
             return false;
         }
     }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/main/java/co/elastic/apm/agent/otelmetricsdk/ElasticOtelMetricsExporter.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/main/java/co/elastic/apm/agent/otelmetricsdk/ElasticOtelMetricsExporter.java
@@ -25,6 +25,7 @@ import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.sdk.internal.util.ExecutorUtils;
 import co.elastic.apm.agent.tracer.configuration.MetricsConfiguration;
 import co.elastic.apm.agent.tracer.configuration.ReporterConfiguration;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.sdk.common.CompletableResultCode;
 import io.opentelemetry.sdk.metrics.Aggregation;
 import io.opentelemetry.sdk.metrics.InstrumentType;
@@ -37,12 +38,15 @@ import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 
 public class ElasticOtelMetricsExporter implements MetricExporter {
 
     private static final Logger logger = LoggerFactory.getLogger(ElasticOtelMetricsExporter.class);
 
     private static final AggregationTemporalitySelector TEMPORALITY_SELECTOR = AggregationTemporalitySelector.deltaPreferred();
+
+    private static final boolean API_SUPPORTS_BUCKET_ADVICE = checkOtelApiSupportsHistogramBucketAdvice();
 
     private final Aggregation defaultHistogramAggregation;
 
@@ -103,10 +107,22 @@ public class ElasticOtelMetricsExporter implements MetricExporter {
 
     @Override
     public Aggregation getDefaultAggregation(InstrumentType instrumentType) {
-        if (instrumentType == InstrumentType.HISTOGRAM) {
+        // Unfortunately advices are not applied when a non-default aggregation is returned here
+        // When instrumenting API-usages, we now apply the default histogram boundaries via the
+        // ProxyLongHistogramBuilder and ProxyDoubleHistogramBuilder
+        if (instrumentType == InstrumentType.HISTOGRAM && !API_SUPPORTS_BUCKET_ADVICE) {
             return defaultHistogramAggregation;
         } else {
             return Aggregation.defaultAggregation();
+        }
+    }
+
+    private static boolean checkOtelApiSupportsHistogramBucketAdvice() {
+        try {
+            DoubleHistogramBuilder.class.getMethod("setExplicitBucketBoundariesAdvice", List.class);
+            return true;
+        } catch (NoSuchMethodException e) {
+            return false;
         }
     }
 }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/test/java/co/elastic/apm/agent/otelmetricsdk/PrivateUserSdkOtelMetricsTest.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/test/java/co/elastic/apm/agent/otelmetricsdk/PrivateUserSdkOtelMetricsTest.java
@@ -20,6 +20,7 @@ package co.elastic.apm.agent.otelmetricsdk;
 
 import co.elastic.apm.agent.configuration.MetricsConfiguration;
 import io.opentelemetry.api.metrics.DoubleHistogram;
+import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.metrics.Aggregation;
@@ -93,6 +94,23 @@ public class PrivateUserSdkOtelMetricsTest extends AbstractOtelMetricsTest {
     @Override
     protected void invokeSdkForceFlush() {
         ((SdkMeterProvider) getMeterProvider()).forceFlush();
+    }
+
+
+    @Test
+    @Override
+    public void testDefaultHistogramBuckets() {
+        // Unfortunately default histogram buckets don't work with user-provided SDKs of version 1.32.0 or newer
+        // The reason is that a default aggregation provided by the exporter would override
+        // bucket boundaries set via DoubleHistogramBuilder.setExplicitBucketBoundaries
+        // We decided to instead respect the bucket boundaries provided by the API
+        try {
+            DoubleHistogramBuilder.class.getMethod("setExplicitBucketBoundariesAdvice", List.class);
+            //Method exists, default bucket boundaries are not supported
+            //Don't execute test for that reason
+        } catch (NoSuchMethodException e) {
+            super.testDefaultHistogramBuckets();
+        }
     }
 
     @Test

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-test/src/test/java/co/elastic/apm/agent/opentelemetry/OpenTelemetryVersionIT.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-test/src/test/java/co/elastic/apm/agent/opentelemetry/OpenTelemetryVersionIT.java
@@ -95,6 +95,7 @@ public class OpenTelemetryVersionIT {
         List<String> dependencies = List.of(
             "io.opentelemetry:opentelemetry-api:" + version,
             "io.opentelemetry:opentelemetry-sdk-metrics:" + version,
+            "io.opentelemetry:opentelemetry-extension-incubator:" + version+"-alpha",
             "io.opentelemetry:opentelemetry-sdk-common:" + version,
             "io.opentelemetry:opentelemetry-context:" + version,
             semConvDep);

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-test/src/test/java/co/elastic/apm/agent/opentelemetry/OpenTelemetryVersionIT.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-test/src/test/java/co/elastic/apm/agent/opentelemetry/OpenTelemetryVersionIT.java
@@ -65,25 +65,18 @@ public class OpenTelemetryVersionIT {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "1.10.0",
-        //"1.11.0",
-        //"1.12.0",
-        //"1.13.0",
-        "1.14.0",
-        "1.15.0",
-        //"1.16.0",
-        //"1.17.0",
-        //"1.18.0",
-        //"1.19.0",
-        //"1.20.0",
-        "1.21.0"
-    })
-    void testAgentProvidedMetricsSdkForApiVersion(String version) throws Exception {
+    @CsvSource(value = {
+        "1.10.0|io.opentelemetry:opentelemetry-semconv:1.10.0-alpha",
+        "1.14.0|io.opentelemetry:opentelemetry-semconv:1.14.0-alpha",
+        "1.15.0|io.opentelemetry:opentelemetry-semconv:1.15.0-alpha",
+        "1.21.0|io.opentelemetry:opentelemetry-semconv:1.21.0-alpha",
+        "1.31.0|io.opentelemetry.semconv:opentelemetry-semconv:1.22.0-alpha",
+    }, delimiterString = "|")
+    void testAgentProvidedMetricsSdkForApiVersion(String version, String semConvDep) throws Exception {
         List<String> dependencies = List.of(
             "io.opentelemetry:opentelemetry-api:" + version,
             "io.opentelemetry:opentelemetry-context:" + version,
-            "io.opentelemetry:opentelemetry-semconv:" + version + "-alpha");
+            semConvDep);
         TestClassWithDependencyRunner runner = new TestClassWithDependencyRunner(dependencies,
             "co.elastic.apm.agent.opentelemetry.metrics.AgentProvidedSdkOtelMetricsTest",
             "co.elastic.apm.agent.otelmetricsdk.AbstractOtelMetricsTest",
@@ -93,21 +86,18 @@ public class OpenTelemetryVersionIT {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = {
-        "1.16.0",
-        //"1.17.0",
-        //"1.18.0",
-        //"1.19.0",
-        //"1.20.0",
-        "1.21.0"
-    })
-    void testUserProvidedMetricsSdkVersion(String version) throws Exception {
+    @CsvSource(value = {
+        "1.16.0|io.opentelemetry:opentelemetry-semconv:1.16.0-alpha",
+        "1.21.0|io.opentelemetry:opentelemetry-semconv:1.21.0-alpha",
+        "1.31.0|io.opentelemetry.semconv:opentelemetry-semconv:1.22.0-alpha",
+    }, delimiterString = "|")
+    void testUserProvidedMetricsSdkVersion(String version, String semConvDep) throws Exception {
         List<String> dependencies = List.of(
             "io.opentelemetry:opentelemetry-api:" + version,
             "io.opentelemetry:opentelemetry-sdk-metrics:" + version,
             "io.opentelemetry:opentelemetry-sdk-common:" + version,
             "io.opentelemetry:opentelemetry-context:" + version,
-            "io.opentelemetry:opentelemetry-semconv:" + version + "-alpha");
+            semConvDep);
         TestClassWithDependencyRunner runner = new TestClassWithDependencyRunner(dependencies,
             "co.elastic.apm.agent.otelmetricsdk.PrivateUserSdkOtelMetricsTest",
             "co.elastic.apm.agent.otelmetricsdk.AbstractOtelMetricsTest",

--- a/apm-agent-plugins/apm-opentelemetry/pom.xml
+++ b/apm-agent-plugins/apm-opentelemetry/pom.xml
@@ -19,7 +19,7 @@
         When updating the version, add the old version to OpenTelemetryVersionIT
         to make sure that in the future we stay compatible with the previous version.
         -->
-        <version.opentelemetry>1.31.0</version.opentelemetry>
+        <version.opentelemetry>1.32.0</version.opentelemetry>
         <version.opentelemetry-semconv>1.22.0-alpha</version.opentelemetry-semconv>
 
         <maven.compiler.target>8</maven.compiler.target>

--- a/docs/api-opentelemetry.asciidoc
+++ b/docs/api-opentelemetry.asciidoc
@@ -149,6 +149,8 @@ In both cases the Elastic APM Agent will respect the <<config-disable-metrics, `
 
 You can use the <<config-custom-metrics-histogram-boundaries, `custom_metrics_histogram_boundaries`>> setting to customize histogram bucket boundaries.
 Alternatively you can use OpenTelemetry `Views` to define histogram buckets on a per-metric basis when providing your own `MeterProvider`.
+Note that  `custom_metrics_histogram_boundaries` will only work for API Usages. If you bring your own `MeterProvider` and therefore your own OpenTelemetry SDK,
+the setting will only work for SDK versions prior to `1.32.0`.
 
 [float]
 [[otel-metrics-api]]
@@ -178,7 +180,7 @@ If you provide your own `MeterProvider` (see <<otel-metrics-sdk>>), the agent wi
 In some cases using just the <<otel-metrics-api, OpenTelemetry API for metrics>> might not be flexible enough.
 Some example use cases are:
 
- * Using OpenTelemetry Views (e.g. to customize histogram buckets on a per-metric basis)
+ * Using OpenTelemetry Views
  * Exporting metrics to other tools in addition to Elastic APM (e.g. prometheus)
 
 For these use cases you can just setup you OpenTelemetry SDK `MeterProvider`.

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -2547,6 +2547,8 @@ NOTE: This feature is currently experimental, which means it is disabled by defa
 
 Defines the default bucket boundaries to use for OpenTelemetry histograms.
 
+Note that for OpenTelemetry 1.32.0 or newer this setting will only work when using API only. The default buckets will not be applied when bringing your own SDK.
+
 
 
 
@@ -4618,6 +4620,8 @@ Example: `5ms`.
 # dedot_custom_metrics=true
 
 # Defines the default bucket boundaries to use for OpenTelemetry histograms.
+# 
+# Note that for OpenTelemetry 1.32.0 or newer this setting will only work when using API only. The default buckets will not be applied when bringing your own SDK.
 #
 # This setting can not be changed at runtime. Changes require a restart of the application.
 # Type: comma separated list


### PR DESCRIPTION
## What does this PR do?

Upgrades to OpenTelemetry 1.32.0. Superseeds #3433.

Looks like our unit tests are doing their job and detected a new OpenTelemetry default method for which we need to add support:
```
AssertionFailedError: Expected bridge type 'co.elastic.apm.agent.opentelemetry.metrics.bridge.v1_14.BridgeLongHistogramBuilder' to implement default method 'public default io.opentelemetry.api.metrics.LongHistogramBuilder io.opentelemetry.api.metrics.LongHistogramBuilder.setExplicitBucketBoundariesAdvice(java.util.List)' from type 'interface io.opentelemetry.api.metrics.LongHistogramBuilder'
```

OpenTelemetry `1.32.0` adds the capability to define histogram bucket boundaries via the OpenTelemetry API.
Unfortunately this feature only works for exporters which rely on the default aggregation.

For our `custom_metrics_histogram_boundaries` however we needed to provide a custom aggregation from our exporter.
I've fixed this by changing the approach:
 * Our exporter uses the default aggregation
 * Whenever a new `HistogramBuilder` is created, we initialize it's bucket boundaries to `custom_metrics_histogram_boundaries` via the new `setExplicitBucketBoundariesAdvice` method.
 
 Unfortunately this will not work in use-cases where we [instrument the SDK](https://www.elastic.co/guide/en/apm/agent/java/current/opentelemetry-bridge.html#otel-metrics-sdk) instead of the [API](https://www.elastic.co/guide/en/apm/agent/java/current/opentelemetry-bridge.html#otel-metrics-api).
 
 I would however say that this is acceptable and clarified the behaviour in the documentation.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] ~Added an API method or config option? Document in which version this will be introduced~
  - [x] I have made corresponding changes to the documentation
