### PR TITLE
buildkite: fallback if home is not available

### DIFF
--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -4,18 +4,14 @@ set -eo pipefail
 # Configure the java version
 JAVA_VERSION=$(cat .java-version | xargs | tr -dc '[:print:]')
 set +u
-echo "--- Debug variables"
-env | sort
-cat ~/.bashrc  || true
-source ~/.bashrc  || true
-env | sort
 # In case the HOME is not available in the context of the runner.
 if [ -z "${HOME}" ] ; then
-  JAVA_HOME="~/.java/openjdk${JAVA_VERSION}"
-else
-  JAVA_HOME="${HOME}/.java/openjdk${JAVA_VERSION}"
+  HOME="${BUILDKITE_BUILD_CHECKOUT_PATH}"
+  export HOME
 fi
+JAVA_HOME="${HOME}/.java/openjdk${JAVA_VERSION}"
 set -u
+
 export JAVA_HOME
 PATH="${JAVA_HOME}/bin:${PATH}"
 export PATH

--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -3,6 +3,7 @@ set -eo pipefail
 
 # Configure the java version
 JAVA_VERSION=$(cat .java-version | xargs | tr -dc '[:print:]')
+set +u
 # In case the HOME is not available in the context of the runner.
 if [ -z "${HOME}" ] ; then
   HOME="${BUILDKITE_BUILD_CHECKOUT_PATH}"

--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -3,7 +3,6 @@ set -eo pipefail
 
 # Configure the java version
 JAVA_VERSION=$(cat .java-version | xargs | tr -dc '[:print:]')
-set +u
 # In case the HOME is not available in the context of the runner.
 if [ -z "${HOME}" ] ; then
   HOME="${BUILDKITE_BUILD_CHECKOUT_PATH}"

--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -4,6 +4,11 @@ set -eo pipefail
 # Configure the java version
 JAVA_VERSION=$(cat .java-version | xargs | tr -dc '[:print:]')
 set +u
+echo "--- Debug variables"
+env | sort
+cat ~/.bashrc  || true
+source ~/.bashrc  || true
+env | sort
 # In case the HOME is not available in the context of the runner.
 if [ -z "${HOME}" ] ; then
   JAVA_HOME="~/.java/openjdk${JAVA_VERSION}"

--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -eo pipefail
 
 # Configure the java version
 JAVA_VERSION=$(cat .java-version | xargs | tr -dc '[:print:]')
-JAVA_HOME="${HOME}/.java/openjdk${JAVA_VERSION}"
+set +u
+# In case the HOME is not available in the context of the runner.
+if [ -z "${HOME}" ] ; then
+  JAVA_HOME="~/.java/openjdk${JAVA_VERSION}"
+else
+  JAVA_HOME="${HOME}/.java/openjdk${JAVA_VERSION}"
+fi
+set -u
 export JAVA_HOME
 PATH="${JAVA_HOME}/bin:${PATH}"
 export PATH


### PR DESCRIPTION
For some reason HOME is not available in the Runner  :/

> Agent Targeting Rules	queue=observability-microbenchmarks

Those runners are the ones for the microbenchmarks.

## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
