### PR TITLE
Switch to new maven-central publishing plugin

### DIFF
--- a/.ci/settings.xml
+++ b/.ci/settings.xml
@@ -6,12 +6,7 @@
     </pluginGroups>
     <servers>
         <server>
-            <id>sonatype-nexus-snapshots</id>
-            <username>${env.SERVER_USERNAME}</username>
-            <password>${env.SERVER_PASSWORD}</password>
-        </server>
-        <server>
-            <id>sonatype-nexus-staging</id>
+            <id>central</id>
             <username>${env.SERVER_USERNAME}</username>
             <password>${env.SERVER_PASSWORD}</password>
         </server>

--- a/apm-agent-benchmarks/pom.xml
+++ b/apm-agent-benchmarks/pom.xml
@@ -18,7 +18,6 @@
         <maven.compiler.showWarnings>false</maven.compiler.showWarnings>
         <maven.compiler.errorprone>false</maven.compiler.errorprone>
         <animal.sniffer.skip>true</animal.sniffer.skip>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
     </properties>
 

--- a/apm-agent-bootstrap/pom.xml
+++ b/apm-agent-bootstrap/pom.xml
@@ -12,7 +12,6 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
 
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
 

--- a/apm-agent-builds/pom.xml
+++ b/apm-agent-builds/pom.xml
@@ -12,7 +12,6 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
     </properties>
 

--- a/apm-agent-cached-lookup-key/pom.xml
+++ b/apm-agent-cached-lookup-key/pom.xml
@@ -18,7 +18,6 @@
     </licenses>
 
     <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
     </properties>
 

--- a/apm-agent-common/pom.xml
+++ b/apm-agent-common/pom.xml
@@ -11,7 +11,6 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
     </properties>
 

--- a/apm-agent-core/pom.xml
+++ b/apm-agent-core/pom.xml
@@ -18,7 +18,6 @@
     </licenses>
 
     <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
     </properties>
 

--- a/apm-agent-lambda-layer/pom.xml
+++ b/apm-agent-lambda-layer/pom.xml
@@ -11,7 +11,6 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
     </properties>
 

--- a/apm-agent-plugins/pom.xml
+++ b/apm-agent-plugins/pom.xml
@@ -13,7 +13,6 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
     </properties>
 

--- a/elastic-apm-agent-premain/pom.xml
+++ b/elastic-apm-agent-premain/pom.xml
@@ -11,7 +11,6 @@
     <name>${project.groupId}:${project.artifactId}</name>
 
     <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
     </properties>
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -33,7 +33,6 @@
     </modules>
 
     <properties>
-        <maven-deploy-plugin.skip>true</maven-deploy-plugin.skip>
         <apm-agent-parent.base.dir>${project.basedir}/..</apm-agent-parent.base.dir>
         <!-- integration tests do not require javadoc -->
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -42,17 +42,6 @@
         </developer>
     </developers>
 
-    <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
-
     <prerequisites>
         <maven>3.8.3</maven>
     </prerequisites>
@@ -76,16 +65,6 @@
         <module>apm-agent-cached-lookup-key</module>
         <module>apm-agent-tracer</module>
         <module>apm-opentracing</module>
