### PR TITLE
Prevent NPE when using otel metrics bridge asynchronously to agent start

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -31,6 +31,10 @@ Use subheadings with the "=====" level for adding notes for unreleased changes:
 
 === Unreleased
 
+[float]
+===== Bug fixes
+* Prevent NPE in OpenTelemetry metrics bridge in case of asynchronous agent start - {pull}3880[#3880]
+
 [[release-notes-1.x]]
 === Java Agent version 1.x
 

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-embedded-metrics-sdk/src/test/java/co/elastic/apm/agent/embeddedotel/EmbeddedSdkManagerTest.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-embedded-metrics-sdk/src/test/java/co/elastic/apm/agent/embeddedotel/EmbeddedSdkManagerTest.java
@@ -1,0 +1,22 @@
+package co.elastic.apm.agent.embeddedotel;
+
+import co.elastic.apm.agent.embeddedotel.proxy.ProxyMeter;
+import co.elastic.apm.agent.tracer.Tracer;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EmbeddedSdkManagerTest {
+
+    /**
+     * The instrumentation of the agent is performed before {@link EmbeddedSdkManager#init(Tracer)} is invoked.
+     * This means if the agent is started asynchronously, it can happen that {@link EmbeddedSdkManager#getMeterProvider()}
+     * is invoked before the tracer has been provided.
+     * This test verifies that in that case no exception occurs and a noop-meter implementation is used.
+     */
+    @Test
+    public void ensureNoExceptionOnMissingTracer() throws Exception {
+        ProxyMeter meter = new EmbeddedSdkManager().getMeterProvider().get("foobar");
+        assertThat(meter.getDelegate()).isInstanceOf(Class.forName("io.opentelemetry.api.metrics.DefaultMeter"));
+    }
+}


### PR DESCRIPTION
## What does this PR do?

The elasticsearch team reported a NPE in the Otel metrics bridge, which is likely due to an asynchronous agent start.

```
java.lang.NullPointerException: Cannot invoke "io.opentelemetry.api.metrics.MeterProvider.get(String)" because "this.delegate" is null 
 at co.elastic.apm.agent.embeddedotel.proxy.ProxyMeterProvider.get(ProxyMeterProvider.java:36) ~[?:?]
 at co.elastic.apm.agent.opentelemetry.metrics.bridge.v1_14.BridgeMeterProvider.get(BridgeMeterProvider.java:41) ~[?:?]
 at io.opentelemetry.api.OpenTelemetry.getMeter(OpenTelemetry.java:102) ~[?:?]
 at org.elasticsearch.telemetry.apm.internal.APMMeterService.otelMeter(APMMeterService.java:90) ~[?:?]
 at org.elasticsearch.telemetry.apm.internal.APMMeterService.<init>(APMMeterService.java:33) ~[?:?]
 at org.elasticsearch.telemetry.apm.internal.APMTelemetryProvider.<init>(APMTelemetryProvider.java:22) ~[?:?]
 at org.elasticsearch.telemetry.apm.APM.getTelemetryProvider(APM.java:59) ~[?:?]
 at org.elasticsearch.node.NodeConstruction.lambda$createTelemetryProvider$1(NodeConstruction.java:475) ~[elasticsearch-8.15.2.jar:?]
 at java.util.Optional.map(Optional.java:260) ~[?:?]
 at org.elasticsearch.node.NodeConstruction.createTelemetryProvider(NodeConstruction.java:475) ~[elasticsearch-8.15.2.jar:?]
 at org.elasticsearch.node.NodeConstruction.prepareConstruction(NodeConstruction.java:258) ~[elasticsearch-8.15.2.jar:?]
 at org.elasticsearch.node.Node.<init>(Node.java:192) ~[elasticsearch-8.15.2.jar:?]
 at org.elasticsearch.bootstrap.Elasticsearch$2.<init>(Elasticsearch.java:242) ~[elasticsearch-8.15.2.jar:?]
 at org.elasticsearch.bootstrap.Elasticsearch.initPhase3(Elasticsearch.java:242) ~[elasticsearch-8.15.2.jar:?]
 at org.elasticsearch.bootstrap.Elasticsearch.main(Elasticsearch.java:76) ~[elasticsearch-8.15.2.jar:?]
```
This PR should prevent this exception and print warnings that a NoOp metrics implementation will be used in this case.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [x] I have added tests that would fail without this fix