### PR TITLE
fix span stacktrace capture

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
+[float]
+===== Bug fixes
+* Fix span stack trace when combined with span compression - {pull}3474[#3474]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -107,7 +107,6 @@ public class ElasticApmTracer implements Tracer {
     private static volatile boolean classloaderCheckOk = false;
 
     private final ConfigurationRegistry configurationRegistry;
-    private final StacktraceConfiguration stacktraceConfiguration;
     private final ApmServerClient apmServerClient;
     private final List<LifecycleListener> lifecycleListeners = new CopyOnWriteArrayList<>();
     private final ObjectPool<Transaction> transactionPool;
@@ -203,7 +202,6 @@ public class ElasticApmTracer implements Tracer {
         this.metricRegistry = metricRegistry;
         this.configurationRegistry = configurationRegistry;
         this.reporter = reporter;
-        this.stacktraceConfiguration = configurationRegistry.getConfig(StacktraceConfiguration.class);
         this.apmServerClient = apmServerClient;
         this.ephemeralId = ephemeralId;
         this.metaDataFuture = metaDataFuture;
@@ -574,12 +572,6 @@ public class ElasticApmTracer implements Tracer {
         // makes sure that parents are also non-discardable
         span.setNonDiscardable();
 
-        long spanStackTraceMinDurationMs = stacktraceConfiguration.getSpanStackTraceMinDurationMs();
-        if (spanStackTraceMinDurationMs >= 0 && span.isSampled() && span.getStackFrames() == null) {
-            if (span.getDurationMs() >= spanStackTraceMinDurationMs) {
-                span.withStacktrace(new Throwable());
-            }
-        }
         reporter.report(span);
     }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -159,11 +159,20 @@ class ElasticApmTracerTest {
             Span span = tracerImpl.getActive().createSpan();
             try (Scope spanScope = span.activateInScope()) {
                 Thread.sleep(10);
-                span.end();
+                stackTraceEndSpan(span);
             }
             transaction.end();
         }
-        assertThat(reporter.getFirstSpan().getStacktrace()).isNotNull();
+        Throwable stackTrace = reporter.getFirstSpan().getStacktrace();
+        assertThat(stackTrace).isNotNull();
+        assertThat(Arrays.stream(stackTrace.getStackTrace()).filter(stackTraceElement ->
+            stackTraceElement.getMethodName().equals("stackTraceEndSpan")
+                && stackTraceElement.getClassName().equals(ElasticApmTracerTest.class.getName()))).hasSize(1);
+    }
+
+    private static void stackTraceEndSpan(Span span) {
+        // dummy method used just to verify that the captured stack trace contains it
+        span.end();
     }
 
     @Test

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -48,6 +48,7 @@ import org.stagemonitor.configuration.ConfigurationRegistry;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;


### PR DESCRIPTION
## What does this PR do?

Span stack trace is captured when the span ends, currently when the span is reported to the tracer. This implementation worked well until the introduction of compressed spans because the call to `ElasticApmTracer.report(Span)` was synchronous.

However, with the addition of compressed spans now the calls to `ElasticApmTracer.report(...)` can happen while the compression algorithm is executed, thus after the span has already been ended. As a consequence, the captured stack trace needs to be captured when the span ends and not when it's reported.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix

