### PR TITLE
Bump Alpine version to 3.19.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-# Pin to Alpine 3.9
+# Pin to Alpine 3.19.1
 # For a complete list of hashes, see:
 # https://github.com/docker-library/repo-info/tree/master/repos/alpine/remote
-FROM alpine@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1
+FROM alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b
 RUN mkdir /usr/agent
 ARG JAR_FILE
 ARG HANDLER_FILE


### PR DESCRIPTION
Bump Alpine version to 3.19.1 (alpine@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761f8e1ad6b)

## What does this PR do?
Updates used base alpine docker image version to 3.19.1. Alpine:3.18.2 has several vulnerabilities so we need to update it.

`trivy image alpine@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1

2024-02-12T17:36:41.726+0300	INFO	Vulnerability scanning is enabled
2024-02-12T17:36:41.726+0300	INFO	Secret scanning is enabled
2024-02-12T17:36:41.726+0300	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-02-12T17:36:41.726+0300	INFO	Please see also https://aquasecurity.github.io/trivy/v0.48/docs/scanner/secret/#recommendation for faster secret detection
2024-02-12T17:36:43.889+0300	INFO	Detected OS: alpine
2024-02-12T17:36:43.889+0300	INFO	Detecting Alpine vulnerabilities...
2024-02-12T17:36:43.896+0300	INFO	Number of language-specific files: 0

alpine@sha256:82d1e9d7ed48a7523bdebc18cf6290bdb97b82302a8a9c27d4fe885949ea94d1 (alpine 3.18.2)

Total: 19 (UNKNOWN: 0, LOW: 0, MEDIUM: 14, HIGH: 2, CRITICAL: 3)

┌───────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│    Library    │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                            Title                            │
├───────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ busybox       │ CVE-2022-48174 │ CRITICAL │ fixed  │ 1.36.1-r0         │ 1.36.1-r1     │ stack overflow vulnerability in ash.c leads to arbitrary    │
│               │                │          │        │                   │               │ code execution                                              │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-48174                  │
├───────────────┤                │          │        │                   │               │                                                             │
│ busybox-binsh │                │          │        │                   │               │                                                             │
│               │                │          │        │                   │               │                                                             │
│               │                │          │        │                   │               │                                                             │
├───────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ libcrypto3    │ CVE-2023-5363  │ HIGH     │        │ 3.1.1-r1          │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing      │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363                   │
│               ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-2975  │ MEDIUM   │        │                   │ 3.1.1-r2      │ openssl: AES-SIV cipher implementation contains a bug that  │
│               │                │          │        │                   │               │ causes it to ignore...                                      │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-3446  │          │        │                   │ 3.1.1-r3      │ openssl: Excessive time spent checking DH keys and          │
│               │                │          │        │                   │               │ parameters                                                  │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-3817  │          │        │                   │ 3.1.2-r0      │ OpenSSL: Excessive time spent checking DH q parameter value │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-5678  │          │        │                   │ 3.1.4-r1      │ openssl: Generating excessively long X9.42 DH keys or       │
│               │                │          │        │                   │               │ checking excessively long X9.42...                          │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-6129  │          │        │                   │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector        │
│               │                │          │        │                   │               │ registers on PowerPC                                        │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-6237  │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public   │
│               │                │          │        │                   │               │ keys                                                        │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-0727  │          │        │                   │ 3.1.4-r5      │ openssl: denial of service via null dereference             │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-0727                   │
├───────────────┼────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│ libssl3       │ CVE-2023-5363  │ HIGH     │        │                   │ 3.1.4-r0      │ openssl: Incorrect cipher key and IV length processing      │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363                   │
│               ├────────────────┼──────────┤        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-2975  │ MEDIUM   │        │                   │ 3.1.1-r2      │ openssl: AES-SIV cipher implementation contains a bug that  │
│               │                │          │        │                   │               │ causes it to ignore...                                      │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-2975                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-3446  │          │        │                   │ 3.1.1-r3      │ openssl: Excessive time spent checking DH keys and          │
│               │                │          │        │                   │               │ parameters                                                  │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3446                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-3817  │          │        │                   │ 3.1.2-r0      │ OpenSSL: Excessive time spent checking DH q parameter value │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-3817                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-5678  │          │        │                   │ 3.1.4-r1      │ openssl: Generating excessively long X9.42 DH keys or       │
│               │                │          │        │                   │               │ checking excessively long X9.42...                          │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5678                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-6129  │          │        │                   │ 3.1.4-r3      │ openssl: POLY1305 MAC implementation corrupts vector        │
│               │                │          │        │                   │               │ registers on PowerPC                                        │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6129                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2023-6237  │          │        │                   │ 3.1.4-r4      │ openssl: Excessive time spent checking invalid RSA public   │
│               │                │          │        │                   │               │ keys                                                        │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2023-6237                   │
│               ├────────────────┤          │        │                   ├───────────────┼─────────────────────────────────────────────────────────────┤
│               │ CVE-2024-0727  │          │        │                   │ 3.1.4-r5      │ openssl: denial of service via null dereference             │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2024-0727                   │
├───────────────┼────────────────┼──────────┤        ├───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ ssl_client    │ CVE-2022-48174 │ CRITICAL │        │ 1.36.1-r0         │ 1.36.1-r1     │ stack overflow vulnerability in ash.c leads to arbitrary    │
│               │                │          │        │                   │               │ code execution                                              │
│               │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2022-48174                  │
└───────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴─────────────────────────────────────────────────────────────┘
`



## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [X] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
