### PR TITLE
dependabot with codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @elastic/apm-agent-java

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,8 +13,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
-    reviewers:
-      - "@elastic/apm-agent-java"
     allow:
       - dependency-name: "com.lmax:disruptor"
       - dependency-name: "org.jctools:jctools-core"


### PR DESCRIPTION
## What does this PR do?

Handle deprecated dependabot `reviewers` field and replace it with `.github/CODEOWNERS`.
Reference: https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/

