### PR TITLE
Universal profiling integration: write shared memory

### DIFF
--- a/apm-agent-common/src/main/java/co/elastic/apm/agent/common/util/AgentInfo.java
+++ b/apm-agent-common/src/main/java/co/elastic/apm/agent/common/util/AgentInfo.java
@@ -36,7 +36,8 @@ public class AgentInfo {
         "com.blogspot.mydailyjava.weaklockfree",
         "com.lmax.disruptor",
         "com.dslplatform.json",
-        "com.googlecode.concurrentlinkedhashmap"
+        "com.googlecode.concurrentlinkedhashmap",
+        "co.elastic.otel"
     ));
 
     private static final Set<String> agentRootPackages = new HashSet<>(Arrays.asList(

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>co.elastic.otel</groupId>
             <artifactId>jvmti-access</artifactId>
-            <version>0.1.1-SNAPSHOT</version>
+            <version>0.3.0</version>
         </dependency>
         <!--
         We can't use caffeine due to requiring Java 7.

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -100,6 +100,11 @@
             <artifactId>HdrHistogram</artifactId>
             <version>2.1.11</version>
         </dependency>
+        <dependency>
+            <groupId>co.elastic.otel</groupId>
+            <artifactId>jvmti-access</artifactId>
+            <version>0.1.1-SNAPSHOT</version>
+        </dependency>
         <!--
         We can't use caffeine due to requiring Java 7.
         As recommended by the author, we use concurrentlinkedhashmap-lru instead:

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/UniversalProfilingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/UniversalProfilingConfiguration.java
@@ -21,6 +21,8 @@ package co.elastic.apm.agent.configuration;
 import org.stagemonitor.configuration.ConfigurationOption;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
 
+import static co.elastic.apm.agent.tracer.configuration.RangeValidator.isInRange;
+
 public class UniversalProfilingConfiguration extends ConfigurationOptionProvider {
 
     private static final String PROFILING_CATEGORY = "Profiling";
@@ -34,6 +36,7 @@ public class UniversalProfilingConfiguration extends ConfigurationOptionProvider
 
     private final ConfigurationOption<Long> bufferSize = ConfigurationOption.longOption()
         .key("universal_profiling_integration_buffer_size")
+        .addValidator(isInRange(64L, Long.MAX_VALUE))
         .tags("added[1.50.0]", "internal")
         .configurationCategory(PROFILING_CATEGORY)
         .description("The feature needs to buffer ended local-root spans for a short duration to ensure that all of its profiling data has been received." +

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/UniversalProfilingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/UniversalProfilingConfiguration.java
@@ -1,0 +1,51 @@
+package co.elastic.apm.agent.configuration;
+
+import org.stagemonitor.configuration.ConfigurationOption;
+import org.stagemonitor.configuration.ConfigurationOptionProvider;
+
+public class UniversalProfilingConfiguration extends ConfigurationOptionProvider {
+
+    private static final String PROFILING_CATEGORY = "Profiling";
+
+    private final ConfigurationOption<Boolean> enabled = ConfigurationOption.booleanOption()
+        .key("universal_profiling_integration_enabled")
+        .tags("added[1.50.0]")
+        .configurationCategory(PROFILING_CATEGORY)
+        .description("If enabled, the apm agent will correlate it's transaction with the profiling data from elastic universal profiling running on the same host.")
+        .buildWithDefault(false);
+
+    private final ConfigurationOption<Long> bufferSize = ConfigurationOption.longOption()
+        .key("universal_profiling_integration_buffer_size")
+        .tags("added[1.50.0]")
+        .configurationCategory(PROFILING_CATEGORY)
+        .description("The feature needs to buffer ended local-root spans for a short duration to ensure that all of its profiling data has been received." +
+                     "This configuration option configures the buffer size in number of spans. " +
+                     "The higher the number of local root spans per second, the higher this buffer size should be set.\n" +
+                     "The agent will log a warning if it is not capable of buffering a span due to insufficient buffer size. " +
+                     "This will cause the span to be exported immediately instead with possibly incomplete profiling correlation data.")
+        .buildWithDefault(4096L);
+
+    private final ConfigurationOption<String> socketDir = ConfigurationOption.stringOption()
+        .key("universal_profiling_integration_socket_dir")
+        .tags("added[1.50.0]")
+        .configurationCategory(PROFILING_CATEGORY)
+        .description("The extension needs to bind a socket to a file for communicating with the universal profiling host agent." +
+                     "This configuration option can be used to change the location. " +
+                     "Note that the total path name (including the socket) must not exceed 100 characters due to OS restrictions.\n" +
+                     "If unset, the value of the `java.io.tmpdir` system property will be used.")
+        .build();
+
+    public boolean isEnabled() {
+        return enabled.get();
+    }
+
+    public long getBufferSize() {
+        return bufferSize.get();
+    }
+
+    public String getSocketDir() {
+        String dir = socketDir.get();
+        return dir == null || dir.isEmpty() ? System.getProperty("java.io.tmpdir") : dir;
+    }
+
+}

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/UniversalProfilingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/UniversalProfilingConfiguration.java
@@ -9,14 +9,14 @@ public class UniversalProfilingConfiguration extends ConfigurationOptionProvider
 
     private final ConfigurationOption<Boolean> enabled = ConfigurationOption.booleanOption()
         .key("universal_profiling_integration_enabled")
-        .tags("added[1.50.0]")
+        .tags("added[1.50.0]", "internal")
         .configurationCategory(PROFILING_CATEGORY)
         .description("If enabled, the apm agent will correlate it's transaction with the profiling data from elastic universal profiling running on the same host.")
         .buildWithDefault(false);
 
     private final ConfigurationOption<Long> bufferSize = ConfigurationOption.longOption()
         .key("universal_profiling_integration_buffer_size")
-        .tags("added[1.50.0]")
+        .tags("added[1.50.0]", "internal")
         .configurationCategory(PROFILING_CATEGORY)
         .description("The feature needs to buffer ended local-root spans for a short duration to ensure that all of its profiling data has been received." +
                      "This configuration option configures the buffer size in number of spans. " +
@@ -27,7 +27,7 @@ public class UniversalProfilingConfiguration extends ConfigurationOptionProvider
 
     private final ConfigurationOption<String> socketDir = ConfigurationOption.stringOption()
         .key("universal_profiling_integration_socket_dir")
-        .tags("added[1.50.0]")
+        .tags("added[1.50.0]", "internal")
         .configurationCategory(PROFILING_CATEGORY)
         .description("The extension needs to bind a socket to a file for communicating with the universal profiling host agent." +
                      "This configuration option can be used to change the location. " +

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/UniversalProfilingConfiguration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/UniversalProfilingConfiguration.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.configuration;
 
 import org.stagemonitor.configuration.ConfigurationOption;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/metadata/SystemInfo.java
@@ -138,7 +138,7 @@ public class SystemInfo {
         return systemInfo.findContainerDetails();
     }
 
-    static boolean isWindows(String osName) {
+    public static boolean isWindows(String osName) {
         return osName.startsWith("Windows");
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Id.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/Id.java
@@ -89,6 +89,10 @@ public class Id implements Recyclable, co.elastic.apm.agent.tracer.Id {
         return offset + data.length;
     }
 
+    public void writeToBuffer(ByteBuffer buffer) {
+        buffer.put(data);
+    }
+
     public void fromLongs(long... values) {
         if (values.length * Long.BYTES != data.length) {
             throw new IllegalArgumentException("Invalid number of long values");

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/ProfilerSharedMemoryWriter.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/ProfilerSharedMemoryWriter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.universalprofiling;
 
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
@@ -74,11 +74,12 @@ public class UniversalProfilingIntegration {
             ByteBuffer processCorrelationStorage = ProfilerSharedMemoryWriter.generateProcessCorrelationStorage(
                 coreConfig.getServiceName(), coreConfig.getEnvironment(), "");
             UniversalProfilingCorrelation.setProcessStorage(processCorrelationStorage);
+            
+            isActive = true;
+            tracer.registerSpanListener(activationListener);
         } catch (Exception e) {
             log.error("Failed to start universal profiling integration", e);
         }
-        isActive = true;
-        tracer.registerSpanListener(activationListener);
     }
 
     public void stop() {

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.universalprofiling;
 
 import co.elastic.apm.agent.configuration.CoreConfiguration;

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
@@ -74,7 +74,7 @@ public class UniversalProfilingIntegration {
             ByteBuffer processCorrelationStorage = ProfilerSharedMemoryWriter.generateProcessCorrelationStorage(
                 coreConfig.getServiceName(), coreConfig.getEnvironment(), "");
             UniversalProfilingCorrelation.setProcessStorage(processCorrelationStorage);
-            
+
             isActive = true;
             tracer.registerSpanListener(activationListener);
         } catch (Exception e) {
@@ -96,6 +96,16 @@ public class UniversalProfilingIntegration {
         //TODO: store the transaction in a map for correlating with profiling data
     }
 
+    /**
+     * This method will get invoked for ended transactions which shall be reported.
+     * This method is responsible for eventually reporting those transactions.
+     * <p>
+     * The tracer calls this method instead of reporting directly in order to allow
+     * the correlation to delay the transaction reporting until all correlation
+     * data has been received from the universal profiling host agent.
+     *
+     * @param endedTransaction the transaction to be reported
+     */
     public void correlateAndReport(Transaction endedTransaction) {
         //TODO: perform correlation and report after buffering for a certain delay
         tracer.getReporter().report(endedTransaction);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
@@ -64,7 +64,7 @@ public class UniversalProfilingIntegration {
             return;
         }
         if (SystemInfo.isWindows(System.getProperty("os.name"))) {
-            log.warn("Universal profiling integration cannot be enabled on windows");
+            log.warn("Universal profiling integration is not supported on Windows");
             return;
         }
         try {
@@ -92,7 +92,7 @@ public class UniversalProfilingIntegration {
         }
     }
 
-    public void afterTransactionStart(Transaction startedTransactions) {
+    public void afterTransactionStart(Transaction startedTransaction) {
         //TODO: store the transaction in a map for correlating with profiling data
     }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegration.java
@@ -1,0 +1,88 @@
+package co.elastic.apm.agent.universalprofiling;
+
+import co.elastic.apm.agent.configuration.CoreConfiguration;
+import co.elastic.apm.agent.configuration.UniversalProfilingConfiguration;
+import co.elastic.apm.agent.impl.ActivationListener;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.metadata.SystemInfo;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.ElasticContext;
+import co.elastic.apm.agent.impl.transaction.Transaction;
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
+import co.elastic.otel.JvmtiAccess;
+import co.elastic.otel.UniversalProfilingCorrelation;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+
+public class UniversalProfilingIntegration {
+
+    private static final Logger log = LoggerFactory.getLogger(UniversalProfilingIntegration.class);
+
+    private volatile ElasticApmTracer tracer;
+
+    // Visible for testing
+    volatile boolean isActive = false;
+
+    private ActivationListener activationListener = new ActivationListener() {
+
+        @Override
+        public void beforeActivate(AbstractSpan<?> span) {
+            ProfilerSharedMemoryWriter.updateThreadCorrelationStorage(span);
+        }
+
+        @Override
+        public void afterDeactivate(@Nullable AbstractSpan<?> deactivatedSpan) {
+            ElasticContext<?> currentContext = tracer.currentContext();
+            ProfilerSharedMemoryWriter.updateThreadCorrelationStorage(currentContext.getSpan());
+        }
+    };
+
+    public void start(ElasticApmTracer tracer) {
+        this.tracer = tracer;
+        UniversalProfilingConfiguration config = tracer.getConfig(UniversalProfilingConfiguration.class);
+        if (!config.isEnabled()) {
+            return;
+        }
+        if (SystemInfo.isWindows(System.getProperty("os.name"))) {
+            log.warn("Universal profiling integration cannot be enabled on windows");
+            return;
+        }
+        try {
+            log.debug("Starting universal profiling correlation");
+
+            CoreConfiguration coreConfig = tracer.getConfig(CoreConfiguration.class);
+            ByteBuffer processCorrelationStorage = ProfilerSharedMemoryWriter.generateProcessCorrelationStorage(
+                coreConfig.getServiceName(), coreConfig.getEnvironment(), "");
+            UniversalProfilingCorrelation.setProcessStorage(processCorrelationStorage);
+        } catch (Exception e) {
+            log.error("Failed to start universal profiling integration", e);
+        }
+        isActive = true;
+        tracer.registerSpanListener(activationListener);
+    }
+
+    public void stop() {
+        try {
+            if (isActive) {
+                JvmtiAccess.destroy();
+            }
+        } catch (Exception e) {
+            log.error("Failed to stop universal profiling integration", e);
+        }
+    }
+
+    public void afterTransactionStart(Transaction startedTransactions) {
+        //TODO: store the transaction in a map for correlating with profiling data
+    }
+
+    public void correlateAndReport(Transaction endedTransaction) {
+        //TODO: perform correlation and report after buffering for a certain delay
+        tracer.getReporter().report(endedTransaction);
+    }
+
+    public void drop(Transaction endedTransaction) {
+        //TODO: remove dropped transactions from correlation storage without reporting
+    }
+}

--- a/apm-agent-core/src/main/resources/META-INF/services/org.stagemonitor.configuration.ConfigurationOptionProvider
+++ b/apm-agent-core/src/main/resources/META-INF/services/org.stagemonitor.configuration.ConfigurationOptionProvider
@@ -7,3 +7,4 @@ co.elastic.apm.agent.impl.circuitbreaker.CircuitBreakerConfiguration
 co.elastic.apm.agent.configuration.MetricsConfiguration
 co.elastic.apm.agent.configuration.ServerlessConfiguration
 co.elastic.apm.agent.configuration.SpanConfiguration
+co.elastic.apm.agent.configuration.UniversalProfilingConfiguration

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegrationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegrationTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.universalprofiling;
 
 import co.elastic.apm.agent.MockReporter;

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegrationTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/universalprofiling/UniversalProfilingIntegrationTest.java
@@ -1,0 +1,212 @@
+package co.elastic.apm.agent.universalprofiling;
+
+import co.elastic.apm.agent.MockReporter;
+import co.elastic.apm.agent.MockTracer;
+import co.elastic.apm.agent.configuration.CoreConfiguration;
+import co.elastic.apm.agent.configuration.SpyConfiguration;
+import co.elastic.apm.agent.configuration.UniversalProfilingConfiguration;
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.Tracer;
+import co.elastic.apm.agent.impl.transaction.AbstractSpan;
+import co.elastic.apm.agent.impl.transaction.Id;
+import co.elastic.apm.agent.impl.transaction.Span;
+import co.elastic.apm.agent.impl.transaction.Transaction;
+import co.elastic.apm.agent.objectpool.TestObjectPoolFactory;
+import co.elastic.otel.JvmtiAccessImpl;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.stagemonitor.configuration.ConfigurationRegistry;
+
+import javax.annotation.Nullable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.function.Consumer;
+
+import static co.elastic.apm.agent.testutils.assertions.Assertions.assertThat;
+import static co.elastic.apm.agent.universalprofiling.ProfilerSharedMemoryWriter.TLS_STORAGE_SIZE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class UniversalProfilingIntegrationTest {
+
+    private Tracer tracer;
+    private MockReporter reporter;
+
+    private TestObjectPoolFactory poolFactory;
+
+    void setupTracer(Consumer<ConfigurationRegistry> configCustomizer) {
+        ConfigurationRegistry config = SpyConfiguration.createSpyConfig();
+        configCustomizer.accept(config);
+        MockTracer.MockInstrumentationSetup mockInstrumentationSetup = MockTracer.createMockInstrumentationSetup(config);
+
+        tracer = mockInstrumentationSetup.getTracer();
+        reporter = mockInstrumentationSetup.getReporter();
+        poolFactory = mockInstrumentationSetup.getObjectPoolFactory();
+    }
+
+    @AfterEach
+    public void cleanupTracer() {
+        if (tracer != null) {
+            reporter.assertRecycledAfterDecrementingReferences();
+            poolFactory.checkAllPooledObjectsHaveBeenRecycled();
+            tracer.stop();
+            tracer = null;
+        }
+    }
+
+    @EnabledOnOs(OS.WINDOWS)
+    @Test
+    public void ensureDisabledOnWindows() {
+        ConfigurationRegistry configRegistry = SpyConfiguration.createSpyConfig();
+        UniversalProfilingConfiguration config = configRegistry.getConfig(UniversalProfilingConfiguration.class);
+
+        doReturn(true).when(config).isEnabled();
+
+        UniversalProfilingIntegration universalProfilingIntegration = new UniversalProfilingIntegration();
+        ElasticApmTracer mockTracer = MockTracer.create(configRegistry);
+        universalProfilingIntegration.start(mockTracer);
+
+        verify(mockTracer, never()).registerSpanListener(any());
+        assertThat(universalProfilingIntegration.isActive).isFalse();
+    }
+
+    @Test
+    public void ensureDisabledByDefault() {
+        ConfigurationRegistry configRegistry = SpyConfiguration.createSpyConfig();
+        UniversalProfilingIntegration universalProfilingIntegration = new UniversalProfilingIntegration();
+        ElasticApmTracer mockTracer = MockTracer.create(configRegistry);
+        universalProfilingIntegration.start(mockTracer);
+
+        verify(mockTracer, never()).registerSpanListener(any());
+        assertThat(universalProfilingIntegration.isActive).isFalse();
+    }
+
+    @Nested
+    @DisabledOnOs(OS.WINDOWS)
+    class SharedMemory {
+
+        @Test
+        public void testNestedActivations() {
+            setupTracer(conf -> doReturn(true)
+                .when(conf.getConfig(UniversalProfilingConfiguration.class)).isEnabled());
+
+            Transaction first = tracer.startRootTransaction(null);
+            Transaction second = tracer.startRootTransaction(null);
+            Span third = second.createSpan();
+
+            checkTlsIs(null);
+
+            first.activate();
+            {
+                checkTlsIs(first);
+
+                //nested activation
+                first.activate();
+                {
+                    checkTlsIs(first);
+                }
+                first.deactivate();
+                second.activate();
+                {
+                    checkTlsIs(second);
+                    third.activate();
+                    {
+                        checkTlsIs(third);
+
+                        first.activate();
+                        {
+                            checkTlsIs(first);
+                        }
+                        first.deactivate();
+                    }
+                    third.deactivate();
+                    checkTlsIs(second);
+                }
+                second.deactivate();
+                checkTlsIs(first);
+            }
+            first.deactivate();
+            checkTlsIs(null);
+
+            first.end();
+            second.end();
+            third.end();
+            assertThat(reporter.getTransactions()).containsExactly(first, second);
+            assertThat(reporter.getSpans()).containsExactly(third);
+        }
+
+
+        @ParameterizedTest
+        @ValueSource(strings = {"my nameßspace", ""})
+        public void testProcessStoragePopulated(String environment) {
+            setupTracer(conf -> {
+                doReturn(true).when(conf.getConfig(UniversalProfilingConfiguration.class)).isEnabled();
+                CoreConfiguration core = conf.getConfig(CoreConfiguration.class);
+                doReturn("service Ä 1").when(core).getServiceName();
+                doReturn(environment).when(core).getEnvironment();
+            });
+            ByteBuffer buffer = JvmtiAccessImpl.createProcessProfilingCorrelationBufferAlias(1000);
+            buffer.order(ByteOrder.nativeOrder());
+
+            assertThat(buffer.getChar()).describedAs("layout-minor-version").isEqualTo((char) 1);
+            assertThat(readUtf8Str(buffer)).isEqualTo("service Ä 1");
+            assertThat(readUtf8Str(buffer)).isEqualTo(environment);
+            assertThat(readUtf8Str(buffer)).describedAs("socket-path").isEqualTo("");
+        }
+
+        private String readUtf8Str(ByteBuffer buffer) {
+            int serviceNameLen = buffer.getInt();
+            byte[] serviceUtf8 = new byte[serviceNameLen];
+            buffer.get(serviceUtf8);
+            return new String(serviceUtf8, StandardCharsets.UTF_8);
+        }
+    }
+
+    static void checkTlsIs(@Nullable AbstractSpan<?> span) {
+        ByteBuffer tls = JvmtiAccessImpl.createThreadProfilingCorrelationBufferAlias(TLS_STORAGE_SIZE);
+        if (tls != null) {
+            tls.order(ByteOrder.nativeOrder());
+            Assertions.assertThat(tls.getChar(0)).describedAs("layout-minor-version").isEqualTo((char) 1);
+            Assertions.assertThat(tls.get(2)).describedAs("valid byte").isEqualTo((byte) 1);
+        }
+
+        if (span != null) {
+            assertThat(tls).isNotNull();
+            Assertions.assertThat(tls.get(3)).describedAs("trace-present-flag").isEqualTo((byte) 1);
+            Assertions.assertThat(tls.get(4)).describedAs("trace-flags").isEqualTo(span.getTraceContext().getFlags());
+
+            byte[] traceId = new byte[16];
+            byte[] spanId = new byte[8];
+            byte[] localRootSpanId = new byte[8];
+            tls.position(5);
+            tls.get(traceId);
+            assertThat(traceId).containsExactly(idToBytes(span.getTraceContext().getTraceId()));
+            tls.position(21);
+            tls.get(spanId);
+            assertThat(spanId).containsExactly(idToBytes(span.getTraceContext().getId()));
+            tls.position(29);
+            tls.get(localRootSpanId);
+            assertThat(localRootSpanId).containsExactly(idToBytes(span.getParentTransaction().getTraceContext().getId()));
+        } else if (tls != null) {
+            Assertions.assertThat(tls.get(3)).describedAs("trace-present-flag").isEqualTo((byte) 0);
+        }
+    }
+
+    private static byte[] idToBytes(Id id) {
+        byte[] buff = new byte[32];
+        int len = id.toBytes(buff, 0);
+        byte[] result = new byte[len];
+        System.arraycopy(buff, 0, result, 0, len);
+        return result;
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Implements the first part of the universal profiling correlation: Writing the shared memory to be read by the profiler.

This PR also already adds all the config options, but marks them as "internal" so that the feature is basically hidden.
The full feature will likely be split across three pull requests. Until the last one is merged, the feature should not be used.

Therefore I also won't add it to the changelog. This PR also should not prevent us from doing patch-releases.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [ ] ~I have made corresponding changes to the documentation~

