### PR TITLE
Make capture_http_client_request_body_size config option public

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -35,6 +35,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 ===== Bug fixes
 * Fix log4j2 log correlation with shaded application jar - {pull}3764[#3764]
 
+[float]
+===== Features
+* Added experimental option to capture HTTP client request bodies for Apache Http Client v4 and v5, HttpUrlConnection and Spring WebClient - {pull}3776[#3776], {pull}3962[#3962], {pull}3724[#3724], {pull}3754[#3754], {pull}3767[#3767]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/WebConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/WebConfiguration.java
@@ -129,10 +129,12 @@ public class WebConfiguration extends ConfigurationOptionProvider {
         .addValidator(isInRange(0, MAX_BODY_CAPTURE_BYTES))
         .key("capture_http_client_request_body_size")
         .configurationCategory(HTTP_CATEGORY)
-        .tags("added[1.50.0]", "internal")
-        .description("Configures how many bytes of http-client request bodies shall be captured. " +
-                     "Note that only request bodies will be captured for content types matching the capture_body_content_types configuration. " +
-                     " The maximum allowed value is " + MAX_BODY_CAPTURE_BYTES + " , a value of 0 disables body capturing")
+        .tags("added[1.52.0]", "experimental")
+        .description("Configures that the first n bytes of http-client request bodies shall be captured. " +
+                     "Note that only request bodies will be captured for content types matching the <<config-transaction-name-groups,`transaction_name_groups`>> configuration. " +
+                     "The maximum allowed value is " + MAX_BODY_CAPTURE_BYTES + ", a value of 0 disables body capturing.\n\n" +
+                     "Currently only support for Apache Http Client v4 and v5, HttpUrlConnection, Spring Webflux WebClient and other frameworks building on top of these (e.g. Spring RestTemplate).\n\n" +
+                     "The body will be stored in the `labels.http_request_body_content` field on the span documents.")
         .dynamic(true)
         .buildWithDefault(0);
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -147,6 +147,7 @@ Click on a key to get more information.
 ** <<config-transaction-ignore-user-agents>>
 ** <<config-use-path-as-transaction-name>>
 ** <<config-url-groups>>
+** <<config-capture-http-client-request-body-size>>
 * <<config-huge-traces>>
 ** <<config-span-compression-enabled>>
 ** <<config-span-compression-exact-match-max-duration>>
@@ -1827,6 +1828,35 @@ Prepending an element with `(?-i)` makes the matching case sensitive.
 |============
 | Java System Properties      | Property file   | Environment
 | `elastic.apm.url_groups` | `url_groups` | `ELASTIC_APM_URL_GROUPS`
+|============
+
+// This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
+[float]
+[[config-capture-http-client-request-body-size]]
+==== `capture_http_client_request_body_size` (added[1.52.0] experimental)
+
+NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
+
+Configures that the first n bytes of http-client request bodies shall be captured. Note that only request bodies will be captured for content types matching the <<config-transaction-name-groups,`transaction_name_groups`>> configuration. The maximum allowed value is 1024, a value of 0 disables body capturing.
+
+Currently only support for Apache Http Client v4 and v5, HttpUrlConnection, Spring Webflux WebClient and other frameworks building on top of these (e.g. Spring RestTemplate).
+
+The body will be stored in the `labels.http_request_body_content` field on the span documents.
+
+<<configuration-dynamic, image:./images/dynamic-config.svg[] >>
+
+
+[options="header"]
+|============
+| Default                          | Type                | Dynamic
+| `0` | Integer | true
+|============
+
+
+[options="header"]
+|============
+| Java System Properties      | Property file   | Environment
+| `elastic.apm.capture_http_client_request_body_size` | `capture_http_client_request_body_size` | `ELASTIC_APM_CAPTURE_HTTP_CLIENT_REQUEST_BODY_SIZE`
 |============
 
 [[config-huge-traces]]
@@ -4330,6 +4360,18 @@ Example: `5ms`.
 # Default value: 
 #
 # url_groups=
+
+# Configures that the first n bytes of http-client request bodies shall be captured. Note that only request bodies will be captured for content types matching the <<config-transaction-name-groups,`transaction_name_groups`>> configuration. The maximum allowed value is 1024, a value of 0 disables body capturing.
+# 
+# Currently only support for Apache Http Client v4 and v5, HttpUrlConnection, Spring Webflux WebClient and other frameworks building on top of these (e.g. Spring RestTemplate).
+# 
+# The body will be stored in the `labels.http_request_body_content` field on the span documents.
+#
+# This setting can be changed at runtime
+# Type: Integer
+# Default value: 0
+#
+# capture_http_client_request_body_size=0
 
 ############################################
 # Huge Traces                              #


### PR DESCRIPTION
## What does this PR do?

Makes the experimental HTTP client body capturing feature public.
Closes #3725.

## Checklist

- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
