### PR TITLE
github-action: sbom generation (initial attempt)

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,158 @@
+---
+# Releases the agent
+name: sbom
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'The branch to release'
+        required: true
+        default: 'main'
+      version:
+        description: 'The version to release (e.g. 1.2.3). This workflow will automatically perform the required version bumps'
+        required: true
+      update_changelog:
+        description: |
+          If enabled, everything in the changelog from the "Unreleased" section will be automatically moved to a new section for the new release.
+          If disabled, the changelog needs to be prepared for the release manually before triggering this workflow.
+        type: boolean
+        required: true
+        default: true
+      skip_preparation:
+        description: |
+          If enabled, the version bump, release notes update and tag creation will be skipped.
+          Select this option if those tasks have already been done in a previous run.
+        type: boolean
+        required: true
+        default: false
+      skip_maven_deploy:
+        description: |
+          If enabled, the deployment to maven central will be skipped.
+          Select this if the deployment job for this release failed in a previous version but the release was actually published.
+          Check manually on maven central beforehand!
+        type: boolean
+        required: true
+        default: false
+      dry_run:
+        description: If set, run a dry-run release
+        default: false
+        type: boolean
+
+env:
+  TAG_NAME: v${{ inputs.version }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  prepare_release:
+    permissions:
+      contents: write
+    name: "Changelog and Version Bump"
+    if: ${{ ! inputs.skip_preparation }}
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo skipped'
+
+  maven_central_deploy:
+    name: "Deploy to Maven Central (Buildkite)"
+    if: ${{ ! inputs.skip_maven_deploy && ( inputs.skip_preparation || success() ) }}
+    runs-on: ubuntu-latest
+    needs:
+      - prepare_release
+    steps:
+      - run: 'echo TBD'
+
+  await_artifact_on_maven_central:
+    name: "Wait for artifacts to be available on maven central"
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo skipped'
+
+  update_major_branch:
+    name: "Update Major Branch"
+    runs-on: ubuntu-latest
+    needs:
+      - await_artifact_on_maven_central
+    permissions:
+      contents: write
+    steps:
+      - run: 'echo skipped'
+
+  update_cloudfoundry:
+    name: "Update Cloudfoundry"
+    runs-on: ubuntu-latest
+    needs:
+      - await_artifact_on_maven_central
+    permissions:
+      contents: write
+    steps:
+      - run: 'echo skipped'
+
+  build_and_push_docker_images:
+    name: "Build and push docker images"
+    runs-on: ubuntu-latest
+    needs:
+      - await_artifact_on_maven_central
+    env:
+      SONATYPE_FALLBACK: 1
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG_NAME }}
+          fetch-depth: 0 # Load entire history as it is required for the push-script
+      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
+        with:
+          registry: docker.elastic.co
+          secret: secret/apm-team/ci/docker-registry/prod
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - name: "Build docker image"
+        shell: bash
+        run: ./scripts/docker-release/build_docker.sh
+
+  publish_aws_lambda:
+    name: "Publish AWS Lambda"
+    runs-on: ubuntu-latest
+    needs:
+      - await_artifact_on_maven_central
+    outputs:
+      arn_content: ${{ steps.arn_output.outputs.arn_content }}
+    env:
+      # Random region. This needs to be set in GH Actions or the usage of aws-cli will fail.
+      # The default region does not matter, since we are publishing in all regions.
+      AWS_DEFAULT_REGION: eu-west-1
+    steps:
+      - run: 'echo skipped'
+
+  create_github_release:
+    name: "Create GitHub Release"
+    needs:
+      - publish_aws_lambda
+      - update_major_branch
+    runs-on: ubuntu-latest
+    if: ${{ ! inputs.dry_run }}
+    permissions:
+      contents: write
+    steps:
+      - run: 'echo skipped'
+
+  notify:
+    if: ${{ always() && ! inputs.dry_run }}
+    needs:
+      - prepare_release
+      - maven_central_deploy
+      - await_artifact_on_maven_central
+      - update_major_branch
+      - update_cloudfoundry
+      - build_and_push_docker_images
+      - publish_aws_lambda
+      - create_github_release
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo skipped'

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -3,12 +3,17 @@
 name: sbom
 
 on:
+  # Begin - For testing purposes only
+  push:
+    branches:
+      - "feature/sbom"
+  # End - For testing purposes only
   workflow_dispatch:
     inputs:
       branch:
         description: 'The branch to release'
         required: true
-        default: 'main'
+        default: 'feature/sbom'
       version:
         description: 'The version to release (e.g. 1.2.3). This workflow will automatically perform the required version bumps'
         required: true


### PR DESCRIPTION
## What does this PR do?

Test SBOM generation using the release GitHub action but doing nothing for now

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
