### PR TITLE
buildkite: use bot user

### DIFF
--- a/.buildkite/hooks/prepare-benchmark.sh
+++ b/.buildkite/hooks/prepare-benchmark.sh
@@ -8,11 +8,10 @@ ES_PASS_SECRET=$(vault read -field=es_pass secret/ci/elastic-apm-agent-java/open
 export ES_URL_SECRET ES_USER_SECRET ES_PASS_SECRET
 
 echo "--- Prepare github secrets :vault:"
-GITHUB_SECRET=$(vault kv get -field token "kv/ci-shared/observability-ci/github-apmmachine")
+GITHUB_SECRET=$(vault kv get -field token "kv/ci-shared/observability-ci/github-bot-user")
+GITHUB_USERNAME=$(vault kv get -field username "kv/ci-shared/observability-ci/github-bot-user")
 GH_TOKEN=$GITHUB_SECRET
-export GITHUB_SECRET GH_TOKEN
-GITHUB_USERNAME=apmmachine
-export GITHUB_USERNAME
+export GITHUB_SECRET GH_TOKEN GITHUB_USERNAME
 
 echo "--- Install gh :github:"
 GH_URL=https://github.com/cli/cli/releases/download/v2.37.0/gh_2.37.0_linux_amd64.tar.gz


### PR DESCRIPTION
## What does this PR do?

Remove the need to use `apmmachine` and use the service machine account that we, robots, own

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
