### PR TITLE
Fix labeler workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -49,6 +49,8 @@ jobs:
     - name: Assign new internal pull requests to project
       uses: elastic/assign-one-project-github-action@1.2.2
       if: contains(steps.is_elastic_member.outputs.result, 'true') && github.event.pull_request
+      env:
+        MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
       with:
         project: 'https://github.com/orgs/elastic/projects/454'
         project_id: '5882982'


### PR DESCRIPTION
The `MY_GITHUB_TOKEN` env var which was removed in #3536 is actually required as an input to the project assignment step.