### PR TITLE
Exclude new Cisco AppD packages

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Features
 * Added support for correlating APM data with elastic universal profiling data - {pull}3615[#3615], {pull}3602[#3602], {pull}3607[#3607], {pull}3598[#3598]
+* Excluded latest AppDynamics packages from instrumentation (`com.cisco.mtagent.*`) - {pull}3632[#3632]
 
 [float]
 ===== Bug fixes

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/bci/ElasticApmAgent.java
@@ -737,6 +737,8 @@ public class ElasticApmAgent {
             .or(nameStartsWith("com.singularity."))
             .or(any(), classLoaderWithNamePrefix("com.appdynamics."))
             .or(nameStartsWith("com.appdynamics."))
+            .or(any(), classLoaderWithNamePrefix("com.cisco.mtagent."))
+            .or(nameStartsWith("com.cisco.mtagent."))
             .or(any(), classLoaderWithNamePrefix("com.instana."))
             .or(nameStartsWith("com.instana."))
             .or(any(), classLoaderWithNamePrefix("datadog."))


### PR DESCRIPTION
## What does this PR do?

A customer has encountered instrumentation errors with what apparently are new AppD packages. This PR attempts to exclude them from instrumentation.

## Checklist

- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
