### PR TITLE
mergify: replace queue action for queue_rules

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 queue_rules:
   - name: default
-  # merge method needs to be set to 'squash' to match the repository config
     merge_method: squash
+  # merge method needs to be set to 'squash' to match the repository config
   # branch protection rules are automatically included, no extra rule needed for now
 
 pull_request_rules:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Use queue_rules instead of queue action

## Why

The queue action from workflow automation has deprecated all of its configuration options

https://changelog.mergify.com/changelog/queue-action-options-deprecation
