### PR TITLE
github-actions: use number output

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -94,7 +94,7 @@ jobs:
 
       - uses: elastic/oblt-actions/buildkite/download-artifact@v1
         with:
-          build-number: ${{ steps.buildkite-run.outputs.build }}
+          build-number: ${{ steps.buildkite-run.outputs.number }}
           path: "${{ env.TARBALL_FILE }}"
           pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
           token: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: elastic/oblt-actions/buildkite/download-artifact@v1
         with:
-          build-number: ${{ steps.buildkite-run.outputs.build }}
+          build-number: ${{ steps.buildkite-run.outputs.number }}
           path: "${{ env.TARBALL_FILE }}"
           pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
           token: ${{ secrets.BUILDKITE_TOKEN }}


### PR DESCRIPTION
## What does this PR do?

Use the right output

<img width="600" alt="image" src="https://github.com/elastic/apm-agent-java/assets/2871786/fd79d36d-515b-4023-b09f-e9eccd146b55">

Unfortunately, the docs in `oblt-actions` contained a wrong example :/ 

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
