### PR TITLE
Clarify rabbitmq naming mode support

### DIFF
--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
@@ -111,7 +111,9 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
     private final ConfigurationOption<RabbitMQNamingMode> rabbitMQNamingMode = ConfigurationOption.enumOption(RabbitMQNamingMode.class)
         .key("rabbitmq_naming_mode")
         .configurationCategory(MESSAGING_CATEGORY)
-        .description("Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE` and `EXCHANGE`")
+        .description("Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE` and `EXCHANGE`.\n" +
+                     "Note that `QUEUE` only works when using RabbitMQ via spring-amqp."
+        )
         .dynamic(true)
         .tags("added[1.46.0]")
         .buildWithDefault(RabbitMQNamingMode.EXCHANGE);

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -2510,7 +2510,8 @@ Starting from version 1.43.0, the classes that are part of the 'application_pack
 [[config-rabbitmq-naming-mode]]
 ==== `rabbitmq_naming_mode` (added[1.46.0])
 
-Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE` and `EXCHANGE`
+Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE` and `EXCHANGE`.
+Note that `QUEUE` only works when using RabbitMQ via spring-amqp.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
 
@@ -4628,7 +4629,8 @@ Example: `5ms`.
 #
 # jms_listener_packages=
 
-# Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE` and `EXCHANGE`
+# Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE` and `EXCHANGE`.
+# Note that `QUEUE` only works when using RabbitMQ via spring-amqp.
 #
 # Valid options: EXCHANGE, QUEUE
 # This setting can be changed at runtime


### PR DESCRIPTION
## What does this PR do?

A suer in the [discussion forums](https://discuss.elastic.co/t/the-rabbitmq-naming-mode-configuration-is-not-working-when-rabbitmq-is-used-without-spring/359509/1) raised that the `QUEUE` RabbitMQ naming mode only works for spring, which is true.

IINM, it is not possible to support this for the standard RabbitMQ client, because it doesn't seem to expose the queue name.

This PR clarifies the documentation that `QUEUE` is only functional when using `spring-amqp`.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
