### PR TITLE
Uses MockWebServer instead of a docker container for servlet ITs

### DIFF
--- a/integration-tests/application-server-integration-tests/pom.xml
+++ b/integration-tests/application-server-integration-tests/pom.xml
@@ -119,6 +119,12 @@
             <version>${version.okhttp}</version>
         </dependency>
         <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>mockwebserver</artifactId>
+            <version>${version.okhttp}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
## What does this PR do?

This uses MockWebServer instead of a docker container for servlet ITs. In doing so, this simplifies the docker containers explicitly managed in our tests to one. That allows a simpler migration to the container jupiter extension in the future.

As this is test fixture only, I didn't check any checkbox as it isn't user-affecting enhancement or bug.

I chose okhttp MockWebServer..
* because we already have most classes in the classpath and a single version to manage via okhttp
* instead of `com.sun.net.httpserver.HttpServer`: as this is a dodgy type that only gets worse with new JREs
* instead of wiremock as this is doing simple dispatch, and MWS is more straightforward

Thoughts on the future enabled by this:

If we were to simplify to extensions, a better devex is possible, notably being able to run a single test, such as a method in `SoapTestApp` without running all other tests in a loop. This would be via other jupiter things such as `@Nested`, and in consideration of some limitations (in my experience, it is best to have a top-level class per docker image under test, vs a matrix, as it is easier to manage the sub-tests that way).


## Checklist
- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
