### PR TITLE
fix codeowners ordering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
+* @elastic/apm-agent-java
 /.github/actions/  @elastic/apm-agent-java @elastic/observablt-ci
 /.github/workflows/  @elastic/apm-agent-java @elastic/observablt-ci
-* @elastic/apm-agent-java


### PR DESCRIPTION
## What does this PR do?

Fixes reverse ordering in codeowners: last rule to match has priority, thus most generic must come first.
