### PR TITLE
updatecli: dynamic specs

### DIFF
--- a/.ci/scripts/update-specs.sh
+++ b/.ci/scripts/update-specs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Bash strict mode
+set -eo pipefail
+
+cd apm-agent-core/src/test/resources/apm-server-schema/current
+ls -l .
+tar -xvzf $1 || true
+ls -ltra .

--- a/.ci/scripts/update-specs.sh
+++ b/.ci/scripts/update-specs.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-
-# Bash strict mode
-set -eo pipefail
-
-cd apm-agent-core/src/test/resources/apm-server-schema/current
-ls -l .
-tar -xvzf $1 || true
-ls -ltra .

--- a/.ci/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli.d/update-gherkin-specs.yml
@@ -1,6 +1,5 @@
 name: update-gherkin-specs
 pipelineid: update-gherkin-specs
-title: synchronize gherkin specs
 
 scms:
   default:
@@ -10,6 +9,16 @@ scms:
       email: '{{ requiredEnv "GIT_EMAIL" }}'
       owner: elastic
       repository: apm-agent-java
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: main
+  apm:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: apm
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
       branch: main
@@ -32,36 +41,22 @@ sources:
       environments:
         - name: GITHUB_TOKEN
         - name: PATH
-  api_key.feature:
-    kind: file
+  agents-gherkin-specs-tarball:
+    kind: shell
+    scmid: apm
+    dependson:
+      - sha
     spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/gherkin-specs/api_key.feature
-  azure_app_service_metadata.feature:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/gherkin-specs/azure_app_service_metadata.feature
-  azure_functions_metadata.feature:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/gherkin-specs/azure_functions_metadata.feature
-  otel_bridge.feature:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/gherkin-specs/otel_bridge.feature
-  outcome.feature:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/gherkin-specs/outcome.feature
-  user_agent.feature:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/gherkin-specs/user_agent.feature
+      command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
+      environments:
+        - name: PATH
+      workdir: tests/agents/gherkin-specs
 
 actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
-    title: '[Automation] Update Gherkin specs'
+    name: '[Automation] Update Gherkin specs'
     spec:
       automerge: false
       draft: false
@@ -76,53 +71,12 @@ actions:
         * {{ source "pull_request" }}
         * https://github.com/elastic/apm/commit/{{ source "sha" }}
 
-
 targets:
-  api_key.feature:
-    name: api_key.feature
+  agent-gherkin-specs:
+    name: APM agent gherkin specs {{ source "sha" }}
     scmid: default
-    sourceid: api_key.feature
-    kind: file
+    sourceid: agents-gherkin-specs-tarball
+    kind: shell
     spec:
-      file: apm-agent-core/src/test/resources/specs/api_key.feature
-      forcecreate: true
-  azure_app_service_metadata.feature:
-    name: azure_app_service_metadata.feature
-    scmid: default
-    sourceid: azure_app_service_metadata.feature
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/specs/azure_app_service_metadata.feature
-      forcecreate: true
-  azure_functions_metadata.feature:
-    name: azure_functions_metadata.feature
-    scmid: default
-    sourceid: azure_functions_metadata.feature
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/specs/azure_functions_metadata.feature
-      forcecreate: true
-  otel_bridge.feature:
-    name: otel_bridge.feature
-    scmid: default
-    sourceid: otel_bridge.feature
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/specs/otel_bridge.feature
-      forcecreate: true
-  outcome.feature:
-    name: outcome.feature
-    scmid: default
-    sourceid: outcome.feature
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/specs/outcome.feature
-      forcecreate: true
-  user_agent.feature:
-    name: user_agent.feature
-    scmid: default
-    sourceid: user_agent.feature
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/specs/user_agent.feature
-      forcecreate: true
+      command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended
+      workdir: apm-agent-core/src/test/resources/specs

--- a/.ci/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli.d/update-json-specs.yml
@@ -1,6 +1,5 @@
 name: update-json-specs
 pipelineid: update-json-specs
-title: synchronize json specs
 
 scms:
   default:
@@ -10,6 +9,16 @@ scms:
       email: '{{ requiredEnv "GIT_EMAIL" }}'
       owner: elastic
       repository: apm-agent-java
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: main
+  apm:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: apm
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
       branch: main
@@ -32,39 +41,22 @@ sources:
       environments:
         - name: GITHUB_TOKEN
         - name: PATH
