### PR TITLE
[ci] add list of published artifacts

### DIFF
--- a/.ci/scripts/published-artifacts-list.sh
+++ b/.ci/scripts/published-artifacts-list.sh
@@ -1,0 +1,21 @@
+#!/bin/env bash
+
+targets="$(find . -type d -name 'target'|grep -v apm-agent-plugins|grep -v integration-tests|sort)"
+
+for t in ${targets}; do
+    find "${t}" \
+        -name '*.jar' \
+        | grep -v '\-sources.jar' \
+        | grep -v '\-tests.jar' \
+        | grep -v '\-javadoc.jar' \
+        | grep -v 'original-' \
+        | grep -v 'classes/' \
+        | grep -v 'benchmarks' \
+        | grep -v 'apm-agent-bootstrap' \
+        | grep -v 'apm-agent-builds' \
+        | grep -v 'apm-agent-cached-lookup-key' \
+        | grep -v 'apm-agent-core' \
+        | grep -v 'apm-agent-common' \
+        | grep -v 'apm-agent-lambda-layer' \
+        | grep -v 'apm-agent-premain'
+done


### PR DESCRIPTION
## What does this PR do?

adds script that produces the list of published artifacts

invocation:

```
.ci/scripts/published-artifacts-list.sh
```

Sample output:
```
./apm-agent-api/target/apm-agent-api-1.49.1-SNAPSHOT.jar
./apm-agent-attach-cli/target/apm-agent-attach-cli-1.49.1-SNAPSHOT-slim.jar
./apm-agent-attach-cli/target/apm-agent-attach-cli-1.49.1-SNAPSHOT.jar
./apm-agent-attach/target/apm-agent-attach-1.49.1-SNAPSHOT.jar
./apm-agent-plugin-sdk/target/apm-agent-plugin-sdk-1.49.1-SNAPSHOT.jar
./apm-agent-tracer/target/apm-agent-tracer-1.49.1-SNAPSHOT.jar
./apm-opentracing/target/apm-opentracing-1.49.1-SNAPSHOT.jar
./elastic-apm-agent-java8/target/elastic-apm-agent-java8-1.49.1-SNAPSHOT.jar
./elastic-apm-agent/target/elastic-apm-agent-1.49.1-SNAPSHOT.jar
```
