### PR TITLE
add missing micrometer for lettuce integration test

### DIFF
--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/pom.xml
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/pom.xml
@@ -28,6 +28,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <version>1.15.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
             <version>(5.0.5.RELEASE,]</version>


### PR DESCRIPTION
## What does this PR do?

fixes class not found error triggered during lettuce integration test

