### PR TITLE
Fix JMX invalid composite value type log message

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,12 +31,12 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
-[[release-notes-1.x]]
-=== Java Agent version 1.x
-
 [float]
 ===== Bug fixes
 * Fix JMX metric warning message about unsupported composite value types - {pull}3849[#3849]
+
+[[release-notes-1.x]]
+=== Java Agent version 1.x
 
 [[release-notes-1.52.0]]
 ==== 1.52.0 - 2024/09/23

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [[release-notes-1.x]]
 === Java Agent version 1.x
 
+[float]
+===== Bug fixes
+* Fix JMX metric warning message about unsupported composite value types - {pull}3849[#3849]
+
 [[release-notes-1.52.0]]
 ==== 1.52.0 - 2024/09/23
 


### PR DESCRIPTION
## What does this PR do?

For JMX metrics we support composite values: Each entry becomes a separate metric.
However, this only works as long as the values of the entries in the composite are numbers. Otherwise we'll print a warning.

This warning was a bit misleading, because it would print the entire composite instead of just the offending value, which gets fixed by this PR.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] ~I have added tests that would fail without this fix~
