### PR TITLE
Add support for apache http client v5 body capturing

### DIFF
--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/AbstractApacheHttpClientAdvice.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/AbstractApacheHttpClientAdvice.java
@@ -20,9 +20,9 @@ package co.elastic.apm.agent.httpclient.common;
 
 
 import co.elastic.apm.agent.httpclient.HttpClientHelper;
-import co.elastic.apm.agent.tracer.TraceState;
 import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.tracer.Span;
+import co.elastic.apm.agent.tracer.TraceState;
 import co.elastic.apm.agent.tracer.Tracer;
 import co.elastic.apm.agent.tracer.dispatch.TextHeaderGetter;
 import co.elastic.apm.agent.tracer.dispatch.TextHeaderSetter;
@@ -34,11 +34,11 @@ public abstract class AbstractApacheHttpClientAdvice {
 
     public static <REQUEST, WRAPPER extends REQUEST, HTTPHOST, RESPONSE,
         HeaderAccessor extends TextHeaderSetter<REQUEST> &
-            TextHeaderGetter<REQUEST>> Span<?> startSpan(final Tracer tracer,
-                                                        final ApacheHttpClientApiAdapter<REQUEST, WRAPPER, HTTPHOST, RESPONSE> adapter,
-                                                        final WRAPPER request,
-                                                        @Nullable final HTTPHOST httpHost,
-                                                        final HeaderAccessor headerAccessor) throws URISyntaxException {
+            TextHeaderGetter<REQUEST>, HTTPENTITY> Span<?> startSpan(final Tracer tracer,
+                                                                     final ApacheHttpClientApiAdapter<REQUEST, WRAPPER, HTTPHOST, RESPONSE, HTTPENTITY> adapter,
+                                                                     final WRAPPER request,
+                                                                     @Nullable final HTTPHOST httpHost,
+                                                                     final HeaderAccessor headerAccessor) throws URISyntaxException {
         TraceState<?> traceState = tracer.currentContext();
         Span<?> span = null;
         if (traceState.getSpan() != null) {
@@ -51,10 +51,11 @@ public abstract class AbstractApacheHttpClientAdvice {
         return span;
     }
 
-    public static <REQUEST, WRAPPER extends REQUEST, HTTPHOST, RESPONSE> void endSpan(ApacheHttpClientApiAdapter<REQUEST, WRAPPER, HTTPHOST, RESPONSE> adapter,
-                                                                                      Object spanObj,
-                                                                                      Throwable t,
-                                                                                      RESPONSE response) {
+    public static <REQUEST, WRAPPER extends REQUEST, HTTPHOST, RESPONSE, HTTPENTITY>
+    void endSpan(ApacheHttpClientApiAdapter<REQUEST, WRAPPER, HTTPHOST, RESPONSE, HTTPENTITY> adapter,
+                 Object spanObj,
+                 Throwable t,
+                 RESPONSE response) {
         Span<?> span = (Span<?>) spanObj;
         if (span == null) {
             return;

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/AbstractApacheHttpRequestBodyCaptureAdvice.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/AbstractApacheHttpRequestBodyCaptureAdvice.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.httpclient.common;
+
+
+import co.elastic.apm.agent.httpclient.RequestBodyRecordingInputStream;
+import co.elastic.apm.agent.httpclient.RequestBodyRecordingOutputStream;
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
+import co.elastic.apm.agent.tracer.Span;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public abstract class AbstractApacheHttpRequestBodyCaptureAdvice {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractApacheHttpRequestBodyCaptureAdvice.class);
+
+    public static <HTTPENTITY> InputStream maybeCaptureRequestBodyInputStream(HTTPENTITY thiz, InputStream requestBody) {
+        Span<?> clientSpan = RequestBodyCaptureRegistry.removeSpanFor(thiz);
+        if (clientSpan != null) {
+            logger.debug("Wrapping input stream for request body capture for HttpEntity {} ({}) for span {}", thiz.getClass().getName(), System.identityHashCode(thiz), clientSpan);
+            return new RequestBodyRecordingInputStream(requestBody, clientSpan);
+        }
+        return requestBody;
+    }
+
+    public static <HTTPENTITY> OutputStream maybeCaptureRequestBodyOutputStream(HTTPENTITY thiz, OutputStream requestBody) {
+        Span<?> clientSpan = RequestBodyCaptureRegistry.removeSpanFor(thiz);
+        if (clientSpan != null) {
+            logger.debug("Wrapping output stream for request body capture for HttpEntity {} ({}) for span {}", thiz.getClass().getName(), System.identityHashCode(thiz), clientSpan);
+            return new RequestBodyRecordingOutputStream(requestBody, clientSpan);
+        }
+        return requestBody;
+    }
+
+    public static void releaseRequestBodyOutputStream(OutputStream maybeWrapped) {
+        if (maybeWrapped instanceof RequestBodyRecordingOutputStream) {
+            ((RequestBodyRecordingOutputStream) maybeWrapped).releaseSpan();
+        }
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/ApacheHttpClientEntityAccessor.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/ApacheHttpClientEntityAccessor.java
@@ -18,22 +18,9 @@
  */
 package co.elastic.apm.agent.httpclient.common;
 
-
 import javax.annotation.Nullable;
-import java.net.URI;
-import java.net.URISyntaxException;
 
-public interface ApacheHttpClientApiAdapter<REQUEST, WRAPPER extends REQUEST, HTTPHOST, RESPONSE, HTTPENTITY> extends ApacheHttpClientEntityAccessor<REQUEST, HTTPENTITY> {
-    String getMethod(WRAPPER request);
-
-    URI getUri(WRAPPER request) throws URISyntaxException;
-
+public interface ApacheHttpClientEntityAccessor<REQUEST, HTTPENTITY> {
     @Nullable
-    CharSequence getHostName(@Nullable HTTPHOST httpHost, WRAPPER request);
-
-    int getResponseCode(RESPONSE response);
-
-    boolean isCircularRedirectException(Throwable t);
-
-    boolean isNotNullStatusLine(RESPONSE response);
+    HTTPENTITY getRequestEntity(REQUEST request);
 }

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/ApacheHttpClientEntityAccessor.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/ApacheHttpClientEntityAccessor.java
@@ -23,4 +23,7 @@ import javax.annotation.Nullable;
 public interface ApacheHttpClientEntityAccessor<REQUEST, HTTPENTITY> {
     @Nullable
     HTTPENTITY getRequestEntity(REQUEST request);
+
+    @Nullable
+    byte[] getSimpleBodyBytes(REQUEST request);
 }

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/RequestBodyCaptureRegistry.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient-common/src/main/java/co/elastic/apm/agent/httpclient/common/RequestBodyCaptureRegistry.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.httpclient.v4.helper;
+package co.elastic.apm.agent.httpclient.common;
 
 import co.elastic.apm.agent.httpclient.HttpClientHelper;
 import co.elastic.apm.agent.sdk.logging.Logger;
@@ -25,10 +25,8 @@ import co.elastic.apm.agent.sdk.state.GlobalState;
 import co.elastic.apm.agent.tracer.AbstractSpan;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Span;
+import co.elastic.apm.agent.tracer.dispatch.TextHeaderGetter;
 import co.elastic.apm.agent.tracer.reference.ReferenceCountedMap;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpEntityEnclosingRequest;
-import org.apache.http.HttpRequest;
 
 import javax.annotation.Nullable;
 
@@ -52,25 +50,26 @@ public class RequestBodyCaptureRegistry {
     }
 
 
-    public static void potentiallyCaptureRequestBody(HttpRequest request, @Nullable AbstractSpan<?> span) {
-        if (HttpClientHelper.startRequestBodyCapture(span, request, RequestHeaderAccessor.INSTANCE)) {
-            if (request instanceof HttpEntityEnclosingRequest) {
-                HttpEntity entity = ((HttpEntityEnclosingRequest) request).getEntity();
-                if (entity != null) {
-                    logger.debug("Enabling request capture for entity {}() for span {}", entity.getClass().getName(), System.identityHashCode(entity), span);
-                    MapHolder.captureBodyFor(entity, (Span<?>) span);
-                } else {
-                    logger.debug("HttpEntity is null for span {}", span);
-                }
+    public static <REQUEST, HTTPENTITY> void potentiallyCaptureRequestBody(
+        REQUEST request,
+        @Nullable AbstractSpan<?> span,
+        ApacheHttpClientEntityAccessor<REQUEST, HTTPENTITY> adapter,
+        TextHeaderGetter<REQUEST> headerGetter
+    ) {
+        if (HttpClientHelper.startRequestBodyCapture(span, request, headerGetter)) {
+            HTTPENTITY httpEntity = adapter.getRequestEntity(request);
+            if (httpEntity != null) {
+                logger.debug("Enabling request capture for entity {}() for span {}", httpEntity.getClass().getName(), System.identityHashCode(httpEntity), span);
+                MapHolder.captureBodyFor(httpEntity, (Span<?>) span);
             } else {
-                logger.debug("Not capturing request body because {} is not an HttpEntityEnclosingRequest", request.getClass().getName());
+                logger.debug("Not capturing request body because HttpEntity is null for span {}", span);
             }
         }
     }
 
     @Nullable
-    public static Span<?> removeSpanFor(HttpEntity entity) {
-        return MapHolder.removeSpanFor(entity);
+    public static Span<?> removeSpanFor(Object httpEntity) {
+        return MapHolder.removeSpanFor(httpEntity);
     }
 
 }

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/ApacheHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/ApacheHttpClientInstrumentation.java
@@ -19,8 +19,8 @@
 package co.elastic.apm.agent.httpclient.v4;
 
 import co.elastic.apm.agent.httpclient.common.AbstractApacheHttpClientAdvice;
+import co.elastic.apm.agent.httpclient.common.RequestBodyCaptureRegistry;
 import co.elastic.apm.agent.httpclient.v4.helper.ApacheHttpClient4ApiAdapter;
-import co.elastic.apm.agent.httpclient.v4.helper.RequestBodyCaptureRegistry;
 import co.elastic.apm.agent.httpclient.v4.helper.RequestHeaderAccessor;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
@@ -60,7 +60,7 @@ public class ApacheHttpClientInstrumentation extends BaseApacheHttpClientInstrum
         public static Object onBeforeExecute(@Advice.Argument(0) HttpRoute route,
                                              @Advice.Argument(1) HttpRequestWrapper request) throws URISyntaxException {
             Span<?> span = startSpan(tracer, adapter, request, route.getTargetHost(), RequestHeaderAccessor.INSTANCE);
-            RequestBodyCaptureRegistry.potentiallyCaptureRequestBody(request, tracer.getActive());
+            RequestBodyCaptureRegistry.potentiallyCaptureRequestBody(request, tracer.getActive(), adapter, RequestHeaderAccessor.INSTANCE);
             return span;
         }
 

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/ApacheHttpEntityGetContentInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/ApacheHttpEntityGetContentInstrumentation.java
@@ -20,24 +20,16 @@ package co.elastic.apm.agent.httpclient.v4;
 
 import co.elastic.apm.agent.httpclient.common.AbstractApacheHttpRequestBodyCaptureAdvice;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
-import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.HttpEntity;
 
 import java.io.InputStream;
 
-import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
-import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
-import static net.bytebuddy.matcher.ElementMatchers.nameContains;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-public class ApacheHttpEntityGetContentInstrumentation extends BaseApacheHttpClientInstrumentation {
+public class ApacheHttpEntityGetContentInstrumentation extends BaseApacheHttpEntityInstrumentation {
 
     public static class ApacheHttpEntityGetContentAdvice extends AbstractApacheHttpRequestBodyCaptureAdvice {
 
@@ -51,22 +43,6 @@ public class ApacheHttpEntityGetContentInstrumentation extends BaseApacheHttpCli
     @Override
     public String getAdviceClassName() {
         return "co.elastic.apm.agent.httpclient.v4.ApacheHttpEntityGetContentInstrumentation$ApacheHttpEntityGetContentAdvice";
-    }
-
-    @Override
-    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
-        return not(isBootstrapClassLoader())
-            .and(classLoaderCanLoadClass("org.apache.http.HttpEntity"));
-    }
-
-    @Override
-    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("org.apache.http").and(nameContains("Entity"));
-    }
-
-    @Override
-    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return hasSuperType(named("org.apache.http.HttpEntity"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/ApacheHttpEntityWriteToInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/ApacheHttpEntityWriteToInstrumentation.java
@@ -20,25 +20,17 @@ package co.elastic.apm.agent.httpclient.v4;
 
 import co.elastic.apm.agent.httpclient.common.AbstractApacheHttpRequestBodyCaptureAdvice;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
-import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.http.HttpEntity;
 
 import java.io.OutputStream;
 
-import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
-import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
-import static net.bytebuddy.matcher.ElementMatchers.nameContains;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-public class ApacheHttpEntityWriteToInstrumentation extends BaseApacheHttpClientInstrumentation {
+public class ApacheHttpEntityWriteToInstrumentation extends BaseApacheHttpEntityInstrumentation {
 
     public static class ApacheHttpEntityWriteToAdvice extends AbstractApacheHttpRequestBodyCaptureAdvice {
 
@@ -57,22 +49,6 @@ public class ApacheHttpEntityWriteToInstrumentation extends BaseApacheHttpClient
     @Override
     public String getAdviceClassName() {
         return "co.elastic.apm.agent.httpclient.v4.ApacheHttpEntityWriteToInstrumentation$ApacheHttpEntityWriteToAdvice";
-    }
-
-    @Override
-    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
-        return not(isBootstrapClassLoader())
-            .and(classLoaderCanLoadClass("org.apache.http.HttpEntity"));
-    }
-
-    @Override
-    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("org.apache.http").and(nameContains("Entity"));
-    }
-
-    @Override
-    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return hasSuperType(named("org.apache.http.HttpEntity"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/BaseApacheHttpEntityInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/BaseApacheHttpEntityInstrumentation.java
@@ -1,0 +1,34 @@
+package co.elastic.apm.agent.httpclient.v4;
+
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
+import static net.bytebuddy.matcher.ElementMatchers.nameContains;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+public abstract class BaseApacheHttpEntityInstrumentation extends BaseApacheHttpClientInstrumentation {
+    @Override
+    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
+        return not(isBootstrapClassLoader())
+            .and(classLoaderCanLoadClass("org.apache.http.HttpEntity"));
+    }
+
+    @Override
+    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+        return nameContains("Entity").and(
+            nameStartsWith("org.apache.http")
+                .or(nameStartsWith("org.springframework.http")) //spring implements its own HttpEntities
+        );
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return hasSuperType(named("org.apache.http.HttpEntity"));
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/LegacyApacheHttpClientInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/LegacyApacheHttpClientInstrumentation.java
@@ -19,7 +19,8 @@
 package co.elastic.apm.agent.httpclient.v4;
 
 import co.elastic.apm.agent.httpclient.HttpClientHelper;
-import co.elastic.apm.agent.httpclient.v4.helper.RequestBodyCaptureRegistry;
+import co.elastic.apm.agent.httpclient.common.RequestBodyCaptureRegistry;
+import co.elastic.apm.agent.httpclient.v4.helper.ApacheHttpClient4ApiAdapter;
 import co.elastic.apm.agent.httpclient.v4.helper.RequestHeaderAccessor;
 import co.elastic.apm.agent.tracer.Outcome;
 import co.elastic.apm.agent.tracer.Span;
@@ -106,7 +107,7 @@ public class LegacyApacheHttpClientInstrumentation extends BaseApacheHttpClientI
                 }
             }
 
-            RequestBodyCaptureRegistry.potentiallyCaptureRequestBody(request, tracer.getActive());
+            RequestBodyCaptureRegistry.potentiallyCaptureRequestBody(request, tracer.getActive(), ApacheHttpClient4ApiAdapter.get(), RequestHeaderAccessor.INSTANCE);
             tracer.currentContext().propagateContext(request, RequestHeaderAccessor.INSTANCE, RequestHeaderAccessor.INSTANCE);
             return span;
         }

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/helper/ApacheHttpClient4ApiAdapter.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/helper/ApacheHttpClient4ApiAdapter.java
@@ -32,6 +32,7 @@ import org.apache.http.client.CircularRedirectException;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpRequestWrapper;
 
+import javax.annotation.Nullable;
 import java.net.URI;
 
 public class ApacheHttpClient4ApiAdapter implements ApacheHttpClientApiAdapter<HttpRequest, HttpRequestWrapper, HttpHost, CloseableHttpResponse, HttpEntity> {
@@ -67,6 +68,12 @@ public class ApacheHttpClient4ApiAdapter implements ApacheHttpClientApiAdapter<H
             return ((HttpEntityEnclosingRequest) request).getEntity();
         }
         return null;
+    }
+
+    @Override
+    @Nullable
+    public byte[] getSimpleBodyBytes(HttpRequest request) {
+        return null; //Apache v4 client only provides body via HttpEntity
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/helper/ApacheHttpClient4ApiAdapter.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/helper/ApacheHttpClient4ApiAdapter.java
@@ -23,6 +23,8 @@ import co.elastic.apm.agent.httpclient.common.ApacheHttpClientApiAdapter;
 import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Tracer;
 import co.elastic.apm.agent.tracer.configuration.CoreConfiguration;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.StatusLine;
@@ -32,7 +34,7 @@ import org.apache.http.client.methods.HttpRequestWrapper;
 
 import java.net.URI;
 
-public class ApacheHttpClient4ApiAdapter implements ApacheHttpClientApiAdapter<HttpRequest, HttpRequestWrapper, HttpHost, CloseableHttpResponse> {
+public class ApacheHttpClient4ApiAdapter implements ApacheHttpClientApiAdapter<HttpRequest, HttpRequestWrapper, HttpHost, CloseableHttpResponse, HttpEntity> {
     private static final ApacheHttpClient4ApiAdapter INSTANCE = new ApacheHttpClient4ApiAdapter();
 
     private final Tracer tracer = GlobalTracer.get();
@@ -57,6 +59,14 @@ public class ApacheHttpClient4ApiAdapter implements ApacheHttpClientApiAdapter<H
     @Override
     public CharSequence getHostName(HttpHost httpHost, HttpRequestWrapper request) {
         return httpHost.getHostName();
+    }
+
+    @Override
+    public HttpEntity getRequestEntity(HttpRequest request) {
+        if (request instanceof HttpEntityEnclosingRequest) {
+            return ((HttpEntityEnclosingRequest) request).getEntity();
+        }
+        return null;
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/helper/HttpAsyncRequestProducerWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/main/java/co/elastic/apm/agent/httpclient/v4/helper/HttpAsyncRequestProducerWrapper.java
@@ -19,8 +19,9 @@
 package co.elastic.apm.agent.httpclient.v4.helper;
 
 import co.elastic.apm.agent.httpclient.HttpClientHelper;
-import co.elastic.apm.agent.tracer.TraceState;
+import co.elastic.apm.agent.httpclient.common.RequestBodyCaptureRegistry;
 import co.elastic.apm.agent.tracer.Span;
+import co.elastic.apm.agent.tracer.TraceState;
 import co.elastic.apm.agent.tracer.pooling.Recyclable;
 import org.apache.http.HttpException;
 import org.apache.http.HttpHost;
@@ -85,7 +86,7 @@ public class HttpAsyncRequestProducerWrapper implements HttpAsyncRequestProducer
         // trace context propagation
         if (request != null) {
             if (span != null) {
-                RequestBodyCaptureRegistry.potentiallyCaptureRequestBody(request, span);
+                RequestBodyCaptureRegistry.potentiallyCaptureRequestBody(request, span, ApacheHttpClient4ApiAdapter.get(), RequestHeaderAccessor.INSTANCE);
                 RequestLine requestLine = request.getRequestLine();
                 if (requestLine != null) {
                     String method = requestLine.getMethod();

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttp5EntityGetContentInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttp5EntityGetContentInstrumentation.java
@@ -20,24 +20,16 @@ package co.elastic.apm.agent.httpclient.v5;
 
 import co.elastic.apm.agent.httpclient.common.AbstractApacheHttpRequestBodyCaptureAdvice;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
-import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.hc.core5.http.HttpEntity;
 
 import java.io.InputStream;
 
-import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
-import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
-import static net.bytebuddy.matcher.ElementMatchers.nameContains;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-public class ApacheHttp5EntityGetContentInstrumentation extends BaseApacheHttpClient5Instrumentation {
+public class ApacheHttp5EntityGetContentInstrumentation extends BaseApacheHttp5EntityInstrumentation {
 
     public static class ApacheHttpEntityGetContentAdvice extends AbstractApacheHttpRequestBodyCaptureAdvice {
 
@@ -51,21 +43,6 @@ public class ApacheHttp5EntityGetContentInstrumentation extends BaseApacheHttpCl
     @Override
     public String getAdviceClassName() {
         return "co.elastic.apm.agent.httpclient.v5.ApacheHttp5EntityGetContentInstrumentation$ApacheHttpEntityGetContentAdvice";
-    }
-
-    @Override
-    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
-        return not(isBootstrapClassLoader()).and(classLoaderCanLoadClass("org.apache.hc.core5.http.HttpEntity"));
-    }
-
-    @Override
-    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("org.apache.hc").and(nameContains("Entity"));
-    }
-
-    @Override
-    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return hasSuperType(named("org.apache.hc.core5.http.HttpEntity"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttp5EntityWriteToInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttp5EntityWriteToInstrumentation.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.agent.httpclient.v4;
+package co.elastic.apm.agent.httpclient.v5;
 
 import co.elastic.apm.agent.httpclient.common.AbstractApacheHttpRequestBodyCaptureAdvice;
 import net.bytebuddy.asm.Advice;
@@ -24,7 +24,7 @@ import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
 import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
-import org.apache.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntity;
 
 import java.io.OutputStream;
 
@@ -38,7 +38,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-public class ApacheHttpEntityWriteToInstrumentation extends BaseApacheHttpClientInstrumentation {
+public class ApacheHttp5EntityWriteToInstrumentation extends BaseApacheHttpClient5Instrumentation {
 
     public static class ApacheHttpEntityWriteToAdvice extends AbstractApacheHttpRequestBodyCaptureAdvice {
 
@@ -56,23 +56,22 @@ public class ApacheHttpEntityWriteToInstrumentation extends BaseApacheHttpClient
 
     @Override
     public String getAdviceClassName() {
-        return "co.elastic.apm.agent.httpclient.v4.ApacheHttpEntityWriteToInstrumentation$ApacheHttpEntityWriteToAdvice";
+        return "co.elastic.apm.agent.httpclient.v5.ApacheHttp5EntityWriteToInstrumentation$ApacheHttpEntityWriteToAdvice";
     }
 
     @Override
     public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
-        return not(isBootstrapClassLoader())
-            .and(classLoaderCanLoadClass("org.apache.http.HttpEntity"));
+        return not(isBootstrapClassLoader()).and(classLoaderCanLoadClass("org.apache.hc.core5.http.HttpEntity"));
     }
 
     @Override
     public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("org.apache.http").and(nameContains("Entity"));
+        return nameStartsWith("org.apache.hc").and(nameContains("Entity"));
     }
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return hasSuperType(named("org.apache.http.HttpEntity"));
+        return hasSuperType(named("org.apache.hc.core5.http.HttpEntity"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttp5EntityWriteToInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttp5EntityWriteToInstrumentation.java
@@ -20,25 +20,17 @@ package co.elastic.apm.agent.httpclient.v5;
 
 import co.elastic.apm.agent.httpclient.common.AbstractApacheHttpRequestBodyCaptureAdvice;
 import net.bytebuddy.asm.Advice;
-import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
-import net.bytebuddy.description.type.TypeDescription;
 import net.bytebuddy.matcher.ElementMatcher;
 import org.apache.hc.core5.http.HttpEntity;
 
 import java.io.OutputStream;
 
-import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
-import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
-import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
-import static net.bytebuddy.matcher.ElementMatchers.nameContains;
-import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
 import static net.bytebuddy.matcher.ElementMatchers.named;
-import static net.bytebuddy.matcher.ElementMatchers.not;
 import static net.bytebuddy.matcher.ElementMatchers.takesArgument;
 import static net.bytebuddy.matcher.ElementMatchers.takesArguments;
 
-public class ApacheHttp5EntityWriteToInstrumentation extends BaseApacheHttpClient5Instrumentation {
+public class ApacheHttp5EntityWriteToInstrumentation extends BaseApacheHttp5EntityInstrumentation {
 
     public static class ApacheHttpEntityWriteToAdvice extends AbstractApacheHttpRequestBodyCaptureAdvice {
 
@@ -57,21 +49,6 @@ public class ApacheHttp5EntityWriteToInstrumentation extends BaseApacheHttpClien
     @Override
     public String getAdviceClassName() {
         return "co.elastic.apm.agent.httpclient.v5.ApacheHttp5EntityWriteToInstrumentation$ApacheHttpEntityWriteToAdvice";
-    }
-
-    @Override
-    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
-        return not(isBootstrapClassLoader()).and(classLoaderCanLoadClass("org.apache.hc.core5.http.HttpEntity"));
-    }
-
-    @Override
-    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
-        return nameStartsWith("org.apache.hc").and(nameContains("Entity"));
-    }
-
-    @Override
-    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return hasSuperType(named("org.apache.hc.core5.http.HttpEntity"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpClient5Instrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpClient5Instrumentation.java
@@ -20,8 +20,10 @@ package co.elastic.apm.agent.httpclient.v5;
 
 
 import co.elastic.apm.agent.httpclient.common.AbstractApacheHttpClientAdvice;
+import co.elastic.apm.agent.httpclient.common.RequestBodyCaptureRegistry;
 import co.elastic.apm.agent.httpclient.v5.helper.ApacheHttpClient5ApiAdapter;
 import co.elastic.apm.agent.httpclient.v5.helper.RequestHeaderAccessor;
+import co.elastic.apm.agent.tracer.Span;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.NamedElement;
 import net.bytebuddy.description.method.MethodDescription;
@@ -50,7 +52,9 @@ public class ApacheHttpClient5Instrumentation extends BaseApacheHttpClient5Instr
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
         public static Object onBeforeExecute(@Advice.Argument(0) @Nullable HttpHost httpHost,
                                              @Advice.Argument(1) ClassicHttpRequest request) throws URISyntaxException {
-            return startSpan(tracer, adapter, request, httpHost, RequestHeaderAccessor.INSTANCE);
+            Span<?> resultSpan = startSpan(tracer, adapter, request, httpHost, RequestHeaderAccessor.INSTANCE);
+            RequestBodyCaptureRegistry.potentiallyCaptureRequestBody(request, tracer.getActive(), adapter, RequestHeaderAccessor.INSTANCE);
+            return resultSpan;
         }
 
         @Advice.OnMethodExit(suppress = Throwable.class, onThrowable = Throwable.class, inline = false)

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/BaseApacheHttp5EntityInstrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/BaseApacheHttp5EntityInstrumentation.java
@@ -1,0 +1,33 @@
+package co.elastic.apm.agent.httpclient.v5;
+
+import net.bytebuddy.description.NamedElement;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.matcher.ElementMatcher;
+
+import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
+import static net.bytebuddy.matcher.ElementMatchers.hasSuperType;
+import static net.bytebuddy.matcher.ElementMatchers.isBootstrapClassLoader;
+import static net.bytebuddy.matcher.ElementMatchers.nameContains;
+import static net.bytebuddy.matcher.ElementMatchers.nameStartsWith;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+public abstract class BaseApacheHttp5EntityInstrumentation extends BaseApacheHttpClient5Instrumentation {
+    @Override
+    public ElementMatcher.Junction<ClassLoader> getClassLoaderMatcher() {
+        return not(isBootstrapClassLoader()).and(classLoaderCanLoadClass("org.apache.hc.core5.http.HttpEntity"));
+    }
+
+    @Override
+    public ElementMatcher<? super NamedElement> getTypeMatcherPreFilter() {
+        return nameContains("Entity").and(
+            nameStartsWith("org.apache.hc")
+                .or(nameStartsWith("org.springframework.http")) //spring implements its own HttpEntities
+        );
+    }
+
+    @Override
+    public ElementMatcher<? super TypeDescription> getTypeMatcher() {
+        return hasSuperType(named("org.apache.hc.core5.http.HttpEntity"));
+    }
+}

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/ApacheHttpClient5ApiAdapter.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/ApacheHttpClient5ApiAdapter.java
@@ -25,6 +25,7 @@ import co.elastic.apm.agent.tracer.GlobalTracer;
 import co.elastic.apm.agent.tracer.Tracer;
 import co.elastic.apm.agent.tracer.configuration.CoreConfiguration;
 import org.apache.hc.client5.http.CircularRedirectException;
+import org.apache.hc.client5.http.async.methods.SimpleHttpRequest;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.routing.RoutingSupport;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -76,6 +77,15 @@ public class ApacheHttpClient5ApiAdapter implements ApacheHttpClientApiAdapter<H
 
             return null;
         }
+    }
+
+    @Nullable
+    @Override
+    public byte[] getSimpleBodyBytes(HttpRequest httpRequest) {
+        if (httpRequest instanceof SimpleHttpRequest) {
+            return ((SimpleHttpRequest) httpRequest).getBodyBytes();
+        }
+        return null;
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/ApacheHttpClient5ApiAdapter.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/ApacheHttpClient5ApiAdapter.java
@@ -28,6 +28,8 @@ import org.apache.hc.client5.http.CircularRedirectException;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.routing.RoutingSupport;
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpEntityContainer;
 import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequest;
@@ -36,7 +38,7 @@ import javax.annotation.Nullable;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-public class ApacheHttpClient5ApiAdapter implements ApacheHttpClientApiAdapter<HttpRequest, ClassicHttpRequest, HttpHost, CloseableHttpResponse> {
+public class ApacheHttpClient5ApiAdapter implements ApacheHttpClientApiAdapter<HttpRequest, ClassicHttpRequest, HttpHost, CloseableHttpResponse, HttpEntity> {
     private static final ApacheHttpClient5ApiAdapter INSTANCE = new ApacheHttpClient5ApiAdapter();
 
     private static final Logger logger = LoggerFactory.getLogger(ApacheHttpClient5ApiAdapter.class);
@@ -93,5 +95,14 @@ public class ApacheHttpClient5ApiAdapter implements ApacheHttpClientApiAdapter<H
     public boolean isNotNullStatusLine(CloseableHttpResponse closeableHttpResponse) {
         // HTTP response messages in HttpClient 5.x no longer have a status line.
         return true;
+    }
+
+    @Nullable
+    @Override
+    public HttpEntity getRequestEntity(HttpRequest httpRequest) {
+        if (httpRequest instanceof HttpEntityContainer) {
+            return ((HttpEntityContainer) httpRequest).getEntity();
+        }
+        return null;
     }
 }

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/RequestChannelWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/RequestChannelWrapper.java
@@ -20,10 +20,11 @@ package co.elastic.apm.agent.httpclient.v5.helper;
 
 
 import co.elastic.apm.agent.httpclient.HttpClientHelper;
+import co.elastic.apm.agent.httpclient.common.RequestBodyCaptureRegistry;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
-import co.elastic.apm.agent.tracer.TraceState;
 import co.elastic.apm.agent.tracer.Span;
+import co.elastic.apm.agent.tracer.TraceState;
 import co.elastic.apm.agent.tracer.pooling.Recyclable;
 import org.apache.hc.core5.http.EntityDetails;
 import org.apache.hc.core5.http.HttpException;
@@ -78,6 +79,7 @@ public class RequestChannelWrapper implements RequestChannel, Recyclable {
 
             if (httpRequest != null) {
                 if (span != null) {
+                    RequestBodyCaptureRegistry.potentiallyCaptureRequestBody(httpRequest, span, ApacheHttpClient5ApiAdapter.get(), RequestHeaderAccessor.INSTANCE);
                     String host = null;
                     String protocol = null;
                     int port = -1;

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/resources/META-INF/services/co.elastic.apm.agent.sdk.ElasticApmInstrumentation
@@ -1,2 +1,4 @@
 co.elastic.apm.agent.httpclient.v5.ApacheHttpClient5Instrumentation
 co.elastic.apm.agent.httpclient.v5.ApacheHttpAsyncClient5Instrumentation
+co.elastic.apm.agent.httpclient.v5.ApacheHttp5EntityWriteToInstrumentation
+co.elastic.apm.agent.httpclient.v5.ApacheHttp5EntityGetContentInstrumentation

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/test/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpClientExecuteOpenInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/test/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpClientExecuteOpenInstrumentationTest.java
@@ -22,15 +22,19 @@ package co.elastic.apm.agent.httpclient.v5;
 import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.InputStreamEntity;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 public class ApacheHttpClientExecuteOpenInstrumentationTest extends AbstractHttpClientInstrumentationTest {
@@ -59,20 +63,34 @@ public class ApacheHttpClientExecuteOpenInstrumentationTest extends AbstractHttp
         return false;
     }
 
+    private final HttpClientResponseHandler<String> responseHandler = response -> {
+        int status = response.getCode();
+        if (status >= 200 && status < 300) {
+            HttpEntity entity = response.getEntity();
+            return entity != null ? EntityUtils.toString(entity) : null;
+        } else {
+            throw new ClientProtocolException("Unexpected response status: " + status);
+        }
+    };
+
     @Override
     protected void performGet(String path) throws Exception {
-        HttpClientResponseHandler<String> responseHandler = response -> {
-            int status = response.getCode();
-            if (status >= 200 && status < 300) {
-                HttpEntity entity = response.getEntity();
-                String res = entity != null ? EntityUtils.toString(entity) : null;
-                return res;
-            } else {
-                throw new ClientProtocolException("Unexpected response status: " + status);
-            }
-        };
-
         ClassicHttpResponse response = client.executeOpen(null, new HttpGet(path), null);
+        responseHandler.handleResponse(response);
+    }
+
+    @Override
+    protected boolean isBodyCapturingSupported() {
+        return true;
+    }
+
+    @Override
+    protected void performPost(String path, byte[] content, String contentTypeHeader) throws Exception {
+        HttpPost request = new HttpPost(path);
+        request.setEntity(new InputStreamEntity(new ByteArrayInputStream(content), ContentType.parse(contentTypeHeader)));
+        request.setHeader("Content-Type", contentTypeHeader);
+
+        ClassicHttpResponse response = client.executeOpen(null, request, null);
         responseHandler.handleResponse(response);
     }
 }

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/test/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/test/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpClientInstrumentationTest.java
@@ -22,14 +22,18 @@ package co.elastic.apm.agent.httpclient.v5;
 import co.elastic.apm.agent.httpclient.AbstractHttpClientInstrumentationTest;
 import org.apache.hc.client5.http.ClientProtocolException;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
+import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.HttpClientResponseHandler;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.InputStreamEntity;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
 public class ApacheHttpClientInstrumentationTest extends AbstractHttpClientInstrumentationTest {
@@ -58,18 +62,33 @@ public class ApacheHttpClientInstrumentationTest extends AbstractHttpClientInstr
         return false;
     }
 
+    private final HttpClientResponseHandler<String> responseHandler = response -> {
+        int status = response.getCode();
+        if (status >= 200 && status < 300) {
+            HttpEntity entity = response.getEntity();
+            String res = entity != null ? EntityUtils.toString(entity) : null;
+            return res;
+        } else {
+            throw new ClientProtocolException("Unexpected response status: " + status);
+        }
+    };
+
     @Override
     protected void performGet(String path) throws Exception {
-        HttpClientResponseHandler<String> responseHandler = response -> {
-            int status = response.getCode();
-            if (status >= 200 && status < 300) {
-                HttpEntity entity = response.getEntity();
-                String res = entity != null ? EntityUtils.toString(entity) : null;
-                return res;
-            } else {
-                throw new ClientProtocolException("Unexpected response status: " + status);
-            }
-        };
-        String response = client.execute(new HttpGet(path), responseHandler);
+        client.execute(new HttpGet(path), responseHandler);
+    }
+
+    @Override
+    protected boolean isBodyCapturingSupported() {
+        return true;
+    }
+
+    @Override
+    protected void performPost(String path, byte[] content, String contentTypeHeader) throws Exception {
+        HttpPost request = new HttpPost(path);
+        request.setEntity(new InputStreamEntity(new ByteArrayInputStream(content), ContentType.parse(contentTypeHeader)));
+        request.setHeader("Content-Type", contentTypeHeader);
+
+        client.execute(request, responseHandler);
     }
 }

--- a/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-plugin/src/test/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-resttemplate/apm-spring-resttemplate-plugin/src/test/java/co/elastic/apm/agent/resttemplate/SpringRestTemplateInstrumentationTest.java
@@ -103,10 +103,6 @@ public class SpringRestTemplateInstrumentationTest extends AbstractHttpClientIns
                 // We do not support body capturing for OkHttp yet
                 return false;
             }
-            if (restTemplate.getRequestFactory() instanceof HttpComponentsClientHttpRequestFactory) {
-                //apache http client v5 is also not supported yet
-                return false;
-            }
             return true;
         }
 


### PR DESCRIPTION
## What does this PR do?

Like #3724, adds support for capturing request bodies for apache http client v5 via a currently internal config option.

## Checklist

- [x] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~ no changelog because curently hidden behind feature flag
  - [x] I have added tests that prove my fix is effective or that my feature works
  - [ ] ~Added an API method or config option? Document in which version this will be introduced~
  - [ ] ~I have made corresponding changes to the documentation~