### PR TITLE
avoid NPE in ES instrumentation due to recycling

### DIFF
--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/AsyncRequestProducerWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/AsyncRequestProducerWrapper.java
@@ -78,22 +78,26 @@ public class AsyncRequestProducerWrapper implements AsyncRequestProducer, Recycl
 
     @Override
     public boolean isRepeatable() {
-        return delegate.isRepeatable();
+        return delegate != null && delegate.isRepeatable();
     }
 
     @Override
     public void failed(Exception e) {
-        delegate.failed(e);
+        if (delegate != null) {
+            delegate.failed(e);
+        }
     }
 
     @Override
     public int available() {
-        return delegate.available();
+        return delegate != null ? delegate.available() : 0;
     }
 
     @Override
     public void produce(DataStreamChannel dataStreamChannel) throws IOException {
-        delegate.produce(dataStreamChannel);
+        if (delegate != null) {
+            delegate.produce(dataStreamChannel);
+        }
     }
 
     @Override


### PR DESCRIPTION
## What does this PR do?

We had at least one report where the `delegate` field is `null` in ES instrumentation and causes issues. This PR implements a workaround that would avoid flooding agent logs with warnings.