-        <!-- IMPORTANT:
-            For the nexus deployment to work correctly, the last project in the build order needs to have deployment
-            enabled (maven-deploy-plugin.skip must be false).
-            The reason is that for SNAPSHOT builds the upload is performed by the nexus-staging-maven-plugin
-            after the last project build and EVERYTHING is skipped if this project is not part of the deployment.
-            See the documentation (https://github.com/sonatype/nexus-maven-plugins/tree/main/staging/maven-plugin#plugin-flags)
-            and the related issue (https://issues.sonatype.org/browse/NEXUS-9138).
-
-            You can verify the build order by executing ./mvnw clean and looking for the "Reactor Build Order log".
-        -->
     </modules>
 
     <properties>
@@ -106,12 +85,6 @@
 
         <!-- do not use javax.tools and use javac instead, work around https://bugs.openjdk.java.net/browse/JDK-8216202 -->
         <maven.compiler.forceJavacCompilerUse>true</maven.compiler.forceJavacCompilerUse>
-
-        <!--
-        By default, artifacts are part of the deployment (mvn deploy:deploy).
-        But the artifacts of some projects should not be deployed (to maven central for example).
-        -->
-        <maven-deploy-plugin.skip>false</maven-deploy-plugin.skip>
 
         <!-- -dependencies versions -->
         <version.error_prone>2.2.0</version.error_prone>
@@ -384,16 +357,16 @@
                 <version>2.16.2</version>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <!-- The Base URL of Nexus instance where we want to stage -->
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <!-- The server "id" element from settings to use authentication from -->
-                    <serverId>sonatype-nexus-staging</serverId>
-                    <skipNexusStagingDeployMojo>${maven-deploy-plugin.skip}</skipNexusStagingDeployMojo>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <excludeArtifacts>
+                        apm-agent-parent,apm-agent-common,apm-agent-cached-lookup-key,apm-agent-bootstrap,apm-agent-core,elastic-apm-agent-premain,apm-agent-plugins,apm-httpclient-core,apm-apache-httpclient,apm-apache-httpclient3-plugin,apm-apache-httpclient-common,apm-apache-httpclient4-plugin,apm-apache-httpclient5-plugin,apm-api-plugin,apm-asynchttpclient-plugin,apm-java-concurrent-plugin,apm-cassandra,apm-cassandra-core-plugin,apm-cassandra3-plugin,apm-cassandra4-plugin,apm-okhttp-plugin,apm-dubbo-plugin,apm-es-restclient-plugin,apm-es-restclient-plugin-common,apm-es-restclient-plugin-5_6,apm-es-restclient-plugin-6_4,apm-es-restclient-plugin-7_x,apm-es-restclient-plugin-8_x,apm-grails-plugin,apm-grpc,apm-grpc-plugin,apm-hibernate-search-plugin,apm-hibernate-search-plugin-common,apm-hibernate-search-plugin-5_x,apm-hibernate-search-plugin-6_x,apm-httpserver-core,apm-servlet-plugin,apm-javalin-plugin,apm-jaxrs-plugin,apm-jaxws-plugin,apm-jdbc-plugin,apm-jdk-httpclient-plugin,apm-jdk-httpserver-plugin,apm-redis-plugin,apm-redis-common,apm-jedis-plugin,apm-jedis-4-plugin,apm-jms-plugin,apm-jms-plugin-base,apm-jms-javax,apm-jms-jakarta,apm-jmx-plugin,apm-jsf-plugin,apm-kafka-plugin,apm-kafka-base-plugin,apm-kafka-headers-plugin,apm-kafka-spring-plugin,apm-lettuce-plugin,apm-logging-plugin,apm-logging-plugin-common,apm-log4j1-plugin,apm-log4j2-plugin,apm-opentelemetry,apm-opentelemetry-embedded-metrics-sdk,apm-opentelemetry-metrics-bridge-parent,apm-opentelemetry-metrics-bridge-common,apm-opentelemetry-metrics-bridge-v1_14,apm-opentelemetry-metrics-bridge-latest,apm-opentelemetry-metricsdk-plugin,apm-opentelemetry-plugin,apm-slf4j-plugin,apm-logback-plugin,apm-logback-plugin-impl,apm-jboss-logging-plugin,apm-jul-plugin,apm-tomcat-logging-plugin,apm-micrometer-plugin,apm-mongodb,apm-mongodb-common,apm-mongodb3-plugin,apm-mongodb4-plugin,apm-opentracing-plugin,apm-process-plugin,apm-profiling-plugin,apm-quartz,apm-quartz-common,apm-quartz-plugin-1,apm-quartz-plugin-2,apm-rabbitmq,apm-rabbitmq-plugin,apm-rabbitmq-spring5,apm-reactor-plugin,apm-redisson-plugin,apm-scala-concurrent-plugin,apm-scheduled-annotation-plugin,apm-sparkjava-plugin,apm-urlconnection-plugin,apm-spring-resttemplate,apm-spring-resttemplate-plugin,apm-spring-webflux,apm-spring-webflux-common-spring5,apm-spring-webflux-common,apm-spring-webclient-plugin,apm-spring-webflux-testapp,apm-spring-webflux-spring5,apm-spring-webflux-plugin,apm-spring-webmvc,apm-spring-webmvc-spring5,apm-spring-webmvc-plugin,apm-struts-plugin,apm-vertx,apm-vertx-common,apm-vertx3-plugin,apm-vertx4-plugin,apm-awslambda-plugin,apm-jakarta-websocket-plugin,apm-ecs-logging-plugin,apm-aws-sdk,apm-aws-sdk-common,apm-aws-sdk-1-plugin,apm-aws-sdk-2-plugin,apm-finagle-httpclient-plugin,apm-java-ldap-plugin,apm-agent-builds,apm-agent,apm-agent-lambda-layer,apm-agent-java8,apm-agent-benchmarks,apm-spring-resttemplate-test,apm-spring-restclient-test,apm-logback-plugin-legacy-tests,apm-log4j2-plugin-tests,apm-jms-spring-plugin,apm-jedis-2-tests,apm-jedis-3-tests,apm-jedis-5-tests,apm-lettuce-3-tests,apm-grpc-test-latest,apm-rabbitmq-test-3,apm-rabbitmq-test-4,apm-rabbitmq-test-spring6,apm-okhttp-test,apm-opentelemetry-test,apm-vertx3-test-latest,apm-servlet-jakarta-test,apm-jaxws-plugin-jakartaee-test,apm-jaxrs-plugin-jakartaee-test,apm-scheduled-annotation-plugin-jakartaee-test,integration-tests,simple-webapp,jakartaee-simple-webapp,jsf-app,jsf-app-dependent,jsf-app-standalone,jakartaee-jsf-app,jakartaee-jsf-app-dependent,jakartaee-jsf-app-standalone,cdi-app,cdi-app-dependent,cdi-app-standalone,soap-test,external-plugin-test,plugin-instrumentation-target,external-plugin-app,external-plugin-jakarta-app,external-plugin,application-server-integration-tests,spring-boot-1-5,spring-boot-2,spring-boot-2-base,spring-boot-2-jetty,spring-boot-2-tomcat,spring-boot-2-undertow,cdi-jakartaee-app,cdi-jakartaee-app-dependent,cdi-jakartaee-app-standalone,quarkus,quarkus-jaxrs-base,quarkus-jaxrs-undertow,quarkus-jaxrs-vertx,external-plugin-otel-test,external-plugin-otel-test-app,external-plugin-otel-test-plugin1,external-plugin-otel-test-plugin2,runtime-attach,runtime-attach-app,runtime-attach-test,main-app-test,spring-boot-3,spring-boot-3-jetty,spring-boot-3-tomcat,spring-boot-3-undertow,aws-lambda-test
+                    </excludeArtifacts>
                 </configuration>
             </plugin>
             <!-- The shadowed source files of this module need to be included explicitly to create a javadoc artifact.-->


### PR DESCRIPTION
## What does this PR do?

Same as https://github.com/elastic/ecs-logging-java/pull/343 for ecs-logging: Switch to the new plugin for publishing to central.sonatype.org.
