### PR TITLE
Set context CL for reliable weblogic connection

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,6 +34,7 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 [float]
 ===== Bug fixes
 * Prevent NPE in OpenTelemetry metrics bridge in case of asynchronous agent start - {pull}3880[#3880]
+* Fix random Weblogic ClassNotFoundException related to thread context classloader - {pull}3870[#3870]
 
 [[release-notes-1.x]]
 === Java Agent version 1.x

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/util/UrlConnectionUtilsTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/util/UrlConnectionUtilsTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.util;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nullable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class UrlConnectionUtilsTest {
+
+    @BeforeEach
+    void beforeEach() {
+        Thread.currentThread().setContextClassLoader(null);
+    }
+
+    @AfterEach
+    void afterEach() {
+        Thread.currentThread().setContextClassLoader(null);
+    }
+
+    @Test
+    void threadContextClassLoader_noop() {
+        ClassLoader cl = UrlConnectionUtils.class.getClassLoader();
+        testContextClassLoader(null, null, false);
+        testContextClassLoader(cl, cl, false);
+    }
+
+    @Test
+    void threadContextClassLoader_override() {
+        ClassLoader cl = UrlConnectionUtils.class.getClassLoader();
+        testContextClassLoader(null, cl, true);
+        testContextClassLoader(cl, cl, true);
+
+        DummyClassLoader overrideCl = new DummyClassLoader();
+        testContextClassLoader(null, overrideCl, true);
+        testContextClassLoader(cl, overrideCl, true);
+    }
+
+    private void testContextClassLoader(@Nullable ClassLoader initialClassLoader, @Nullable ClassLoader scopeClassLoader, boolean override) {
+        Thread.currentThread().setContextClassLoader(initialClassLoader);
+        checkContextClassLoader(initialClassLoader);
+        try (UrlConnectionUtils.ContextClassloaderScope scope = UrlConnectionUtils.withContextClassloader(scopeClassLoader, override)) {
+            checkContextClassLoader(scopeClassLoader);
+        }
+        checkContextClassLoader(initialClassLoader);
+    }
+
+    private void checkContextClassLoader(@Nullable ClassLoader expected) {
+        ClassLoader threadContextCl = Thread.currentThread().getContextClassLoader();
+        if (expected == null) {
+            assertThat(threadContextCl).isNull();
+        } else {
+            assertThat(threadContextCl).isSameAs(expected);
+        }
+    }
+
+    private static class DummyClassLoader extends ClassLoader {
+
+    }
+}

--- a/docs/troubleshooting.asciidoc
+++ b/docs/troubleshooting.asciidoc
@@ -288,6 +288,10 @@ further information about how to download this file can be found <<setup-javaage
 `java.net.SocketException: Broken pipe` - one option is that client authentication fails. Check out
 <<ssl-client-authentication>>.
 
+With Oracle Weblogic application server wildcard TLS certificates are not allowed by default, when this
+happens a message error like this is visible in agent logs: `Hostname verification failed: HostnameVerifier=weblogic.security.utils.SSLWLSHostnameVerifier`.
+Disabling this extra check can be done with `-Dweblogic.security.SSL.ignoreHostnameVerification=true`.
+
 For other SSL/TLS related problems, - check out
 https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/JSSERefGuide.html#Troubleshooting[the JSSE
 troubleshooting section].


### PR DESCRIPTION
## What does this PR do?

Fixes #2409

Weblogic overrides the default `HttpURLConnection` implementation of the JDK with its own, as a consequence the agent is sometimes unable to connect to the remote server due to classpath issues.

After digging into the WL implementation details, the reason we get a `ClassNotFoundException` is because the thread context classloader is used to load parts of the SSL/TLS implementation. 

When this happens, for example when calling `getInputStream()` or `getStatusCode()` on the connection, then we have to make sure the current thread context CL is able to load such classes, which is not the case by default because it's the `ShadedClassLoader` of the agent which is not aware of the weblogic implementation details that are only visible to WL and not in the bootstrap CL of the JVM.

Luckily, if the thread context CL is set to the same CL as the one that the Weblogic flavor of `HttpURLConnection` is loaded from, we are able to load the class that was previously not found.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix
