### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/config-circuit-breaker.md
+++ b/docs/reference/config-circuit-breaker.md
@@ -12,7 +12,7 @@ mapped_pages:
 
 A boolean specifying whether the circuit breaker should be enabled or not. When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state. If ANY of the monitors detects a stress indication, the agent will become inactive, as if the [`recording`](/reference/config-core.md#config-recording) configuration option has been set to `false`, thus reducing resource consumption to a minimum. When inactive, the agent continues polling the same monitors in order to detect whether the stress state has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the agent will resume and become fully functional.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -42,7 +42,7 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `5s`.
 
 The threshold used by the GC monitor to rely on for identifying heap stress. The same threshold will be used for all heap pools, so that if ANY has a usage percentage that crosses it, the agent will consider it as a heap stress. The GC monitor relies only on memory consumption measured after a recent GC.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -57,7 +57,7 @@ The threshold used by the GC monitor to rely on for identifying heap stress. The
 
 The threshold used by the GC monitor to rely on for identifying when the heap is not under stress . If `stress_monitor_gc_stress_threshold` has been crossed, the agent will consider it a heap-stress state. In order to determine that the stress state is over, percentage of occupied memory in ALL heap pools should be lower than this threshold. The GC monitor relies only on memory consumption measured after a recent GC.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -72,7 +72,7 @@ The threshold used by the GC monitor to rely on for identifying when the heap is
 
 The minimal time required in order to determine whether the system is either currently under stress, or that the stress detected previously has been relieved. All measurements during this time must be consistent in comparison to the relevant threshold in order to detect a change of stress state. Must be at least `1m`.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `ms`, `s` and `m`. Example: `1m`.
 
@@ -89,7 +89,7 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `1m`.
 
 The threshold used by the system CPU monitor to detect system CPU stress. If the system CPU crosses this threshold for a duration of at least `stress_monitor_cpu_duration_threshold`, the monitor considers this as a stress state.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -104,7 +104,7 @@ The threshold used by the system CPU monitor to detect system CPU stress. If the
 
 The threshold used by the system CPU monitor to determine that the system is not under CPU stress. If the monitor detected a CPU stress, the measured system CPU needs to be below this threshold for a duration of at least `stress_monitor_cpu_duration_threshold` in order for the monitor to decide that the CPU stress has been relieved.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |

--- a/docs/reference/config-core.md
+++ b/docs/reference/config-core.md
@@ -19,7 +19,7 @@ A boolean specifying if the agent should be recording or not. When recording, th
 
 You can use this setting to dynamically disable Elastic APM at runtime.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -57,7 +57,7 @@ Changing this value at runtime can slow down the application temporarily.
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -212,7 +212,7 @@ By default, the agent will sample every transaction (e.g. request to your servic
 
 Value will be rounded with 4 significant digits, as an example, value *0.55555* will be rounded to `0.5556`
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -233,7 +233,7 @@ Setting an upper limit will prevent overloading the agent and the APM server wit
 
 A message will be logged when the max number of spans has been exceeded but only at a rate of once every 5 minutes to ensure performance is not impacted.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -281,7 +281,7 @@ Review the data captured by Elastic APM carefully to make sure it does not captu
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -301,7 +301,7 @@ Changing this value at runtime can slow down the application temporarily.
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -321,7 +321,7 @@ Changing this value at runtime can slow down the application temporarily.
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -341,7 +341,7 @@ Changing this value at runtime can slow down the application temporarily. Settin
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -358,7 +358,7 @@ When reporting exceptions, un-nests the exceptions matching the wildcard pattern
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -386,7 +386,7 @@ Exception inheritance is not supported, thus you have to explicitly list all the
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -420,7 +420,7 @@ Request bodies often contain sensitive values like passwords, credit card number
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Valid options: `off`, `errors`, `transactions`, `all`
 
@@ -442,7 +442,7 @@ Setting this to `false` reduces network bandwidth, disk space and object allocat
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -488,7 +488,7 @@ A boolean specifying if the agent should instrument pre-Java-1.4 bytecode.
 
 When set to true, disables log sending, metrics and trace collection. Trace context propagation and log correlation will stay active. Note that in contrast to [`disable_send`](/reference/config-reporter.md#config-disable-send) the agent will still connect to the APM-server for fetching configuration updates and health checks.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -576,7 +576,7 @@ Changing this value at runtime can slow down the application temporarily.
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -623,7 +623,7 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `0ms`.
 
 When enabled, the agent will make periodic requests to the APM Server to fetch updated configuration. The frequency of the periodic request is driven by the `Cache-Control` header returned from APM Server/Integration, falling back to 5 minutes if not defined.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -691,7 +691,7 @@ To enable [distributed tracing](docs-content://solutions/observability/apm/trace
 
 When this setting is `true`, the agent will also add the header `elastic-apm-traceparent` for backwards compatibility with older versions of Elastic APM agents.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -711,7 +711,7 @@ Disabling `tracecontext` headers injection means that [distributed tracing](docs
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -730,7 +730,7 @@ The attempt fails if they lead up to a span that can’t be discarded. Spans tha
 
 However, external calls that don’t propagate context, such as calls to a database, can be discarded using this threshold.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `ms`, `s` and `m`. Example: `0ms`.
 
@@ -777,7 +777,7 @@ With this option, you can group transaction names that contain dynamic parts wit
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -805,7 +805,7 @@ Starting with Elastic Observability 8.2, span links are visible in trace views.
 
 This option is case-insensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Valid options: `continue`, `restart`, `restart_external`
 
@@ -822,7 +822,7 @@ Valid options: `continue`, `restart`, `restart_external`
 
 If any baggage key matches any of the patterns provided via this config option, the corresponding baggage key and value will be automatically stored on the corresponding transactions, spans and errors. The baggage keys will be prefixed with "baggage." on storage.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |

--- a/docs/reference/config-datastore.md
+++ b/docs/reference/config-datastore.md
@@ -14,7 +14,7 @@ The URL path patterns for which the APM agent will capture the request body of o
 
 The captured request body (if any) is stored on the `span.db.statement` field. Captured request bodies are truncated to a maximum length defined by [`long_field_max_length` (performance [1.37.0])](/reference/config-core.md#config-long-field-max-length). This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -31,7 +31,7 @@ MongoDB command names for which the command document will be captured, limited t
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |

--- a/docs/reference/config-http.md
+++ b/docs/reference/config-http.md
@@ -16,7 +16,7 @@ The defaults end with a wildcard so that content types like `text/plain; charset
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -35,7 +35,7 @@ This property should be set to an array containing one or more strings. When an 
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -54,7 +54,7 @@ When an incoming HTTP request is detected, the User-Agent from the request heade
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -74,7 +74,7 @@ If your URLs contain path parameters like `/user/$userId`, you should be very ca
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -95,7 +95,7 @@ With this option, you can group several URL paths together by using a wildcard e
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -119,7 +119,7 @@ Currently only support for Apache Http Client v4 and v5, HttpUrlConnection, Spri
 
 The body will be stored in the `labels.http_request_body_content` field on the span documents.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |

--- a/docs/reference/config-huge-traces.md
+++ b/docs/reference/config-huge-traces.md
@@ -12,7 +12,7 @@ mapped_pages:
 
 Setting this option to true will enable span compression feature. Span compression reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that some information such as DB statements of all the compressed spans will not be collected.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -27,7 +27,7 @@ Setting this option to true will enable span compression feature. Span compressi
 
 Consecutive spans that are exact match and that are under this threshold will be compressed into a single composite span. This option does not apply to composite spans. This reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that the DB statements of all the compressed spans will not be collected.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `ms`, `s` and `m`. Example: `50ms`.
 
@@ -44,7 +44,7 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `50ms`.
 
 Consecutive spans to the same destination that are under this threshold will be compressed into a single composite span. This option does not apply to composite spans. This reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that the DB statements of all the compressed spans will not be collected.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `ms`, `s` and `m`. Example: `0ms`.
 
@@ -66,7 +66,7 @@ If a span propagates distributed tracing ids, it will not be ignored, even if it
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `us`, `ms`, `s` and `m`. Example: `0ms`.
 

--- a/docs/reference/config-jmx.md
+++ b/docs/reference/config-jmx.md
@@ -100,7 +100,7 @@ The resulting documents in Elasticsearch look similar to this:
 }
 ```
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |

--- a/docs/reference/config-logging.md
+++ b/docs/reference/config-logging.md
@@ -17,7 +17,7 @@ Sets the logging level for the agent. This option is case-insensitive.
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Valid options: `OFF`, `ERROR`, `CRITICAL`, `WARN`, `WARNING`, `INFO`, `DEBUG`, `TRACE`
 
@@ -73,7 +73,7 @@ while `SHADE` and `REPLACE` options are only relevant to file log appenders, the
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Valid options: `OFF`, `SHADE`, `REPLACE`, `OVERRIDE`
 
@@ -189,7 +189,7 @@ Note that logs can get lost if the agent can’t keep up with the logs, if APM S
 
 For better delivery guarantees, it’s recommended to ship ECS JSON log files with Filebeat See also [`log_ecs_reformatting`](#config-log-ecs-reformatting). Log sending does not currently support custom MDC fields, `log_ecs_reformatting` and shipping the logs with Filebeat must be used if custom MDC fields are required.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |

--- a/docs/reference/config-messaging.md
+++ b/docs/reference/config-messaging.md
@@ -16,7 +16,7 @@ This property should be set to an array containing one or more strings. When set
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -48,7 +48,7 @@ Starting from version 1.43.0, the classes that are part of the *application_pack
 
 Defines whether the agent should use the exchanges, the routing key or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE`, `ROUTING_KEY` and `EXCHANGE`. Note that `QUEUE` only works when using RabbitMQ via spring-amqp and `ROUTING_KEY` only works for the non spring-client.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Valid options: `EXCHANGE`, `QUEUE`, `ROUTING_KEY`
 

--- a/docs/reference/config-metrics.md
+++ b/docs/reference/config-metrics.md
@@ -17,7 +17,7 @@ Setting this to `false` can lead to mapping conflicts as dots indicate nesting i
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |

--- a/docs/reference/config-profiling.md
+++ b/docs/reference/config-profiling.md
@@ -67,7 +67,7 @@ This feature is not available on Windows and on OpenJ9
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -82,7 +82,7 @@ This feature is not available on Windows and on OpenJ9
 
 By default, async profiler prints warning messages about missing JVM symbols to standard output. Set this option to `false` to suppress such messages
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -97,7 +97,7 @@ By default, async profiler prints warning messages about missing JVM symbols to 
 
 The frequency at which stack traces are gathered within a profiling session. The lower you set it, the more accurate the durations will be. This comes at the expense of higher overhead and more spans for potentially irrelevant operations. The minimal duration of a profiling-inferred span is the same as the value of this setting.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `ms`, `s` and `m`. Example: `50ms`.
 
@@ -114,7 +114,7 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `50ms`.
 
 The minimum duration of an inferred span. Note that the min duration is also implicitly set by the sampling interval. However, increasing the sampling interval also decreases the accuracy of the duration of inferred spans.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `ms`, `s` and `m`. Example: `0ms`.
 
@@ -133,7 +133,7 @@ If set, the agent will only create inferred spans for methods which match this l
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -150,7 +150,7 @@ Excludes classes for which no profiler-inferred spans should be created.
 
 This option supports the wildcard `*`, which matches zero or more characters. Examples: `/foo/*/bar/*/baz*`, `*foo*`. Matching is case insensitive by default. Prepending an element with `(?-i)` makes the matching case sensitive.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |

--- a/docs/reference/config-reporter.md
+++ b/docs/reference/config-reporter.md
@@ -14,7 +14,7 @@ This string is used to ensure that only your agents can send data to your APM se
 
 Both the agents and the APM server have to be configured with the same secret token. Use if APM Server requires a token.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -31,7 +31,7 @@ This string is used to ensure that only your agents can send data to your APM se
 
 Agents can use API keys as a replacement of secret token, APM server can have multiple API keys. When both secret token and API key are used, API key has priority and secret token is ignored. Use if APM Server requires an API key.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -55,7 +55,7 @@ This configuration can only be reloaded dynamically as of 1.8.0
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -81,7 +81,7 @@ This configuration is specific to the Java agent and does not align with any oth
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -114,7 +114,7 @@ If timeouts are disabled or set to a high value, your app could experience memor
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `ms`, `s` and `m`. Example: `5s`.
 
@@ -183,7 +183,7 @@ This value has to be lower than the APM Server’s `read_timeout` setting.
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `ms`, `s` and `m`. Example: `10s`.
 
@@ -202,7 +202,7 @@ The maximum total compressed size of the request body which is sent to the APM s
 
 Allowed byte units are `b`, `kb` and `mb`. `1kb` is equal to `1024b`.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |

--- a/docs/reference/config-stacktrace.md
+++ b/docs/reference/config-stacktrace.md
@@ -25,7 +25,7 @@ the instrumentation aspect of this configuration option - specifying which class
 ::::
 
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -40,7 +40,7 @@ the instrumentation aspect of this configuration option - specifying which class
 
 Setting it to 0 will disable stack trace collection. Any positive integer value will be used as the maximum number of frames to collect. Setting it -1 means that all frames will be collected.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -57,7 +57,7 @@ While this is very helpful to find the exact place in your code that causes the 
 
 To disable stack trace collection for spans completely, set the value to `-1ms`.
 
-[![dynamic config](/reference/images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
+[![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)
 
 Supports the duration suffixes `ms`, `s` and `m`. Example: `5ms`.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -8,13 +8,13 @@ mapped_pages:
 To adapt the Elastic APM Java agent to your needs, you can configure it using one of the methods below, listed in descending order of precedence:
 
 1) [Central configuration](docs-content://solutions/observability/apm/apm-agent-central-configuration.md)
-:   Configure the Agent in the Kibana APM app. [![dynamic config](/reference/images/dynamic-config.svg "") ](#configuration-dynamic)
+:   Configure the Agent in the Kibana APM app. [![dynamic config](images/dynamic-config.svg "") ](#configuration-dynamic)
 
 2) Properties file
-:   The `elasticapm.properties` file is located in the same folder as the agent jar, or provided through the [`config_file`](/reference/config-core.md#config-config-file) option. ![dynamic config](/reference/images/dynamic-config.svg "")
+:   The `elasticapm.properties` file is located in the same folder as the agent jar, or provided through the [`config_file`](/reference/config-core.md#config-config-file) option. ![dynamic config](images/dynamic-config.svg "")
 
 3) Java system properties
-:   All configuration keys are prefixed with `elastic.apm.`<br> ![dynamic config](/reference/images/dynamic-config.svg "")
+:   All configuration keys are prefixed with `elastic.apm.`<br> ![dynamic config](images/dynamic-config.svg "")
 
 4) Environment variables
 :   All configuration keys are in uppercase and prefixed with `ELASTIC_APM_`.
@@ -29,7 +29,7 @@ To adapt the Elastic APM Java agent to your needs, you can configure it using on
 :   Defined for each configuration.
 
 
-## Dynamic configuration ![dynamic config](/reference/images/dynamic-config.svg "") [configuration-dynamic]
+## Dynamic configuration ![dynamic config](images/dynamic-config.svg "") [configuration-dynamic]
 
 Configuration options marked with Dynamic true can be changed at runtime when set from supported sources:
 

--- a/docs/reference/how-to-find-slow-methods.md
+++ b/docs/reference/how-to-find-slow-methods.md
@@ -15,7 +15,7 @@ Identifying a problematic service is only half of the battle when diagnosing app
 
 Find out which part of your code is making your application slow by periodically recording running methods with a sampling-based profiler.
 
-![green check](/reference/images/green-check.svg "") Very low overhead.<br> ![green check](/reference/images/green-check.svg "") No code changes required.<br> ![red x](/reference/images/red-x.svg "") Does not work on Windows and on OpenJ9.<br> ![red x](/reference/images/red-x.svg "") The duration of profiler-inferred spans are not exact measurements, only estimates.
+![green check](images/green-check.svg "") Very low overhead.<br> ![green check](images/green-check.svg "") No code changes required.<br> ![red x](images/red-x.svg "") Does not work on Windows and on OpenJ9.<br> ![red x](images/red-x.svg "") The duration of profiler-inferred spans are not exact measurements, only estimates.
 
 [Learn more](/reference/method-sampling-based.md)
 
@@ -27,7 +27,7 @@ Find out which part of your code is making your application slow by periodically
 
 Use the API or OpenTracing bridge to manually create spans for methods of interest.
 
-![green check](/reference/images/green-check.svg "") Most flexible.<br> ![red x](/reference/images/red-x.svg "") Incorrect API usage may lead to invalid traces (scope leaks).
+![green check](images/green-check.svg "") Most flexible.<br> ![red x](images/red-x.svg "") Incorrect API usage may lead to invalid traces (scope leaks).
 
 [Learn more](/reference/method-api.md)
 
@@ -36,7 +36,7 @@ Use the API or OpenTracing bridge to manually create spans for methods of intere
 
 Annotations can be placed on top of methods to automatically create spans for them.
 
-![green check](/reference/images/green-check.svg "") Easier and more robust than the API.<br> ![red x](/reference/images/red-x.svg "") Less flexible on its own, but can be combined with the API.
+![green check](images/green-check.svg "") Easier and more robust than the API.<br> ![red x](images/red-x.svg "") Less flexible on its own, but can be combined with the API.
 
 [Learn more](/reference/method-annotations.md)
 
@@ -45,7 +45,7 @@ Annotations can be placed on top of methods to automatically create spans for th
 
 Use a configuration option to specify additional methods to instrument.
 
-![green check](/reference/images/green-check.svg "") No need to modify source code.<br> ![green check](/reference/images/green-check.svg "") Possible to monitor code in third-party libraries.<br> ![green check](/reference/images/green-check.svg "") Match methods via wildcards.<br> ![red x](/reference/images/red-x.svg "") Easy to overuse which hurts runtime and startup performance.
+![green check](images/green-check.svg "") No need to modify source code.<br> ![green check](images/green-check.svg "") Possible to monitor code in third-party libraries.<br> ![green check](images/green-check.svg "") Match methods via wildcards.<br> ![red x](images/red-x.svg "") Easy to overuse which hurts runtime and startup performance.
 
 [Learn more](/reference/method-config-based.md)
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 