### PR TITLE
Added a note on centralized agent config support for AWS Lambda

### DIFF
--- a/docs/setup-aws-lambda.asciidoc
+++ b/docs/setup-aws-lambda.asciidoc
@@ -4,6 +4,10 @@
 
 The Java APM Agent can be used with AWS Lambda to monitor the execution of your AWS Lambda functions.
 
+```
+Note: The Centralized Agent Configuration on the Elasticsearch APM currently does NOT support AWS Lambda.
+```
+
 [float]
 [[aws-lambda-java-quick-start]]
 === Quick Start


### PR DESCRIPTION
## What does this PR do?

The centralized Agent configuration does not work well with the AWS Lambda because it is not supported. The problem is you will be able to add the Lambda services in the central config without an understanding of its support. So, this PR will keep an alert when creating Lambda services.

