### PR TITLE
Fix inferred spans logging config option docs

### DIFF
--- a/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
+++ b/apm-agent-plugins/apm-profiling-plugin/src/main/java/co/elastic/apm/agent/profiler/ProfilingConfiguration.java
@@ -60,7 +60,7 @@ public class ProfilingConfiguration extends ConfigurationOptionProvider {
         .key("profiling_inferred_spans_logging_enabled")
         .configurationCategory(PROFILING_CATEGORY)
         .description("By default, async profiler prints warning messages about missing JVM symbols to standard output. \n" +
-            "Set this option to `true` to suppress such messages")
+                     "Set this option to `false` to suppress such messages")
         .dynamic(true)
         .tags("added[1.37.0]")
         .buildWithDefault(true);

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -2818,7 +2818,7 @@ NOTE: This feature is not available on Windows and on OpenJ9
 ==== `profiling_inferred_spans_logging_enabled` (added[1.37.0])
 
 By default, async profiler prints warning messages about missing JVM symbols to standard output. 
-Set this option to `true` to suppress such messages
+Set this option to `false` to suppress such messages
 
 <<configuration-dynamic, image:./images/dynamic-config.svg[] >>
 
@@ -4857,7 +4857,7 @@ Example: `5ms`.
 # profiling_inferred_spans_enabled=false
 
 # By default, async profiler prints warning messages about missing JVM symbols to standard output. 
-# Set this option to `true` to suppress such messages
+# Set this option to `false` to suppress such messages
 #
 # This setting can be changed at runtime
 # Type: Boolean


### PR DESCRIPTION
## What does this PR do?

Based on #3947.
Fixes the invalid docs for the `profiling_inferred_spans_logging_enabled` config option.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.asciidoc](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.asciidoc)~
