### PR TITLE
buildkite: support version 21 for opentelemetry

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -14,6 +14,9 @@ if [[ "$BUILDKITE_COMMAND" =~ .*"upload".* ]]; then
   exit 0
 fi
 
+# Run always
+source .buildkite/hooks/prepare-common.sh
+
 if [ "$BUILDKITE_PIPELINE_SLUG" == "apm-agent-java-opentelemetry-benchmark" ]; then
     source .buildkite/hooks/prepare-benchmark.sh
 fi
@@ -25,6 +28,3 @@ fi
 if [ "$BUILDKITE_PIPELINE_SLUG" == "apm-agent-java-release" ]; then
     source .buildkite/hooks/prepare-release.sh
 fi
-
-# Run always
-source .buildkite/hooks/prepare-common.sh

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -19,6 +19,10 @@ source .buildkite/hooks/prepare-common.sh
 
 if [ "$BUILDKITE_PIPELINE_SLUG" == "apm-agent-java-opentelemetry-benchmark" ]; then
     source .buildkite/hooks/prepare-benchmark.sh
+    # NOTE: https://github.com/open-telemetry/opentelemetry-java-instrumentation/pull/11323 might
+    #       support .java-version, if so then it might be worthy to read the file.
+    JAVA_VERSION=21
+    source .buildkite/hooks/prepare-common.sh
 fi
 
 if [ "$BUILDKITE_PIPELINE_SLUG" == "apm-agent-java-snapshot" ]; then

--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -2,7 +2,9 @@
 set -eo pipefail
 
 # Configure the java version
-JAVA_VERSION=$(cat .java-version | xargs | tr -dc '[:print:]')
+if [ -z "$JAVA_VERSION" ] ; then
+  JAVA_VERSION=$(cat .java-version | xargs | tr -dc '[:print:]')
+fi
 set +u
 # In case the HOME is not available in the context of the runner.
 if [ -z "${HOME}" ] ; then


### PR DESCRIPTION
## What does this PR do?

Use java 21.
Fixes https://github.com/open-telemetry/opentelemetry-java-instrumentation/issues/11267

## Test

<img width="331" alt="image" src="https://github.com/elastic/apm-agent-java/assets/2871786/a5f6a6e0-c001-414f-839e-2f14d91fd538">


## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
