### PR TITLE
Revert "Use 1.5.5 lambda layer for tests because 1.5.6 seems to be broken

### DIFF
--- a/integration-tests/aws-lambda-test/src/test/java/co/elastic/apm/awslambda/AwsLambdaIT.java
+++ b/integration-tests/aws-lambda-test/src/test/java/co/elastic/apm/awslambda/AwsLambdaIT.java
@@ -187,7 +187,7 @@ public class AwsLambdaIT {
         ImageFromDockerfile imageBuilder = new ImageFromDockerfile().withDockerfileFromBuilder(builder ->
                 {
                     builder
-                        .withStatement(raw("FROM docker.elastic.co/observability/apm-lambda-extension-x86_64:1.5.5 AS lambda-extension"))
+                        .withStatement(raw("FROM docker.elastic.co/observability/apm-lambda-extension-x86_64:latest AS lambda-extension"))
                         .withStatement(raw("FROM --platform=linux/amd64 public.ecr.aws/lambda/java:11"))
                         .withStatement(raw("COPY --from=lambda-extension /opt/elastic-apm-extension /opt/extensions/elastic-apm-extension"))
                         .copy("aws-lambda-test.jar", "${LAMBDA_TASK_ROOT}/lib/aws-lambda-test.jar")


### PR DESCRIPTION
We should switch back to testing with latest as soon as the fixed lambda layer has been released:
https://github.com/elastic/apm-aws-lambda/pull/510

When that change has been released, we should be able to simply rerun the tests on this PR and they should become green again.

## What does this PR do?
<!--
Replace this comment with a description of what's being changed by this PR.
Please explain the WHAT: A clear and concise description of what (patterns used, algorithms implemented, design architecture, message processing, etc.)
Can be as simple as Fixes #123 if there's a corresponding issue.
-->

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
