### PR TITLE
Fix log4j2 correlation with shaded log4j

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
+[float]
+===== Bug fixes
+* Fix log4j2 log correlation with shaded application jar - {pull}3764[#3764]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchers.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchers.java
@@ -19,9 +19,9 @@
 package co.elastic.apm.agent.sdk.bytebuddy;
 
 import co.elastic.apm.agent.sdk.internal.InternalUtil;
+import co.elastic.apm.agent.sdk.internal.util.PrivilegedActionUtils;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
-import co.elastic.apm.agent.sdk.internal.util.PrivilegedActionUtils;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakConcurrent;
 import co.elastic.apm.agent.sdk.weakconcurrent.WeakMap;
 import net.bytebuddy.description.NamedElement;
@@ -45,9 +45,7 @@ import java.util.jar.JarFile;
 import java.util.jar.Manifest;
 import java.util.zip.ZipEntry;
 
-import static net.bytebuddy.matcher.ElementMatchers.nameContains;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
-import static net.bytebuddy.matcher.ElementMatchers.none;
+import static net.bytebuddy.matcher.ElementMatchers.*;
 
 public class CustomElementMatchers {
 
@@ -273,7 +271,10 @@ public class CustomElementMatchers {
                     }
 
                     // reading manifest if library packaged as a jar
-                    if(version == null) {
+                    //
+                    // doing this after maven properties is important as it might report executable jar version
+                    // when application is packaged as a "fat jar"
+                    if (version == null) {
                         Manifest manifest = jarFile.getManifest();
                         if (manifest != null) {
                             Attributes attributes = manifest.getMainAttributes();

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchers.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchers.java
@@ -31,6 +31,7 @@ import net.bytebuddy.matcher.ElementMatcher;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.JarURLConnection;
 import java.net.URISyntaxException;
 import java.net.URL;
@@ -38,9 +39,11 @@ import java.net.URLConnection;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;
 import java.util.Collection;
+import java.util.Properties;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.jar.Manifest;
+import java.util.zip.ZipEntry;
 
 import static net.bytebuddy.matcher.ElementMatchers.nameContains;
 import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
@@ -183,15 +186,23 @@ public class CustomElementMatchers {
      * @param version the version to check against
      * @return an LTE SemVer matcher
      */
-    public static ElementMatcher.Junction<ProtectionDomain> implementationVersionLte(final String version) {
-        return implementationVersion(version, Matcher.LTE);
+    public static ElementMatcher.Junction<ProtectionDomain> implementationVersionLte(String version) {
+        return implementationVersion(version, Matcher.LTE, null, null);
     }
 
-    public static ElementMatcher.Junction<ProtectionDomain> implementationVersionGte(final String version) {
-        return implementationVersion(version, Matcher.GTE);
+    public static ElementMatcher.Junction<ProtectionDomain> implementationVersionGte(String version) {
+        return implementationVersion(version, Matcher.GTE, null, null);
     }
 
-    private static ElementMatcher.Junction<ProtectionDomain> implementationVersion(final String version, final Matcher matcher) {
+    public static ElementMatcher.Junction<ProtectionDomain> implementationVersionLte(String version, String groupId, String artifactId) {
+        return implementationVersion(version, Matcher.LTE, groupId, artifactId);
+    }
+
+    public static ElementMatcher.Junction<ProtectionDomain> implementationVersionGte(String version, String groupId, String artifactId) {
+        return implementationVersion(version, Matcher.GTE, groupId, artifactId);
+    }
+
+    private static ElementMatcher.Junction<ProtectionDomain> implementationVersion(final String version, final Matcher matcher, @Nullable final String mavenGroupId, @Nullable final String mavenArtifactId) {
         return new ElementMatcher.Junction.AbstractBase<ProtectionDomain>() {
             /**
              * Returns true if the implementation version read from the manifest file referenced by the given
@@ -205,7 +216,7 @@ public class CustomElementMatchers {
             @Override
             public boolean matches(@Nullable ProtectionDomain protectionDomain) {
                 try {
-                    Version pdVersion = readImplementationVersionFromManifest(protectionDomain);
+                    Version pdVersion = readImplementationVersion(protectionDomain, mavenGroupId, mavenArtifactId);
                     if (pdVersion != null) {
                         Version limitVersion = Version.of(version);
                         return matcher.match(pdVersion, limitVersion);
@@ -221,22 +232,48 @@ public class CustomElementMatchers {
     }
 
     @Nullable
-    private static Version readImplementationVersionFromManifest(@Nullable ProtectionDomain protectionDomain) throws IOException, URISyntaxException {
+    private static Version readImplementationVersion(@Nullable ProtectionDomain protectionDomain, @Nullable String mavenGroupId, @Nullable String mavenArtifactId) throws IOException, URISyntaxException {
         Version version = null;
         JarFile jarFile = null;
+
+        if (protectionDomain == null) {
+            logger.info("Cannot read implementation version - got null ProtectionDomain");
+            return null;
+        }
+
         try {
-            if (protectionDomain != null) {
-                CodeSource codeSource = protectionDomain.getCodeSource();
-                if (codeSource != null) {
-                    URL jarUrl = codeSource.getLocation();
-                    if (jarUrl != null) {
-                        // does not yet establish an actual connection
-                        URLConnection urlConnection = jarUrl.openConnection();
-                        if (urlConnection instanceof JarURLConnection) {
-                            jarFile = ((JarURLConnection) urlConnection).getJarFile();
-                        } else {
-                            jarFile = new JarFile(new File(jarUrl.toURI()));
+            CodeSource codeSource = protectionDomain.getCodeSource();
+            if (codeSource != null) {
+                URL jarUrl = codeSource.getLocation();
+                if (jarUrl != null) {
+                    // does not yet establish an actual connection
+                    URLConnection urlConnection = jarUrl.openConnection();
+                    if (urlConnection instanceof JarURLConnection) {
+                        jarFile = ((JarURLConnection) urlConnection).getJarFile();
+                    } else {
+                        jarFile = new JarFile(new File(jarUrl.toURI()));
+                    }
+
+                    // read maven properties first as they have higher priority over manifest
+                    // this is mostly for shaded libraries in "fat-jar" applications
+                    if (mavenGroupId != null && mavenArtifactId != null) {
+                        ZipEntry zipEntry = jarFile.getEntry(String.format("META-INF/maven/%s/%s/pom.properties", mavenGroupId, mavenArtifactId));
+                        if (zipEntry != null) {
+                            Properties properties = new Properties();
+                            try (InputStream input = jarFile.getInputStream(zipEntry)) {
+                                properties.load(input);
+                            }
+                            if (mavenGroupId.equals(properties.getProperty("groupId")) && mavenArtifactId.equals(properties.getProperty("artifactId"))) {
+                                String stringVersion = properties.getProperty("version");
+                                if (stringVersion != null) {
+                                    version = Version.of(stringVersion);
+                                }
+                            }
                         }
+                    }
+
+                    // reading manifest if library packaged as a jar
+                    if(version == null) {
                         Manifest manifest = jarFile.getManifest();
                         if (manifest != null) {
                             Attributes attributes = manifest.getMainAttributes();
@@ -248,12 +285,9 @@ public class CustomElementMatchers {
                             if (manifestVersion != null) {
                                 version = Version.of(manifestVersion);
                             }
-
                         }
                     }
                 }
-            } else {
-                logger.info("Cannot read implementation version - got null ProtectionDomain");
             }
         } finally {
             if (jarFile != null) {

--- a/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
+++ b/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
@@ -25,8 +25,16 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
-import java.net.*;
-import java.nio.file.*;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.security.CodeSigner;
 import java.security.CodeSource;
 import java.security.ProtectionDomain;

--- a/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/main/java/co/elastic/apm/agent/log4j2/correlation/Log4j2LogCorrelationInstrumentation.java
+++ b/apm-agent-plugins/apm-logging-plugin/apm-log4j2-plugin/src/main/java/co/elastic/apm/agent/log4j2/correlation/Log4j2LogCorrelationInstrumentation.java
@@ -71,9 +71,11 @@ public abstract class Log4j2LogCorrelationInstrumentation extends AbstractLogInt
     }
 
     public static class Log4J2_6LogCorrelationInstrumentation extends Log4j2LogCorrelationInstrumentation {
+
         @Override
         public ElementMatcher.Junction<ProtectionDomain> getProtectionDomainPostFilter() {
-            return implementationVersionGte("2.6").and(not(implementationVersionGte("2.7")));
+            return implementationVersionGte("2.6", "org.apache.logging.log4j", "log4j-core")
+                .and(not(implementationVersionGte("2.7", "org.apache.logging.log4j", "log4j-core")));
         }
 
         public static class AdviceClass {
@@ -94,7 +96,7 @@ public abstract class Log4j2LogCorrelationInstrumentation extends AbstractLogInt
     public static class Log4J2_7PlusLogCorrelationInstrumentation extends Log4j2LogCorrelationInstrumentation {
         @Override
         public ElementMatcher.Junction<ProtectionDomain> getProtectionDomainPostFilter() {
-            return implementationVersionGte("2.7");
+            return implementationVersionGte("2.7", "org.apache.logging.log4j", "log4j-core");
         }
 
         public static class AdviceClass {


### PR DESCRIPTION
## What does this PR do?

Fixes #3745 

Fixes only for log4j2 log correlation, the underlying issue might still happen with the few other instrumentations that rely on manifest version, but it would be quite easy to fix in the future if we get a report about it.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix

