### PR TITLE
wiremock update

### DIFF
--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/AbstractAws1ClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-1-plugin/src/test/java/co/elastic/apm/agent/awssdk/v1/AbstractAws1ClientIT.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.awssdk.v1;
 
 import co.elastic.apm.agent.awssdk.common.AbstractAwsClientIT;

--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/AbstractAws2ClientIT.java
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/src/test/java/co/elastic/apm/agent/awssdk/v2/AbstractAws2ClientIT.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.awssdk.v2;
 
 import co.elastic.apm.agent.awssdk.common.AbstractAwsClientIT;

--- a/pom.xml
+++ b/pom.xml
@@ -777,7 +777,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>
-            <version>2.35.0</version>
+            <version>2.35.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
closes #3464 

## What does this PR do?
- just update wiremock to prevent further reports as it's just used as test dependency and we don't use the impacted features.