-  container_metadata_discovery.json:
-    kind: file
+  agents-json-specs-tarball:
+    kind: shell
+    scmid: apm
+    dependson:
+      - sha
     spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/container_metadata_discovery.json
-  service_resource_inference.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/service_resource_inference.json
-  span_types.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/span_types.json
-  sql_signature_examples.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/sql_signature_examples.json
-  sql_token_examples.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/sql_token_examples.json
-  w3c_distributed_tracing.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/w3c_distributed_tracing.json
-  wildcard_matcher_tests.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm/main/tests/agents/json-specs/wildcard_matcher_tests.json
+      command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
+      environments:
+        - name: PATH
+      workdir: tests/agents/json-specs
+
 actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
-    title: '[Automation] Update JSON specs'
+    name: '[Automation] Update JSON specs'
     spec:
       automerge: false
       draft: false
@@ -80,52 +72,11 @@ actions:
         * https://github.com/elastic/apm/commit/{{ source "sha" }}
 
 targets:
-  container_metadata_discovery.json:
-    name: container_metadata_discovery.json
+  agent-json-specs:
+    name: APM agent json specs {{ source "sha" }}
     scmid: default
-    sourceid: container_metadata_discovery.json
-    kind: file
+    sourceid: agents-json-specs-tarball
+    kind: shell
     spec:
-      file: apm-agent-core/src/test/resources/json-specs/container_metadata_discovery.json
-  service_resource_inference.json:
-    name: service_resource_inference.json
-    scmid: default
-    sourceid: service_resource_inference.json
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/json-specs/service_resource_inference.json
-  span_types.json:
-    name: span_types.json
-    scmid: default
-    sourceid: span_types.json
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/json-specs/span_types.json
-  sql_signature_examples.json:
-    name: sql_signature_examples.json
-    scmid: default
-    sourceid: sql_signature_examples.json
-    kind: file
-    spec:
-      file: apm-agent-plugin-sdk/src/test/resources/json-specs/sql_signature_examples.json
-  sql_token_examples.json:
-    name: sql_token_examples.json
-    scmid: default
-    sourceid: sql_token_examples.json
-    kind: file
-    spec:
-      file: apm-agent-plugin-sdk/src/test/resources/json-specs/sql_token_examples.json
-  w3c_distributed_tracing.json:
-    name: w3c_distributed_tracing.json
-    scmid: default
-    sourceid: w3c_distributed_tracing.json
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/json-specs/w3c_distributed_tracing.json
-  wildcard_matcher_tests.json:
-    name: wildcard_matcher_tests.json
-    scmid: default
-    sourceid: wildcard_matcher_tests.json
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/json-specs/wildcard_matcher_tests.json
+      command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended
+      workdir: apm-agent-core/src/test/resources/json-specs

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -1,6 +1,5 @@
 name: update-specs
 pipelineid: update-schema-specs
-title: synchronize schema specs
 
 scms:
   default:
@@ -49,9 +48,10 @@ sources:
     dependson:
       - sha
     spec:
-      command: cd input/elasticapm/docs/spec/v2 && tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
+      command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
       environments:
         - name: PATH
+      workdir: input/elasticapm/docs/spec/v2
 
 actions:
   pr:
@@ -80,7 +80,5 @@ targets:
     sourceid: agent-specs-tarball
     kind: shell
     spec:
