### PR TITLE
jmx-metrics-fix

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Restore compatibility with Java 7 - {pull}3657[#3657]
 * Avoid `ClassCastException` and issue warning when trying to use otel span links - {pull}3672[#3672]
 * Avoid `NullPointerException` with runtime attach API and invalid map entries - {pull}3712[#3712]
+* Enhance invalid state JMX metrics handling - {pull}3713[#3713]
 
 [float]
 ===== Features


### PR DESCRIPTION
## What does this PR do?

When registering JMX with a wildcard, getting an `MBeanRuntimeException` is managed and allows to consider the metric attribute as having a transient error.

However this is not the case when not using wildcards, which makes it fail for example when the implementation throws an `MbeanRuntimeException` with `NullPointerException` as cause.

This PR just applies the same heuristics for both cases with a minor refactor to prevent this from happening in the future.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix

