### PR TITLE
Update labeler.yml

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -58,7 +58,7 @@ jobs:
           })
     - name: Add comment for community PR
       if: contains(steps.is_elastic_member.outputs.result, 'false') && github.actor != 'dependabot[bot]' && github.actor != 'elastic-renovate-prod[bot]' && github.actor != 'elastic-observability-automation[bot]'
-      uses: wow-actions/auto-comment@v1
+      uses: wow-actions/auto-comment@2fc064c21cfb2505de3c5c10e1473b8eb7beca1a  # v1.1.2
       with:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         pullRequestOpened: |


### PR DESCRIPTION
Pinning action to a full length commit SHA [see](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

