### PR TITLE
fix apache httpclient 5.x async instrumentation

### DIFF
--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/test/java/co/elastic/apm/agent/httpclient/v4/ApacheHttpAsyncClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient4-plugin/src/test/java/co/elastic/apm/agent/httpclient/v4/ApacheHttpAsyncClientInstrumentationTest.java
@@ -64,7 +64,7 @@ public class ApacheHttpAsyncClientInstrumentationTest extends AbstractHttpClient
     }
 
     @Override
-    protected void performGet(String path) throws Exception {
+    protected void performGet(String uri) throws Exception {
         final CompletableFuture<HttpResponse> responseFuture = new CompletableFuture<>();
 
         RequestConfig requestConfig = RequestConfig.custom()
@@ -72,7 +72,7 @@ public class ApacheHttpAsyncClientInstrumentationTest extends AbstractHttpClient
             .build();
         HttpClientContext httpClientContext = HttpClientContext.create();
         httpClientContext.setRequestConfig(requestConfig);
-        client.execute(new HttpGet(path), httpClientContext, new FutureCallback<>() {
+        client.execute(new HttpGet(uri), httpClientContext, new FutureCallback<>() {
             @Override
             public void completed(HttpResponse result) {
                 responseFuture.complete(result);

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpAsyncClient5Instrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpAsyncClient5Instrumentation.java
@@ -65,16 +65,11 @@ public class ApacheHttpAsyncClient5Instrumentation extends BaseApacheHttpClient5
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        // the execute public method can be called with a null callback, in which case the wrapped callback will never
-        // be called by the client code, and will block the caller indefinitely. The doExecute method wraps it another
-        // time and returns it, and the caller is expected to call this returned value.
-        return named("doExecute").and(takesArguments(6))
-            .and(takesArgument(0, named("org.apache.hc.core5.http.HttpHost")))
-            .and(takesArgument(1, named("org.apache.hc.core5.http.nio.AsyncRequestProducer")))
-            .and(takesArgument(2, named("org.apache.hc.core5.http.nio.AsyncResponseConsumer")))
-            .and(takesArgument(3, named("org.apache.hc.core5.http.nio.HandlerFactory")))
-            .and(takesArgument(4, named("org.apache.hc.core5.http.protocol.HttpContext")))
-            .and(takesArgument(5, named("org.apache.hc.core5.concurrent.FutureCallback")));
+        return named("execute").and(takesArguments(4))
+            .and(takesArgument(0, named("org.apache.hc.core5.http.nio.AsyncRequestProducer")))
+            .and(takesArgument(1, named("org.apache.hc.core5.http.nio.AsyncResponseConsumer")))
+            .and(takesArgument(2, named("org.apache.hc.core5.http.protocol.HttpContext")))
+            .and(takesArgument(3, named("org.apache.hc.core5.concurrent.FutureCallback")));
     }
 
     public static class ApacheHttpClient5AsyncAdvice extends AbstractApacheHttpClientAsyncAdvice {
@@ -83,13 +78,13 @@ public class ApacheHttpAsyncClient5Instrumentation extends BaseApacheHttpClient5
 
         @Nullable
         @Advice.AssignReturned.ToArguments({
-            @Advice.AssignReturned.ToArguments.ToArgument(index = 0, value = 1, typing = DYNAMIC),
-            @Advice.AssignReturned.ToArguments.ToArgument(index = 1, value = 5, typing = DYNAMIC)
+            @Advice.AssignReturned.ToArguments.ToArgument(index = 0, value = 0, typing = DYNAMIC),
+            @Advice.AssignReturned.ToArguments.ToArgument(index = 1, value = 3, typing = DYNAMIC)
         })
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-        public static Object[] onBeforeExecute(@Advice.Argument(value = 1) AsyncRequestProducer asyncRequestProducer,
-                                               @Advice.Argument(value = 4) HttpContext context,
-                                               @Advice.Argument(value = 5) FutureCallback<?> futureCallback) {
+        public static Object[] onBeforeExecute(@Advice.Argument(value = 0) AsyncRequestProducer asyncRequestProducer,
+                                               @Advice.Argument(value = 2) HttpContext context,
+                                               @Advice.Argument(value = 3) FutureCallback<?> futureCallback) {
             return startSpan(tracer, asyncHelper, asyncRequestProducer, context, futureCallback);
         }
 

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpAsyncClient5Instrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpAsyncClient5Instrumentation.java
@@ -60,16 +60,21 @@ public class ApacheHttpAsyncClient5Instrumentation extends BaseApacheHttpClient5
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return hasSuperType(named("org.apache.hc.client5.http.async.HttpAsyncClient"));
+        return hasSuperType(named("org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient"));
     }
 
     @Override
     public ElementMatcher<? super MethodDescription> getMethodMatcher() {
-        return named("execute").and(takesArguments(4))
-            .and(takesArgument(0, named("org.apache.hc.core5.http.nio.AsyncRequestProducer")))
-            .and(takesArgument(1, named("org.apache.hc.core5.http.nio.AsyncResponseConsumer")))
-            .and(takesArgument(2, named("org.apache.hc.core5.http.protocol.HttpContext")))
-            .and(takesArgument(3, named("org.apache.hc.core5.concurrent.FutureCallback")));
+        // the execute public method can be called with a null callback, in which case the wrapped callback will never
+        // be called by the client code, and will block the caller indefinitely. The doExecute method wraps it another
+        // time and returns it, and the caller is expected to call this returned value.
+        return named("doExecute").and(takesArguments(6))
+            .and(takesArgument(0, named("org.apache.hc.core5.http.HttpHost")))
+            .and(takesArgument(1, named("org.apache.hc.core5.http.nio.AsyncRequestProducer")))
+            .and(takesArgument(2, named("org.apache.hc.core5.http.nio.AsyncResponseConsumer")))
+            .and(takesArgument(3, named("org.apache.hc.core5.http.nio.HandlerFactory")))
+            .and(takesArgument(4, named("org.apache.hc.core5.http.protocol.HttpContext")))
+            .and(takesArgument(5, named("org.apache.hc.core5.concurrent.FutureCallback")));
     }
 
     public static class ApacheHttpClient5AsyncAdvice extends AbstractApacheHttpClientAsyncAdvice {
@@ -78,11 +83,13 @@ public class ApacheHttpAsyncClient5Instrumentation extends BaseApacheHttpClient5
 
         @Nullable
         @Advice.AssignReturned.ToArguments({
-            @Advice.AssignReturned.ToArguments.ToArgument(index = 0, value = 0, typing = DYNAMIC),
-            @Advice.AssignReturned.ToArguments.ToArgument(index = 1, value = 3, typing = DYNAMIC)
+            @Advice.AssignReturned.ToArguments.ToArgument(index = 0, value = 1, typing = DYNAMIC),
+            @Advice.AssignReturned.ToArguments.ToArgument(index = 1, value = 5, typing = DYNAMIC)
         })
         @Advice.OnMethodEnter(suppress = Throwable.class, inline = false)
-        public static Object[] onBeforeExecute(@Advice.Argument(value = 0) AsyncRequestProducer asyncRequestProducer, @Advice.Argument(value = 2) HttpContext context, @Advice.Argument(value = 3) FutureCallback<?> futureCallback) {
+        public static Object[] onBeforeExecute(@Advice.Argument(value = 1) AsyncRequestProducer asyncRequestProducer,
+                                               @Advice.Argument(value = 4) HttpContext context,
+                                               @Advice.Argument(value = 5) FutureCallback<?> futureCallback) {
             return startSpan(tracer, asyncHelper, asyncRequestProducer, context, futureCallback);
         }
 

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpAsyncClient5Instrumentation.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpAsyncClient5Instrumentation.java
@@ -60,7 +60,7 @@ public class ApacheHttpAsyncClient5Instrumentation extends BaseApacheHttpClient5
 
     @Override
     public ElementMatcher<? super TypeDescription> getTypeMatcher() {
-        return hasSuperType(named("org.apache.hc.client5.http.impl.async.CloseableHttpAsyncClient"));
+        return hasSuperType(named("org.apache.hc.client5.http.async.HttpAsyncClient"));
     }
 
     @Override

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/AsyncRequestProducerWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/AsyncRequestProducerWrapper.java
@@ -32,10 +32,14 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import javax.annotation.Nullable;
 import java.io.IOException;
 
-public class AsyncRequestProducerWrapper implements AsyncRequestProducer, Recyclable {
+/**
+ * Unfortunately, it can't implement {@link Recyclable} because {@link #releaseResources} method might not always be the
+ * last method called, hence we don't have any reliable hook to trigger recycling.
+ */
+public class AsyncRequestProducerWrapper implements AsyncRequestProducer {
 
     private final ApacheHttpClient5AsyncHelper asyncClientHelper;
-    private volatile AsyncRequestProducer delegate;
+    private final AsyncRequestProducer delegate;
 
     @Nullable
     private TraceState<?> toPropagate;
@@ -43,18 +47,14 @@ public class AsyncRequestProducerWrapper implements AsyncRequestProducer, Recycl
     @Nullable
     private Span<?> span;
 
-    AsyncRequestProducerWrapper(ApacheHttpClient5AsyncHelper helper) {
+    AsyncRequestProducerWrapper(ApacheHttpClient5AsyncHelper helper,
+                                AsyncRequestProducer delegate,
+                                @Nullable Span<?> span,
+                                TraceState<?> toPropagate) {
         this.asyncClientHelper = helper;
-    }
-
-    public AsyncRequestProducerWrapper with(AsyncRequestProducer delegate, @Nullable Span<?> span,
-                                            TraceState<?> toPropagate) {
-        this.span = span;
-        toPropagate.incrementReferences();
-        this.toPropagate = toPropagate;
-        // write to volatile field last
         this.delegate = delegate;
-        return this;
+        this.span = span;
+        this.toPropagate = toPropagate;
     }
 
     /**
@@ -68,7 +68,8 @@ public class AsyncRequestProducerWrapper implements AsyncRequestProducer, Recycl
         try {
             delegate.sendRequest(isNotNullWrappedRequestChannel ? wrappedRequestChannel : requestChannel, httpContext);
         } catch (HttpException | IOException | IllegalStateException e) {
-            asyncClientHelper.recycle(this);
+            // ensures that toPropagate reference count is properly decremented in case of an exception
+            internalResetState();
             throw e;
         } finally {
             if (isNotNullWrappedRequestChannel) {
@@ -79,45 +80,42 @@ public class AsyncRequestProducerWrapper implements AsyncRequestProducer, Recycl
 
     @Override
     public boolean isRepeatable() {
-        return delegate != null && delegate.isRepeatable();
+        return delegate.isRepeatable();
     }
 
     @Override
     public void failed(Exception e) {
-        if (delegate != null) {
+        try {
             delegate.failed(e);
+        } finally {
+            internalResetState();
         }
     }
 
     @Override
     public int available() {
-        return delegate != null ? delegate.available() : 0;
+        return delegate.available();
     }
 
     @Override
     public void produce(DataStreamChannel dataStreamChannel) throws IOException {
-        if (delegate != null) {
-            delegate.produce(dataStreamChannel);
-        }
+        // this method might be called after releaseResources, hence preventing us from implementing recycling easily
+        delegate.produce(dataStreamChannel);
     }
 
     @Override
     public void releaseResources() {
-        if (delegate != null) {
-            delegate.releaseResources();
-            asyncClientHelper.recycle(this);
-        }
+        delegate.releaseResources();
+        internalResetState();
     }
 
-    @Override
-    public void resetState() {
+    private void internalResetState(){
         span = null;
         if (toPropagate != null) {
             toPropagate.decrementReferences();
             toPropagate = null;
         }
-        // write to volatile field last
-        delegate = null;
+
     }
 
 }

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/AsyncRequestProducerWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/AsyncRequestProducerWrapper.java
@@ -54,6 +54,7 @@ public class AsyncRequestProducerWrapper implements AsyncRequestProducer {
         this.asyncClientHelper = helper;
         this.delegate = delegate;
         this.span = span;
+        toPropagate.incrementReferences();
         this.toPropagate = toPropagate;
     }
 

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/AsyncRequestProducerWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/AsyncRequestProducerWrapper.java
@@ -52,6 +52,7 @@ public class AsyncRequestProducerWrapper implements AsyncRequestProducer, Recycl
         this.span = span;
         toPropagate.incrementReferences();
         this.toPropagate = toPropagate;
+        // write to volatile field last
         this.delegate = delegate;
         return this;
     }
@@ -115,6 +116,7 @@ public class AsyncRequestProducerWrapper implements AsyncRequestProducer, Recycl
             toPropagate.decrementReferences();
             toPropagate = null;
         }
+        // write to volatile field last
         delegate = null;
     }
 

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/FutureCallbackWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/FutureCallbackWrapper.java
@@ -29,7 +29,7 @@ import org.apache.hc.core5.http.protocol.HttpCoreContext;
 
 import javax.annotation.Nullable;
 
-class FutureCallbackWrapper<T> implements FutureCallback<T>, Recyclable {
+public class FutureCallbackWrapper<T> implements FutureCallback<T>, Recyclable {
     private final ApacheHttpClient5AsyncHelper helper;
     @Nullable
     private FutureCallback<T> delegate;
@@ -109,7 +109,7 @@ class FutureCallbackWrapper<T> implements FutureCallback<T>, Recyclable {
         try {
             if (context instanceof HttpCoreContext) {
                 HttpResponse response = ((HttpCoreContext) context).getResponse();
-                if(response != null){
+                if (response != null) {
                     span.getContext().getHttp().withStatusCode(response.getCode());
                 }
             }

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/FutureCallbackWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/FutureCallbackWrapper.java
@@ -107,11 +107,10 @@ class FutureCallbackWrapper<T> implements FutureCallback<T>, Recyclable {
         // start by reading the volatile field
         final Span<?> localSpan = span;
         try {
-            if (context != null) {
-                Object responseObject = context.getAttribute(HttpCoreContext.HTTP_RESPONSE);
-                if (responseObject instanceof HttpResponse) {
-                    int statusCode = ((HttpResponse) responseObject).getCode();
-                    span.getContext().getHttp().withStatusCode(statusCode);
+            if (context instanceof HttpCoreContext) {
+                HttpResponse response = ((HttpCoreContext) context).getResponse();
+                if(response != null){
+                    span.getContext().getHttp().withStatusCode(response.getCode());
                 }
             }
             localSpan.captureException(e);

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/RequestChannelWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/RequestChannelWrapper.java
@@ -56,6 +56,7 @@ public class RequestChannelWrapper implements RequestChannel, Recyclable {
         this.span = span;
         toPropagate.incrementReferences();
         this.toPropagate = toPropagate;
+        // write to volatile field last
         this.delegate = delegate;
         return this;
     }

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/RequestChannelWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/RequestChannelWrapper.java
@@ -68,6 +68,7 @@ public class RequestChannelWrapper implements RequestChannel, Recyclable {
             toPropagate.decrementReferences();
             toPropagate = null;
         }
+        // write to volatile field last
         delegate = null;
     }
 

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/RequestChannelWrapper.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/main/java/co/elastic/apm/agent/httpclient/v5/helper/RequestChannelWrapper.java
@@ -99,7 +99,13 @@ public class RequestChannelWrapper implements RequestChannel, Recyclable {
                     if (host != null) {
                         span.appendToName(host);
                     }
-                    span.getContext().getHttp().withMethod(method).withUrl(httpRequest.getRequestUri());
+                    String requestUri = httpRequest.getRequestUri();
+                    // starting with httpclient 5.1 "getRequestUri" can return relative path, not always the absolute one
+                    // thus we have to fallback on using the URI instance
+                    if(requestUri != null && requestUri.startsWith("/") && httpRequestURI != null) {
+                        requestUri = httpRequestURI.toString();
+                    }
+                    span.getContext().getHttp().withMethod(method).withUrl(requestUri);
                     HttpClientHelper.setDestinationServiceDetails(span, protocol, host, port);
                 }
 

--- a/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/test/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpAsyncClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-apache-httpclient/apm-apache-httpclient5-plugin/src/test/java/co/elastic/apm/agent/httpclient/v5/ApacheHttpAsyncClientInstrumentationTest.java
@@ -37,7 +37,6 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Future;
 
 import static co.elastic.apm.agent.testutils.assertions.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;

--- a/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
+++ b/apm-agent-plugins/apm-httpclient-core/src/test/java/co/elastic/apm/agent/httpclient/AbstractHttpClientInstrumentationTest.java
@@ -344,7 +344,7 @@ public abstract class AbstractHttpClientInstrumentationTest extends AbstractInst
     }
 
     // assumption
-    public boolean isTestHttpCallWithUserInfoEnabled() {
+    protected boolean isTestHttpCallWithUserInfoEnabled() {
         return true;
     }
 


### PR DESCRIPTION
This issue was initially reported to happen with Elasticsearch client 9.x instrumentation, which happens to use the async API of apache httpclient by default.

The initial workaround implemented in #4176 did in fact broke the instrumentation even further and made the application hang forever when doing http calls.

After further investigation it turns out that the `AsyncRequestProducerWrapper` instance was recycled too early and thus the delegation not triggered, hence making the caller wait forever on an asynchronous result that would never be made available.
