### PR TITLE
Add support for jax-ws method annotated with @WebMethod not declared by super-interfaces

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Bug fixes
 * Fix JMX metric warning message about unsupported composite value types - {pull}3849[#3849]
+* Fix JAX-WS transaction naming for @WebMethod annotated methods - {pull}3850[#3850]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-plugins/apm-jaxws-plugin-jakartaee-test/src/test/java/co/elastic/apm/agent/jaxws/JakartaeeJaxWsTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jaxws-plugin-jakartaee-test/src/test/java/co/elastic/apm/agent/jaxws/JakartaeeJaxWsTransactionNameInstrumentationTest.java
@@ -18,6 +18,7 @@
  */
 package co.elastic.apm.agent.jaxws;
 
+import jakarta.jws.WebMethod;
 import jakarta.jws.WebService;
 import jakarta.jws.soap.SOAPBinding;
 import org.junit.jupiter.api.BeforeEach;
@@ -41,6 +42,11 @@ class JakartaeeJaxWsTransactionNameInstrumentationTest extends AbstractJaxWsInst
         @Override
         public String sayHello() {
             return "Hello World";
+        }
+
+        @WebMethod
+        public String webMethodAnnotated() {
+            return "foo bar";
         }
     }
 

--- a/apm-agent-plugins/apm-jaxws-plugin/src/test/java/co/elastic/apm/agent/jaxws/AbstractJaxWsInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jaxws-plugin/src/test/java/co/elastic/apm/agent/jaxws/AbstractJaxWsInstrumentationTest.java
@@ -41,6 +41,19 @@ public abstract class AbstractJaxWsInstrumentationTest extends AbstractInstrumen
         assertThat(transaction.getFrameworkName()).isEqualTo("JAX-WS");
     }
 
+
+    @Test
+    void testTransactionNameForWebMethod() throws Exception {
+        final TransactionImpl transaction = tracer.startRootTransaction(getClass().getClassLoader());
+        try (Scope scope = transaction.activateInScope()) {
+            helloWorldService.getClass().getMethod("webMethodAnnotated").invoke(helloWorldService);
+        } finally {
+            transaction.end();
+        }
+        assertThat(transaction.getNameAsString()).isEqualTo("HelloWorldServiceImpl#webMethodAnnotated");
+        assertThat(transaction.getFrameworkName()).isEqualTo("JAX-WS");
+    }
+
     public interface BaseHelloWorldService {
         String sayHello();
     }

--- a/apm-agent-plugins/apm-jaxws-plugin/src/test/java/co/elastic/apm/agent/jaxws/JaxWsTransactionNameInstrumentationTest.java
+++ b/apm-agent-plugins/apm-jaxws-plugin/src/test/java/co/elastic/apm/agent/jaxws/JaxWsTransactionNameInstrumentationTest.java
@@ -47,6 +47,11 @@ class JaxWsTransactionNameInstrumentationTest extends AbstractJaxWsInstrumentati
         public String sayHello() {
             return "Hello World";
         }
+
+        @WebMethod
+        public String webMethodAnnotated() {
+            return "foo bar";
+        }
     }
 
 }


### PR DESCRIPTION
## What does this PR do?

#2667 added support for capturing the JAX-WS transaction names for methods which were inherited from an `@WebService` interface and do not have the `@WebMethod` annotation. It looks like this change accidentally removed the ability of instrumenting methods with `@WebMethod` which do not come from an interface.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
