### PR TITLE
cleanup servlet request attribute

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,12 +31,12 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
-[[release-notes-1.x]]
-=== Java Agent version 1.x
-
 [float]
 ===== Bug fixes
 * Cleanup extra servlet request attribute used for Spring exception handler - {pull}3527[#3527]
+
+[[release-notes-1.x]]
+=== Java Agent version 1.x
 
 [[release-notes-1.47.0]]
 ==== 1.47.0 - 2024/02/13

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [[release-notes-1.x]]
 === Java Agent version 1.x
 
+[float]
+===== Bug fixes
+* Cleanup extra servlet request attribute used for Spring exception handler - {pull}3527[#3527]
+
 [[release-notes-1.47.0]]
 ==== 1.47.0 - 2024/02/13
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -202,7 +202,7 @@ public abstract class ServletApiAdvice {
             httpServletRequest != null &&
             httpServletResponse != null) {
 
-            if (adapter.getHttpAttribute(httpServletRequest, ServletTransactionHelper.ASYNC_ATTRIBUTE) != null) {
+            if (adapter.getAttribute(httpServletRequest, ServletTransactionHelper.ASYNC_ATTRIBUTE) != null) {
                 // HttpServletRequest.startAsync was invoked on this httpServletRequest.
                 // The transaction should be handled from now on by the other thread committing the response
                 transaction.deactivate();
@@ -230,7 +230,7 @@ public abstract class ServletApiAdvice {
                     final int size = requestExceptionAttributes.size();
                     for (int i = 0; i < size; i++) {
                         String attributeName = requestExceptionAttributes.get(i);
-                        Object throwable = adapter.getHttpAttribute(httpServletRequest, attributeName);
+                        Object throwable = adapter.getAttribute(httpServletRequest, attributeName);
                         if (throwable instanceof Throwable) {
                             t2 = (Throwable) throwable;
                             if (!attributeName.equals("javax.servlet.error.exception") && !attributeName.equals("jakarta.servlet.error.exception")) {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -55,7 +55,15 @@ public abstract class ServletApiAdvice {
     private static final DetachedThreadLocal<Object> servletPathTL = GlobalVariables.get(ServletApiAdvice.class, "servletPath", WeakConcurrent.buildThreadLocal());
     private static final DetachedThreadLocal<Object> pathInfoTL = GlobalVariables.get(ServletApiAdvice.class, "pathInfo", WeakConcurrent.buildThreadLocal());
 
-    private static final List<String> requestExceptionAttributes = Arrays.asList("javax.servlet.error.exception", "jakarta.servlet.error.exception", "exception", "org.springframework.web.servlet.DispatcherServlet.EXCEPTION", "co.elastic.apm.exception");
+    private static final String ELASTIC_EXCEPTION = "co.elastic.apm.exception";
+    private static final String JAVAX_ERROR_EXCEPTION = "javax.servlet.error.exception";
+    private static final String JAKARTA_ERROR_EXCEPTION = "jakarta.servlet.error.exception";
+    private static final List<String> requestExceptionAttributes = Arrays.asList(
+        JAVAX_ERROR_EXCEPTION,
+        JAKARTA_ERROR_EXCEPTION,
+        "exception",
+        "org.springframework.web.servlet.DispatcherServlet.EXCEPTION",
+        ELASTIC_EXCEPTION);
 
     @Nullable
     public static <HttpServletRequest, HttpServletResponse, ServletContext, ServletContextEvent, FilterConfig, ServletConfig> Object onServletEnter(
@@ -233,7 +241,13 @@ public abstract class ServletApiAdvice {
                         Object throwable = adapter.getAttribute(httpServletRequest, attributeName);
                         if (throwable instanceof Throwable) {
                             t2 = (Throwable) throwable;
-                            if (!attributeName.equals("javax.servlet.error.exception") && !attributeName.equals("jakarta.servlet.error.exception")) {
+
+                            // elastic exception can be removed as it's not needed after transaction end
+                            if (attributeName.equals(ELASTIC_EXCEPTION)) {
+                                adapter.removeAttribute(httpServletRequest, attributeName);
+                            }
+
+                            if (!attributeName.equals(JAVAX_ERROR_EXCEPTION) && !attributeName.equals(JAKARTA_ERROR_EXCEPTION)) {
                                 overrideStatusCodeOnThrowable = false;
                             }
                             break;

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -244,6 +244,13 @@ public abstract class ServletApiAdvice {
 
                             // elastic exception can be removed as it's not needed after transaction end
                             if (attributeName.equals(ELASTIC_EXCEPTION)) {
+                                try {
+                                    // extra safety: try to remove hard reference from the map entry to the exception
+                                    // but map implementation might throw if it does not support null values
+                                    adapter.setAttribute(httpServletRequest, attributeName, null);
+                                } catch (RuntimeException e){
+                                    // silently ignored
+                                }
                                 adapter.removeAttribute(httpServletRequest, attributeName);
                             }
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -244,13 +244,6 @@ public abstract class ServletApiAdvice {
 
                             // elastic exception can be removed as it's not needed after transaction end
                             if (attributeName.equals(ELASTIC_EXCEPTION)) {
-                                try {
-                                    // extra safety: try to remove hard reference from the map entry to the exception
-                                    // but map implementation might throw if it does not support null values
-                                    adapter.setAttribute(httpServletRequest, attributeName, null);
-                                } catch (RuntimeException e){
-                                    // silently ignored
-                                }
                                 adapter.removeAttribute(httpServletRequest, attributeName);
                             }
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JakartaServletApiAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JakartaServletApiAdapter.java
@@ -242,12 +242,6 @@ public class JakartaServletApiAdapter implements ServletApiAdapter<HttpServletRe
         servletRequest.setAttribute(attributeName, value);
     }
 
-    @Nullable
-    @Override
-    public Object getHttpAttribute(HttpServletRequest httpServletRequest, String attributeName) {
-        return httpServletRequest.getAttribute(attributeName);
-    }
-
     @Override
     public Collection<String> getHeaderNames(HttpServletResponse httpServletResponse) {
         return httpServletResponse.getHeaderNames();

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JakartaServletApiAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JakartaServletApiAdapter.java
@@ -243,6 +243,11 @@ public class JakartaServletApiAdapter implements ServletApiAdapter<HttpServletRe
     }
 
     @Override
+    public void removeAttribute(HttpServletRequest httpServletRequest, String attributeName) {
+        httpServletRequest.removeAttribute(attributeName);
+    }
+
+    @Override
     public Collection<String> getHeaderNames(HttpServletResponse httpServletResponse) {
         return httpServletResponse.getHeaderNames();
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
@@ -257,6 +257,11 @@ public class JavaxServletApiAdapter implements ServletApiAdapter<HttpServletRequ
     }
 
     @Override
+    public void removeAttribute(HttpServletRequest servletRequest, String attributeName) {
+        servletRequest.removeAttribute(attributeName);
+    }
+
+    @Override
     public Collection<String> getHeaderNames(HttpServletResponse httpServletResponse) {
         return httpServletResponse.getHeaderNames();
     }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/JavaxServletApiAdapter.java
@@ -256,12 +256,6 @@ public class JavaxServletApiAdapter implements ServletApiAdapter<HttpServletRequ
         servletRequest.setAttribute(attributeName, value);
     }
 
-    @Nullable
-    @Override
-    public Object getHttpAttribute(HttpServletRequest httpServletRequest, String attributeName) {
-        return httpServletRequest.getAttribute(attributeName);
-    }
-
     @Override
     public Collection<String> getHeaderNames(HttpServletResponse httpServletResponse) {
         return httpServletResponse.getHeaderNames();

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/ServletRequestAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/ServletRequestAdapter.java
@@ -90,9 +90,6 @@ public interface ServletRequestAdapter<HttpServletRequest, ServletContext> {
 
     void setAttribute(HttpServletRequest request, String attributeName, Object value);
 
-    @Nullable
-    Object getHttpAttribute(HttpServletRequest request, String attributeName);
-
     Map<String, String[]> getParameterMap(HttpServletRequest httpServletRequest);
 
     TextHeaderGetter<HttpServletRequest> getRequestHeaderGetter();

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/ServletRequestAdapter.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/adapter/ServletRequestAdapter.java
@@ -90,6 +90,8 @@ public interface ServletRequestAdapter<HttpServletRequest, ServletContext> {
 
     void setAttribute(HttpServletRequest request, String attributeName, Object value);
 
+    void removeAttribute(HttpServletRequest request, String attributeName);
+
     Map<String, String[]> getParameterMap(HttpServletRequest httpServletRequest);
 
     TextHeaderGetter<HttpServletRequest> getRequestHeaderGetter();

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/test/java/co/elastic/apm/agent/springwebmvc/exception/AbstractExceptionHandlerInstrumentationWithExceptionResolverTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/test/java/co/elastic/apm/agent/springwebmvc/exception/AbstractExceptionHandlerInstrumentationWithExceptionResolverTest.java
@@ -26,6 +26,9 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.Enumeration;
+
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
@@ -44,6 +47,16 @@ public abstract class AbstractExceptionHandlerInstrumentationWithExceptionResolv
         ResultActions resultActions = this.mockMvc.perform(get("/exception-resolver/throw-exception"));
         MvcResult result = resultActions.andReturn();
         MockHttpServletResponse response = result.getResponse();
+
+
+        Enumeration<String> attributeNames = result.getRequest().getAttributeNames();
+        while (attributeNames.hasMoreElements()) {
+            String attributeName = attributeNames.nextElement();
+            assertThat(attributeName)
+                .describedAs("elastic attributes should be removed after usage")
+                .doesNotStartWith("co.elastic.");
+        }
+
 
         assertExceptionCapture(ExceptionResolverRuntimeException.class, response, 200, "", "runtime exception occurred", "View#render error-page");
         assertEquals("error-page", response.getForwardedUrl());


### PR DESCRIPTION
- remove duplicated method
- remove attribute after use
- add test assertion for elastic attribute leak

## What does this PR do?

Removes the servlet request attributes used to capture spring MVC exceptions after they have been used. This helps prevent undesirable side effects that could be related to the presence of extra request attributes.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix

