### PR TITLE
add automatic module name to apm-agent-attach

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -49,6 +49,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Features
 * Added option to make routing-key part of RabbitMQ transaction/span names - {pull}3636[#3636]
 * Added internal option for capturing request bodies for apache httpclient v4 - {pull}3692[#3692]
+* Added automatic module name to apm-agent-attach - {pull}3743[#3743]
 
 [[release-notes-1.50.0]]
 ==== 1.50.0 - 2024/05/28

--- a/apm-agent-attach/pom.xml
+++ b/apm-agent-attach/pom.xml
@@ -165,6 +165,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>${project.groupId}.attach</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## What does this PR do?
This PR adds an `Automatic-Module-Name` for the `apm-agent-attach`. This way, we can use the programmatic attach also in JPMS projects.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] ~~This is an enhancement of existing features, or a new feature in existing plugins~~
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
  - [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
  - [ ] ~~Added an API method or config option? Document in which version this will be introduced~~
  - [ ] ~~I have made corresponding changes to the documentation~~
- [ ] ~~This is a bugfix~~
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
  - [ ] ~~I have added tests that would fail without this fix~~
- [ ] ~~This is a new plugin~~
  - [ ] ~~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~~
  - [ ] ~~My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)~~
  - [ ] ~~I have made corresponding changes to the documentation~~
  - [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
  - [ ] ~~New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes~~
  - [ ] ~~I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)~~
  - [ ] ~~Added an API method or config option? Document in which version this will be introduced~~
  - [ ] ~~Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.~~
- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
