### PR TITLE
z/OS avoids using NOFOLLOW_LINKS

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -36,6 +36,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 * Restore compatibility with Java 7 - {pull}3657[#3657]
 * Avoid `ClassCastException` and issue warning when trying to use otel span links - {pull}3672[#3672]
 * Avoid `NullPointerException` with runtime attach API and invalid map entries - {pull}3712[#3712]
+* Skips using NOFOLLOW_LINKS file open option when running on z/OS as it's unsupported there - {pull}3722[#3722]
 
 [float]
 ===== Features

--- a/apm-agent-common/src/main/java/co/elastic/apm/agent/common/JvmRuntimeInfo.java
+++ b/apm-agent-common/src/main/java/co/elastic/apm/agent/common/JvmRuntimeInfo.java
@@ -25,7 +25,8 @@ import javax.annotation.Nullable;
 public class JvmRuntimeInfo {
 
     private static final JvmRuntimeInfo CURRENT_VM = new JvmRuntimeInfo(System.getProperty("java.version"),
-        System.getProperty("java.vm.name"), System.getProperty("java.vendor"), System.getProperty("java.vm.version"));
+        System.getProperty("java.vm.name"), System.getProperty("java.vendor"), System.getProperty("java.vm.version"),
+        System.getProperty("os.name"));
 
     private final String javaVersion;
     private final String javaVmName;
@@ -37,6 +38,7 @@ public class JvmRuntimeInfo {
     private final boolean isJ9;
     private final boolean isHpUx;
     private final boolean isCoretto;
+    private final boolean isZos;
 
     public static JvmRuntimeInfo ofCurrentVM() {
         return CURRENT_VM;
@@ -52,6 +54,10 @@ public class JvmRuntimeInfo {
      * @param vmVersion jvm version, from {@code System.getProperty("java.vm.version")}
      */
     public JvmRuntimeInfo(String version, String vmName, String vendorName, @Nullable String vmVersion) {
+        this(version, vmName, vendorName, vmVersion, null);
+    }
+
+    private JvmRuntimeInfo(String version, String vmName, String vendorName, @Nullable String vmVersion, @Nullable String osName) {
         javaVersion = version;
         javaVmName = vmName;
         javaVmVersion = vmVersion;
@@ -61,6 +67,7 @@ public class JvmRuntimeInfo {
         isJ9 = vmName.contains("J9");
         isHpUx = version.endsWith("-hp-ux");
         isCoretto = vendorName != null && vendorName.contains("Amazon");
+        isZos = (osName != null) && osName.toLowerCase().contains("z/os");
 
         if (isHpUx) {
             // remove extra hp-ux suffix for parsing
@@ -160,6 +167,10 @@ public class JvmRuntimeInfo {
 
     public boolean isCoretto() {
         return isCoretto;
+    }
+
+    public boolean isZos() {
+        return isZos;
     }
 
     @Override

--- a/apm-agent-common/src/main/java/co/elastic/apm/agent/common/util/ResourceExtractionUtil.java
+++ b/apm-agent-common/src/main/java/co/elastic/apm/agent/common/util/ResourceExtractionUtil.java
@@ -18,6 +18,8 @@
  */
 package co.elastic.apm.agent.common.util;
 
+import co.elastic.apm.agent.common.JvmRuntimeInfo;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
@@ -99,7 +101,9 @@ public class ResourceExtractionUtil {
                     }
                 }
             } catch (FileAlreadyExistsException e) {
-                try (FileChannel channel = FileChannel.open(tempFile, READ, NOFOLLOW_LINKS)) {
+                try (FileChannel channel = JvmRuntimeInfo.ofCurrentVM().isZos() ?
+                        FileChannel.open(tempFile, READ) :
+                        FileChannel.open(tempFile, READ, NOFOLLOW_LINKS)) {
                     // wait until other JVM instances have fully written the file
                     // multiple JVMs can read the file at the same time
                     try (FileLock readLock = channel.lock(0, Long.MAX_VALUE, true)) {


### PR DESCRIPTION
## What does this PR do?
Skips using NOFOLLOW_LINKS file open option when running on z/OS. Confirmed works by a z/OS user

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
