### PR TITLE
OS/400 avoids using NOFOLLOW_LINKS

### DIFF
--- a/apm-agent-common/src/main/java/co/elastic/apm/agent/common/JvmRuntimeInfo.java
+++ b/apm-agent-common/src/main/java/co/elastic/apm/agent/common/JvmRuntimeInfo.java
@@ -39,6 +39,7 @@ public class JvmRuntimeInfo {
     private final boolean isHpUx;
     private final boolean isCoretto;
     private final boolean isZos;
+    private final boolean isOs400;
 
     public static JvmRuntimeInfo ofCurrentVM() {
         return CURRENT_VM;
@@ -68,6 +69,7 @@ public class JvmRuntimeInfo {
         isHpUx = version.endsWith("-hp-ux");
         isCoretto = vendorName != null && vendorName.contains("Amazon");
         isZos = (osName != null) && osName.toLowerCase().contains("z/os");
+        isOs400 = (osName != null) && osName.toLowerCase().contains("os/400");
 
         if (isHpUx) {
             // remove extra hp-ux suffix for parsing
@@ -153,7 +155,7 @@ public class JvmRuntimeInfo {
         return isJ9;
     }
 
-    public boolean isHpUx(){
+    public boolean isHpUx() {
         return isHpUx;
     }
 
@@ -171,6 +173,10 @@ public class JvmRuntimeInfo {
 
     public boolean isZos() {
         return isZos;
+    }
+
+    public boolean isOs400() {
+        return isOs400;
     }
 
     @Override

--- a/apm-agent-common/src/main/java/co/elastic/apm/agent/common/util/ResourceExtractionUtil.java
+++ b/apm-agent-common/src/main/java/co/elastic/apm/agent/common/util/ResourceExtractionUtil.java
@@ -101,9 +101,10 @@ public class ResourceExtractionUtil {
                     }
                 }
             } catch (FileAlreadyExistsException e) {
-                try (FileChannel channel = JvmRuntimeInfo.ofCurrentVM().isZos() ?
-                        FileChannel.open(tempFile, READ) :
-                        FileChannel.open(tempFile, READ, NOFOLLOW_LINKS)) {
+                JvmRuntimeInfo jvmRuntimeInfo = JvmRuntimeInfo.ofCurrentVM();
+                try (FileChannel channel = (jvmRuntimeInfo.isZos() || jvmRuntimeInfo.isOs400()) ?
+                    FileChannel.open(tempFile, READ) :
+                    FileChannel.open(tempFile, READ, NOFOLLOW_LINKS)) {
                     // wait until other JVM instances have fully written the file
                     // multiple JVMs can read the file at the same time
                     try (FileLock readLock = channel.lock(0, Long.MAX_VALUE, true)) {


### PR DESCRIPTION
## What does this PR do?
Skips using NOFOLLOW_LINKS file open option when running on OS/400.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [ ] This is a bugfix
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/docs/supported-technologies.asciidoc)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)
