### PR TITLE
Fix CustomElementMatchers test on windows

### DIFF
--- a/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
+++ b/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
@@ -89,7 +89,7 @@ class CustomElementMatchersTest {
             Map<String, String> fsProperties = new HashMap<>();
             fsProperties.put("create", "false");
 
-            URI fsUri = URI.create("jar:" + modifiedJar.toUri().toString());
+            URI fsUri = URI.create("jar:" + modifiedJar.toUri());
             try (FileSystem zipFs = FileSystems.newFileSystem(fsUri, fsProperties)) {
                 Files.delete(zipFs.getPath("META-INF", "MANIFEST.MF"));
             }

--- a/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
+++ b/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
@@ -26,13 +26,13 @@ import org.junit.jupiter.api.io.TempDir;
 import java.io.File;
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.net.URI;
-import java.nio.file.Files;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.security.CodeSigner;
@@ -42,7 +42,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.*;
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.implementationVersionGte;
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.implementationVersionLte;
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.isAgentClassLoader;
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.isInAnyPackage;
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.isInternalPluginClassLoader;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -76,6 +81,7 @@ class CustomElementMatchersTest {
     void testSemVerFallbackOnMavenProperties(@TempDir Path tempDir) throws URISyntaxException, IOException {
         // Relying on Apache httpclient-4.5.6.jar
         // creates a copy of the jar without the manifest so we should parse maven properties
+
         URL originalUrl = HttpClient.class.getProtectionDomain().getCodeSource().getLocation();
         Path modifiedJar = tempDir.resolve("test.jar");
         try {

--- a/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
+++ b/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
@@ -81,7 +81,6 @@ class CustomElementMatchersTest {
     void testSemVerFallbackOnMavenProperties(@TempDir Path tempDir) throws URISyntaxException, IOException {
         // Relying on Apache httpclient-4.5.6.jar
         // creates a copy of the jar without the manifest so we should parse maven properties
-
         URL originalUrl = HttpClient.class.getProtectionDomain().getCodeSource().getLocation();
         Path modifiedJar = tempDir.resolve("test.jar");
         try {
@@ -90,7 +89,7 @@ class CustomElementMatchersTest {
             Map<String, String> fsProperties = new HashMap<>();
             fsProperties.put("create", "false");
 
-            URI fsUri = URI.create("jar:file://" + modifiedJar.toAbsolutePath());
+            URI fsUri = URI.create("jar:" + modifiedJar.toUri().toString());
             try (FileSystem zipFs = FileSystems.newFileSystem(fsUri, fsProperties)) {
                 Files.delete(zipFs.getPath("META-INF", "MANIFEST.MF"));
             }


### PR DESCRIPTION
## What does this PR do?

Windows tests on CI seems to be failing currently due to a bad URI creation introduced with #3764 .

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
