### PR TITLE
Revert "Uses MockWebServer instead of a docker container for integration tests"

### DIFF
--- a/integration-tests/application-server-integration-tests/pom.xml
+++ b/integration-tests/application-server-integration-tests/pom.xml
@@ -119,12 +119,6 @@
             <version>${version.okhttp}</version>
         </dependency>
         <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>mockwebserver</artifactId>
-            <version>${version.okhttp}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <scope>test</scope>

--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/AbstractServletContainerIntegrationTest.java
@@ -24,6 +24,7 @@ import co.elastic.apm.agent.sdk.logging.LoggerFactory;
 import co.elastic.apm.agent.test.AgentFileAccessor;
 import co.elastic.apm.agent.test.AgentTestContainer;
 import co.elastic.apm.agent.test.JavaExecutable;
+import co.elastic.apm.agent.testutils.TestContainersUtils;
 import co.elastic.apm.servlet.tests.TestApp;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -33,15 +34,11 @@ import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.logging.HttpLoggingInterceptor;
-import okhttp3.mockwebserver.Dispatcher;
-import okhttp3.mockwebserver.MockResponse;
-import okhttp3.mockwebserver.MockWebServer;
-import okhttp3.mockwebserver.RecordedRequest;
-import okio.Buffer;
-import okio.InflaterSource;
 import org.junit.After;
 import org.junit.Test;
-import org.testcontainers.Testcontainers;
+import org.mockserver.model.ClearType;
+import org.mockserver.model.HttpRequest;
+import org.mockserver.model.HttpResponse;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.MountableFile;
@@ -49,7 +46,6 @@ import org.testcontainers.utility.MountableFile;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -59,16 +55,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.zip.Inflater;
 
 import static co.elastic.apm.agent.report.IntakeV2ReportingEventHandler.INTAKE_V2_URL;
-import static co.elastic.apm.agent.report.IntakeV2ReportingEventHandler.INTAKE_V2_FLUSH_URL;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockserver.model.HttpRequest.request;
 
 /**
  * When you want to execute the test in the IDE, execute {@code mvn clean package} before.
@@ -91,14 +84,19 @@ public abstract class AbstractServletContainerIntegrationTest {
     @Nullable
     private static final String AGENT_VERSION_TO_DOWNLOAD_FROM_MAVEN = null;
 
-    private static final MockWebServer apmServer;
-    private static final Queue<String> receivedIntakeEvents = new ConcurrentLinkedQueue<>();
+    private static final MockServerContainer mockServerContainer;
 
     private static final OkHttpClient httpClient;
 
     static {
-        apmServer = new MockWebServer();
-        apmServer.setDispatcher(new ApmDispatcher());
+        mockServerContainer = new MockServerContainer()
+            .withNetworkAliases("apm-server")
+            .waitingFor(Wait.forHttp(MockServerContainer.HEALTH_ENDPOINT).forStatusCode(200))
+            .withNetwork(Network.SHARED);
+
+        if (JavaExecutable.isDebugging()) {
+            mockServerContainer.withLogConsumer(TestContainersUtils.createSlf4jLogConsumer(MockServerContainer.class));
+        }
 
         final HttpLoggingInterceptor loggingInterceptor = new HttpLoggingInterceptor(logger::info);
         loggingInterceptor.setLevel(JavaExecutable.isDebugging() ? HttpLoggingInterceptor.Level.BODY : HttpLoggingInterceptor.Level.BASIC);
@@ -107,13 +105,9 @@ public abstract class AbstractServletContainerIntegrationTest {
             .readTimeout(JavaExecutable.isDebugging() ? 0 : 10, TimeUnit.SECONDS)
             .build();
 
-        // Start the mock apm server and expose it to any container as host.testcontainers.internal:$port
-        try {
-            apmServer.start();
-            Testcontainers.exposeHostPorts(apmServer.getPort());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        mockServerContainer.start();
+        mockServerContainer.getClient().when(request(INTAKE_V2_URL)).respond(HttpResponse.response().withStatusCode(200));
+        mockServerContainer.getClient().when(request("/")).respond(HttpResponse.response().withStatusCode(200));
     }
 
     private final MockReporter mockReporter = new MockReporter();
@@ -156,7 +150,7 @@ public abstract class AbstractServletContainerIntegrationTest {
 
         container
             .withNetwork(Network.SHARED)
-            .withEnv("ELASTIC_APM_SERVER_URL", "http://host.testcontainers.internal:" + apmServer.getPort())
+            .withEnv("ELASTIC_APM_SERVER_URL", "http://apm-server:1080")
             .withEnv("ELASTIC_APM_IGNORE_URLS", ignoreUrlConfig)
             .withEnv("ELASTIC_APM_REPORT_SYNC", "true")
             .withEnv("ELASTIC_APM_LOG_LEVEL", "DEBUG")
@@ -253,7 +247,7 @@ public abstract class AbstractServletContainerIntegrationTest {
     }
 
     public void clearMockServerLog() {
-        receivedIntakeEvents.clear();
+        mockServerContainer.getClient().clear(HttpRequest.request(), ClearType.LOG);
     }
 
     public JsonNode assertTransactionReported(String pathToTest, int expectedResponseCode) {
@@ -274,7 +268,7 @@ public abstract class AbstractServletContainerIntegrationTest {
     }
 
     public void executeAndValidateRequest(String pathToTest, String expectedContent, Integer expectedResponseCode,
-                                          Map<String, String> headersMap) throws IOException, InterruptedException {
+                                            Map<String, String> headersMap) throws IOException, InterruptedException {
         final String responseString;
         try (Response response = executeRequest(pathToTest, headersMap)) {
             if (expectedResponseCode != null) {
@@ -429,20 +423,23 @@ public abstract class AbstractServletContainerIntegrationTest {
         try {
             final List<JsonNode> events = new ArrayList<>();
             final ObjectMapper objectMapper = new ObjectMapper();
-            for (String bodyAsString : receivedIntakeEvents) {
-                final JsonNode ndJson = objectMapper.readTree(bodyAsString);
-                if (ndJson.get(eventType) != null) {
-                    // as inferred spans are created only after the profiling session ends
-                    // they can leak into another test
-                    if (!isInferredSpan(ndJson.get(eventType))) {
-                        validateEventMetadata(bodyAsString);
+            for (HttpRequest httpRequest : mockServerContainer.getClient().retrieveRecordedRequests(request(INTAKE_V2_URL))) {
+                final String bodyAsString = httpRequest.getBodyAsString();
+                for (String ndJsonLine : bodyAsString.split("\n")) {
+                    final JsonNode ndJson = objectMapper.readTree(ndJsonLine);
+                    if (ndJson.get(eventType) != null) {
+                        // as inferred spans are created only after the profiling session ends
+                        // they can leak into another test
+                        if (!isInferredSpan(ndJson.get(eventType))) {
+                            validateEventMetadata(bodyAsString);
+                        }
+                        events.add(ndJson.get(eventType));
                     }
-                    events.add(ndJson.get(eventType));
                 }
             }
             return events;
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -461,7 +458,7 @@ public abstract class AbstractServletContainerIntegrationTest {
                 }
             }
         } catch (IOException e) {
-            throw new UncheckedIOException(e);
+            throw new RuntimeException(e);
         }
     }
 
@@ -511,57 +508,5 @@ public abstract class AbstractServletContainerIntegrationTest {
 
     public OkHttpClient getHttpClient() {
         return httpClient;
-    }
-
-    /**
-     * This is modeled after {@code co.elastic.apm.awslambda.fakeserver.FakeApmServer}, except
-     * deflate instead of gzip and OkHttp instead of {@code com.sun.net.httpserver.HttpServer}.
-     */
-    private static final class ApmDispatcher extends Dispatcher {
-        @Override
-        public MockResponse dispatch(RecordedRequest request) {
-            switch (request.getPath()) {
-                case "/": // health check
-                    return new MockResponse().setBody("{\"version\": \"8.7.1\"}");
-                case INTAKE_V2_URL:
-                case INTAKE_V2_FLUSH_URL:
-                    try {
-                        readIntakeEvents(request);
-                    } catch (IOException e) {
-                        logger.error("Encountered intake request error {}", e);
-                        return new MockResponse().setResponseCode(500);
-                    }
-                    return new MockResponse().setResponseCode(202);
-            }
-            logger.error("Encountered unexpected request {}", request);
-            return new MockResponse().setResponseCode(404);
-        }
-    }
-
-    private static void readIntakeEvents(RecordedRequest request) throws IOException {
-        // The request body is compressed with deflate
-        final Buffer body;
-        String encoding = request.getHeader("Content-Encoding");
-        if (encoding == null) {
-            body = request.getBody().buffer();
-        } else if (encoding.contains("deflate")) {
-            Buffer inflated = new Buffer();
-            try (InflaterSource deflated = new InflaterSource(request.getBody(), new Inflater())) {
-                while (deflated.read(inflated, Integer.MAX_VALUE) != -1) ;
-            }
-            body = inflated;
-        } else {
-            throw new IOException("unsupported encoding: " + encoding);
-        }
-
-        // read each Newline Delimited JSON event into the queue.
-        String event;
-        while ((event = body.readUtf8Line()) != null) {
-            if (!event.startsWith("{")) {
-                throw new IOException("not NDJSON " + request);
-            } else {
-                receivedIntakeEvents.add(event);
-            }
-        }
     }
 }


