### PR TITLE
more stack frames for thread dump

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ThreadDump.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ThreadDump.java
@@ -28,6 +28,8 @@ import javax.annotation.Nullable;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
+import java.lang.management.MonitorInfo;
+import java.lang.management.LockInfo;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ThreadDump.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/util/ThreadDump.java
@@ -95,8 +95,7 @@ public class ThreadDump extends AbstractLifecycleListener {
      */
     private static String toString(ThreadInfo threadInfo) {
         StringBuilder sb = new StringBuilder("\"" + threadInfo.getThreadName() + "\"" +
-            (threadInfo.isDaemon() ? " daemon" : "") +
-            " prio=" + threadInfo.getPriority() +
+            // note: daemon and priority now available < java9
             " Id=" + threadInfo.getThreadId() + " " +
             threadInfo.getThreadState());
         if (threadInfo.getLockName() != null) {


### PR DESCRIPTION
## What does this PR do?

Increase the depth of thread dump stack traces to 40 from the default of 8.

## Checklist

- [x] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
