### PR TITLE
Fix docker maven url

### DIFF
--- a/.github/actions/build-and-publish-docker/action.yml
+++ b/.github/actions/build-and-publish-docker/action.yml
@@ -16,11 +16,6 @@ runs:
   env:
     SONATYPE_FALLBACK: 1
   steps:
-    - uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.ref }}
-        fetch-depth: 0 # Load entire history as it is required for the push-script
-
     - name: Log in to the Elastic Container registry
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
       with:

--- a/.github/actions/build-and-publish-docker/action.yml
+++ b/.github/actions/build-and-publish-docker/action.yml
@@ -1,0 +1,33 @@
+name: 'Build and publish docker images'
+description: 'Builds and publishes the docker images for a given version using the agent artifact from maven central'
+inputs:
+  release-version:
+    description: 'The version to release. If this is the currently latest version based on the git tags, it will also be published as latest'
+    required: true
+  ref:
+    description: 'Branch or tag ref to run the action, defines the version of the scripts in the ./scripts folder to run'
+    required: true
+runs:
+  using: "composite"
+  env:
+    SONATYPE_FALLBACK: 1
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+        fetch-depth: 0 # Load entire history as it is required for the push-script
+
+    - name: Log in to the Elastic Container registry
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
+      with:
+        registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
+        username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
+        password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
+
+    - name: "Build docker image"
+      shell: bash
+      run: ./scripts/docker-release/build_docker.sh "${{ inputs.release-version }}"
+    - name: "Push docker image"
+      if: ${{ ! inputs.dry_run }}
+      shell: bash
+      run: ./scripts/docker-release/push_docker.sh "${{ inputs.release-version }}"

--- a/.github/actions/build-and-publish-docker/action.yml
+++ b/.github/actions/build-and-publish-docker/action.yml
@@ -1,12 +1,16 @@
 name: 'Build and publish docker images'
 description: 'Builds and publishes the docker images for a given version using the agent artifact from maven central'
 inputs:
-  release-version:
+  release_version:
     description: 'The version to release. If this is the currently latest version based on the git tags, it will also be published as latest'
     required: true
   ref:
     description: 'Branch or tag ref to run the action, defines the version of the scripts in the ./scripts folder to run'
     required: true
+  dry_run:
+    description: If set, generate the docker image but don't publish it
+    required: true
+    type: boolean
 runs:
   using: "composite"
   env:
@@ -26,8 +30,8 @@ runs:
 
     - name: "Build docker image"
       shell: bash
-      run: ./scripts/docker-release/build_docker.sh "${{ inputs.release-version }}"
+      run: ./scripts/docker-release/build_docker.sh "${{ inputs.release_version }}"
     - name: "Push docker image"
       if: ${{ ! inputs.dry_run }}
       shell: bash
-      run: ./scripts/docker-release/push_docker.sh "${{ inputs.release-version }}"
+      run: ./scripts/docker-release/push_docker.sh "${{ inputs.release_version }}"

--- a/.github/workflows/regenerate-docker-images.yml
+++ b/.github/workflows/regenerate-docker-images.yml
@@ -30,6 +30,10 @@ jobs:
     name: "Build and push docker images"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0 # Load entire history as it is required for the push-script
       - uses: ./.github/actions/build-and-publish-docker
         with:
           release_version: ${{ inputs.version }}

--- a/.github/workflows/regenerate-docker-images.yml
+++ b/.github/workflows/regenerate-docker-images.yml
@@ -14,6 +14,10 @@ on:
           The version of the agent to re-generate and publish the docker images for (e.g. 1.2.3).
           If this is the latest tag (based on the selected ref), the image will also be published with the latest-tag.
         required: true
+      dry_run:
+        description: If set, generates the images but doesn't push them
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -28,5 +32,6 @@ jobs:
     steps:
       - uses: ./.github/actions/build-and-publish-docker
         with:
-          release-version: ${{ inputs.version }}
+          release_version: ${{ inputs.version }}
           ref: ${{ inputs.ref }}
+          dry_run: ${{ inputs.dry_run }}

--- a/.github/workflows/regenerate-docker-images.yml
+++ b/.github/workflows/regenerate-docker-images.yml
@@ -1,0 +1,32 @@
+---
+# Regenerate the docker images based on what is released at maven central if something went wrong during the standard release process
+name: 'regenerate-docker-images'
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch or tag ref to run the workflow on'
+        required: true
+        default: "main"
+      version:
+        description: |
+          The version of the agent to re-generate and publish the docker images for (e.g. 1.2.3).
+          If this is the latest tag (based on the selected ref), the image will also be published with the latest-tag.
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  build-and-push-docker-images:
+    name: "Build and push docker images"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/build-and-publish-docker
+        with:
+          release-version: ${{ inputs.version }}
+          ref: ${{ inputs.ref }}

