### PR TITLE
Add option to make routing-key part of RabbitMQ transaction/span names

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -38,6 +38,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Bug fixes
 * Restore compatibility with Java 7 - {pull}3657[#3657]
 
+[float]
+===== Features
+* Added option to make routing-key part of RabbitMQ transaction/span names - {pull}3636[#3636]
+
 [[release-notes-1.50.0]]
 ==== 1.50.0 - 2024/05/28
 

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/MessagingConfiguration.java
@@ -111,8 +111,8 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
     private final ConfigurationOption<RabbitMQNamingMode> rabbitMQNamingMode = ConfigurationOption.enumOption(RabbitMQNamingMode.class)
         .key("rabbitmq_naming_mode")
         .configurationCategory(MESSAGING_CATEGORY)
-        .description("Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE` and `EXCHANGE`.\n" +
-                     "Note that `QUEUE` only works when using RabbitMQ via spring-amqp."
+        .description("Defines whether the agent should use the exchanges, the routing key or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE`, `ROUTING_KEY` and `EXCHANGE`.\n" +
+                     "Note that `QUEUE` only works when using RabbitMQ via spring-amqp and `ROUTING_KEY` only works for the non spring-client."
         )
         .dynamic(true)
         .tags("added[1.46.0]")
@@ -187,5 +187,9 @@ public class MessagingConfiguration extends ConfigurationOptionProvider {
          * Use queue in transaction names
          */
         QUEUE,
+        /**
+         * Use routing key in transaction names
+         */
+        ROUTING_KEY
     }
 }

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -2513,12 +2513,12 @@ Starting from version 1.43.0, the classes that are part of the 'application_pack
 [[config-rabbitmq-naming-mode]]
 ==== `rabbitmq_naming_mode` (added[1.46.0])
 
-Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE` and `EXCHANGE`.
-Note that `QUEUE` only works when using RabbitMQ via spring-amqp.
+Defines whether the agent should use the exchanges, the routing key or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE`, `ROUTING_KEY` and `EXCHANGE`.
+Note that `QUEUE` only works when using RabbitMQ via spring-amqp and `ROUTING_KEY` only works for the non spring-client.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
 
-Valid options: `EXCHANGE`, `QUEUE`
+Valid options: `EXCHANGE`, `QUEUE`, `ROUTING_KEY`
 
 [options="header"]
 |============
@@ -4703,10 +4703,10 @@ Example: `5ms`.
 #
 # jms_listener_packages=
 
-# Defines whether the agent should use the exchanges or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE` and `EXCHANGE`.
-# Note that `QUEUE` only works when using RabbitMQ via spring-amqp.
+# Defines whether the agent should use the exchanges, the routing key or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE`, `ROUTING_KEY` and `EXCHANGE`.
+# Note that `QUEUE` only works when using RabbitMQ via spring-amqp and `ROUTING_KEY` only works for the non spring-client.
 #
-# Valid options: EXCHANGE, QUEUE
+# Valid options: EXCHANGE, QUEUE, ROUTING_KEY
 # This setting can be changed at runtime
 # Type: RabbitMQNamingMode
 # Default value: EXCHANGE


### PR DESCRIPTION
## What does this PR do?
This PR adds ROUTING_KEY as an option to the `rabbitmq_naming_mode` configuration. It also enables the ability to use that configuration with the `apm-rabbitmq-plugin` in a similar way to how it's done for the [spring-rabbit-plugin](https://github.com/elastic/apm-agent-java/pull/3424). EXCHANGE is the default and does not change the plugin's current behavior. If one chooses ROUTING_KEY, then the names of the rabbit transactions will contain the routing keys instead of the exchange names.
See Issue https://github.com/elastic/apm-agent-java/issues/3415

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [x] Added an API method or config option? Document in which version this will be introduced
  - [x] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
