### PR TITLE
ci: build and push Docker image based on Chainguard base image

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -90,7 +90,7 @@ jobs:
       - name: prepare context for testing docker build
         run: |
           mkdir -p elastic-apm-agent/target
-          curl -L -s -o elastic-apm-agent/target/apm-agent-java-1.49.0.jar \
+          curl -L -s -o elastic-apm-agent/target/elastic-apm-agent-1.49.0.jar \
             "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=co.elastic.apm&a=elastic-apm-agent&v=1.49.0"
       - name: "Build docker image"
         run: ./scripts/docker-release/build_docker.sh "test"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -75,7 +75,38 @@ jobs:
         with:
           subject-path: "${{ github.workspace }}/**/target/*.jar"
 
-      - if: ${{ failure() }}
+  build-docker-images:
+    name: "Build docker images"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
+        with:
+          registry: docker.elastic.co
+          secret: secret/apm-team/ci/docker-registry/prod
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+      - name: prepare context for testing docker build
+        run: |
+          mkdir -p elastic-apm-agent/target
+          curl -L -s -o elastic-apm-agent/target/apm-agent-java-1.49.0.jar \
+            "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=co.elastic.apm&a=elastic-apm-agent&v=1.49.0"
+      - name: "Build docker image"
+        run: ./scripts/docker-release/build_docker.sh "test"
+
+  notify:
+    needs:
+      - build-docker-images
+      - deploy
+      - validate
+    runs-on: ubuntu-latest
+    steps:
+      - id: check
+        uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
+        with:
+          needs: ${{ toJSON(needs) }}
+      - if: ${{ failure() && ! inputs.dry_run }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
         with:
           url: ${{ secrets.VAULT_ADDR }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -330,8 +330,14 @@ docker.elastic.co and are located in the `observability` namespace.
 
 For example, to download the v1.12.0 of the agent, use the following:
 
+```bash
+docker pull docker.elastic.co/observability/apm-agent-java:1.12.0
 ```
-docker pull  docker.elastic.co/observability/apm-agent-java:1.12.0
+
+In addition, you can use the `wolfi` version by adding the suffix `-wolfi`
+
+```bash
+docker pull docker.elastic.co/observability/apm-agent-java:1.12.0-wolfi
 ```
 
 #### Creating images for a Release

--- a/Dockerfile.wolfi
+++ b/Dockerfile.wolfi
@@ -1,0 +1,7 @@
+FROM docker.elastic.co/wolfi/chainguard-base@sha256:9f940409f96296ef56140bcc4665c204dd499af4c32c96cc00e792558097c3f1
+RUN mkdir /usr/agent
+ARG JAR_FILE
+ARG HANDLER_FILE
+COPY ${JAR_FILE} /usr/agent/elastic-apm-agent.jar
+COPY ${HANDLER_FILE} /usr/agent/elastic-apm-handler
+RUN chmod +x /usr/agent/elastic-apm-handler

--- a/scripts/docker-release/build_docker.sh
+++ b/scripts/docker-release/build_docker.sh
@@ -18,11 +18,13 @@ readonly SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 readonly PROJECT_ROOT=$SCRIPT_PATH/../../
 readonly NAMESPACE="observability"
 
-if [ "$(ls -A  ${PROJECT_ROOT}elastic-apm-agent/target/*.jar)" ]
+FILE=$(ls -A ${PROJECT_ROOT}elastic-apm-agent/target/*.jar | grep -E "elastic-apm-agent-[0-9]+.[0-9]+.[0-9]+(-SNAPSHOT)?.jar" )
+
+if [ -n "${FILE}" ]
 then
   # We have build files to use
   echo "INFO: Found local build artifact. Using locally built for Docker build"
-  find -E ${PROJECT_ROOT}elastic-apm-agent/target -regex '.*/elastic-apm-agent-[0-9]+.[0-9]+.[0-9]+(-SNAPSHOT)?.jar' -exec cp {} ${PROJECT_ROOT}apm-agent-java.jar \; || echo "INFO: No locally built image found"
+  cp "${FILE}" "${PROJECT_ROOT}apm-agent-java.jar" || echo "INFO: No locally built image found"
 elif [ ! -z ${SONATYPE_FALLBACK+x} ]
 then
   echo "INFO: No local build artifact and SONATYPE_FALLBACK. Falling back to downloading artifact from Sonatype Nexus repository for version $RELEASE_VERSION"

--- a/scripts/docker-release/build_docker.sh
+++ b/scripts/docker-release/build_docker.sh
@@ -37,6 +37,8 @@ then
     exit 1
 fi
 
+ls -l apm-agent-java.jar
+
 echo "INFO: Starting Docker build for version $RELEASE_VERSION"
 for DOCKERFILE in "Dockerfile" "Dockerfile.wolfi" ; do
   DOCKER_TAG=$RELEASE_VERSION

--- a/scripts/docker-release/build_docker.sh
+++ b/scripts/docker-release/build_docker.sh
@@ -38,18 +38,24 @@ then
 fi
 
 echo "INFO: Starting Docker build for version $RELEASE_VERSION"
+for DOCKERFILE in "Dockerfile" "Dockerfile.wolfi" ; do
+  DOCKER_TAG=$RELEASE_VERSION
+  if [[ $DOCKERFILE =~ "wolfi" ]]; then
+    DOCKER_TAG="${RELEASE_VERSION}-wolfi"
+  fi
+  docker build -t docker.elastic.co/$NAMESPACE/apm-agent-java:$DOCKER_TAG \
+    --platform linux/amd64 \
+    --build-arg JAR_FILE=apm-agent-java.jar \
+    --build-arg HANDLER_FILE=apm-agent-lambda-layer/src/main/assembly/elastic-apm-handler \
+    --file $DOCKERFILE .
 
-docker build -t docker.elastic.co/$NAMESPACE/apm-agent-java:$RELEASE_VERSION \
-  --platform linux/amd64 \
-  --build-arg JAR_FILE=apm-agent-java.jar \
-  --build-arg HANDLER_FILE=apm-agent-lambda-layer/src/main/assembly/elastic-apm-handler .
-
-if [ $? -eq 0 ]
-then
-  echo "INFO: Docker image built successfully"
-else
-  echo "ERROR: Problem building Docker image!"
-fi
+  if [ $? -eq 0 ]
+  then
+    echo "INFO: Docker image built successfully"
+  else
+    echo "ERROR: Problem building Docker image!"
+  fi
+done
 
 function finish {
 

--- a/scripts/docker-release/push_docker.sh
+++ b/scripts/docker-release/push_docker.sh
@@ -32,6 +32,7 @@ readonly DOCKER_PUSH_IMAGE_LATEST="$DOCKER_REGISTRY_URL/$DOCKER_IMAGE_NAME:lates
 echo "INFO: Pushing image $DOCKER_PUSH_IMAGE to $DOCKER_REGISTRY_URL"
 
 docker push $DOCKER_PUSH_IMAGE || { echo "You may need to run 'docker login' first and then re-run this script"; exit 1; }
+docker push "${DOCKER_PUSH_IMAGE}-wolfi" || { echo "You may need to run 'docker login' first and then re-run this script"; exit 1; }
 
 readonly LATEST_TAG=$(git tag --list --sort=version:refname "v*" | grep -v RC | sed s/^v// | tail -n 1)
 
@@ -40,4 +41,6 @@ then
   echo "INFO: Current version ($RELEASE_VERSION) is the latest version. Tagging and pushing $DOCKER_PUSH_IMAGE_LATEST ..."
   docker tag $DOCKER_PUSH_IMAGE $DOCKER_PUSH_IMAGE_LATEST
   docker push $DOCKER_PUSH_IMAGE_LATEST || { echo "You may need to run 'docker login' first and then re-run this script"; exit 1; }
+  docker tag "${DOCKER_PUSH_IMAGE}-wolfi" "${DOCKER_PUSH_IMAGE_LATEST}-wolfi"
+  docker push "${DOCKER_PUSH_IMAGE_LATEST}-wolfi" || { echo "You may need to run 'docker login' first and then re-run this script"; exit 1; }
 fi


### PR DESCRIPTION
## What does this pull request do?

Release two flavours of Docker images:
- the one we always do
- the one based on [Wolfi](https://www.chainguard.dev/unchained/introducing-wolfi-the-first-linux-un-distro) from [Chainguard](https://edu.chainguard.dev/chainguard/chainguard-images/overview/) 

Please note that we are going to preserve the current `Dockerfile`, so that users will still be able to build their custom images based on `Alpine`: this is needed because `docker.elastic.co/wolfi/chainguard-base` is not a public base image, so docker build would fail for unauthenticated users.

## Tests

I created a feature branch `test/docker-images-wolfi` and ran the snapshot workflow:

- https://github.com/elastic/apm-agent-java/actions/runs/9019062649/job/24781080512


## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
