### PR TITLE
ci: use updatecli with GitHub secrets

### DIFF
--- a/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
@@ -11,6 +11,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
+      commitusingapi: true
   apm:
     kind: github
     spec:

--- a/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-gherkin-specs.yml
@@ -5,22 +5,20 @@ scms:
   default:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
   apm:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.apm_repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
 
 sources:
@@ -78,5 +76,7 @@ targets:
     disablesourceinput: true
     kind: shell
     spec:
+      # git diff helps to print what it changed, If it is empty, then updatecli report a success with no changes applied.
+      # See https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target
       command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/gherkin-specs.tgz && git --no-pager diff'
       workdir: "{{ .apm_agent.gherkin_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-json-specs.yml
@@ -11,6 +11,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
+      commitusingapi: true
   apm:
     kind: github
     spec:

--- a/.ci/updatecli/updatecli.d/update-json-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-json-specs.yml
@@ -5,22 +5,20 @@ scms:
   default:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
   apm:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.apm_repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
 
 sources:
@@ -78,5 +76,7 @@ targets:
     disablesourceinput: true
     kind: shell
     spec:
+      # git diff helps to print what it changed, If it is empty, then updatecli report a success with no changes applied.
+      # See https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target
       command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-specs.tgz && git --no-pager diff'
       workdir: "{{ .apm_agent.json_specs_path }}"

--- a/.ci/updatecli/updatecli.d/update-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-specs.yml
@@ -11,6 +11,7 @@ scms:
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
+      commitusingapi: true
 
   apm-data:
     kind: github

--- a/.ci/updatecli/updatecli.d/update-specs.yml
+++ b/.ci/updatecli/updatecli.d/update-specs.yml
@@ -5,23 +5,21 @@ scms:
   default:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
 
   apm-data:
     kind: github
     spec:
-      user: '{{ requiredEnv "GIT_USER" }}'
-      email: '{{ requiredEnv "GIT_EMAIL" }}'
+      user: '{{ requiredEnv "GITHUB_ACTOR" }}'
       owner: "{{ .github.owner }}"
       repository: "{{ .github.apm_data_repository }}"
       token: '{{ requiredEnv "GITHUB_TOKEN" }}'
-      username: '{{ requiredEnv "GIT_USER" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       branch: "{{ .github.branch }}"
 
 sources:
@@ -80,5 +78,7 @@ targets:
     disablesourceinput: true
     kind: shell
     spec:
+      # git diff helps to print what it changed, If it is empty, then updatecli report a success with no changes applied.
+      # See https://www.updatecli.io/docs/plugins/resource/shell/#_shell_target
       command: 'tar -xzf {{ requiredEnv "GITHUB_WORKSPACE" }}/json-schema.tgz && git --no-pager diff'
       workdir: "{{ .apm_agent.server_schema_specs_path  }}"

--- a/.github/workflows/updatecli.yml
+++ b/.github/workflows/updatecli.yml
@@ -13,17 +13,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: elastic/apm-pipeline-library/.github/actions/updatecli@current
+
+      - uses: elastic/oblt-actions/updatecli/run@v1
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: .ci/updatecli/updatecli.d
-          values: .ci/updatecli/values.yml
+          command: "--experimental apply --config .ci/updatecli/updatecli.d --values .ci/updatecli/values.yml"
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATECLI_GH_TOKEN }}
+
       - if: failure()
-        uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+        uses: elastic/oblt-actions/slack/send@v1
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#apm-agent-java"
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-java"
+          message: ":traffic_cone: updatecli failed for `${{ github.repository }}@${{ github.ref_name }}`, @robots-ci please look what's going on <https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>"


### PR DESCRIPTION
## What does this PR do?

Use oblt-actions with GitHub secrets.

No need to use Vault secrets path

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
