### PR TITLE
remove snapshot link

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,6 @@ Help requests are better served in [APM discuss forum](https://discuss.elastic.c
 
 See the [contributing documentation](CONTRIBUTING.md)
 
-## Snapshots
-
-Snapshots are built from `main` branch and are available here:
-
-* [elastic-apm-agent.jar](https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=co.elastic.apm&a=elastic-apm-agent&v=LATEST)
-* [apm-agent-attach-cli.jar](https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=co.elastic.apm&a=apm-agent-attach-cli&v=LATEST)
-* [apm-agent-attach.jar](https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=co.elastic.apm&a=apm-agent-attach&v=LATEST)
-* [apm-agent-api.jar](https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=co.elastic.apm&a=apm-agent-api&v=LATEST)
-
-Those snapshots include features & bugfixes for the next release, see [releases notes](https://www.elastic.co/guide/en/apm/agent/java/current/_unreleased.html) details.
-
 ## Build form source
 
 Execute `./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true` to build the artifacts and to install them to your local maven repository. The build process requires JDK 17.


### PR DESCRIPTION
Fixes #4175 

The reasons we are removing this link for now are explained in detail here: https://github.com/elastic/elastic-otel-java/issues/768#issuecomment-3175035186