### PR TITLE
ci: support no secrets for dependabot

### DIFF
--- a/.ci/scripts/jboss-pull.sh
+++ b/.ci/scripts/jboss-pull.sh
@@ -3,6 +3,24 @@
 # Bash strict mode
 set -eo pipefail
 
+# Retry the given command for the given times.
+retry() {
+  local retries=$1
+  shift
+  local count=0
+  until "$@"; do
+    exit=$?
+    wait=$((2 ** count))
+    count=$((count + 1))
+    if [ $count -lt "$retries" ]; then
+      sleep $wait
+    else
+      return $exit
+    fi
+  done
+  return 0
+}
+
 ## This script is used by the CI to be able to re-tag the docker images
 ## to use the official docker namespace.
 ## Or by an Elastic employee to configure the docker images as needed.
@@ -10,7 +28,7 @@ while read -r i ; do
   [[ -z $i ]] && continue
   name="${i##*/}"
   echo "::group::$name"
-  docker pull docker.elastic.co/observability-ci/$name --platform linux/amd64
+  retry 3 docker pull --platform linux/amd64 docker.elastic.co/observability-ci/$name
   docker tag docker.elastic.co/observability-ci/$name $i
   echo "::endgroup::"
 done < .ci/scripts/jboss-docker-images.txt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -325,7 +325,8 @@ jobs:
     name: JBoss integration tests
     runs-on: ubuntu-latest
     needs: build
-    if: github.event_name != 'pull_request' || github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
+    # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
+    if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )
     steps:
       - uses: actions/checkout@v4
       - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current


### PR DESCRIPTION
## What does this PR do?

Exclude dependabot from running the JBoss specific CI thing. 
Retry if failures when pulling docker images - to add more resilience. 

`dependabot` does not allow the use of secrets if those secrets are not defined in the dependabot secret section in GitHub. See https://github.com/dependabot/dependabot-core/issues/3253

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
