### PR TITLE
Added test case ensuring client body capturing is dynamic

### DIFF
--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -83,6 +83,9 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         wireMockRule.stubFor(any(urlEqualTo("/"))
             .willReturn(dummyResponse()
                 .withStatus(200)));
+        wireMockRule.stubFor(any(urlEqualTo("/dummy"))
+            .willReturn(dummyResponse()
+                .withStatus(200)));
         wireMockRule.stubFor(get(urlEqualTo("/error"))
             .willReturn(dummyResponse()
                 .withStatus(515)));
@@ -125,11 +128,19 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
         if (!isBodyCapturingSupported()) {
             return;
         }
-        doReturn(5).when(config.getConfig(WebConfiguration.class)).getCaptureClientRequestBytes();
         byte[] content = "Hello World!".getBytes(StandardCharsets.UTF_8);
-        String path = "/";
-        performPost(getBaseUrl() + path, content, "text/plain; charset=utf-8");
-        expectSpan(path)
+
+        // Ensure that the setting can be turned on dynamically by first issuing a request with the feature disabled
+        doReturn(0).when(config.getConfig(WebConfiguration.class)).getCaptureClientRequestBytes();
+        performPost(getBaseUrl() + "/dummy", content, "text/plain; charset=utf-8");
+        expectSpan("/dummy")
+            .withRequestBodySatisfying(body -> assertThat(body.getBody()).isNull())
+            .verify();
+        reporter.reset();
+
+        doReturn(5).when(config.getConfig(WebConfiguration.class)).getCaptureClientRequestBytes();
+        performPost(getBaseUrl() + "/", content, "text/plain; charset=utf-8");
+        expectSpan("/")
             .withRequestBodySatisfying(body -> {
                 ByteBuffer buffer = body.getBody();
                 assertThat(buffer).isNotNull();

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/main/java/co/elastic/apm/agent/springwebclient/BodyCaptureRegistry.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/main/java/co/elastic/apm/agent/springwebclient/BodyCaptureRegistry.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.springwebclient;
 
 import co.elastic.apm.agent.httpclient.RequestBodyRecordingHelper;

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/main/java/co/elastic/apm/agent/springwebclient/ClientRequestHeaderGetter.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webclient-plugin/src/main/java/co/elastic/apm/agent/springwebclient/ClientRequestHeaderGetter.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package co.elastic.apm.agent.springwebclient;
 
 import co.elastic.apm.agent.tracer.dispatch.TextHeaderGetter;


### PR DESCRIPTION
## What does this PR do?

The `capture_http_client_request_body_size` is already dynamic. This PR just adds a enhances the test-case to verify that it actually operates dynamically.

## Checklist

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~ Not required for jsut a testcase
