### PR TITLE
Avoid instanceof if redacted exceptions are active

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,11 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
+[float]
+===== Bug fixes
+* Avoid another case where we might touch application exceptions for `safe_exceptions` - {pull}3553[#3553]
+
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -1002,7 +1002,7 @@ public class ElasticApmTracer implements Tracer {
     @Override
     @Nullable
     public Throwable redactExceptionIfRequired(@Nullable Throwable original) {
-        if (original != null && coreConfiguration.isRedactExceptions() && !(original instanceof RedactedException)) {
+        if (original != null && coreConfiguration.isRedactExceptions()) {
             return new RedactedException();
         }
         return original;

--- a/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
+++ b/apm-agent-core/src/test/java/org/example/stacktrace/ErrorCaptureTest.java
@@ -117,7 +117,8 @@ class ErrorCaptureTest {
         Throwable redacted = tracer.redactExceptionIfRequired(exception);
         assertThat(redacted).isInstanceOf(RedactedException.class);
 
-        assertThat(tracer.redactExceptionIfRequired(redacted)).isSameAs(redacted);
+        // double redaction means no instanceof check
+        assertThat(tracer.redactExceptionIfRequired(redacted)).isNotSameAs(redacted);
 
         ErrorCapture errorCapture = tracer.captureException(exception, tracer.currentContext(), null);
         assertThat(errorCapture).isNotNull();
@@ -125,7 +126,7 @@ class ErrorCaptureTest {
 
         ErrorCapture alreadyRedacted = tracer.captureException(redacted, tracer.currentContext(), null);
         assertThat(alreadyRedacted).isNotNull();
-        assertThat(alreadyRedacted.getException()).isSameAs(redacted);
+        assertThat(alreadyRedacted.getException()).isNotSameAs(redacted);
     }
 
 


### PR DESCRIPTION
## What does this PR do?

Avoids another case where we would touch exceptions, which might be corrupted due to a JVM bug.

- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
