### PR TITLE
add support and test for mongodb 5.x

### DIFF
--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -10,10 +10,11 @@ This file contains all changes which are not released yet.
 # Fixes
 <!--FIXES-START-->
 * Prevent potential memory pressure by limiting OpenTelemetry metrics bridge attribute cache sizes - [#4123](https://github.com/elastic/apm-agent-java/pull/4123)
-* Fix `NoSuchMethodError` for Kafka 4136clients - [#4136](https://github.com/elastic/apm-agent-java/pull/4136)
+* Fix `NoSuchMethodError` for Kafka clients - [#4136](https://github.com/elastic/apm-agent-java/pull/4136)
 <!--FIXES-END-->
 # Features and enhancements
 <!--ENHANCEMENTS-START-->
+* Add support for Mongodb 5.x instrumentation - [#4139](https://github.com/elastic/apm-agent-java/pull/4139)
 
 <!--ENHANCEMENTS-END-->
 # Deprecations

--- a/apm-agent-plugins/apm-mongodb/apm-mongodb-common/src/test/java/co/elastic/apm/agent/mongodb/AbstractMongoClientInstrumentationIT.java
+++ b/apm-agent-plugins/apm-mongodb/apm-mongodb-common/src/test/java/co/elastic/apm/agent/mongodb/AbstractMongoClientInstrumentationIT.java
@@ -43,6 +43,12 @@ import static org.mockito.Mockito.doReturn;
 
 public abstract class AbstractMongoClientInstrumentationIT extends AbstractInstrumentationTest {
 
+    // needs to be updated from time to time as support for older versions is being removed in drivers:
+    // - 3.6 support has been dropped in 5.2.0
+    // - 4.0 support has been dropped in 5.5.0
+    // see https://github.com/mongodb/mongo-java-driver/releases for updates on such changes
+    private static final String MONGO_IMAGE = "mongo:4.4";
+
     protected static GenericContainer<?> container;
     protected static final String DB_NAME = "testdb";
     protected static final String COLLECTION_NAME = "testcollection";
@@ -52,7 +58,7 @@ public abstract class AbstractMongoClientInstrumentationIT extends AbstractInstr
 
     @BeforeClass
     public static void startContainer() {
-        container = new GenericContainer<>("mongo:3.4")
+        container = new GenericContainer<>(MONGO_IMAGE)
             .withExposedPorts(PORT)
             .withCreateContainerCmdModifier(TestContainersUtils.withMemoryLimit(2048));
         container.start();

--- a/apm-agent-plugins/apm-mongodb/apm-mongodb4-plugin/src/main/java/co/elastic/apm/agent/mongodb/v4/Mongo4Instrumentation.java
+++ b/apm-agent-plugins/apm-mongodb/apm-mongodb4-plugin/src/main/java/co/elastic/apm/agent/mongodb/v4/Mongo4Instrumentation.java
@@ -32,8 +32,8 @@ public abstract class Mongo4Instrumentation extends ElasticApmInstrumentation {
 
     @Override
     public ElementMatcher.Junction<ProtectionDomain> getProtectionDomainPostFilter() {
-        // only use this instrumentation for 4.x
-        return implementationVersionGte("4").and(not(implementationVersionGte("5")));
+        // only use this instrumentation for 4.x and 5.x
+        return implementationVersionGte("4");
     }
 
     @Override

--- a/apm-agent-plugins/apm-mongodb/apm-mongodb4-plugin/src/test/java/co/elastic/apm/agent/mongodb/v4/Mongo4VersionIT.java
+++ b/apm-agent-plugins/apm-mongodb/apm-mongodb4-plugin/src/test/java/co/elastic/apm/agent/mongodb/v4/Mongo4VersionIT.java
@@ -44,7 +44,7 @@ public class Mongo4VersionIT {
             "org.mongodb:mongodb-driver-core:" + version,
             "org.mongodb:bson:" + version));
 
-        if(legacyDriver){
+        if (legacyDriver) {
             dependencies.add("org.mongodb:mongodb-driver-legacy:" + version);
         }
 
@@ -63,6 +63,17 @@ public class Mongo4VersionIT {
         // driver are also explicitly included, over time the driver has moved to single monolithic jar to having more
         // and more dependencies instead of embedding them.
         List<String> versions = Arrays.asList(
+            "5.5.0",
+            "5.4.0",
+            "5.3.0",
+            "5.2.0",
+            "5.1.0",
+            "5.0.0",
+            "4.11.0",
+            "4.10.0",
+            "4.9.0",
+            "4.8.0",
+            "4.7.0",
             "4.6.0",
             "4.5.0",
             "4.4.0",

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -114,7 +114,7 @@ The Elastic APM Java agent has generic support for the Servlet API 3+. However, 
 | Redis Lettuce | 3.4+ | The agent creates spans for interactions with the Lettuce client. | 1.13.0 |
 | Redis Redisson | 2.1.5+ | The agent creates spans for interactions with the Redisson client. | 1.15.0 |
 | MongoDB driver | 3.x | The agent creates spans for interactions with the MongoDB driver. At the moment, only the synchronous driver (mongo-java-driver) is supported. The asynchronous and reactive drivers are currently not supported.<br> The name of the span is `<db>.<collection>.<command>`. The actual query will not be recorded. | 1.12.0 |
-| MongoDB Sync Driver | 4.x | The agent creates spans for interactions with the MongoDB 4.x sync driver.This provides support for `org.mongodb:mongodb-driver-sync` | 1.34.0 |
+| MongoDB Sync Driver | 4.x, 5.x | The agent creates spans for interactions with the MongoDB 4.x and 5.x sync driver. This provides support for `org.mongodb:mongodb-driver-sync` | 1.34.0 |
 | Cassandra | 2.x+ | The agent creates spans for interactions with the Cassandra Datastax drivers.This provides support for `com.datastax.cassandra:cassandra-driver-core` and`com.datastax.oss:java-driver-core` | 1.23.0 |
 | AWS DynamoDB | 1.x, 2.x | The agent creates spans for interactions with the AWS DynamoDb service through the AWS Java SDK. | 1.31.0, 2.21+ since 1.44.0 |
 | AWS S3 | 1.x, 2.x | The agent creates spans for interactions with the AWS S3 service through the AWS Java SDK. | 1.31.0, 2.21+ since 1.44.0 |


### PR DESCRIPTION
Fixes #3956 

Instrumentation from 4.x driver is reused as the methods instrumented are the same, however there might still be uncovered corner-cases, but this should provide a good first step.