### PR TITLE
Prevent cycles in inferred spans

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
+[float]
+===== Bug fixes
+* Fixed edge case where inferred spans could cause cycles in the trace parent-child relationships, subsequently resulting in the UI crashing - {pull}3588[#3588]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ChildList.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ChildList.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.profiler;
+
+
+import co.elastic.apm.agent.sdk.internal.collections.LongList;
+
+/** List for maintaining pairs of (spanId,parentIds) both represented as longs. */
+public class ChildList {
+
+    // this list contains the (spanId,parentIds) flattened
+    private final LongList idsWithParentIds = new LongList();
+
+    public void add(long id, long parentId) {
+        idsWithParentIds.add(id);
+        idsWithParentIds.add(parentId);
+    }
+
+    public long getId(int index) {
+        return idsWithParentIds.get(index * 2);
+    }
+
+    public long getParentId(int index) {
+        return idsWithParentIds.get(index * 2 + 1);
+    }
+
+    public int getSize() {
+        return idsWithParentIds.getSize() / 2;
+    }
+
+    public void addAll(ChildList other) {
+        idsWithParentIds.addAll(other.idsWithParentIds);
+    }
+
+    public void clear() {
+        idsWithParentIds.clear();
+    }
+
+    public boolean isEmpty() {
+        return getSize() == 0;
+    }
+
+    public void removeLast() {
+        int size = idsWithParentIds.getSize();
+        idsWithParentIds.remove(size - 1);
+        idsWithParentIds.remove(size - 2);
+    }
+}

--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/SamplingProfiler.java
@@ -106,7 +106,7 @@ import static java.nio.file.StandardOpenOption.WRITE;
  * and at least one stack trace.
  * Once {@linkplain ActivationEvent#handleDeactivationEvent(SamplingProfiler) handling the deactivation event} of the root span in a thread
  * (after which {@link ElasticApmTracer#getActive()} would return {@code null}),
- * the {@link CallTree} is {@linkplain CallTree#spanify(CallTree.Root, TraceContext) converted into regular spans}.
+ * the {@link CallTree} is {@linkplain CallTree#spanify(CallTree.Root, TraceContext, TraceContext) converted into regular spans}.
  * </p>
  * <p>
  * Overall, the allocation rate does not depend on the number of {@link ActivationEvent}s but only on

--- a/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/CallTreeTest.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/test/java/co/elastic/apm/agent/profiler/CallTreeTest.java
@@ -120,7 +120,7 @@ class CallTreeTest {
     @Test
     void testGiveEmptyChildIdsTo() {
         CallTree rich = new CallTree();
-        rich.addChildId(42);
+        rich.addChildId(42, 0L);
         CallTree robinHood = new CallTree();
         CallTree poor = new CallTree();
 


### PR DESCRIPTION
## What does this PR do?

Fixes parent-child cycles which could occur in traces with inferred spans.
Backport of https://github.com/elastic/elastic-otel-java/pull/201.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
