### PR TITLE
add internal config option to capture thread info on span/transaction start

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfigurationImpl.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfigurationImpl.java
@@ -883,6 +883,14 @@ public class CoreConfigurationImpl extends ConfigurationOptionProvider implement
         .dynamic(true)
         .buildWithDefault(Arrays.asList(WildcardMatcher.valueOf("*")));
 
+    private final ConfigurationOption<Boolean> captureThreadOnStart = ConfigurationOption.booleanOption()
+        .key("capture_thread_on_start")
+        .configurationCategory(CORE_CATEGORY)
+        .description("Whether to capture tread name and ID as labels.")
+        .dynamic(true)
+        .tags("internal")
+        .buildWithDefault(false);
+
     public boolean isEnabled() {
         return enabled.get();
     }
@@ -1217,4 +1225,8 @@ public class CoreConfigurationImpl extends ConfigurationOptionProvider implement
         }
     }
 
+    @Override
+    public boolean isCaptureThreadOnStart() {
+        return captureThreadOnStart.get();
+    }
 }

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfigurationImpl.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfigurationImpl.java
@@ -886,7 +886,7 @@ public class CoreConfigurationImpl extends ConfigurationOptionProvider implement
     private final ConfigurationOption<Boolean> captureThreadOnStart = ConfigurationOption.booleanOption()
         .key("capture_thread_on_start")
         .configurationCategory(CORE_CATEGORY)
-        .description("Whether to capture tread name and ID as labels.")
+        .description("Whether to capture thread name and ID as labels.")
         .dynamic(true)
         .tags("internal")
         .buildWithDefault(false);

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpanImpl.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/impl/transaction/AbstractSpanImpl.java
@@ -542,6 +542,12 @@ public abstract class AbstractSpanImpl<T extends AbstractSpanImpl<T>> extends Ab
 
         List<WildcardMatcher> baggageToAttach = tracer.getConfig(CoreConfigurationImpl.class).getBaggageToAttach();
         baggage.storeBaggageInAttributes(this, baggageToAttach);
+
+        if (tracer.getConfig(CoreConfigurationImpl.class).isCaptureThreadOnStart()) {
+            Thread currentThread = Thread.currentThread();
+            this.addLabel("thread_id", currentThread.getId());
+            this.addLabel("thread_name", currentThread.getName());
+        }
     }
 
     @Override

--- a/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/CoreConfiguration.java
+++ b/apm-agent-tracer/src/main/java/co/elastic/apm/agent/tracer/configuration/CoreConfiguration.java
@@ -54,6 +54,8 @@ public interface CoreConfiguration {
 
     boolean isUseServletAttributesForExceptionPropagation();
 
+    boolean isCaptureThreadOnStart();
+
     enum EventType {
         /**
          * Request bodies will never be reported


### PR DESCRIPTION
## What does this PR do?

Adds internal `capture_thread_on_start` boolean option to capture thread id and name as label.

option is dynamic and can be changed at runtime if set through external java properties, it's not supported through central configuration backend.