### PR TITLE
Perform charset-aware decoding of request bodies

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -62,8 +62,13 @@ import co.elastic.apm.agent.impl.transaction.TraceContextImpl;
 import co.elastic.apm.agent.impl.transaction.TransactionImpl;
 import co.elastic.apm.agent.report.ApmServerClient;
 import co.elastic.apm.agent.sdk.internal.collections.LongList;
+import co.elastic.apm.agent.sdk.internal.pooling.ObjectHandle;
+import co.elastic.apm.agent.sdk.internal.pooling.ObjectPool;
+import co.elastic.apm.agent.sdk.internal.pooling.ObjectPooling;
+import co.elastic.apm.agent.sdk.internal.util.IOUtils;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
+import co.elastic.apm.agent.tracer.configuration.WebConfiguration;
 import co.elastic.apm.agent.tracer.metadata.PotentiallyMultiValuedMap;
 import co.elastic.apm.agent.tracer.metrics.DslJsonUtil;
 import co.elastic.apm.agent.tracer.metrics.Labels;
@@ -79,8 +84,10 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
+import java.nio.charset.CoderResult;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -88,6 +95,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
@@ -103,6 +111,13 @@ public class DslJsonSerializer {
     private static final byte NEW_LINE = (byte) '\n';
     private static final Logger logger = LoggerFactory.getLogger(DslJsonSerializer.class);
     private static final List<String> excludedStackFramesPrefixes = Arrays.asList("java.lang.reflect.", "com.sun.", "sun.", "jdk.internal.");
+
+    private static final ObjectPool<? extends ObjectHandle<CharBuffer>> REQUEST_BODY_BUFFER_POOL = ObjectPooling.createWithDefaultFactory(new Callable<CharBuffer>() {
+        @Override
+        public CharBuffer call() throws Exception {
+            return CharBuffer.allocate(WebConfiguration.MAX_BODY_CAPTURE_BYTES);
+        }
+    });
 
 
     private final StacktraceConfigurationImpl stacktraceConfiguration;
@@ -1054,22 +1069,7 @@ public class DslJsonSerializer {
         }
 
         private void serializeOTel(SpanImpl span) {
-            serializeOtel(span, Collections.<IdImpl>emptyList(), requestBodyToString(span.getContext().getHttp().getRequestBody()));
-        }
-
-        @Nullable
-        private CharSequence requestBodyToString(BodyCaptureImpl requestBody) {
-            //TODO: perform proper, charset aware conversion to string
-            ByteBuffer buffer = requestBody.getBody();
-            if (buffer == null || buffer.position() == 0) {
-                return null;
-            }
-            buffer.flip();
-            StringBuilder result = new StringBuilder();
-            while (buffer.hasRemaining()) {
-                result.append((char) buffer.get());
-            }
-            return result;
+            serializeOtel(span, Collections.<IdImpl>emptyList(), span.getContext().getHttp().getRequestBody());
         }
 
         private void serializeOTel(TransactionImpl transaction) {
@@ -1079,11 +1079,12 @@ public class DslJsonSerializer {
             }
         }
 
-        private void serializeOtel(AbstractSpanImpl<?> span, List<IdImpl> profilingStackTraceIds, @Nullable CharSequence httpRequestBody) {
+        private void serializeOtel(AbstractSpanImpl<?> span, List<IdImpl> profilingStackTraceIds, @Nullable BodyCaptureImpl httpRequestBody) {
             OTelSpanKind kind = span.getOtelKind();
             Map<String, Object> attributes = span.getOtelAttributes();
 
-            boolean hasAttributes = !attributes.isEmpty() || !profilingStackTraceIds.isEmpty() || httpRequestBody != null;
+            boolean hasRequestBody = httpRequestBody != null && httpRequestBody.getBody() != null;
+            boolean hasAttributes = !attributes.isEmpty() || !profilingStackTraceIds.isEmpty() || hasRequestBody;
             boolean hasKind = kind != null;
             if (hasKind || hasAttributes) {
                 writeFieldName("otel");
@@ -1133,18 +1134,50 @@ public class DslJsonSerializer {
                         }
                         jw.writeByte(ARRAY_END);
                     }
-                    if (httpRequestBody != null) {
+                    if (hasRequestBody) {
                         if (!isFirstAttrib) {
                             jw.writeByte(COMMA);
                         }
                         writeFieldName("http.request.body.content");
-                        jw.writeString(httpRequestBody);
+                        writeRequestBodyAsString(jw, httpRequestBody);
                     }
                     jw.writeByte(OBJECT_END);
                 }
 
                 jw.writeByte(OBJECT_END);
                 jw.writeByte(COMMA);
+            }
+        }
+
+
+        private void writeRequestBodyAsString(JsonWriter jw, BodyCaptureImpl requestBody) {
+            try (ObjectHandle<CharBuffer> charBufferHandle = REQUEST_BODY_BUFFER_POOL.createInstance()) {
+                CharBuffer charBuffer = charBufferHandle.get();
+                try {
+                    decodeRequestBodyBytes(requestBody, charBuffer);
+                    charBuffer.flip();
+                    jw.writeString(charBuffer);
+                } finally {
+                    ((Buffer) charBuffer).clear();
+                }
+            }
+        }
+
+        private void decodeRequestBodyBytes(BodyCaptureImpl requestBody, CharBuffer charBuffer) {
+            ByteBuffer bodyBytes = requestBody.getBody();
+            ((Buffer) bodyBytes).flip(); //make ready for reading
+            CharSequence charset = requestBody.getCharset();
+            if (charset != null) {
+                CoderResult result = IOUtils.decode(bodyBytes, charBuffer, charset.toString());
+                if (result != null && !result.isMalformed() && !result.isUnmappable()) {
+                    return;
+                }
+            }
+            //fallback to decoding by simply casting bytes to chars
+            ((Buffer) bodyBytes).position(0);
+            ((Buffer) charBuffer).clear();
+            while (bodyBytes.hasRemaining()) {
+                charBuffer.put((char) bodyBytes.get());
             }
         }
 

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/serialize/DslJsonSerializer.java
@@ -1177,7 +1177,7 @@ public class DslJsonSerializer {
             ((Buffer) bodyBytes).position(0);
             ((Buffer) charBuffer).clear();
             while (bodyBytes.hasRemaining()) {
-                charBuffer.put((char) bodyBytes.get());
+                charBuffer.put((char) (((int) bodyBytes.get()) & 0xFF));
             }
         }
 

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/serialize/DslJsonSerializerTest.java
@@ -442,10 +442,10 @@ class DslJsonSerializerTest {
         assertThat(emptyBody).isEqualTo("");
 
         String invalidCharset = extractRequestBodyJson(createSpanWithRequestBody("testö".getBytes("utf-8"), "bad charset!"));
-        assertThat(invalidCharset).isEqualTo("testￃﾶ");
+        assertThat(invalidCharset).isEqualTo("testÃ¶");
 
         String noCharset = extractRequestBodyJson(createSpanWithRequestBody("testö".getBytes("utf-8"), null));
-        assertThat(noCharset).isEqualTo("testￃﾶ");
+        assertThat(noCharset).isEqualTo("testÃ¶");
 
         String utf8 = extractRequestBodyJson(createSpanWithRequestBody("special charßßß!äöü".getBytes("utf-8"), "utf-8"));
         assertThat(utf8).isEqualTo("special charßßß!äöü");
@@ -454,7 +454,7 @@ class DslJsonSerializerTest {
         assertThat(utf16).isEqualTo("special charßßß!äöü");
 
         String invalidUtf8Sequence = extractRequestBodyJson(createSpanWithRequestBody(new byte[]{'t', 'e', 's', 't', (byte) 0xC2, (byte) 0xC2}, "utf-8"));
-        assertThat(invalidUtf8Sequence).isEqualTo("testￂￂ");
+        assertThat(invalidUtf8Sequence).isEqualTo("testÂÂ");
     }
 
     private String extractRequestBodyJson(SpanImpl span) {

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/internal/util/IOUtils.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/internal/util/IOUtils.java
@@ -23,6 +23,7 @@ import co.elastic.apm.agent.sdk.internal.pooling.ObjectHandle;
 import co.elastic.apm.agent.sdk.internal.pooling.ObjectPool;
 import co.elastic.apm.agent.sdk.internal.pooling.ObjectPooling;
 
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.Buffer;

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/internal/util/IOUtils.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/internal/util/IOUtils.java
@@ -277,6 +277,28 @@ public class IOUtils {
         void readInto(S source, ByteBuffer into);
     }
 
+    /**
+     * @param input       the byte data to decode
+     * @param output      the buffer to decode into
+     * @param charsetName the name of the charset
+     * @return null, if the charset is not known/supported. Otherwise the result of the decoding operation.
+     */
+    @Nullable
+    public static CoderResult decode(ByteBuffer input, CharBuffer output, String charsetName) {
+        try (ObjectHandle<CharsetDecoder> decoderHandle = getPooledCharsetDecoder(charsetName)) {
+            if (decoderHandle == null) {
+                return null; //charset is unsupported
+            }
+            CharsetDecoder charsetDecoder = decoderHandle.get();
+            try {
+                final CoderResult coderResult = charsetDecoder.decode(input, output, true);
+                charsetDecoder.flush(output);
+                return coderResult;
+            } finally {
+                charsetDecoder.reset();
+            }
+        }
+    }
 
     private static CoderResult decode(CharBuffer charBuffer, ByteBuffer buffer, CharsetDecoder charsetDecoder) {
         try {

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/internal/util/IOUtils.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/internal/util/IOUtils.java
@@ -71,7 +71,7 @@ public class IOUtils {
             return null;
         }
         try {
-            Charset charset = Charset.forName(charsetName);
+            final Charset charset = Charset.forName(charsetName);
             decoderPool = ObjectPooling.createWithDefaultFactory(new Callable<CharsetDecoder>() {
                 @Override
                 public CharsetDecoder call() throws Exception {


### PR DESCRIPTION
## What does this PR do?

Respects the charset from the `Content-Type` header when capturing HTTP Client request bodies.
Note that it might be possible that the bytes are still not decodeable (e.g. because the content is actually compressed).
In that case we fallback to simply casting the `bytes` to `chars`.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~ Don't think we need a changelog because this feature is not publicly visible yet
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] ~Added an API method or config option? Document in which version this will be introduced~
  - [ ] ~I have made corresponding changes to the documentation~
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