--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -128,6 +128,10 @@ jobs:
       - await-maven-central-artifact
       - create-github-release
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0 # Load entire history as it is required for the push-script
       - uses: ./.github/actions/build-and-publish-docker
         with:
           release_version: "${{ env.RELEASE_VERSION }}"

--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -130,8 +130,9 @@ jobs:
     steps:
       - uses: ./.github/actions/build-and-publish-docker
         with:
-          release-version: "${{ env.RELEASE_VERSION }}"
+          release_version: "${{ env.RELEASE_VERSION }}"
           ref: ${{ inputs.ref }}
+          dry_run: ${{ inputs.dry_run }}
 
   publish-aws-lambda:
     name: "Publish AWS Lambda"

--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -127,28 +127,11 @@ jobs:
     needs:
       - await-maven-central-artifact
       - create-github-release
-    env:
-      SONATYPE_FALLBACK: 1
     steps:
-      - uses: actions/checkout@v4
+      - uses: ./.github/actions/build-and-publish-docker
         with:
+          release-version: "${{ env.RELEASE_VERSION }}"
           ref: ${{ inputs.ref }}
-          fetch-depth: 0 # Load entire history as it is required for the push-script
-
-      - name: Log in to the Elastic Container registry
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: ${{ secrets.ELASTIC_DOCKER_REGISTRY }}
-          username: ${{ secrets.ELASTIC_DOCKER_USERNAME }}
-          password: ${{ secrets.ELASTIC_DOCKER_PASSWORD }}
-
-      - name: "Build docker image"
-        shell: bash
-        run: ./scripts/docker-release/build_docker.sh "${{ env.RELEASE_VERSION }}"
-      - name: "Push docker image"
-        if: ${{ ! inputs.dry_run }}
-        shell: bash
-        run: ./scripts/docker-release/push_docker.sh "${{ env.RELEASE_VERSION }}"
 
   publish-aws-lambda:
     name: "Publish AWS Lambda"

--- a/scripts/docker-release/build_docker.sh
+++ b/scripts/docker-release/build_docker.sh
@@ -34,8 +34,8 @@ then
   then
       echo "ERROR: Pulling images from Sonatype Nexus repo requires cURL to be installed" && exit 1
   fi
-  curl -L -s -o apm-agent-java.jar \
-    "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=releases&g=co.elastic.apm&a=elastic-apm-agent&v=$RELEASE_VERSION"
+  curl -L -s --fail-with-body -o apm-agent-java.jar \
+    "https://repo1.maven.org/maven2/co/elastic/apm/elastic-apm-agent/$RELEASE_VERSION/elastic-apm-agent-$RELEASE_VERSION.jar"
   else
     echo "ERROR: No suitable build artifact was found. Re-running this script with the SONATYPE_FALLBACK variable set to true will try to use the Sonatype artifact for the latest tag"
     exit 1


### PR DESCRIPTION
## What does this PR do?

After the change to releasing to central sonatype, we by accident generated a docker image with the following content of `elastic-apm-agent.jar`:

```
/usr/agent # cat elastic-apm-agent.jar 
<html>
  <head>
    <title>404 - Not Found</title>
    <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>

            
    <link rel="icon" type="image/png" href="https://oss.sonatype.org/favicon.png">
    <!--[if IE]>
    <link rel="SHORTCUT ICON" href="https://oss.sonatype.org/favicon.ico"/>
    <![endif]-->

    <link rel="stylesheet" href="https://oss.sonatype.org/static/css/Sonatype-content.css?2.15.2-03" type="text/css" media="screen" title="no title" charset="utf-8">
  </head>
  <body>
    <h1>404 - Not Found</h1>
    <p>Path /co/elastic/apm/elastic-apm-agent/1.55.0/elastic-apm-agent-1.55.0.jar not found in local storage of repository &quot;Releases&quot; [id=releases]</p>
  </body>
</html>
```

This PR
 * fixes the script to fail instead of generate a bad `elastic-apm-agent.jar` if the file cannot be downloaded
 * fixes the maven-central URL in the script
 * Adds a separate workflow for regenerating and publishing docker images in CI, because doing it locally is a pain due to multi-arch requirements


## Checklist

- [x] This is something else
  - [ ] ~I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)~