-      command: .ci/scripts/update-specs.sh {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz
-      environments:
-        - name: PATH
-        - name: HOME
+      command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz
+      workdir: apm-agent-core/src/test/resources/apm-server-schema/current

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -43,7 +43,7 @@ sources:
       environments:
         - name: GITHUB_TOKEN
         - name: PATH
-  tarball:
+  agent-specs-tarball:
     kind: shell
     scmid: apm-data
     dependson:
@@ -77,7 +77,10 @@ targets:
   agent-json-schema:
     name: APM agent json schema {{ source "sha" }}
     scmid: default
-    sourceid: tarball
+    sourceid: agent-specs-tarball
     kind: shell
     spec:
       command: .ci/scripts/update-specs.sh {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz
+      environments:
+        - name: PATH
+        - name: HOME

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -27,12 +27,13 @@ scms:
 
 sources:
   sha:
-    kind: shell
+    kind: file
     spec:
-      command: gh api /repos/elastic/apm-data/commits --jq '.[0].sha'
-    environments:
-      - name: GITHUB_TOKEN
-      - name: PATH
+      file: 'https://github.com/elastic/apm-data/commit/main.patch'
+      matchpattern: "^From\\s([0-9a-f]{40})\\s"
+    transformers:
+      - findsubmatch:
+          pattern: "[0-9a-f]{40}"
   pull_request:
     kind: shell
     dependson:

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -77,7 +77,7 @@ targets:
   agent-json-schema:
     name: APM agent json schema {{ source "sha" }}
     scmid: default
-    sourceid: sha
+    sourceid: tarball
     kind: shell
     spec:
       command: cd apm-agent-core/src/test/resources/apm-server-schema/current && tar xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -49,7 +49,7 @@ sources:
     dependson:
       - sha
     spec:
-      command: cd input/elasticapm/docs/spec/v2 && tar cvzf /tmp/tarball.tgz .
+      command: cd input/elasticapm/docs/spec/v2 && tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
       environments:
         - name: PATH
 
@@ -80,4 +80,4 @@ targets:
     sourceid: sha
     kind: shell
     spec:
-      command: cd apm-agent-core/src/test/resources/apm-server-schema/current && tar xvzf /tmp/tarball.tgz
+      command: cd apm-agent-core/src/test/resources/apm-server-schema/current && tar xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -58,7 +58,7 @@ actions:
     kind: "github/pullrequest"
     scmid: default
     sourceid: sha
-    title: '[Automation] Update JSON schema specs'
+    name: '[Automation] Update JSON schema specs'
     spec:
       automerge: false
       draft: false

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -80,4 +80,4 @@ targets:
     sourceid: tarball
     kind: shell
     spec:
-      command: cd apm-agent-core/src/test/resources/apm-server-schema/current && tar xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz
+      command: .ci/scripts/update-specs.sh {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -46,8 +46,10 @@ sources:
   tarball:
     kind: shell
     scmid: apm-data
+    dependson:
+      - sha
     spec:
-      command: cd input/elasticapm/docs/spec/v2 && tar cvzf /tmp/tarball.tgz .
+      command: cd input/elasticapm/docs/spec/v2 && tar cvzf /tmp/tarball-{{ source "sha" }}.tgz .
       environments:
         - name: PATH
 
@@ -72,9 +74,10 @@ actions:
         * https://github.com/elastic/apm-data/commit/{{ source "sha" }}
 
 targets:
-  files.json:
+  agent-json-schema:
+    name: APM agent json schema {{ source "sha" }}
     scmid: default
-    sourceid: tarball
+    sourceid: sha
     kind: shell
     spec:
-      command: cd apm-agent-core/src/test/resources/apm-server-schema/current && tar xvzf /tmp/tarball.tgz
+      command: cd apm-agent-core/src/test/resources/apm-server-schema/current && tar xvzf /tmp/tarball-{{ source "sha" }}.tgz

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -80,5 +80,5 @@ targets:
     sourceid: agent-specs-tarball
     kind: shell
     spec:
-      command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz
+      command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended
       workdir: apm-agent-core/src/test/resources/apm-server-schema/current

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -14,15 +14,25 @@ scms:
       username: '{{ requiredEnv "GIT_USER" }}'
       branch: main
 
+  apm-data:
+    kind: github
+    spec:
+      user: '{{ requiredEnv "GIT_USER" }}'
+      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      owner: elastic
+      repository: apm-data
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GIT_USER" }}'
+      branch: main
+
 sources:
   sha:
-    kind: file
+    kind: shell
     spec:
-      file: 'https://github.com/elastic/apm-data/commit/main.patch'
-      matchpattern: "^From\\s([0-9a-f]{40})\\s"
-    transformers:
-      - findsubmatch:
-          pattern: "[0-9a-f]{40}"
+      command: gh api /repos/elastic/apm-data/commits --jq '.[0].sha'
+    environments:
+      - name: GITHUB_TOKEN
+      - name: PATH
   pull_request:
     kind: shell
     dependson:
@@ -32,26 +42,13 @@ sources:
       environments:
         - name: GITHUB_TOKEN
         - name: PATH
-  error.json:
-    kind: file
+  tarball:
+    kind: shell
+    scmid: apm-data
     spec:
-      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/error.json
-  metadata.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/metadata.json
-  metricset.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/metricset.json
-  span.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/span.json
-  transaction.json:
-    kind: file
-    spec:
-      file: https://raw.githubusercontent.com/elastic/apm-data/main/input/elasticapm/docs/spec/v2/transaction.json
+      command: cd input/elasticapm/docs/spec/v2 && tar cvzf /tmp/tarball.tgz .
+      environments:
+        - name: PATH
 
 actions:
   pr:
@@ -74,43 +71,9 @@ actions:
         * https://github.com/elastic/apm-data/commit/{{ source "sha" }}
 
 targets:
-  error.json:
-    name: error.json
+  files.json:
     scmid: default
-    sourceid: error.json
-    kind: file
+    sourceid: tarball
+    kind: shell
     spec:
-      file: apm-agent-core/src/test/resources/apm-server-schema/current/error.json
-      forcecreate: true
-  metadata.json:
-    name: metadata.json
-    scmid: default
-    sourceid: metadata.json
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/apm-server-schema/current/metadata.json
-      forcecreate: true
-  metricset.json:
-    name: metricset.json
-    scmid: default
-    sourceid: metricset.json
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/apm-server-schema/current/metricset.json
-      forcecreate: true
-  span.json:
-    name: span.json
-    scmid: default
-    sourceid: span.json
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/apm-server-schema/current/span.json
-      forcecreate: true
-  transaction.json:
-    name: transaction.json
-    scmid: default
-    sourceid: transaction.json
-    kind: file
-    spec:
-      file: apm-agent-core/src/test/resources/apm-server-schema/current/transaction.json
-      forcecreate: true
+      command: cd apm-agent-core/src/test/resources/apm-server-schema/current && tar xvzf /tmp/tarball.tgz

--- a/.ci/updatecli.d/update-specs.yml
+++ b/.ci/updatecli.d/update-specs.yml
@@ -49,7 +49,7 @@ sources:
     dependson:
       - sha
     spec:
-      command: cd input/elasticapm/docs/spec/v2 && tar cvzf /tmp/tarball-{{ source "sha" }}.tgz .
+      command: cd input/elasticapm/docs/spec/v2 && tar cvzf /tmp/tarball.tgz .
       environments:
         - name: PATH
 
@@ -80,4 +80,4 @@ targets:
     sourceid: sha
     kind: shell
     spec:
-      command: cd apm-agent-core/src/test/resources/apm-server-schema/current && tar xvzf /tmp/tarball-{{ source "sha" }}.tgz
+      command: cd apm-agent-core/src/test/resources/apm-server-schema/current && tar xvzf /tmp/tarball.tgz

--- a/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
@@ -75,8 +75,8 @@ targets:
   agent-gherkin-specs:
     name: APM agent gherkin specs {{ source "sha" }}
     scmid: default
-    sourceid: sha
+    disablesourceinput: true
     kind: shell
     spec:
-      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/gherkin-specs.tgz && git --no-pager diff # required to ignore the sourceid being appended'
+      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/gherkin-specs.tgz && git --no-pager diff'
       workdir: "{{ .apm_agent.gherkin_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
@@ -56,7 +56,6 @@ actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
-    name: '[Automation] Update Gherkin specs'
     spec:
       automerge: false
       draft: false
@@ -70,6 +69,7 @@ actions:
         *Changeset*
         * {{ source "pull_request" }}
         * https://github.com/elastic/apm/commit/{{ source "sha" }}
+      title: '[Automation] Update Gherkin specs'
 
 targets:
   agent-gherkin-specs:

--- a/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
@@ -75,8 +75,8 @@ targets:
   agent-gherkin-specs:
     name: APM agent gherkin specs {{ source "sha" }}
     scmid: default
-    sourceid: agents-gherkin-specs-tarball
+    sourceid: sha
     kind: shell
     spec:
-      command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended
+      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended'
       workdir: "{{ .apm_agent.gherkin_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
@@ -47,7 +47,7 @@ sources:
     dependson:
       - sha
     spec:
-      command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
+      command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/gherkin-specs.tgz .
       environments:
         - name: PATH
       workdir: "{{ .specs.apm_gherkin_path }}"
@@ -78,5 +78,5 @@ targets:
     sourceid: sha
     kind: shell
     spec:
-      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended'
+      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/gherkin-specs.tgz && git --no-pager diff # required to ignore the sourceid being appended'
       workdir: "{{ .apm_agent.gherkin_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
@@ -1,5 +1,5 @@
-name: update-specs
-pipelineid: update-schema-specs
+name: update-gherkin-specs
+pipelineid: update-gherkin-specs
 
 scms:
   default:
@@ -7,28 +7,27 @@ scms:
     spec:
       user: '{{ requiredEnv "GIT_USER" }}'
       email: '{{ requiredEnv "GIT_EMAIL" }}'
-      owner: elastic
-      repository: apm-agent-java
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: main
-
-  apm-data:
+      branch: "{{ .github.branch }}"
+  apm:
     kind: github
     spec:
       user: '{{ requiredEnv "GIT_USER" }}'
       email: '{{ requiredEnv "GIT_EMAIL" }}'
-      owner: elastic
-      repository: apm-data
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.apm_repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: main
+      branch: "{{ .github.branch }}"
 
 sources:
   sha:
     kind: file
     spec:
-      file: 'https://github.com/elastic/apm-data/commit/main.patch'
+      file: 'https://github.com/{{ .github.owner }}/{{ .github.apm_repository }}/commit/{{ .github.branch }}.patch'
       matchpattern: "^From\\s([0-9a-f]{40})\\s"
     transformers:
       - findsubmatch:
@@ -38,27 +37,26 @@ sources:
     dependson:
       - sha
     spec:
-      command: gh api /repos/elastic/apm-data/commits/{{ source "sha" }}/pulls --jq '.[].html_url'
+      command: gh api /repos/{{ .github.owner }}/{{ .github.apm_repository }}/commits/{{ source "sha" }}/pulls --jq '.[].html_url'
       environments:
         - name: GITHUB_TOKEN
         - name: PATH
-  agent-specs-tarball:
+  agents-gherkin-specs-tarball:
     kind: shell
-    scmid: apm-data
+    scmid: apm
     dependson:
       - sha
     spec:
       command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
       environments:
         - name: PATH
-      workdir: input/elasticapm/docs/spec/v2
+      workdir: "{{ .specs.apm_gherkin_path }}"
 
 actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
-    sourceid: sha
-    name: '[Automation] Update JSON schema specs'
+    name: '[Automation] Update Gherkin specs'
     spec:
       automerge: false
       draft: false
@@ -66,19 +64,19 @@ actions:
         - "automation"
       description: |-
         ### What
-        APM agent json schema automatic sync
+        APM agent Gherkin specs automatic sync
 
         ### Why
         *Changeset*
         * {{ source "pull_request" }}
-        * https://github.com/elastic/apm-data/commit/{{ source "sha" }}
+        * https://github.com/elastic/apm/commit/{{ source "sha" }}
 
 targets:
-  agent-json-schema:
-    name: APM agent json schema {{ source "sha" }}
+  agent-gherkin-specs:
+    name: APM agent gherkin specs {{ source "sha" }}
     scmid: default
-    sourceid: agent-specs-tarball
+    sourceid: agents-gherkin-specs-tarball
     kind: shell
     spec:
       command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended
-      workdir: apm-agent-core/src/test/resources/apm-server-schema/current
+      workdir: "{{ .apm_agent.gherkin_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-json-specs.yml
@@ -75,8 +75,8 @@ targets:
   agent-json-specs:
     name: APM agent json specs {{ source "sha" }}
     scmid: default
-    sourceid: sha
+    disablesourceinput: true
     kind: shell
     spec:
-      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-specs.tgz && git --no-pager diff # required to ignore the sourceid being appended'
+      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-specs.tgz && git --no-pager diff'
       workdir: "{{ .apm_agent.json_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-json-specs.yml
@@ -56,7 +56,6 @@ actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
-    name: '[Automation] Update JSON specs'
     spec:
       automerge: false
       draft: false
@@ -70,6 +69,7 @@ actions:
         *Changeset*
         * {{ source "pull_request" }}
         * https://github.com/{{ .github.owner }}/{{ .github.apm_repository }}/commit/{{ source "sha" }}
+      title: '[Automation] Update JSON specs'
 
 targets:
   agent-json-specs:

--- a/.ci/updatecli/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-json-specs.yml
@@ -47,7 +47,7 @@ sources:
     dependson:
       - sha
     spec:
-      command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
+      command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-specs.tgz .
       environments:
         - name: PATH
       workdir: "{{ .specs.apm_json_path }}"
@@ -78,5 +78,5 @@ targets:
     sourceid: sha
     kind: shell
     spec:
-      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended'
+      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-specs.tgz && git --no-pager diff # required to ignore the sourceid being appended'
       workdir: "{{ .apm_agent.json_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-json-specs.yml
@@ -7,27 +7,27 @@ scms:
     spec:
       user: '{{ requiredEnv "GIT_USER" }}'
       email: '{{ requiredEnv "GIT_EMAIL" }}'
-      owner: elastic
-      repository: apm-agent-java
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: main
+      branch: "{{ .github.branch }}"
   apm:
     kind: github
     spec:
       user: '{{ requiredEnv "GIT_USER" }}'
       email: '{{ requiredEnv "GIT_EMAIL" }}'
-      owner: elastic
-      repository: apm
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.apm_repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: main
+      branch: "{{ .github.branch }}"
 
 sources:
   sha:
     kind: file
     spec:
-      file: 'https://github.com/elastic/apm/commit/main.patch'
+      file: 'https://github.com/{{ .github.owner }}/{{ .github.apm_repository }}/commit/{{ .github.branch }}.patch'
       matchpattern: "^From\\s([0-9a-f]{40})\\s"
     transformers:
       - findsubmatch:
@@ -37,7 +37,7 @@ sources:
     dependson:
       - sha
     spec:
-      command: gh api /repos/elastic/apm/commits/{{ source "sha" }}/pulls --jq '.[].html_url'
+      command: gh api /repos/{{ .github.owner }}/{{ .github.apm_repository }}/commits/{{ source "sha" }}/pulls --jq '.[].html_url'
       environments:
         - name: GITHUB_TOKEN
         - name: PATH
@@ -50,7 +50,7 @@ sources:
       command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
       environments:
         - name: PATH
-      workdir: tests/agents/json-specs
+      workdir: "{{ .specs.apm_json_path }}"
 
 actions:
   pr:
@@ -69,7 +69,7 @@ actions:
         ### Why
         *Changeset*
         * {{ source "pull_request" }}
-        * https://github.com/elastic/apm/commit/{{ source "sha" }}
+        * https://github.com/{{ .github.owner }}/{{ .github.apm_repository }}/commit/{{ source "sha" }}
 
 targets:
   agent-json-specs:
@@ -79,4 +79,4 @@ targets:
     kind: shell
     spec:
       command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended
-      workdir: apm-agent-core/src/test/resources/json-specs
+      workdir: "{{ .apm_agent.json_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-json-specs.yml
@@ -75,8 +75,8 @@ targets:
   agent-json-specs:
     name: APM agent json specs {{ source "sha" }}
     scmid: default
-    sourceid: agents-json-specs-tarball
+    sourceid: sha
     kind: shell
     spec:
-      command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended
+      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended'
       workdir: "{{ .apm_agent.json_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-specs.yml
@@ -77,8 +77,8 @@ targets:
   agent-json-schema:
     name: APM agent json server schema {{ source "sha" }}
     scmid: default
-    sourceid: sha
+    disablesourceinput: true
     kind: shell
     spec:
-      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-schema.tgz && git --no-pager diff # required to ignore the sourceid being appended'
+      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-schema.tgz && git --no-pager diff'
       workdir: "{{ .apm_agent.server_schema_specs_path  }}"

--- a/.ci/updatecli/updatecli.d/update-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-specs.yml
@@ -1,5 +1,5 @@
-name: update-gherkin-specs
-pipelineid: update-gherkin-specs
+name: update-specs
+pipelineid: update-schema-specs
 
 scms:
   default:
@@ -7,27 +7,28 @@ scms:
     spec:
       user: '{{ requiredEnv "GIT_USER" }}'
       email: '{{ requiredEnv "GIT_EMAIL" }}'
-      owner: elastic
-      repository: apm-agent-java
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: main
-  apm:
+      branch: "{{ .github.branch }}"
+
+  apm-data:
     kind: github
     spec:
       user: '{{ requiredEnv "GIT_USER" }}'
       email: '{{ requiredEnv "GIT_EMAIL" }}'
-      owner: elastic
-      repository: apm
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.apm_data_repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GIT_USER" }}'
-      branch: main
+      branch: "{{ .github.branch }}"
 
 sources:
   sha:
     kind: file
     spec:
-      file: 'https://github.com/elastic/apm/commit/main.patch'
+      file: 'https://github.com/{{ .github.owner }}/{{ .github.apm_data_repository }}/commit/{{ .github.branch }}.patch'
       matchpattern: "^From\\s([0-9a-f]{40})\\s"
     transformers:
       - findsubmatch:
@@ -37,26 +38,27 @@ sources:
     dependson:
       - sha
     spec:
-      command: gh api /repos/elastic/apm/commits/{{ source "sha" }}/pulls --jq '.[].html_url'
+      command: gh api /repos/{{ .github.owner }}/{{ .github.apm_data_repository }}/commits/{{ source "sha" }}/pulls --jq '.[].html_url'
       environments:
         - name: GITHUB_TOKEN
         - name: PATH
-  agents-gherkin-specs-tarball:
+  agent-specs-tarball:
     kind: shell
-    scmid: apm
+    scmid: apm-data
     dependson:
       - sha
     spec:
       command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
       environments:
         - name: PATH
-      workdir: tests/agents/gherkin-specs
+      workdir: "{{ .specs.apm_data_path }}"
 
 actions:
   pr:
     kind: "github/pullrequest"
     scmid: default
-    name: '[Automation] Update Gherkin specs'
+    sourceid: sha
+    name: '[Automation] Update JSON schema specs'
     spec:
       automerge: false
       draft: false
@@ -64,19 +66,19 @@ actions:
         - "automation"
       description: |-
         ### What
-        APM agent Gherkin specs automatic sync
+        APM agent json schema automatic sync
 
         ### Why
         *Changeset*
         * {{ source "pull_request" }}
-        * https://github.com/elastic/apm/commit/{{ source "sha" }}
+        * https://github.com/{{ .github.owner }}/{{ .github.apm_data_repository }}/commit/{{ source "sha" }}
 
 targets:
-  agent-gherkin-specs:
-    name: APM agent gherkin specs {{ source "sha" }}
+  agent-json-schema:
+    name: APM agent json schema {{ source "sha" }}
     scmid: default
-    sourceid: agents-gherkin-specs-tarball
+    sourceid: agent-specs-tarball
     kind: shell
     spec:
       command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended
-      workdir: apm-agent-core/src/test/resources/specs
+      workdir: "{{ .apm_agent.server_schema_specs_path  }}"

--- a/.ci/updatecli/updatecli.d/update-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-specs.yml
@@ -48,7 +48,7 @@ sources:
     dependson:
       - sha
     spec:
-      command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz .
+      command: tar cvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-schema.tgz .
       environments:
         - name: PATH
       workdir: "{{ .specs.apm_data_path }}"
@@ -66,7 +66,7 @@ actions:
         - "automation"
       description: |-
         ### What
-        APM agent json schema automatic sync
+        APM agent json server schema automatic sync
 
         ### Why
         *Changeset*
@@ -75,10 +75,10 @@ actions:
 
 targets:
   agent-json-schema:
-    name: APM agent json schema {{ source "sha" }}
+    name: APM agent json server schema {{ source "sha" }}
     scmid: default
     sourceid: sha
     kind: shell
     spec:
-      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended'
+      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-schema.tgz && git --no-pager diff # required to ignore the sourceid being appended'
       workdir: "{{ .apm_agent.server_schema_specs_path  }}"

--- a/.ci/updatecli/updatecli.d/update-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-specs.yml
@@ -58,7 +58,6 @@ actions:
     kind: "github/pullrequest"
     scmid: default
     sourceid: sha
-    name: '[Automation] Update JSON schema specs'
     spec:
       automerge: false
       draft: false
@@ -72,6 +71,7 @@ actions:
         *Changeset*
         * {{ source "pull_request" }}
         * https://github.com/{{ .github.owner }}/{{ .github.apm_data_repository }}/commit/{{ source "sha" }}
+      title: '[Automation] Update JSON server schema specs'
 
 targets:
   agent-json-schema:

--- a/.ci/updatecli/updatecli.d/update-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-specs.yml
@@ -77,8 +77,8 @@ targets:
   agent-json-schema:
     name: APM agent json schema {{ source "sha" }}
     scmid: default
-    sourceid: agent-specs-tarball
+    sourceid: sha
     kind: shell
     spec:
-      command: tar -xvzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended
+      command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/tarball.tgz && git --no-pager diff # required to ignore the sourceid being appended'
       workdir: "{{ .apm_agent.server_schema_specs_path  }}"

--- a/.ci/updatecli/values.yml
+++ b/.ci/updatecli/values.yml
@@ -1,5 +1,5 @@
 github:
-  owner: "elastic"
+  owner: "v1v"
   repository: "apm-agent-java"
   apm_repository: "apm"
   apm_data_repository: "apm-data"

--- a/.ci/updatecli/values.yml
+++ b/.ci/updatecli/values.yml
@@ -1,5 +1,5 @@
 github:
-  owner: "v1v"
+  owner: "elastic"
   repository: "apm-agent-java"
   apm_repository: "apm"
   apm_data_repository: "apm-data"

--- a/.ci/updatecli/values.yml
+++ b/.ci/updatecli/values.yml
@@ -1,0 +1,14 @@
+github:
+  owner: "v1v"
+  repository: "apm-agent-java"
+  apm_repository: "apm"
+  apm_data_repository: "apm-data"
+  branch: "main"
+specs:
+  apm_data_path: "input/elasticapm/docs/spec/v2"
+  apm_json_path: "tests/agents/json-specs"
+  apm_gherkin_path: "tests/agents/gherkin-specs"
+apm_agent:
+  gherkin_specs_path: "apm-agent-core/src/test/resources/specs"
+  json_specs_path: "apm-agent-core/src/test/resources/json-specs"
+  server_schema_specs_path: "apm-agent-core/src/test/resources/apm-server-schema/current"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -20,10 +20,16 @@ jobs:
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: .ci/updatecli/updatecli.d
           values: .ci/updatecli/values.yml
+          notifySlackChannel: "#on-week-oblt-productivity"
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#apm-agent-java"
+          slackChannel: "#on-week-oblt-productivity"
+      - if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: specs
+          path: tarball.tgz

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -18,7 +18,8 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: .ci/updatecli.d
+          pipeline: .ci/updatecli/updatecli.d
+          values: .ci/updatecli/values.yml
           notifySlackChannel: "#on-week-oblt-productivity"
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -18,7 +18,7 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: .ci/updatecli.d
+          pipeline: .ci/updatecli.d/update-specs.yml
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -20,16 +20,10 @@ jobs:
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: .ci/updatecli/updatecli.d
           values: .ci/updatecli/values.yml
-          notifySlackChannel: "#on-week-oblt-productivity"
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#on-week-oblt-productivity"
-      - if: always()
-        uses: actions/upload-artifact@v3
-        with:
-          name: specs
-          path: tarball.tgz
+          slackChannel: "#apm-agent-java"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -25,7 +25,7 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#apm-agent-java"
+          slackChannel: "#on-week-oblt-productivity"
       - if: always()
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -18,7 +18,7 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: .ci/updatecli.d/update-specs.yml
+          pipeline: .ci/updatecli.d
           notifySlackChannel: "#on-week-oblt-productivity"
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -26,3 +26,8 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           slackChannel: "#apm-agent-java"
+      - if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: specs
+          path: tarball.tgz

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -19,6 +19,7 @@ jobs:
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
           pipeline: .ci/updatecli.d/update-specs.yml
+          notifySlackChannel: "#on-week-oblt-productivity"
       - if: failure()
         uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
         with:


### PR DESCRIPTION
## What does this PR do?

* Use `values.yml` to define the configuration to be used when running the `updatecli apply`, see https://www.updatecli.io/docs/commands/updatecli_apply/#updatecli-apply
* Use updatecli scm to fetch the specs in `elastic/apm` and `elastic/apm-data` under the different folders.
* To update those files, use `tar` with the shell target.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)

### Test

I iterated in the existing GitHub action by using the upstream branch:
- https://github.com/elastic/apm-agent-java/actions/runs/7545513322/job/20541293368 ran successfully.

Locally:

```bash
GITHUB_WORKSPACE=/tmp \
  PATH=/opt/homebrew/bin:$PATH \
  GIT_USER="Victor Martinez" \
  GIT_EMAIL="VictorMartinezRubio@gmail.com" \
  GITHUB_TOKEN=$(gh auth token) \
  updatecli apply --config .ci/updatecli/updatecli.d --values .ci/updatecli/values.yml --debug
```

or without pushing any changes

```bash
GITHUB_WORKSPACE=/tmp \
  PATH=/opt/homebrew/bin:$PATH \
  GIT_USER="Victor Martinez" \
  GIT_EMAIL="VictorMartinezRubio@gmail.com" \
  GITHUB_TOKEN=$(gh auth token) \
  updatecli apply --config .ci/updatecli/updatecli.d --values .ci/updatecli/values.yml --push=false --debug
```

additionally, you can change the org from `elastic` to your own GitHub avatar.