### PR TITLE
Attempt to fix PR labeling

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -24,7 +24,7 @@ jobs:
     - id: is_elastic_member
       uses: elastic/apm-pipeline-library/.github/actions/is-member-elastic-org@current
       with:
-        username: ${{ github.event.issue.user.login }}
+        username: ${{ github.actor }}
         token: ${{ secrets.APM_TECH_USER_TOKEN }}
     - name: Add community and triage lables
       if: steps.is_elastic_member.outputs.result != true


### PR DESCRIPTION
`${{ github.actor }}` was used in the previous revision, I think that is the correct variable to use
