### PR TITLE
github-actions: use buildkite and slack bot GH secrets

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -81,26 +81,23 @@ jobs:
     env:
       TARBALL_FILE: artifacts.tar
     steps:
-      - id: buildkite
+      - id: buildkite-run
         continue-on-error: true
-        name: Run Deploy
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        uses: elastic/oblt-actions/buildkite/run@v1
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: apm-agent-java-release
-          waitFor: true
-          printBuildLogs: false
-          artifactName: releases
-          artifactPath: ${{ env.TARBALL_FILE }}
-          buildEnvVars: |
+          pipeline: "apm-agent-java-release"
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+          wait-for: true
+          env-vars: |
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: actions/download-artifact@v3
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1
         with:
-          name: releases
+          build-number: ${{ steps.buildkite-run.outputs.build }}
+          path: "${{ env.TARBALL_FILE }}"
+          pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
+          token: ${{ secrets.BUILDKITE_TOKEN }}
 
       - name: untar the buildkite tarball
         run: tar xvf ${{ env.TARBALL_FILE }}
@@ -287,10 +284,8 @@ jobs:
         uses: elastic/apm-pipeline-library/.github/actions/check-dependent-jobs@current
         with:
           needs: ${{ toJSON(needs) }}
-      - uses: elastic/apm-pipeline-library/.github/actions/notify-build-status@current
+      - uses: elastic/oblt-actions/slack/notify-result@v1
         with:
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-java"
           status: ${{ steps.check.outputs.status }}
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          slackChannel: "#apm-agent-java"

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -46,26 +46,24 @@ jobs:
       TARBALL_FILE: artifacts.tar
     if: ${{ contains(needs.validate.outputs.is-snapshot, 'true') }}
     steps:
-      - id: buildkite
-        name: Run Deploy
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+      - id: buildkite-run
+        continue-on-error: true
+        uses: elastic/oblt-actions/buildkite/run@v1
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: apm-agent-java-snapshot
-          pipelineBranch: ${{ github.ref_name }}
-          artifactName: snapshots
-          artifactPath: ${{ env.TARBALL_FILE }}
-          waitFor: true
-          printBuildLogs: false
-          buildEnvVars: |
+          branch: ${{ github.ref_name }}
+          pipeline: "apm-agent-java-snapshot"
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+          wait-for: true
+          env-vars: |
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: actions/download-artifact@v3
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1
         with:
-          name: snapshots
+          build-number: ${{ steps.buildkite-run.outputs.build }}
+          path: "${{ env.TARBALL_FILE }}"
+          pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
+          token: ${{ secrets.BUILDKITE_TOKEN }}
 
       - name: untar the buildkite tarball
         run: tar xvf ${{ env.TARBALL_FILE }}
@@ -108,12 +106,10 @@ jobs:
         with:
           needs: ${{ toJSON(needs) }}
       - if: ${{ failure() && ! inputs.dry_run }}
-        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        uses: elastic/oblt-actions/slack/send@v1
         with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          channel: "#apm-agent-java"
+          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel-id: "#apm-agent-java"
           message: |
             :ghost: [${{ github.repository }}] Snapshot *${{ github.ref_name }}* didn't get triggered in Buildkite.
             Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)


### PR DESCRIPTION
## What does this PR do?

Use oblt-actions with GitHub secrets to:
- Run buildkite
- Download artifacts from Buildkite
- Notify slack messages

There is only one missing piece regarding the cloud access, to be done in a follow-up

## Tests

Release - dry-run mode in a feature branch called https://github.com/elastic/apm-agent-java/tree/test/no-vault-secrets -> https://github.com/elastic/apm-agent-java/actions/runs/9484128176

Snapshot - dry-run mode -> https://github.com/elastic/apm-agent-java/actions/runs/9484023550

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
