### PR TITLE
Await release on maven central and not oss sonatype

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -117,6 +117,8 @@ jobs:
     steps:
       - uses: elastic/oblt-actions/maven/await-artifact@v1
         with:
+          maven-central: true
+          sonatype-central: false
           group-id: 'co.elastic.apm'
           artifact-id: 'elastic-apm-agent'
           version: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
## What does this PR do?

Fixes the release job waiting on the wrong URL now that we release to central sonatype.
