### PR TITLE
Warn unexpected SpanContext in otel span link

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Bug fixes
 * Restore compatibility with Java 7 - {pull}3657[#3657]
+* Avoid `ClassCastException` and issue warning when trying to use otel span links - {pull}3672[#3672]
 
 [float]
 ===== Features

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelSpanBuilder.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-plugin/src/main/java/co/elastic/apm/agent/opentelemetry/tracing/OTelSpanBuilder.java
@@ -22,16 +22,15 @@ import co.elastic.apm.agent.impl.ElasticApmTracer;
 import co.elastic.apm.agent.impl.baggage.Baggage;
 import co.elastic.apm.agent.impl.transaction.AbstractSpan;
 import co.elastic.apm.agent.impl.transaction.MultiValueMapAccessor;
-import co.elastic.apm.agent.impl.transaction.OTelSpanKind;
-import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.impl.transaction.TraceContext;
 import co.elastic.apm.agent.impl.transaction.Transaction;
 import co.elastic.apm.agent.opentelemetry.baggage.OtelBaggage;
-import co.elastic.apm.agent.sdk.logging.Logger;
-import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.sdk.internal.util.LoggerUtils;
 import co.elastic.apm.agent.sdk.internal.util.PrivilegedActionUtils;
 import co.elastic.apm.agent.sdk.internal.util.VersionUtils;
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
+import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.tracer.metadata.PotentiallyMultiValuedMap;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.AttributeKey;
@@ -53,7 +52,8 @@ import java.util.concurrent.TimeUnit;
 
 class OTelSpanBuilder implements SpanBuilder {
 
-    private static final Logger addLinkLogger = LoggerUtils.logOnce(LoggerFactory.getLogger(OTelSpanBuilder.class));
+    private static final Logger addLinkLogger1 = LoggerUtils.logOnce(LoggerFactory.getLogger(OTelSpanBuilder.class));
+    private static final Logger addLinkLogger2 = LoggerUtils.logOnce(LoggerFactory.getLogger(OTelSpanBuilder.class));
 
     private final String spanName;
     private final ElasticApmTracer elasticApmTracer;
@@ -86,15 +86,19 @@ class OTelSpanBuilder implements SpanBuilder {
 
     @Override
     public SpanBuilder addLink(SpanContext spanContext) {
+        if (!(spanContext instanceof OTelSpanContext)) {
+            addLinkLogger2.warn("Adding arbitrary span context to links is currently unsupported");
+            return this;
+        }
         links.add(spanContext);
         return this;
     }
 
     @Override
-    public SpanBuilder addLink(SpanContext spanContext, Attributes attributes1) {
+    public SpanBuilder addLink(SpanContext spanContext, @Nullable Attributes attributes1) {
         addLink(spanContext);
         if (attributes1 != null && !attributes1.isEmpty()) {
-            addLinkLogger.warn("Adding attributes to links is currently unsupported - the links have been added but with no attributes, the following attributes have been ignored: %s",attributes1);
+            addLinkLogger1.warn("Adding attributes to links is currently unsupported - the links have been added but with no attributes, the following attributes have been ignored: %s", attributes1);
         }
         return this;
     }
@@ -182,7 +186,7 @@ class OTelSpanBuilder implements SpanBuilder {
             t.setFrameworkName("OpenTelemetry API");
 
             String otelVersion = VersionUtils.getVersion(OpenTelemetry.class, "io.opentelemetry", "opentelemetry-api");
-            if(otelVersion != null){
+            if (otelVersion != null) {
                 t.setFrameworkVersion(otelVersion);
             }
         }


### PR DESCRIPTION
## What does this PR do?

The OpenTelemetry API allows to use arbitrary `SpanContext` instances with `io.opentelemetry.api.trace.SpanBuilder#addLink(io.opentelemetry.api.trace.SpanContext)`.

However the otel bridge implementation only works with `OTelSpanContext` that are created from Elastic traces, and we do not currently support to create `OTelSpanContext` from arbitrary IDs.

This PR currently introduces a warning and silently avoid throwing an exception.

Relates to https://github.com/elastic/apm-agent-java/issues/3662

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
