### PR TITLE
Disable SpringAmqpBatchIT due to flakyness

### DIFF
--- a/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-spring/src/test/java/co/elastic/apm/agent/rabbitmq/SpringAmqpBatchIT.java
+++ b/apm-agent-plugins/apm-rabbitmq/apm-rabbitmq-spring/src/test/java/co/elastic/apm/agent/rabbitmq/SpringAmqpBatchIT.java
@@ -25,6 +25,7 @@ import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.rabbitmq.components.batch.BatchListenerComponent;
 import co.elastic.apm.agent.rabbitmq.config.BatchConfiguration;
 import co.elastic.apm.agent.tracer.configuration.MessagingConfiguration;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.amqp.rabbit.core.BatchingRabbitTemplate;
@@ -45,6 +46,7 @@ import static org.mockito.Mockito.doReturn;
 @RunWith(SpringRunner.class)
 @SpringBootTest
 @ContextConfiguration(classes = {BatchConfiguration.class, BatchListenerComponent.class}, initializers = {RabbitMqTestBase.Initializer.class})
+@Ignore("Test causes CI flakyness, presumably due to unclean shutdown of RabbitMqTestBase: Can pre reproduced by running the test in repeated mode locally.")
 public class SpringAmqpBatchIT extends RabbitMqTestBase {
 
     @Autowired


### PR DESCRIPTION
## What does this PR do?

Unfortunately is looks like SpringAmqpBatchIT still causes flakyness on the CI, see [this run](https://github.com/elastic/apm-agent-java/actions/runs/7063241319/job/19228982570?pr=3450) for exmaple.
I assume it is due to the RabbitMQ containers not being properly shutdown, because it can be reproduced by running the test in repeated mode locally.
