### PR TITLE
ci(fix): use input value instead of env value for post release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -248,7 +248,7 @@ jobs:
     if: inputs.dry_run == false
     with:
       ref: ${{ inputs.ref }}
-      version: ${{ env.RELEASE_VERSION }}
+      version: ${{ inputs.version }}
       phase: 'post'
     secrets: inherit
 


### PR DESCRIPTION
## What is the change being made?

* Use input value instead of env value.

## Why is the change being made?

* Env values aren't interpolated in the action trigger.