### PR TITLE
Revert "deps(updatecli): bump all policies"

### DIFF
--- a/updatecli-compose.yaml
+++ b/updatecli-compose.yaml
@@ -2,17 +2,17 @@
 # https://www.updatecli.io/docs/core/compose/
 policies:
   - name: Handle apm-data server specs
-    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-data-spec:0.6.0@sha256:c0bbdec23541bed38df1342c95aeb601530a113db1ff11715c1c7616ed5e9e8b
+    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-data-spec:0.5.0@sha256:1307837d72174da906afb40a812b89f9f40efdbc0f6dcb4f632f886f9798577e
     values:
       - .ci/updatecli/values.d/scm.yml
       - .ci/updatecli/values.d/apm-data-spec.yml
   - name: Handle apm gherkin specs
-    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-gherkin:0.6.0@sha256:dbaf4d855c5c212c3b5a8d2cc98c243a2b769ac347198ae8814393a1a0576587
+    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-gherkin:0.5.0@sha256:7166356b1bb5fb39b640dc9712a2a9f16b06b3fdb137dd362ede7d70ca5396e8
     values:
       - .ci/updatecli/values.d/scm.yml
       - .ci/updatecli/values.d/apm-gherkin.yml
   - name: Handle apm json specs
-    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-json-specs:0.6.0@sha256:e5a74c159ceed02fd20515ea76fa25ff81e3ccf977e74e636f9973db86aa52a5
+    policy: ghcr.io/elastic/oblt-updatecli-policies/apm/apm-json-specs:0.5.0@sha256:f4065402be6459507660cb644fffa9cdc77a58303ebd7f8f0325002e206cf6a1
     values:
       - .ci/updatecli/values.d/scm.yml
       - .ci/updatecli/values.d/apm-json-specs.yml


### PR DESCRIPTION
Reverts elastic/apm-agent-java#3886

It seems its' not working as expected yet, see 

```
ERROR: no valid depends_on value: "source#agents-json-specs-tarball"
Pipeline "automation: APM agent json specs" failed
Skipping due to:
	targets stage:	"sort targets: no valid depends_on value"
```

https://github.com/elastic/apm-agent-java/actions/runs/12044653954/job/33581977620#step:5:252