### PR TITLE
buildkite: avoid failing in tear-down failed

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -10,7 +10,7 @@ set -eo pipefail
 clean_up () {
   ARG=$?
   echo "--- Deleting tmp workspace"
-  rm -rf $TMP_WORKSPACE
+  rm -rf $TMP_WORKSPACE || true
   exit $ARG
 }
 trap clean_up EXIT

--- a/.ci/snapshot.sh
+++ b/.ci/snapshot.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 clean_up () {
   ARG=$?
   echo "--- Deleting tmp workspace"
-  rm -rf $TMP_WORKSPACE
+  rm -rf $TMP_WORKSPACE || true
   exit $ARG
 }
 trap clean_up EXIT


### PR DESCRIPTION
## What does this PR do?

We use ephemeral runners, so there is no need to worry about cleaning up the tearing down, but even when the deletion failed. For such, let's avoid the failure

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
