### PR TITLE
rollback #3444 bump of jctools from 4.0.2 to 4.0.1 to keep java 7 compatibility

### DIFF
--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -56,7 +56,8 @@
         <dependency>
             <groupId>org.jctools</groupId>
             <artifactId>jctools-core</artifactId>
-            <version>4.0.2</version>
+            <!-- 4.0.2 is compiled to target java 8 (for no reason I can see), so keep at 4.0.1 and check 4.0.3 https://github.com/JCTools/JCTools/issues/385 -->
+            <version>4.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.googlecode.concurrentlinkedhashmap</groupId>


### PR DESCRIPTION
per discussion https://discuss.elastic.co/t/apm-agent-java-1-45-0-java-7-issue/350027/2