### PR DESCRIPTION
## What does this PR do?

This reverts commit cd893419137fd80981505c754ecea5cce6fb0bbd.

This breaks JBoss startup somehow in non-obvious ways. See #3684

Fastest way to reproduce by using JBossIT with registry.access.redhat.com/jboss-eap-7/eap72-openshift
```
--snip--
2024-06-18 18:01:41,148 [docker-java-stream-922282997] INFO  co.elastic.apm.agent.test.AgentTestContainer - STDOUT: 2024-06-18 10:01:41,155 [main] DEBUG co.elastic.apm.agent.jmx.JmxMetricTracker$JmxMetricRegistration - Registering JMX metric java.lang:type=Memory HeapMemoryUsage.max as metric_name: jvm.jmx.test_heap_metric.max labels: type=Memory
2024-06-18 18:01:41,151 [docker-java-stream-922282997] INFO  co.elastic.apm.agent.test.AgentTestContainer - STDOUT: 2024-06-18 10:01:41,158 [main] DEBUG co.elastic.apm.agent.jmx.JmxMetricTracker$JmxMetricRegistration - Registering JMX metric java.lang:type=Memory HeapMemoryUsage.used as metric_name: jvm.jmx.test_heap_metric.used labels: type=Memory
2024-06-18 18:01:41,262 [docker-java-stream-922282997] INFO  co.elastic.apm.agent.test.AgentTestContainer - STDOUT: 2024-06-18 10:01:41,268 [main] DEBUG co.elastic.apm.agent.bci.ElasticApmAgent - Type match for instrumentation JBossLoggingCorrelationInstrumentation: (name(equals(org.jboss.logging.JDKLogger)) or name(equals(org.jboss.logging.JBossLogManagerLogger))) matches class org.jboss.logging.JBossLogManagerLogger
2024-06-18 18:01:41,271 [docker-java-stream-922282997] INFO  co.elastic.apm.agent.test.AgentTestContainer - STDOUT: 2024-06-18 10:01:41,277 [main] DEBUG co.elastic.apm.agent.bci.ElasticApmAgent - Method match for instrumentation JBossLoggingCorrelationInstrumentation: ((name(equals(doLog)) or name(equals(doLogf))) and not(isAbstract())) matches protected void org.jboss.logging.JBossLogManagerLogger.doLog(org.jboss.logging.Logger$Level,java.lang.String,java.lang.Object,java.lang.Object[],java.lang.Throwable)
2024-06-18 18:01:41,274 [docker-java-stream-922282997] INFO  co.elastic.apm.agent.test.AgentTestContainer - STDOUT: 2024-06-18 10:01:41,281 [main] DEBUG co.elastic.apm.agent.bci.ElasticApmAgent - Method match for instrumentation JBossLoggingCorrelationInstrumentation: ((name(equals(doLog)) or name(equals(doLogf))) and not(isAbstract())) matches protected void org.jboss.logging.JBossLogManagerLogger.doLogf(org.jboss.logging.Logger$Level,java.lang.String,java.lang.String,java.lang.Object[],java.lang.Throwable)
2024-06-18 18:01:41,283 [docker-java-stream-922282997] INFO  co.elastic.apm.agent.test.AgentTestContainer - STDERR: WFLYSRV0073: Invalid option '172.19.0.2'
2024-06-18 18:01:41,355 [docker-java-stream-922282997] INFO  co.elastic.apm.agent.test.AgentTestContainer - STDOUT: 
2024-06-18 18:01:41,355 [docker-java-stream-922282997] INFO  co.elastic.apm.agent.test.AgentTestContainer - STDOUT: Usage: standalone.sh [args...]
```

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
