### PR TITLE
Prevent lambda layer release failure due to eagerly merging version bump

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -196,6 +196,7 @@ jobs:
     name: "Bump versions and create PR"
     needs:
       - await-maven-central-artifact
+      - publish-aws-lambda # The AWS lambda layer publishing breaks if the version-bump PR is accidentally merged before it finished
     uses: ./.github/workflows/pre-post-release.yml
     permissions:
       contents: write


### PR DESCRIPTION
This change should prevent the issue of the previous release from occuring: The version bump PR will now only be created after the AWS lambda layer publishing succeeded.