### PR TITLE
Make health metrics GA

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Features
 * Added experimental option to capture HTTP client request bodies for Apache Http Client v4 and v5, HttpUrlConnection and Spring WebClient - {pull}3776[#3776], {pull}3962[#3962], {pull}3724[#3724], {pull}3754[#3754], {pull}3767[#3767]
+* Agent health metrics now GA - {pull}3802[#3802]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/MetricsConfigurationImpl.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/MetricsConfigurationImpl.java
@@ -93,7 +93,7 @@ public class MetricsConfigurationImpl extends ConfigurationOptionProvider implem
         .key("agent_reporter_health_metrics")
         .configurationCategory(METRICS_CATEGORY)
         .description("Enables metrics which capture the health state of the agent's event reporting mechanism.")
-        .tags("added[1.35.0]", "experimental")
+        .tags("added[1.35.0]")
         .dynamic(false)
         .buildWithDefault(false);
 
@@ -101,7 +101,7 @@ public class MetricsConfigurationImpl extends ConfigurationOptionProvider implem
         .key("agent_background_overhead_metrics")
         .configurationCategory(METRICS_CATEGORY)
         .description("Enables metrics which capture the resource consumption of agent background tasks.")
-        .tags("added[1.35.0]", "experimental")
+        .tags("added[1.35.0]")
         .dynamic(false)
         .buildWithDefault(false);
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -2653,9 +2653,7 @@ But if you must, you can use this option to increase the limit.
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-agent-reporter-health-metrics]]
-==== `agent_reporter_health_metrics` (added[1.35.0] experimental)
-
-NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
+==== `agent_reporter_health_metrics` (added[1.35.0])
 
 Enables metrics which capture the health state of the agent's event reporting mechanism.
 
@@ -2678,9 +2676,7 @@ Enables metrics which capture the health state of the agent's event reporting me
 // This file is auto generated. Please make your changes in *Configuration.java (for example CoreConfiguration.java) and execute ConfigurationExporter
 [float]
 [[config-agent-background-overhead-metrics]]
-==== `agent_background_overhead_metrics` (added[1.35.0] experimental)
-
-NOTE: This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
+==== `agent_background_overhead_metrics` (added[1.35.0])
 
 Enables metrics which capture the resource consumption of agent background tasks.
 

--- a/docs/metrics.asciidoc
+++ b/docs/metrics.asciidoc
@@ -663,8 +663,6 @@ Fields:
 [[metrics-agenthealth]]
 === Agent Health Metrics
 
-experimental::[]
-
 The agent internally uses a queue to buffer the various events (e.g. transactions, spans, metrics) before sending them to the APM server.
 When <<config-agent-reporter-health-metrics, `agent_reporter_health_metrics`>> is enabled, the agent will expose several metrics regarding the health state of this queue and the network connectivity to the APM server.
 In addition, if <<config-agent-background-overhead-metrics, `agent_background_overhead_metrics`>> is enabled, the agent will continuously measure the resource consumption of its own background tasks and provide the results as metrics.


### PR DESCRIPTION
## What does this PR do?
Removes `experimental tag` to make health metrics GA

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [x] This is something else
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
