### PR TITLE
Reapply: Clarify the frequency of config polling

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfigurationImpl.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfigurationImpl.java
@@ -25,7 +25,13 @@ import co.elastic.apm.agent.matcher.MethodMatcher;
 import co.elastic.apm.agent.matcher.MethodMatcherValueConverter;
 import co.elastic.apm.agent.sdk.logging.Logger;
 import co.elastic.apm.agent.sdk.logging.LoggerFactory;
-import co.elastic.apm.agent.tracer.configuration.*;
+import co.elastic.apm.agent.tracer.configuration.CoreConfiguration;
+import co.elastic.apm.agent.tracer.configuration.ListValueConverter;
+import co.elastic.apm.agent.tracer.configuration.RegexValidator;
+import co.elastic.apm.agent.tracer.configuration.RoundedDoubleConverter;
+import co.elastic.apm.agent.tracer.configuration.TimeDuration;
+import co.elastic.apm.agent.tracer.configuration.TimeDurationValueConverter;
+import co.elastic.apm.agent.tracer.configuration.WildcardMatcherValueConverter;
 import org.stagemonitor.configuration.ConfigurationOption;
 import org.stagemonitor.configuration.ConfigurationOptionProvider;
 import org.stagemonitor.configuration.converter.AbstractValueConverter;
@@ -696,7 +702,8 @@ public class CoreConfigurationImpl extends ConfigurationOptionProvider implement
         .key("central_config")
         .tags("added[1.8.0]")
         .configurationCategory(CORE_CATEGORY)
-        .description("When enabled, the agent will make periodic requests to the APM Server to fetch updated configuration.")
+        .description("When enabled, the agent will make periodic requests to the APM Server to fetch updated configuration.\n"
+                     + "The frequency of the periodic request is driven by the `Cache-Control` header returned from APM Server/Integration, falling back to 5 minutes if not defined.")
         .dynamic(true)
         .buildWithDefault(true);
 

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -1271,6 +1271,7 @@ Example: `0ms`.
 ==== `central_config` (added[1.8.0])
 
 When enabled, the agent will make periodic requests to the APM Server to fetch updated configuration.
+The frequency of the periodic request is driven by the `Cache-Control` header returned from APM Server/Integration, falling back to 5 minutes if not defined.
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
 
@@ -4087,6 +4088,7 @@ Example: `5ms`.
 # trace_methods_duration_threshold=0ms
 
 # When enabled, the agent will make periodic requests to the APM Server to fetch updated configuration.
+# The frequency of the periodic request is driven by the `Cache-Control` header returned from APM Server/Integration, falling back to 5 minutes if not defined.
 #
 # This setting can be changed at runtime
 # Type: Boolean


### PR DESCRIPTION
Reapplies #3799 , because that PR was merged to the wrong branch and had to be reverted during the last release to avoid conflicts.