### PR TITLE
Limit attribute cache sizes on Otel metrics bridge

### DIFF
--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -9,7 +9,7 @@ This file contains all changes which are not released yet.
 
 # Fixes
 <!--FIXES-START-->
-
+* Prevent potential memory pressure by limiting OpenTelemetry metrics bridge attribute cache sizes - [#4123](https://github.com/elastic/apm-agent-java/pull/4123)
 <!--FIXES-END-->
 # Features and enhancements
 <!--ENHANCEMENTS-START-->

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-v1_14/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/BridgeFactoryV1_14.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-v1_14/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/BridgeFactoryV1_14.java
@@ -138,14 +138,15 @@ public class BridgeFactoryV1_14 implements BridgeFactory {
     }
 
     public final ProxyAttributes convertAttributes(Attributes attributes) {
-        ProxyAttributes cached = convertedAttributes.get(attributes);
-        if (cached == null) {
-            cached = doConvertAttributes(attributes);
-            if (cached != null && convertedAttributes.approximateSize() < MAX_ATTRIBUTE_CACHE_SIZE) {
-                convertedAttributes.put(attributes, cached);
+        ProxyAttributes result = convertedAttributes.get(attributes);
+        if (result == null) {
+            result = doConvertAttributes(attributes);
+            // A slight overshoot of the limit is possible due to concurrency, but this is fine for us
+            if (result != null && convertedAttributes.approximateSize() < MAX_ATTRIBUTE_CACHE_SIZE) {
+                convertedAttributes.put(attributes, result);
             }
         }
-        return cached;
+        return result;
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -164,14 +165,15 @@ public class BridgeFactoryV1_14 implements BridgeFactory {
 
     @Nullable
     public ProxyAttributeKey<?> convertAttributeKey(AttributeKey<?> key) {
-        ProxyAttributeKey<?> cached = convertedAttributeKeys.get(key);
-        if (cached == null) {
-            cached = doConvertAttributeKey(key);
-            if (cached != null && convertedAttributeKeys.approximateSize() < MAX_ATTRIBUTE_KEY_CACHE_SIZE) {
-                convertedAttributeKeys.put(key, cached);
+        ProxyAttributeKey<?> result = convertedAttributeKeys.get(key);
+        if (result == null) {
+            result = doConvertAttributeKey(key);
+            // A slight overshoot of the limit is possible due to concurrency, but this is fine for us
+            if (result != null && convertedAttributeKeys.approximateSize() < MAX_ATTRIBUTE_KEY_CACHE_SIZE) {
+                convertedAttributeKeys.put(key, result);
             }
         }
-        return cached;
+        return result;
     }
 
     @Nullable

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-v1_14/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/BridgeFactoryV1_14.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-v1_14/src/main/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/BridgeFactoryV1_14.java
@@ -108,8 +108,15 @@ public class BridgeFactoryV1_14 implements BridgeFactory {
 
     private static volatile BridgeFactoryV1_14 instance;
 
-    private final WeakMap<AttributeKey<?>, ProxyAttributeKey<?>> convertedAttributeKeys;
-    private final WeakMap<io.opentelemetry.api.common.Attributes, ProxyAttributes> convertedAttributes;
+    // Visible for testing
+    static final int MAX_ATTRIBUTE_KEY_CACHE_SIZE = 2048;
+    // Visible for testing
+    static final int MAX_ATTRIBUTE_CACHE_SIZE = 2048;
+
+    // Visible for testing
+    final WeakMap<AttributeKey<?>, ProxyAttributeKey<?>> convertedAttributeKeys;
+    // Visible for testing
+    final WeakMap<io.opentelemetry.api.common.Attributes, ProxyAttributes> convertedAttributes;
 
     public BridgeFactoryV1_14() {
         convertedAttributeKeys = WeakConcurrent.buildMap();
@@ -134,7 +141,7 @@ public class BridgeFactoryV1_14 implements BridgeFactory {
         ProxyAttributes cached = convertedAttributes.get(attributes);
         if (cached == null) {
             cached = doConvertAttributes(attributes);
-            if (cached != null) {
+            if (cached != null && convertedAttributes.approximateSize() < MAX_ATTRIBUTE_CACHE_SIZE) {
                 convertedAttributes.put(attributes, cached);
             }
         }
@@ -160,7 +167,7 @@ public class BridgeFactoryV1_14 implements BridgeFactory {
         ProxyAttributeKey<?> cached = convertedAttributeKeys.get(key);
         if (cached == null) {
             cached = doConvertAttributeKey(key);
-            if (cached != null) {
+            if (cached != null && convertedAttributeKeys.approximateSize() < MAX_ATTRIBUTE_KEY_CACHE_SIZE) {
                 convertedAttributeKeys.put(key, cached);
             }
         }

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-v1_14/src/test/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/BridgeFactoryV1_14Test.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metrics-bridge-parent/apm-opentelemetry-metrics-bridge-v1_14/src/test/java/co/elastic/apm/agent/opentelemetry/metrics/bridge/BridgeFactoryV1_14Test.java
@@ -1,0 +1,28 @@
+package co.elastic.apm.agent.opentelemetry.metrics.bridge;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class BridgeFactoryV1_14Test {
+
+    @Test
+    void checkAttributeCachesLimited() {
+        List<Attributes> attributes = LongStream.range(0, 10_000)
+            .mapToObj(i -> Attributes.of(AttributeKey.longKey("foo-" + i), i))
+            .collect(Collectors.toList());
+
+        BridgeFactoryV1_14 bridge = new BridgeFactoryV1_14();
+        attributes.forEach(bridge::convertAttributes);
+
+        assertThat(bridge.convertedAttributes.approximateSize()).isEqualTo(BridgeFactoryV1_14.MAX_ATTRIBUTE_CACHE_SIZE);
+        assertThat(bridge.convertedAttributeKeys.approximateSize()).isEqualTo(BridgeFactoryV1_14.MAX_ATTRIBUTE_KEY_CACHE_SIZE);
+    }
+
+}


### PR DESCRIPTION
## What does this PR do?

Fixes #4122.
The limits are just reasonable estimates, it is not dramatic if a value doesn't make it into the cache. In this case, it means just a slightly increased allocation rate.

If necessary at a point in the future, we could make the limits configurable, but I think that this is not needed for now.

## Checklist

- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [x] I have added tests that would fail without this fix
