### PR TITLE
Use 1.5.5 lambda layer for tests because 1.5.6 seems to be broken

### DIFF
--- a/integration-tests/aws-lambda-test/src/test/java/co/elastic/apm/awslambda/AwsLambdaIT.java
+++ b/integration-tests/aws-lambda-test/src/test/java/co/elastic/apm/awslambda/AwsLambdaIT.java
@@ -187,7 +187,7 @@ public class AwsLambdaIT {
         ImageFromDockerfile imageBuilder = new ImageFromDockerfile().withDockerfileFromBuilder(builder ->
                 {
                     builder
-                        .withStatement(raw("FROM docker.elastic.co/observability/apm-lambda-extension-x86_64:latest AS lambda-extension"))
+                        .withStatement(raw("FROM docker.elastic.co/observability/apm-lambda-extension-x86_64:1.5.5 AS lambda-extension"))
                         .withStatement(raw("FROM --platform=linux/amd64 public.ecr.aws/lambda/java:11"))
                         .withStatement(raw("COPY --from=lambda-extension /opt/elastic-apm-extension /opt/extensions/elastic-apm-extension"))
                         .copy("aws-lambda-test.jar", "${LAMBDA_TASK_ROOT}/lib/aws-lambda-test.jar")


### PR DESCRIPTION
## What does this PR do?

The `AwsLambdaIT` is currently failing because there seems to be a problem with the layer version 1.5.6 released yesterday.

## Checklist

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
