### PR TITLE
guard stack remove with isEmpty

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActiveStack.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/ActiveStack.java
@@ -116,7 +116,9 @@ class ActiveStack {
         }
 
         TraceStateImpl<?> activeContext = currentContext();
-        activeContextStack.remove();
+        if (!activeContextStack.isEmpty()) {
+            activeContextStack.remove();
+        }
 
         try {
             assertIsActive(context, activeContext, assertionsEnabled);
@@ -185,7 +187,9 @@ class ActiveStack {
 
         // replace the currently active on the stack, however currentContext() will make sure to return the original
         // context in order to keep wrapping transparent.
-        activeContextStack.remove();
+        if (!activeContextStack.isEmpty()) {
+            activeContextStack.remove();
+        }
         activeContextStack.push(wrapper);
 
         return wrapped;


### PR DESCRIPTION
## What does this PR do?
Fix a pop-on-empty bug

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
