### PR TITLE
remove obsolete tomcat docker image from integration tests

### DIFF
--- a/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/TomcatIT.java
+++ b/integration-tests/application-server-integration-tests/src/test/java/co/elastic/apm/servlet/TomcatIT.java
@@ -40,7 +40,6 @@ public class TomcatIT extends AbstractTomcatIT {
     @Parameterized.Parameters(name = "Tomcat {0}")
     public static Iterable<Object[]> data() {
         return Arrays.asList(new Object[][]{
-            {"8.5.0-jre8"},
             {"9-jre11-slim"},
             {"9.0.39-jdk14-openjdk-oracle"},
             {"jdk8-adoptopenjdk-openj9"},


### PR DESCRIPTION
## What does this PR do?

Removes the tomcat 8.5.0 docker image.

When trying to pull this docker image from CLI with `docker pull tomcat:8.5.0-jre8` we get the following error:
```
8.5.0-jre8: Pulling from library/tomcat
[DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/library/tomcat:8.5.0-jre8 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/
```

This docker image is being used by the `co.elastic.apm.servlet.TomcatIT` integration tests, which fails when run locally and in CI, but does not trigger a failure in CI, which will need proper investigation.

This 9 year old docker image is not maintained anymore, thus the simplest way to move forward is to remove it.

