### PR TITLE
github-action: use oblt-actions/maven/await-artifact

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -115,10 +115,10 @@ jobs:
     needs:
       - validate-tag
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/await-maven-artifact@current
+      - uses: elastic/oblt-actions/maven/await-artifact@v1
         with:
-          groupid: 'co.elastic.apm'
-          artifactid: 'elastic-apm-agent'
+          group-id: 'co.elastic.apm'
+          artifact-id: 'elastic-apm-agent'
           version: ${{ env.RELEASE_VERSION }}
 
   build-and-push-docker-images:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

NOTE: https://github.com/elastic/apm-pipeline-library has been deprecated in favor of 
https://github.com/elastic/oblt-actions.

Requires https://github.com/elastic/oblt-actions/pull/118 to be merged.

If there are any questions, please reach out to the @elastic/observablt-ci
