### PR TITLE
Added internal option to fully redact exceptions

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,7 +33,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 [float]
 ===== Features
-* Added internal `redact_exceptions` config option to workaround JVM bugs related to touching exceptions - {pull}3528[#3528]
+* Added internal `safe_exceptions` config option to workaround JVM bugs related to touching exceptions - {pull}3528[#3528]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
+[float]
+===== Features
+* Added internal `redact_exceptions` config option to workaround JVM bugs related to touching exceptions - {pull}3528[#3528]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 
@@ -40,9 +44,6 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Features
 * Added a configuration option to use queues in names of spring-rabbit transactions - {pull}3424[#3424]
-
-[float]
-===== Features
 * Add option to retry JMX metrics capture in case of exception - {pull}3511[#3511]
 
 [float]

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -518,12 +518,12 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
         .buildWithDefault(false);
 
 
-    private final ConfigurationOption<Boolean> redactExceptions = ConfigurationOption.<Boolean>booleanOption()
+    private final ConfigurationOption<Integer> redactExceptions = ConfigurationOption.<Boolean>integerOption()
         .key("redact_exceptions")
         .tags("internal")
         .configurationCategory(CORE_CATEGORY)
         .dynamic(true)
-        .buildWithDefault(false);
+        .buildWithDefault(0);
 
     private final ConfigurationOption<List<WildcardMatcher>> classesExcludedFromInstrumentation = ConfigurationOption
         .builder(new ValueConverter<List<WildcardMatcher>>() {
@@ -1172,7 +1172,12 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
     }
 
     public boolean isRedactExceptions() {
-        return redactExceptions.get();
+        return (redactExceptions.get() & 1) != 0;
+    }
+
+    @Override
+    public boolean isNotUseServletAttributesForExceptionPropagation() {
+        return (redactExceptions.get() & 2) != 0;
     }
 
     public enum CloudProvider {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -517,6 +517,14 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
         .tags("added[1.44.0]")
         .buildWithDefault(false);
 
+
+    private final ConfigurationOption<Boolean> redactExceptions = ConfigurationOption.<Boolean>booleanOption()
+        .key("redact_exceptions")
+        .tags("internal")
+        .configurationCategory(CORE_CATEGORY)
+        .dynamic(true)
+        .buildWithDefault(true);
+
     private final ConfigurationOption<List<WildcardMatcher>> classesExcludedFromInstrumentation = ConfigurationOption
         .builder(new ValueConverter<List<WildcardMatcher>>() {
 
@@ -1161,6 +1169,10 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
 
     public boolean isContextPropagationOnly() {
         return contextPropagationOnly.get();
+    }
+
+    public boolean isRedactExceptions() {
+        return redactExceptions.get();
     }
 
     public enum CloudProvider {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -518,8 +518,8 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
         .buildWithDefault(false);
 
 
-    private final ConfigurationOption<Integer> redactExceptions = ConfigurationOption.<Boolean>integerOption()
-        .key("redact_exceptions")
+    private final ConfigurationOption<Integer> safeExceptions = ConfigurationOption.<Boolean>integerOption()
+        .key("safe_exceptions")
         .tags("internal")
         .configurationCategory(CORE_CATEGORY)
         .dynamic(true)
@@ -1172,12 +1172,12 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
     }
 
     public boolean isRedactExceptions() {
-        return (redactExceptions.get() & 1) != 0;
+        return (safeExceptions.get() & 1) != 0;
     }
 
     @Override
-    public boolean isNotUseServletAttributesForExceptionPropagation() {
-        return (redactExceptions.get() & 2) != 0;
+    public boolean isUseServletAttributesForExceptionPropagation() {
+        return (safeExceptions.get() & 2) == 0;
     }
 
     public enum CloudProvider {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -523,7 +523,7 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
         .tags("internal")
         .configurationCategory(CORE_CATEGORY)
         .dynamic(true)
-        .buildWithDefault(true);
+        .buildWithDefault(false);
 
     private final ConfigurationOption<List<WildcardMatcher>> classesExcludedFromInstrumentation = ConfigurationOption
         .builder(new ValueConverter<List<WildcardMatcher>>() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/RedactedException.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/RedactedException.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.impl.error;
 
 public class RedactedException extends Exception {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/RedactedException.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/error/RedactedException.java
@@ -1,0 +1,10 @@
+package co.elastic.apm.agent.impl.error;
+
+public class RedactedException extends Exception {
+
+    public RedactedException() {
+        super("This exception is a placeholder for an exception which has occurred in the application." +
+            "The stacktrace corresponds to where elastic APM detected the exception.");
+    }
+
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -104,6 +104,8 @@ public class Transaction extends AbstractSpan<Transaction> implements co.elastic
     @Nullable
     private String frameworkVersion;
 
+    private Throwable pendingException;
+
     /**
      * Faas
      * <p>
@@ -337,6 +339,7 @@ public class Transaction extends AbstractSpan<Transaction> implements co.elastic
         frameworkVersion = null;
         faas.resetState();
         wasActivated.set(false);
+        pendingException = null;
         // don't clear timerBySpanTypeAndSubtype map (see field-level javadoc)
     }
 
@@ -535,4 +538,17 @@ public class Transaction extends AbstractSpan<Transaction> implements co.elastic
             phaser.readerUnlock();
         }
     }
+
+
+    @Override
+    public void setPendingTransactionException(Throwable exception) {
+        this.pendingException = exception;
+    }
+
+    @Nullable
+    @Override
+    public Throwable getPendingTransactionException() {
+        return this.pendingException;
+    }
+
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Transaction.java
@@ -104,6 +104,7 @@ public class Transaction extends AbstractSpan<Transaction> implements co.elastic
     @Nullable
     private String frameworkVersion;
 
+    @Nullable
     private Throwable pendingException;
 
     /**
@@ -541,7 +542,7 @@ public class Transaction extends AbstractSpan<Transaction> implements co.elastic
 
 
     @Override
-    public void setPendingTransactionException(Throwable exception) {
+    public void setPendingTransactionException(@Nullable Throwable exception) {
         this.pendingException = exception;
     }
 

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/ServletApiAdvice.java
@@ -239,6 +239,12 @@ public abstract class ServletApiAdvice {
                             break;
                         }
                     }
+                    if (t2 == null) {
+                        t2 = transaction.getPendingTransactionException();
+                        if(t2 != null) {
+                            overrideStatusCodeOnThrowable = false;
+                        }
+                    }
                 }
 
                 ServletContext servletContext = adapter.getServletContext(httpServletRequest);

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/JakartaApmAsyncListener.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/JakartaApmAsyncListener.java
@@ -79,7 +79,7 @@ public class JakartaApmAsyncListener implements AsyncListener, Recyclable {
 
     @Override
     public void onTimeout(AsyncEvent event) {
-        throwable = event.getThrowable();
+        throwable = asyncContextAdviceHelperImpl.getTracer().redactExceptionIfRequired(event.getThrowable());
         if (isJBossEap6(event)) {
             endTransaction(event);
         }
@@ -98,7 +98,7 @@ public class JakartaApmAsyncListener implements AsyncListener, Recyclable {
 
     @Override
     public void onError(AsyncEvent event) {
-        throwable = event.getThrowable();
+        throwable = asyncContextAdviceHelperImpl.getTracer().redactExceptionIfRequired(event.getThrowable());
         if (isJBossEap6(event)) {
             endTransaction(event);
         }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/JakartaAsyncContextAdviceHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/JakartaAsyncContextAdviceHelper.java
@@ -44,6 +44,10 @@ public class JakartaAsyncContextAdviceHelper implements AsyncContextAdviceHelper
             new JakartaAsyncContextAdviceHelper.JakartaApmAsyncListenerAllocator());
     }
 
+    public Tracer getTracer() {
+        return tracer;
+    }
+
     private final class JakartaApmAsyncListenerAllocator implements Allocator<JakartaApmAsyncListener> {
         @Override
         public JakartaApmAsyncListener createInstance() {

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/JavaxApmAsyncListener.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/JavaxApmAsyncListener.java
@@ -78,7 +78,7 @@ public class JavaxApmAsyncListener implements AsyncListener, Recyclable {
 
     @Override
     public void onTimeout(AsyncEvent event) {
-        throwable = event.getThrowable();
+        throwable = asyncContextAdviceHelperImpl.getTracer().redactExceptionIfRequired(event.getThrowable());
         if (isJBossEap6(event)) {
             endTransaction(event);
         }
@@ -97,7 +97,7 @@ public class JavaxApmAsyncListener implements AsyncListener, Recyclable {
 
     @Override
     public void onError(AsyncEvent event) {
-        throwable = event.getThrowable();
+        throwable = asyncContextAdviceHelperImpl.getTracer().redactExceptionIfRequired(event.getThrowable());
         if (isJBossEap6(event)) {
             endTransaction(event);
         }

--- a/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/JavaxAsyncContextAdviceHelper.java
+++ b/apm-agent-plugins/apm-servlet-plugin/src/main/java/co/elastic/apm/agent/servlet/helper/JavaxAsyncContextAdviceHelper.java
@@ -45,6 +45,10 @@ public class JavaxAsyncContextAdviceHelper implements AsyncContextAdviceHelper<A
             new JavaxAsyncContextAdviceHelper.ApmAsyncListenerAllocator());
     }
 
+    public Tracer getTracer() {
+        return tracer;
+    }
+
     private final class ApmAsyncListenerAllocator implements Allocator<JavaxApmAsyncListener> {
         @Override
         public JavaxApmAsyncListener createInstance() {

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/main/java/co/elastic/apm/agent/springwebmvc/AbstractSpringExceptionHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/main/java/co/elastic/apm/agent/springwebmvc/AbstractSpringExceptionHandlerInstrumentation.java
@@ -21,6 +21,7 @@ package co.elastic.apm.agent.springwebmvc;
 import co.elastic.apm.agent.sdk.ElasticApmInstrumentation;
 import co.elastic.apm.agent.servlet.Constants;
 import co.elastic.apm.agent.servlet.adapter.ServletRequestAdapter;
+import co.elastic.apm.agent.tracer.GlobalTracer;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
@@ -63,7 +64,8 @@ public abstract class AbstractSpringExceptionHandlerInstrumentation extends Elas
                                                                     @Nullable HttpServletRequest request,
                                                                     @Nullable Exception e) {
             if (request != null && e != null) {
-                adapter.setAttribute(request, "co.elastic.apm.exception", e);
+                Throwable maybeRedacted = GlobalTracer.get().redactExceptionIfRequired(e);
+                adapter.setAttribute(request, "co.elastic.apm.exception", maybeRedacted);
             }
         }
     }

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/main/java/co/elastic/apm/agent/springwebmvc/AbstractSpringExceptionHandlerInstrumentation.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/main/java/co/elastic/apm/agent/springwebmvc/AbstractSpringExceptionHandlerInstrumentation.java
@@ -68,16 +68,15 @@ public abstract class AbstractSpringExceptionHandlerInstrumentation extends Elas
                                                                     @Nullable Exception e) {
             if (request != null && e != null) {
                 Tracer tracer = GlobalTracer.get();
-                boolean notUseAttribs = tracer.getConfig(CoreConfiguration.class).isNotUseServletAttributesForExceptionPropagation();
+                boolean useAttribs = tracer.getConfig(CoreConfiguration.class).isUseServletAttributesForExceptionPropagation();
                 Throwable maybeRedacted = tracer.redactExceptionIfRequired(e);
-
-                if (notUseAttribs) {
+                if (useAttribs) {
+                    adapter.setAttribute(request, "co.elastic.apm.exception", maybeRedacted);
+                } else {
                     Transaction<?> transaction = tracer.currentContext().getTransaction();
                     if(transaction != null) {
                         transaction.setPendingTransactionException(maybeRedacted);
                     }
-                } else {
-                    adapter.setAttribute(request, "co.elastic.apm.exception", maybeRedacted);
                 }
             }
         }

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/test/java/co/elastic/apm/agent/springwebmvc/exception/AbstractExceptionHandlerInstrumentationWithExceptionResolverTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/test/java/co/elastic/apm/agent/springwebmvc/exception/AbstractExceptionHandlerInstrumentationWithExceptionResolverTest.java
@@ -21,7 +21,6 @@ package co.elastic.apm.agent.springwebmvc.exception;
 import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_resolver.ExceptionResolverController;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_resolver.ExceptionResolverRuntimeException;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.mock.web.MockHttpServletResponse;
@@ -47,7 +46,7 @@ public abstract class AbstractExceptionHandlerInstrumentationWithExceptionResolv
     @ValueSource(booleans = {true,false})
     public void testCallApiWithExceptionThrown(boolean useAttributeBasedPropagation) throws Exception {
         CoreConfiguration coreConfig = config.getConfig(CoreConfiguration.class);
-        doReturn(useAttributeBasedPropagation).when(coreConfig).isNotUseServletAttributesForExceptionPropagation();
+        doReturn(useAttributeBasedPropagation).when(coreConfig).isUseServletAttributesForExceptionPropagation();
 
         ResultActions resultActions = this.mockMvc.perform(get("/exception-resolver/throw-exception"));
         MvcResult result = resultActions.andReturn();

--- a/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/test/java/co/elastic/apm/agent/springwebmvc/exception/AbstractExceptionHandlerInstrumentationWithExceptionResolverTest.java
+++ b/apm-agent-plugins/apm-spring-webmvc/apm-spring-webmvc-spring5/src/test/java/co/elastic/apm/agent/springwebmvc/exception/AbstractExceptionHandlerInstrumentationWithExceptionResolverTest.java
@@ -18,15 +18,19 @@
  */
 package co.elastic.apm.agent.springwebmvc.exception;
 
+import co.elastic.apm.agent.configuration.CoreConfiguration;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_resolver.ExceptionResolverController;
 import co.elastic.apm.agent.springwebmvc.exception.testapp.exception_resolver.ExceptionResolverRuntimeException;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.ResultActions;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doReturn;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 /**
@@ -39,8 +43,12 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 })
 public abstract class AbstractExceptionHandlerInstrumentationWithExceptionResolverTest extends AbstractExceptionHandlerInstrumentationTest {
 
-    @Test
-    public void testCallApiWithExceptionThrown() throws Exception {
+    @ParameterizedTest
+    @ValueSource(booleans = {true,false})
+    public void testCallApiWithExceptionThrown(boolean useAttributeBasedPropagation) throws Exception {
+        CoreConfiguration coreConfig = config.getConfig(CoreConfiguration.class);
+        doReturn(useAttributeBasedPropagation).when(coreConfig).isNotUseServletAttributesForExceptionPropagation();
+
         ResultActions resultActions = this.mockMvc.perform(get("/exception-resolver/throw-exception"));
         MvcResult result = resultActions.andReturn();
         MockHttpServletResponse response = result.getResponse();

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/GlobalTracer.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/GlobalTracer.java
@@ -150,4 +150,10 @@ public class GlobalTracer implements Tracer {
     public Service createService(String ephemeralId) {
         return tracer.createService(ephemeralId);
     }
+
+    @Nullable
+    @Override
+    public Throwable redactExceptionIfRequired(@Nullable Throwable original) {
+        return tracer.redactExceptionIfRequired(original);
+    }
 }

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/NoopTracer.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/NoopTracer.java
@@ -125,4 +125,10 @@ class NoopTracer implements Tracer {
     public Service createService(String ephemeralId) {
         return null;
     }
+
+    @Nullable
+    @Override
+    public Throwable redactExceptionIfRequired(@Nullable Throwable original) {
+        return original;
+    }
 }

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/Tracer.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/Tracer.java
@@ -88,4 +88,7 @@ public interface Tracer {
 
     @Nullable
     Service createService(String ephemeralId);
+
+    @Nullable
+    Throwable redactExceptionIfRequired(@Nullable Throwable original);
 }

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/Transaction.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/Transaction.java
@@ -56,4 +56,9 @@ public interface Transaction<T extends Transaction<T>> extends AbstractSpan<T> {
     void setFrameworkName(@Nullable String frameworkName);
 
     void setFrameworkVersion(@Nullable String frameworkVersion);
+
+    void setPendingTransactionException(Throwable exception);
+
+    @Nullable
+    Throwable getPendingTransactionException();
 }

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/CoreConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/CoreConfiguration.java
@@ -50,6 +50,8 @@ public interface CoreConfiguration {
 
     TimeDuration getSpanMinDuration();
 
+    boolean isNotUseServletAttributesForExceptionPropagation();
+
     enum EventType {
         /**
          * Request bodies will never be reported

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/CoreConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/CoreConfiguration.java
@@ -50,7 +50,7 @@ public interface CoreConfiguration {
 
     TimeDuration getSpanMinDuration();
 
-    boolean isNotUseServletAttributesForExceptionPropagation();
+    boolean isUseServletAttributesForExceptionPropagation();
 
     enum EventType {
         /**


### PR DESCRIPTION
## What does this PR do?

~Adds a new, internal config option `redact_exceptions`. If enabled, application exceptions will be replaced with instances of `RedactedExceptions` with a stacktrace where the original exception would have been recorded.~

The config option has been added with the name `safe_exceptions` with two flags:
 - `1` enables redacted exceptions
 - `2` changes the propagation to not use the servlet-attributes

This config option can be used to try to workaround JVM bugs related to touching exceptions.

I've tried to identify all places where the redaction needs to be applied by searching for reference of both `Exception` and `Throwable`: I've looked for method having those types as parameters and fields using those types.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [ ] ~I have made corresponding changes to the documentation~