### PR TITLE
chore: rename apm-mutating-webhook to apm-k8s-attacher

### DIFF
--- a/.buildkite/scripts/opentelemetry-benchmark.sh
+++ b/.buildkite/scripts/opentelemetry-benchmark.sh
@@ -27,8 +27,8 @@ BENCHMARKS_JAR_FILE="$(pwd)/$BENCHMARKS_JAR"
 echo "$BENCHMARKS_JAR_FILE has been downloaded."
 
 echo "--- Start APM Server mock"
-git clone https://github.com/elastic/apm-mutating-webhook.git
-pushd apm-mutating-webhook/test/mock
+git clone https://github.com/elastic/apm-k8s-attacher.git
+pushd apm-k8s-attacher/test/mock
 docker build -t $CONTAINER_NAME .
 docker run -dp 127.0.0.1:8027:8027 $CONTAINER_NAME
 popd

--- a/apm-agent-common/src/main/java/co/elastic/apm/agent/configuration/ActivationMethod.java
+++ b/apm-agent-common/src/main/java/co/elastic/apm/agent/configuration/ActivationMethod.java
@@ -20,7 +20,7 @@ package co.elastic.apm.agent.configuration;
 
 public enum ActivationMethod {
     // Set explicitly by the process starting the agent
-    K8S_ATTACH, // https://github.com/elastic/apm-mutating-webhook
+    K8S_ATTACH, // https://github.com/elastic/apm-k8s-attacher
     AWS_LAMBDA_LAYER, // Only if installed by using layers (as other metadata already identifies lambda)
     FLEET, // Fleet using 'java -jar apm-agent-attach-cli.jar ...' to attach (directly or through webhook)
     APM_AGENT_ATTACH_CLI, // 'java -jar apm-agent-attach-cli.jar ...' used


### PR DESCRIPTION
## What is the change being made?

* Rename `apm-mutating-webhook` to `apm-k8s-attacher`

## Why is the change being made?

* The repository `apm-mutating-webhook` has been renamed to `apm-k8s-attacher`.
* The documentation CI doesn't build it anymore.