### PR TITLE
[ci] fix GH release version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,7 +246,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create ${{ env.RELEASE_VERSION }} \
+          gh release create ${{ env.RELEASE_VERSION_TAG }} \
             --title="Release ${{ env.RELEASE_VERSION }}" \
             --notes="[Release Notes for ${{ env.RELEASE_VERSION }}](https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-${{ steps.get_dotx_branch.outputs.dotx_branch }}.html#release-notes-${{ env.RELEASE_VERSION }})
             ${{ needs.publish-aws-lambda.outputs.arn_content }}"


### PR DESCRIPTION
## What does this PR do?

Fixes a small typo in the release pipeline that makes the GH release created with the wrong tag label.

The `1.49.0` version is listed with the `1.49.0` tag whereas it should be the `v1.49.0` tag with the extra `v` prefix, however both tags are on the same commit so there is no impact here.
 
![image](https://github.com/elastic/apm-agent-java/assets/763082/b13a660c-10ae-4143-9879-a3cb53d2367b)

Compared to previous release

![image](https://github.com/elastic/apm-agent-java/assets/763082/250af4e0-4841-4cd6-a5ee-8d8a128d1014)

Once this will be merged, the 1.49.0 release will be updated manually.

