### PR TITLE
[release] fix docker image build for release

### DIFF
--- a/scripts/docker-release/build_docker.sh
+++ b/scripts/docker-release/build_docker.sh
@@ -18,7 +18,9 @@ readonly SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
 readonly PROJECT_ROOT=$SCRIPT_PATH/../../
 readonly NAMESPACE="observability"
 
+set +e
 FILE=$(ls -A ${PROJECT_ROOT}elastic-apm-agent/target/*.jar | grep -E "elastic-apm-agent-[0-9]+.[0-9]+.[0-9]+(-SNAPSHOT)?.jar" )
+set -e
 
 if [ -n "${FILE}" ]
 then


### PR DESCRIPTION
## What does this PR do?

Ignore missing agent jar file when using the published artifact from maven central.

Failed during the last 1.50.0 release.

