### PR TITLE
ci(bk): use specialised VMs

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -36,7 +36,7 @@ This is the Buildkite pipeline for the Opentelemetry Benchmark.
 To view the pipeline and its configuration, click [here](https://buildkite.com/elastic/apm-agent-java-opentelemetry-benchmark) or
 go to the definition in `opentelemetry-benchmark.yml`.
 
-## Buildkite VM runners
+## Buildkite VM runners
 
 A set of Buildkite VM runners has been created for this repository. The VM runners contain
 the required software:

--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -9,7 +9,7 @@ This is the Buildkite pipeline for releasing the APM Agent Java.
 ### Pipeline Configuration
 
 To view the pipeline and its configuration, click [here](https://buildkite.com/elastic/apm-agent-java-release) or
-go to the definition in the `elastic/ci` repository.
+go to the definition in `release.yml`.
 
 ### Credentials
 
@@ -25,7 +25,7 @@ This is the Buildkite pipeline for the APM Agent Java in charge of the snapshots
 ### Pipeline Configuration
 
 To view the pipeline and its configuration, click [here](https://buildkite.com/elastic/apm-agent-java-snapshot) or
-go to the definition in the `elastic/ci` repository.
+go to the definition in `snapshot.yml`.
 
 ## opentelemetry-benchmark pipeline
 
@@ -35,3 +35,15 @@ This is the Buildkite pipeline for the Opentelemetry Benchmark.
 
 To view the pipeline and its configuration, click [here](https://buildkite.com/elastic/apm-agent-java-opentelemetry-benchmark) or
 go to the definition in `opentelemetry-benchmark.yml`.
+
+## Buildkite VM runners
+
+A set of Buildkite VM runners has been created for this repository. The VM runners contain
+the required software:
+* JDK
+* GPG
+* Maven dependencies
+
+If a new version of Java is required, update the `.java-version` file with the latest major. When the changes are merged onto `main,` wait for the following day; that's when the automation will be responsible for recreating the VM with the new Java version.
+
+If you would like to know more about how it works, please go to https://github.com/elastic/ci-agent-images/tree/main/vm-images/apm-agent-java (**NOTE**: only available for Elastic employees)

--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -5,19 +5,23 @@ set -euo pipefail
 JAVA_VERSION=$(cat .java-version | xargs | tr -dc '[:print:]')
 JAVA_HOME="${HOME}/.java/openjdk${JAVA_VERSION}"
 export JAVA_HOME
-PATH="${JAVA_HOME}/bin:$PATH"
+PATH="${JAVA_HOME}/bin:${PATH}"
 export PATH
 
-# Fallback to install at runtime
-if [ ! -d "${JAVA_HOME}" ] ; then
+if [ -d "${JAVA_HOME}" ] ; then
+  echo "--- Skip installing JDK${JAVA_VERSION} :java:"
+  echo "already available in the Buildkite runner"
+else
+  # Fallback to install at runtime
   # This should not be the case normally untless the .java-version file has been changed
   # and the VM Image is not yet available with the latest version.
   echo "--- Install JDK${JAVA_VERSION} :java:"
   JAVA_URL=https://jvm-catalog.elastic.co/jdk
   JAVA_PKG="${JAVA_URL}/latest_openjdk_${JAVA_VERSION}_linux.tar.gz"
-  curl -L --output /tmp/jdk.tar.gz "$JAVA_PKG"
-  mkdir -p "$JAVA_HOME"
-  tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
+  curl -L --output /tmp/jdk.tar.gz "${JAVA_PKG}"
+  mkdir -p "${JAVA_HOME}"
+  tar --extract --file /tmp/jdk.tar.gz --directory "${JAVA_HOME}" --strip-components 1
 fi
 
+# Validate java is available in the runner.
 java -version

--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -1,6 +1,6 @@
 agents:
   provider: "gcp"
-  #image: "family/apm-agent-java-ubuntu-2204"
+  image: "family/apm-agent-java-ubuntu-2204"
 
 steps:
   - label: "Run the release"

--- a/.buildkite/snapshot.yml
+++ b/.buildkite/snapshot.yml
@@ -1,6 +1,6 @@
 agents:
   provider: "gcp"
-  #image: "family/apm-agent-java-ubuntu-2204"
+  image: "family/apm-agent-java-ubuntu-2204"
 
 steps:
   - label: "Run the snapshot"


### PR DESCRIPTION
## What does this PR do?

Enable the specialised BK VM images.

## Why

Faster builds and reliable

`13%` ~ `18%` faster than installing things at runtime.


<img width="1382" alt="image" src="https://github.com/elastic/apm-agent-java/assets/2871786/c329da1d-f0a2-4939-b7c6-e866bf2de8ea">


## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)


## Test

Only for `Elastic` employees:

- Snapshot Buildkite build, see [here](https://buildkite.com/elastic/apm-agent-java-snapshot/builds/349)