### PR TITLE
ci: use GitHub app for ephemeral tokens

### DIFF
--- a/.buildkite/hooks/prepare-common.sh
+++ b/.buildkite/hooks/prepare-common.sh
@@ -37,9 +37,11 @@ fi
 java -version
 
 echo "--- Prepare github secrets :vault:"
-VAULT_SECRET_PATH=kv/ci-shared/observability-ci/github-bot-user
-GITHUB_SECRET=$(vault kv get -field token "${VAULT_SECRET_PATH}")
-GIT_USER=$(vault kv get -field username "${VAULT_SECRET_PATH}")
-GIT_EMAIL=$(vault kv get -field email "${VAULT_SECRET_PATH}")
+# Only accessible by Elastic employees
+# The GitHub Permission Set can be found at:
+# https://github.com/v1v/terrazzo/blob/main/manifests/prod/vault/apm-agent-java-permission-set.yaml
+GITHUB_SECRET=$VAULT_GITHUB_TOKEN
+GIT_USER="elastic-vault-github-plugin-prod"
+GIT_EMAIL="obltmachine@users.noreply.github.com"
 GH_TOKEN=$GITHUB_SECRET
 export GITHUB_SECRET GH_TOKEN GIT_USER GIT_EMAIL


### PR DESCRIPTION
## What does this PR do?

Use the GitHub app to generate the required ephemeral tokens with the least permissive principle.

Token expires after 55 minutes since it was requested. It's asked for once per step in the BK pipeline. Hence, if one step takes longer than 60 minutes and the token is required afterwards, then it will expire.

I cannot see this is the case in this project. See below

## Tasks

- [x] Confirm CI builds don't take longer than 55 minutes.

`apm-agent-java-snapshot` never took longer than 45 minutes and average is 15 minutes

<img width="1653" alt="image" src="https://github.com/user-attachments/assets/b09ef284-76f8-4d29-b504-2b785c4af324">

`apm-agent-java-release` never took longer than 45 minutes and average is 18 minutes

<img width="1653" alt="image" src="https://github.com/user-attachments/assets/f76cafbd-99f2-47fe-87d3-34f1328c4e18">

`apm-agent-java-benchmarks` took only once over 6k minutes and average is 24 minutes:

<img width="1627" alt="image" src="https://github.com/user-attachments/assets/0bc39683-c8cf-4734-84b1-1848cdbc4467">

## Why is it important?

* Finer-grained tokens with Service Machine accounts are required to rotate the secrets manually.
* GitHub app to generate temporary tokens is the advanced approach to avoid the above
* Document what the CI requires to run in terms of access

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
