### PR TITLE
Add thread dump debug option

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfiguration.java
@@ -488,6 +488,13 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
             "exist and use it to dump bytecode of instrumented classes.")
         .buildWithDefault("");
 
+    private final ConfigurationOption<TimeDuration> threadDumpInterval = TimeDurationValueConverter.durationOption("ms")
+        .key("thread_dump_interval")
+        .configurationCategory(CORE_CATEGORY)
+        .tags("internal")
+        .description("Triggers a thread dump at regular frequency, should be used to help configure trace_methods without knowledge of application code")
+        .buildWithDefault(TimeDuration.of("0ms"));
+
     private final ConfigurationOption<Boolean> typeMatchingWithNamePreFilter = ConfigurationOption.booleanOption()
         .key("enable_type_matching_name_pre_filtering")
         .configurationCategory(CORE_CATEGORY)
@@ -1015,6 +1022,10 @@ public class CoreConfiguration extends ConfigurationOptionProvider implements co
     @Nullable
     public String getBytecodeDumpPath() {
         return bytecodeDumpPath.get();
+    }
+
+    public long getThreadDumpInterval() {
+        return threadDumpInterval.get().getMillis();
     }
 
     public boolean isTypeMatchingWithNamePreFilter() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ThreadDump.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ThreadDump.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.util;
+
+import co.elastic.apm.agent.configuration.CoreConfiguration;
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
+import co.elastic.apm.agent.tracer.AbstractLifecycleListener;
+import co.elastic.apm.agent.tracer.Tracer;
+
+import javax.annotation.Nullable;
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadInfo;
+import java.lang.management.ThreadMXBean;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+public class ThreadDump extends AbstractLifecycleListener {
+
+    private Logger log = LoggerFactory.getLogger(ThreadDump.class);
+
+    @Nullable
+    private ScheduledThreadPoolExecutor executor;
+
+    @Override
+    public void start(Tracer tracer) throws Exception {
+
+        long threadDumpInterval = tracer.getConfig(CoreConfiguration.class).getThreadDumpInterval();
+        if (threadDumpInterval <= 0) {
+            return;
+        }
+
+        if (threadDumpInterval < 100) {
+            log.error("thread dump frequency too high, adjusted to every 100ms");
+            threadDumpInterval = 100;
+        }
+
+        log.warn("thread dump will be generated every %s ms", threadDumpInterval);
+
+        executor = ExecutorUtils.createSingleThreadSchedulingDaemonPool("thread-dump");
+
+        executor.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+                StringBuilder sb = new StringBuilder();
+                for (ThreadInfo threadInfo : threadMXBean.dumpAllThreads(true, true)) {
+                    sb.append(threadInfo.toString());
+                }
+
+                log.debug("thread dump: \n\n {}", sb);
+
+            }
+        }, threadDumpInterval, threadDumpInterval, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        if (executor == null) {
+            return;
+        }
+        ExecutorUtils.shutdownAndWaitTermination(executor);
+    }
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ThreadDump.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ThreadDump.java
@@ -46,6 +46,11 @@ public class ThreadDump extends AbstractLifecycleListener {
             return;
         }
 
+        if (!log.isDebugEnabled()) {
+            log.error("thread dump option requires debug log level");
+            return;
+        }
+
         if (threadDumpInterval < 100) {
             log.error("thread dump frequency too high, adjusted to every 100ms");
             threadDumpInterval = 100;

--- a/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.tracer.LifecycleListener
+++ b/apm-agent-core/src/main/resources/META-INF/services/co.elastic.apm.agent.tracer.LifecycleListener
@@ -10,3 +10,4 @@ co.elastic.apm.agent.metrics.builtin.AgentOverheadMetrics
 co.elastic.apm.agent.impl.circuitbreaker.CircuitBreaker
 co.elastic.apm.agent.collections.WeakMapCleaner
 co.elastic.apm.agent.report.serialize.MetricRegistryReporter
+co.elastic.apm.agent.util.ThreadDump


### PR DESCRIPTION
## What does this PR do?

Adds an internal option that triggers a thread dump at regular interval.
minimal frequency is limited at 100ms

One of the expected usages is when the application code is not known and relies on unsupported technologies, in this case `trace_methods` has to be configured for transactions, the expected usage scenario is:
- configure the agent with `log_level=debug` and `thread_dump_interval=1000ms`
- start the application and trigger a few transactions manually
- analyze the agent logs with the thread dumps to find relevant classes and methods to instrument.
- thread dump interval needs to be adjusted relative to the usual transaction duration, for very fast transactions less than 100ms triggering more transactions will be required to get at least a few thread dumps that contain relevant application code.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
