### PR TITLE
buildkite: use shared secret for obltmachine

### DIFF
--- a/.buildkite/hooks/prepare-benchmark.sh
+++ b/.buildkite/hooks/prepare-benchmark.sh
@@ -7,12 +7,6 @@ ES_USER_SECRET=$(vault read -field=es_user secret/ci/elastic-apm-agent-java/open
 ES_PASS_SECRET=$(vault read -field=es_pass secret/ci/elastic-apm-agent-java/opentelemetry-benchmark)
 export ES_URL_SECRET ES_USER_SECRET ES_PASS_SECRET
 
-echo "--- Prepare github secrets :vault:"
-GITHUB_SECRET=$(vault kv get -field token "kv/ci-shared/observability-ci/github-bot-user")
-GITHUB_USERNAME=$(vault kv get -field username "kv/ci-shared/observability-ci/github-bot-user")
-GH_TOKEN=$GITHUB_SECRET
-export GITHUB_SECRET GH_TOKEN GITHUB_USERNAME
-
 echo "--- Install gh :github:"
 GH_URL=https://github.com/cli/cli/releases/download/v2.37.0/gh_2.37.0_linux_amd64.tar.gz
 GH_HOME=$(pwd)/.gh

--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -35,3 +35,11 @@ fi
 
 # Validate java is available in the runner.
 java -version
+
+echo "--- Prepare github secrets :vault:"
+VAULT_SECRET_PATH=kv/ci-shared/observability-ci/github-bot-user
+GITHUB_SECRET=$(vault kv get -field token "${VAULT_SECRET_PATH}")
+GIT_USER=$(vault kv get -field username "${VAULT_SECRET_PATH}")
+GIT_EMAIL=$(vault kv get -field email "${VAULT_SECRET_PATH}")
+GH_TOKEN=$GITHUB_SECRET
+export GITHUB_SECRET GH_TOKEN GIT_USER GIT_EMAIL

--- a/.buildkite/hooks/prepare-release.sh
+++ b/.buildkite/hooks/prepare-release.sh
@@ -35,5 +35,5 @@ echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"
 echo "--- Configure git context :git:"
 # Configure the committer since the maven release requires to push changes to GitHub
 # This will help with the SLSA requirements.
-git config --global user.email "infra-root+apmmachine@elastic.co"
-git config --global user.name "apmmachine"
+git config --global user.email "${GIT_EMAIL}"
+git config --global user.name "${GIT_USER}"


### PR DESCRIPTION
## What does this PR do?

Leftover when migrating from `apmmachine` to `obltmachine`

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
