### PR TITLE
Remove unused functions and clean up servlet integration test base

### DIFF
--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -28,10 +28,10 @@ import co.elastic.apm.agent.testutils.TestContainersUtils;
 import co.elastic.apm.servlet.tests.TestApp;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.dockerjava.api.command.StopContainerCmd;
 import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
-import okhttp3.RequestBody;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 import okhttp3.logging.HttpLoggingInterceptor;
@@ -49,7 +49,13 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.time.Duration;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -176,21 +182,8 @@ public abstract class AbstractServletContainerIntegrationTest {
         container.start();
 
         if (runtimeAttachSupported()) {
-            if (AGENT_VERSION_TO_DOWNLOAD_FROM_MAVEN != null) {
-                container.startCliRuntimeAttach(AGENT_VERSION_TO_DOWNLOAD_FROM_MAVEN);
-            } else {
-                container.startCliRuntimeAttach(AGENT_VERSION_TO_DOWNLOAD_FROM_MAVEN);
-            }
+            container.startCliRuntimeAttach(AGENT_VERSION_TO_DOWNLOAD_FROM_MAVEN);
         }
-    }
-
-    private static OkHttpClient setupHttpClient(boolean isDebug) {
-        final HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor(logger::info);
-        loggingInterceptor.setLevel(isDebug ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.BASIC);
-        return new OkHttpClient.Builder()
-            .addInterceptor(loggingInterceptor)
-            .readTimeout(isDebug ? 0 : 10, TimeUnit.SECONDS)
-            .build();
     }
 
     protected void beforeContainerStart(AgentTestContainer.AppServer container) {
@@ -216,9 +209,13 @@ public abstract class AbstractServletContainerIntegrationTest {
 
     @After
     public final void stopServer() {
-        container.getDockerClient()
-            .stopContainerCmd(container.getContainerId())
-            .exec();
+        if (!container.isRunning()) {
+            return; // prevent NPE on container.getContainerId()
+        }
+        // allow graceful shutdown before killing and removing the container
+        try (StopContainerCmd stopContainerCmd = container.getDockerClient().stopContainerCmd(container.getContainerId())) {
+            stopContainerCmd.exec();
+        }
         container.stop();
     }
 
@@ -271,15 +268,17 @@ public abstract class AbstractServletContainerIntegrationTest {
         return transaction;
     }
 
-    public String executeAndValidateRequest(String pathToTest, String expectedContent, Integer expectedResponseCode,
+    public void executeAndValidateRequest(String pathToTest, String expectedContent, Integer expectedResponseCode,
                                             Map<String, String> headersMap) throws IOException, InterruptedException {
-        Response response = executeRequest(pathToTest, headersMap);
-        if (expectedResponseCode != null) {
-            assertThat(response.code())
-                .withFailMessage(response.toString() + getServerLogs())
-                .isEqualTo(expectedResponseCode);
+        final ResponseBody responseBody;
+        try (Response response = executeRequest(pathToTest, headersMap)) {
+            if (expectedResponseCode != null) {
+                assertThat(response.code())
+                    .withFailMessage(response + getServerLogs())
+                    .isEqualTo(expectedResponseCode);
+            }
+            responseBody = response.body();
         }
-        final ResponseBody responseBody = response.body();
         assertThat(responseBody).isNotNull();
         String responseString = responseBody.string();
         if (expectedContent != null) {
@@ -287,13 +286,13 @@ public abstract class AbstractServletContainerIntegrationTest {
                 .describedAs("unexpected response content")
                 .contains(expectedContent);
         }
-        return responseString;
     }
 
     private void executeStatusRequestAndCheckIgnored(String statusEndpoint) throws IOException {
         Map<String, String> headers = Collections.emptyMap();
-        Response response = executeRequest(statusEndpoint, headers);
-        assertThat(response.code()).isEqualTo(200);
+        try (Response response = executeRequest(statusEndpoint, headers)) {
+            assertThat(response.code()).isEqualTo(200);
+        }
 
         try {
             Thread.sleep(200);
@@ -306,33 +305,6 @@ public abstract class AbstractServletContainerIntegrationTest {
             .describedAs("status transaction should be ignored by configuration %s", transactions)
             .isTrue();
 
-    }
-
-    public String executeAndValidatePostRequest(String pathToTest, RequestBody postBody, String expectedContent, Integer expectedResponseCode) throws IOException, InterruptedException {
-        Response response = executePostRequest(pathToTest, postBody);
-        if (expectedResponseCode != null) {
-            assertThat(response.code())
-                .withFailMessage(response.toString() + getServerLogs())
-                .isEqualTo(expectedResponseCode);
-        }
-        final ResponseBody responseBody = response.body();
-        assertThat(responseBody).isNotNull();
-        String responseString = responseBody.string();
-        if (expectedContent != null) {
-            assertThat(responseString).contains(expectedContent);
-        }
-        return responseString;
-    }
-
-    public Response executePostRequest(String pathToTest, RequestBody postBody) throws IOException {
-        if (!pathToTest.startsWith("/")) {
-            pathToTest = "/" + pathToTest;
-        }
-        return httpClient.newCall(new Request.Builder()
-                .post(postBody)
-                .url(getBaseUrl() + pathToTest)
-                .build())
-            .execute();
     }
 
     public Response executeRequest(String pathToTest, Map<String, String> headersMap) throws IOException {
@@ -368,7 +340,7 @@ public abstract class AbstractServletContainerIntegrationTest {
         List<JsonNode> reportedSpans;
         do {
             reportedSpans = supplier.get();
-        } while (reportedSpans.size() == 0 && System.currentTimeMillis() - start < timeout);
+        } while (reportedSpans.isEmpty() && System.currentTimeMillis() - start < timeout);
         assertThat(reportedSpans)
             .describedAs("at least one span is expected")
             .isNotEmpty();
@@ -386,7 +358,7 @@ public abstract class AbstractServletContainerIntegrationTest {
         List<JsonNode> reportedErrors;
         do {
             reportedErrors = supplier.get();
-        } while (reportedErrors.size() == 0 && System.currentTimeMillis() - start < timeoutMs);
+        } while (reportedErrors.isEmpty() && System.currentTimeMillis() - start < timeoutMs);
         assertThat(reportedErrors.size()).isEqualTo(1);
         for (JsonNode error : reportedErrors) {
             assertThat(error.get("transaction_id").textValue()).isEqualTo(transactionId);
@@ -529,16 +501,6 @@ public abstract class AbstractServletContainerIntegrationTest {
         assertThat(jsonContainer.get("id").textValue()).isEqualTo(container.getContainerId());
     }
 
-    private void addSpans(List<JsonNode> spans, JsonNode payload) {
-        final JsonNode jsonSpans = payload.get("spans");
-        if (jsonSpans != null) {
-            for (JsonNode jsonSpan : jsonSpans) {
-                mockReporter.verifyTransactionSchema(jsonSpan);
-                spans.add(jsonSpan);
-            }
-        }
-    }
-
     private void waitFor(String path) {
         Wait.forHttp(path)
             .forPort(webPort)
@@ -549,9 +511,5 @@ public abstract class AbstractServletContainerIntegrationTest {
 
     public OkHttpClient getHttpClient() {
         return httpClient;
-    }
-
-    public boolean isHotSpotBased() {
-        return true;
     }
 }

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -33,7 +33,6 @@ import okhttp3.Headers;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import okhttp3.ResponseBody;
 import okhttp3.logging.HttpLoggingInterceptor;
 import org.junit.After;
 import org.junit.Test;
@@ -270,17 +269,15 @@ public abstract class AbstractServletContainerIntegrationTest {
 
     public void executeAndValidateRequest(String pathToTest, String expectedContent, Integer expectedResponseCode,
                                             Map<String, String> headersMap) throws IOException, InterruptedException {
-        final ResponseBody responseBody;
+        final String responseString;
         try (Response response = executeRequest(pathToTest, headersMap)) {
             if (expectedResponseCode != null) {
                 assertThat(response.code())
                     .withFailMessage(response + getServerLogs())
                     .isEqualTo(expectedResponseCode);
             }
-            responseBody = response.body();
+            responseString = response.body().string();
         }
-        assertThat(responseBody).isNotNull();
-        String responseString = responseBody.string();
         if (expectedContent != null) {
             assertThat(responseString)
                 .describedAs("unexpected response content")

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebSphereIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/WebSphereIT.java
@@ -53,11 +53,6 @@ public class WebSphereIT extends AbstractServletContainerIntegrationTest {
     }
 
     @Override
-    public boolean isHotSpotBased() {
-        return false;
-    }
-
-    @Override
     protected Iterable<Class<? extends TestApp>> getTestClasses() {
         return Arrays.asList(
             ServletApiTestApp.class,


### PR DESCRIPTION
## What does this PR do?

This removes unused functions and clean up servlet integration test base I noticed while attempting to run WildFlyIT. Notably, when image download or container start failed, our stop function would NPE over it. The other changes are more taking care of drift or resource management.

I'm not sure what category below as it isn't a CHANGELOG worthy bug as it is test infra 🤷 

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
