### PR TITLE
Test with jdk 24 ea

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -310,6 +310,8 @@ jobs:
             distribution: 'temurin'
           - version: 23
             distribution: 'temurin'
+          - version: 24-ea
+            distribution: 'temurin'
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/maven-goal-jdk


### PR DESCRIPTION
## What does this PR do?

Tests with Java 24 ea to ensure that the blocked bytebuddy-bump #3946 doesn't bite us.
