### PR TITLE
ci: add some job timeouts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/maven-goal
@@ -128,6 +129,7 @@ jobs:
     name: License
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/unstash
@@ -148,6 +150,7 @@ jobs:
     # When undefined, we need to emulate the default value
     if: inputs.test_ci == true || inputs.test_ci == null
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: build
     steps:
       - uses: actions/checkout@v4
@@ -169,6 +172,7 @@ jobs:
 
   non-app-server-integration-tests:
     name: Non-Application Server integration tests
+    timeout-minutes: 60
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:agent-integration')
       || github.event.pull_request.draft == false
@@ -207,6 +211,7 @@ jobs:
 
   app-server-integration-tests:
     name: Application Server integration tests
+    timeout-minutes: 60
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:agent-integration')
       || github.event.pull_request.draft == false
@@ -248,6 +253,7 @@ jobs:
     name: Javadoc
     runs-on: ubuntu-latest
     needs: build
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/unstash
@@ -260,6 +266,7 @@ jobs:
 
   unit-tests-windows:
     name: Build & Test Windows
+    timeout-minutes: 60
     # Inputs aren't defined on some events
     # When undefined, we need to emulate the default value
     if: |
@@ -287,6 +294,7 @@ jobs:
 
   jdk-compatibility-tests:
     name: JDK Compatibility Tests
+    timeout-minutes: 60
     if: |
       contains(github.event.pull_request.labels.*.name, 'ci:jdk-compatibility')
       || inputs.jdk_compatibility_ci == true
@@ -324,6 +332,7 @@ jobs:
   jboss:
     name: JBoss integration tests
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: build
     # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
     if: github.event_name != 'pull_request' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]' )


### PR DESCRIPTION
## What does this PR do?

Timeout the CI jobs if they get stalled

I saw something weird in the UTs:

<img width="857" alt="image" src="https://github.com/elastic/apm-agent-java/assets/2871786/6145b0da-54e9-4e4f-8c8c-02448738d13b">


## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
