### PR TITLE
Fix too small activation stack for low transaction_max_spans values

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Bug fixes
 * Fixed edge case where inferred spans could cause cycles in the trace parent-child relationships, subsequently resulting in the UI crashing - {pull}3588[#3588]
 * Fix NPE in dropped spans statistics - {pull}3590[#3590]
+* Fix too small activation stack size for small `transaction_max_spans` values - {pull}3643[#3643]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -138,7 +138,10 @@ public class ElasticApmTracer implements Tracer {
     private final ThreadLocal<ActiveStack> activeStack = new ThreadLocal<ActiveStack>() {
         @Override
         protected ActiveStack initialValue() {
-            return new ActiveStack(transactionMaxSpans, emptyContext);
+            //We allow transactionMaxSpan activation plus a constant minimum of 16 to account for
+            // * the activation of the transaction itself
+            // * account for baggage updates, which also count towards the depth
+            return new ActiveStack(16 + transactionMaxSpans, emptyContext);
         }
     };
 
@@ -673,7 +676,7 @@ public class ElasticApmTracer implements Tracer {
     public Reporter getReporter() {
         return reporter;
     }
-    
+
     public UniversalProfilingIntegration getProfilingIntegration() {
         return profilingIntegration;
     }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ElasticApmTracer.java
@@ -112,6 +112,7 @@ public class ElasticApmTracer implements Tracer {
     private static final Map<Class<?>, Class<? extends ConfigurationOptionProvider>> configs = new HashMap<>();
 
     public static final Set<String> TRACE_HEADER_NAMES;
+    public static final int ACTIVATION_STACK_BASE_SIZE = 16;
 
     static {
         Set<String> headerNames = new HashSet<>();
@@ -141,7 +142,7 @@ public class ElasticApmTracer implements Tracer {
             //We allow transactionMaxSpan activation plus a constant minimum of 16 to account for
             // * the activation of the transaction itself
             // * account for baggage updates, which also count towards the depth
-            return new ActiveStack(16 + transactionMaxSpans, emptyContext);
+            return new ActiveStack(ACTIVATION_STACK_BASE_SIZE + transactionMaxSpans, emptyContext);
         }
     };
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/impl/ElasticApmTracerTest.java
@@ -413,7 +413,7 @@ class ElasticApmTracerTest {
                 assertThat(tracer.getActive()).isEqualTo(transaction);
                 transaction.end();
             }
-        }, tracer, 16);
+        }, tracer, ElasticApmTracer.ACTIVATION_STACK_BASE_SIZE);
         assertThat(tracer.getActive()).isNull();
         assertThat(reporter.getTransactions()).hasSize(1);
         assertThat(reporter.getSpans()).hasSize(2);


### PR DESCRIPTION
## What does this PR do?

Fixes #3642. Tests have been adapted to reproduce the issue.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
