### PR TITLE
Add applies_to statements

### DIFF
--- a/docs/reference/aws-lambda.md
+++ b/docs/reference/aws-lambda.md
@@ -4,6 +4,16 @@ mapped_pages:
 sub:
   apm-lambda-ext-v: ver-1-5-7
   apm-java-v: ver-1-52-2
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Monitoring AWS Lambda Java Functions [aws-lambda]

--- a/docs/reference/community-plugins.md
+++ b/docs/reference/community-plugins.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/community-plugins.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Community plugins [community-plugins]

--- a/docs/reference/config-circuit-breaker.md
+++ b/docs/reference/config-circuit-breaker.md
@@ -2,13 +2,25 @@
 navigation_title: "Circuit-Breaker"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-circuit-breaker.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Circuit-Breaker configuration options [config-circuit-breaker]
 
+## `circuit_breaker_enabled` [config-circuit-breaker-enabled]
 
-
-## `circuit_breaker_enabled` ([1.14.0] performance) [config-circuit-breaker-enabled]
+```{applies_to}
+apm_agent_java: ga 1.14.0
+```
 
 A boolean specifying whether the circuit breaker should be enabled or not. When enabled, the agent periodically polls stress monitors to detect system/process/JVM stress state. If ANY of the monitors detects a stress indication, the agent will become inactive, as if the [`recording`](/reference/config-core.md#config-recording) configuration option has been set to `false`, thus reducing resource consumption to a minimum. When inactive, the agent continues polling the same monitors in order to detect whether the stress state has been relieved. If ALL monitors approve that the system/process/JVM is not under stress anymore, the agent will resume and become fully functional.
 

--- a/docs/reference/config-core.md
+++ b/docs/reference/config-core.md
@@ -2,13 +2,25 @@
 navigation_title: "Core"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-core.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Core configuration options [config-core]
 
+## `recording` [config-recording]
 
-
-## `recording` ([1.15.0]) [config-recording]
+```{applies_to}
+apm_agent_java: ga 1.15.0
+```
 
 ::::{note}
 This option was available in older versions through the `active` key. The old key is still supported in newer versions, but it is now deprecated.
@@ -30,7 +42,11 @@ You can use this setting to dynamically disable Elastic APM at runtime.
 | `elastic.apm.recording` | `recording` | `ELASTIC_APM_RECORDING` |
 
 
-## `enabled` ([1.18.0]) [config-enabled]
+## `enabled` [config-enabled]
+
+```{applies_to}
+apm_agent_java: ga 1.18.0
+```
 
 Setting to false will completely disable the agent, including instrumentation and remote config polling. If you want to dynamically change the status of the agent, use [`recording`](#config-recording) instead.
 
@@ -43,7 +59,11 @@ Setting to false will completely disable the agent, including instrumentation an
 | `elastic.apm.enabled` | `enabled` | `ELASTIC_APM_ENABLED` |
 
 
-## `instrument` ([1.0.0]) [config-instrument]
+## `instrument` [config-instrument]
+
+```{applies_to}
+apm_agent_java: ga 1.0.0
+```
 
 A boolean specifying if the agent should instrument the application to collect traces for the app. When set to `false`, most built-in instrumentation plugins are disabled, which would minimize the effect on your application. However, the agent would still apply instrumentation related to manual tracing options and it would still collect and send metrics to APM Server.
 
@@ -135,7 +155,11 @@ Service name auto discovery mechanisms require APM Server 7.0+.
 | `elastic.apm.service_name` | `service_name` | `ELASTIC_APM_SERVICE_NAME` |
 
 
-## `service_node_name` ([1.11.0]) [config-service-node-name]
+## `service_node_name` [config-service-node-name]
+
+```{applies_to}
+apm_agent_java: ga 1.11.0
+```
 
 If set, this name is used to distinguish between different nodes of a service, therefore it should be unique for each JVM within a service. If not set, data aggregations will be done based on a container ID (where valid) or on the reported hostname (automatically discovered or manually configured through [`hostname`](#config-hostname)).
 
@@ -173,7 +197,11 @@ Similar to the auto-detection of [`service_name`](#config-service-name), the age
 | `elastic.apm.service_version` | `service_version` | `ELASTIC_APM_SERVICE_VERSION` |
 
 
-## `hostname` ([1.10.0]) [config-hostname]
+## `hostname` [config-hostname]
+
+```{applies_to}
+apm_agent_java: ga 1.10.0
+```
 
 Allows for the reported hostname to be manually specified. If unset the hostname will be looked up.
 
@@ -244,7 +272,11 @@ A message will be logged when the max number of spans has been exceeded but only
 | `elastic.apm.transaction_max_spans` | `transaction_max_spans` | `ELASTIC_APM_TRANSACTION_MAX_SPANS` |
 
 
-## `long_field_max_length` (performance [1.37.0]) [config-long-field-max-length]
+## `long_field_max_length` (performance) [config-long-field-max-length]
+
+```{applies_to}
+apm_agent_java: ga 1.37.0
+```
 
 The following transaction, span, and error fields will be truncated at this number of unicode characters before being sent to APM server:
 
@@ -292,7 +324,11 @@ Review the data captured by Elastic APM carefully to make sure it does not captu
 | `elastic.apm.sanitize_field_names` | `sanitize_field_names` | `ELASTIC_APM_SANITIZE_FIELD_NAMES` |
 
 
-## `enable_instrumentations` ([1.28.0]) [config-enable-instrumentations]
+## `enable_instrumentations` [config-enable-instrumentations]
+
+```{applies_to}
+apm_agent_java: ga 1.28.0
+```
 
 A list of instrumentations which should be selectively enabled. Valid options are `annotations`, `annotations-capture-span`, `annotations-capture-transaction`, `annotations-traced`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `aws-lambda`, `aws-sdk`, `cassandra`, `concurrent`, `dubbo`, `elasticsearch-restclient`, `exception-handler`, `executor`, `executor-collection`, `experimental`, `finagle-httpclient`, `fork-join`, `grails`, `grpc`, `hibernate-search`, `http-client`, `jakarta-websocket`, `java-ldap`, `javalin`, `javax-websocket`, `jax-rs`, `jax-ws`, `jdbc`, `jdk-httpclient`, `jdk-httpserver`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log-correlation`, `log-error`, `log-reformatting`, `logging`, `micrometer`, `mongodb`, `mongodb-client`, `okhttp`, `opentelemetry`, `opentelemetry-annotations`, `opentelemetry-metrics`, `opentracing`, `process`, `public-api`, `quartz`, `rabbitmq`, `reactor`, `redis`, `redisson`, `render`, `scala-future`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-api-dispatch`, `servlet-input-stream`, `servlet-service-name`, `servlet-version`, `sparkjava`, `spring-amqp`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `spring-webclient`, `spring-webflux`, `ssl-context`, `struts`, `timer-task`, `urlconnection`, `vertx`, `vertx-web`, `vertx-webclient`, `websocket`. When set to non-empty value, only listed instrumentations will be enabled if they are not disabled through [`disable_instrumentations` ([1.0.0])](#config-disable-instrumentations) or [`enable_experimental_instrumentations` ([1.25.0])](#config-enable-experimental-instrumentations). When not set or empty (default), all instrumentations enabled by default will be enabled unless they are disabled through [`disable_instrumentations` ([1.0.0])](#config-disable-instrumentations) or [`enable_experimental_instrumentations` ([1.25.0])](#config-enable-experimental-instrumentations).
 
@@ -312,7 +348,11 @@ Changing this value at runtime can slow down the application temporarily.
 | `elastic.apm.enable_instrumentations` | `enable_instrumentations` | `ELASTIC_APM_ENABLE_INSTRUMENTATIONS` |
 
 
-## `disable_instrumentations` ([1.0.0]) [config-disable-instrumentations]
+## `disable_instrumentations` [config-disable-instrumentations]
+
+```{applies_to}
+apm_agent_java: ga 1.0.0
+```
 
 A list of instrumentations which should be disabled. Valid options are `annotations`, `annotations-capture-span`, `annotations-capture-transaction`, `annotations-traced`, `apache-commons-exec`, `apache-httpclient`, `asynchttpclient`, `aws-lambda`, `aws-sdk`, `cassandra`, `concurrent`, `dubbo`, `elasticsearch-restclient`, `exception-handler`, `executor`, `executor-collection`, `experimental`, `finagle-httpclient`, `fork-join`, `grails`, `grpc`, `hibernate-search`, `http-client`, `jakarta-websocket`, `java-ldap`, `javalin`, `javax-websocket`, `jax-rs`, `jax-ws`, `jdbc`, `jdk-httpclient`, `jdk-httpserver`, `jedis`, `jms`, `jsf`, `kafka`, `lettuce`, `log-correlation`, `log-error`, `log-reformatting`, `logging`, `micrometer`, `mongodb`, `mongodb-client`, `okhttp`, `opentelemetry`, `opentelemetry-annotations`, `opentelemetry-metrics`, `opentracing`, `process`, `public-api`, `quartz`, `rabbitmq`, `reactor`, `redis`, `redisson`, `render`, `scala-future`, `scheduled`, `servlet-api`, `servlet-api-async`, `servlet-api-dispatch`, `servlet-input-stream`, `servlet-service-name`, `servlet-version`, `sparkjava`, `spring-amqp`, `spring-mvc`, `spring-resttemplate`, `spring-service-name`, `spring-view-render`, `spring-webclient`, `spring-webflux`, `ssl-context`, `struts`, `timer-task`, `urlconnection`, `vertx`, `vertx-web`, `vertx-webclient`, `websocket`. For version `1.25.0` and later, use [`enable_experimental_instrumentations` ([1.25.0])](#config-enable-experimental-instrumentations) to enable experimental instrumentations.
 
@@ -332,7 +372,11 @@ Changing this value at runtime can slow down the application temporarily.
 | `elastic.apm.disable_instrumentations` | `disable_instrumentations` | `ELASTIC_APM_DISABLE_INSTRUMENTATIONS` |
 
 
-## `enable_experimental_instrumentations` ([1.25.0]) [config-enable-experimental-instrumentations]
+## `enable_experimental_instrumentations` [config-enable-experimental-instrumentations]
+
+```{applies_to}
+apm_agent_java: ga 1.25.0
+```
 
 Whether to apply experimental instrumentations.
 
@@ -369,7 +413,11 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 | `elastic.apm.unnest_exceptions` | `unnest_exceptions` | `ELASTIC_APM_UNNEST_EXCEPTIONS` |
 
 
-## `ignore_exceptions` ([1.11.0]) [config-ignore-exceptions]
+## `ignore_exceptions` [config-ignore-exceptions]
+
+```{applies_to}
+apm_agent_java: ga 1.11.0
+```
 
 A list of exceptions that should be ignored and not reported as errors. This allows to ignore exceptions thrown in regular control flow that are not actual errors
 
@@ -453,7 +501,11 @@ Setting this to `false` reduces network bandwidth, disk space and object allocat
 | `elastic.apm.capture_headers` | `capture_headers` | `ELASTIC_APM_CAPTURE_HEADERS` |
 
 
-## `global_labels` ([1.7.0]) [config-global-labels]
+## `global_labels` [config-global-labels]
+
+```{applies_to}
+apm_agent_java: ga 1.7.0
+```
 
 Labels added to all events, with the format `key=value[,key=value[,...]]`. Any labels set by application via the API will override global labels with the same keys.
 
@@ -471,7 +523,11 @@ This feature requires APM Server 7.2+
 | `elastic.apm.global_labels` | `global_labels` | `ELASTIC_APM_GLOBAL_LABELS` |
 
 
-## `instrument_ancient_bytecode` ([1.35.0]) [config-instrument-ancient-bytecode]
+## `instrument_ancient_bytecode` [config-instrument-ancient-bytecode]
+
+```{applies_to}
+apm_agent_java: ga 1.35.0
+```
 
 A boolean specifying if the agent should instrument pre-Java-1.4 bytecode.
 
@@ -484,7 +540,11 @@ A boolean specifying if the agent should instrument pre-Java-1.4 bytecode.
 | `elastic.apm.instrument_ancient_bytecode` | `instrument_ancient_bytecode` | `ELASTIC_APM_INSTRUMENT_ANCIENT_BYTECODE` |
 
 
-## `context_propagation_only` ([1.44.0]) [config-context-propagation-only]
+## `context_propagation_only` [config-context-propagation-only]
+
+```{applies_to}
+apm_agent_java: ga 1.44.0
+```
 
 When set to true, disables log sending, metrics and trace collection. Trace context propagation and log correlation will stay active. Note that in contrast to [`disable_send`](/reference/config-reporter.md#config-disable-send) the agent will still connect to the APM-server for fetching configuration updates and health checks.
 
@@ -512,7 +572,11 @@ Use to exclude specific classes from being instrumented. In order to exclude ent
 | `elastic.apm.classes_excluded_from_instrumentation` | `classes_excluded_from_instrumentation` | `ELASTIC_APM_CLASSES_EXCLUDED_FROM_INSTRUMENTATION` |
 
 
-## `trace_methods` ([1.0.0]) [config-trace-methods]
+## `trace_methods` [config-trace-methods]
+
+```{applies_to}
+apm_agent_java: ga 1.0.0
+```
 
 A list of methods for which to create a transaction or span.
 
@@ -533,7 +597,7 @@ The syntax is `modifier @fully.qualified.AnnotationName fully.qualified.ClassNam
 
 A few examples:
 
-* `org.example.*` [1.4.0]
+* `org.example.*` {applies_to}`apm_agent_java: ga 1.4.0`
 * `org.example.*#*` (before 1.4.0, you need to specify a method matcher)
 * `org.example.MyClass#myMethod`
 * `org.example.MyClass#myMethod()`
@@ -587,7 +651,11 @@ Changing this value at runtime can slow down the application temporarily.
 | `elastic.apm.trace_methods` | `trace_methods` | `ELASTIC_APM_TRACE_METHODS` |
 
 
-## `trace_methods_duration_threshold` ([1.7.0]) [config-trace-methods-duration-threshold]
+## `trace_methods_duration_threshold` [config-trace-methods-duration-threshold]
+
+```{applies_to}
+apm_agent_java: ga 1.7.0
+```
 
 If [`trace_methods`](#config-trace-methods) config option is set, provides a threshold to limit spans based on duration. When set to a value greater than 0, spans representing methods traced based on `trace_methods` will be discarded by default. Such methods will be traced and reported if one of the following applies:
 
@@ -619,7 +687,11 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `0ms`.
 | `elastic.apm.trace_methods_duration_threshold` | `trace_methods_duration_threshold` | `ELASTIC_APM_TRACE_METHODS_DURATION_THRESHOLD` |
 
 
-## `central_config` ([1.8.0]) [config-central-config]
+## `central_config` [config-central-config]
+
+```{applies_to}
+apm_agent_java: ga 1.8.0
+```
 
 When enabled, the agent will make periodic requests to the APM Server to fetch updated configuration. The frequency of the periodic request is driven by the `Cache-Control` header returned from APM Server/Integration, falling back to 5 minutes if not defined.
 
@@ -634,7 +706,11 @@ When enabled, the agent will make periodic requests to the APM Server to fetch u
 | `elastic.apm.central_config` | `central_config` | `ELASTIC_APM_CENTRAL_CONFIG` |
 
 
-## `breakdown_metrics` ([1.8.0]) [config-breakdown-metrics]
+## `breakdown_metrics` [config-breakdown-metrics]
+
+```{applies_to}
+apm_agent_java: ga 1.8.0
+```
 
 Disables the collection of breakdown metrics (`span.self_time`)
 
@@ -647,7 +723,11 @@ Disables the collection of breakdown metrics (`span.self_time`)
 | `elastic.apm.breakdown_metrics` | `breakdown_metrics` | `ELASTIC_APM_BREAKDOWN_METRICS` |
 
 
-## `config_file` ([1.8.0]) [config-config-file]
+## `config_file` [config-config-file]
+
+```{applies_to}
+apm_agent_java: ga 1.8.0
+```
 
 Sets the path of the agent config file. The special value `_AGENT_HOME_` is a placeholder for the folder the `elastic-apm-agent.jar` is in. The file has to be on the file system. You can not refer to classpath locations.
 
@@ -685,7 +765,11 @@ Use the `apm-agent-plugin-sdk` and the `apm-agent-api` artifacts to create a jar
 | `elastic.apm.plugins_dir` | `plugins_dir` | `ELASTIC_APM_PLUGINS_DIR` |
 
 
-## `use_elastic_traceparent_header` ([1.14.0]) [config-use-elastic-traceparent-header]
+## `use_elastic_traceparent_header` [config-use-elastic-traceparent-header]
+
+```{applies_to}
+apm_agent_java: ga 1.14.0
+```
 
 To enable [distributed tracing](docs-content://solutions/observability/apm/traces.md), the agent adds trace context headers to outgoing requests (like HTTP requests, Kafka records, gRPC requests etc.). These headers (`traceparent` and `tracestate`) are defined in the [W3C Trace Context](https://www.w3.org/TR/trace-context-1/) specification.
 
@@ -702,7 +786,11 @@ When this setting is `true`, the agent will also add the header `elastic-apm-tra
 | `elastic.apm.use_elastic_traceparent_header` | `use_elastic_traceparent_header` | `ELASTIC_APM_USE_ELASTIC_TRACEPARENT_HEADER` |
 
 
-## `disable_outgoing_tracecontext_headers` ([1.37.0]) [config-disable-outgoing-tracecontext-headers]
+## `disable_outgoing_tracecontext_headers` [config-disable-outgoing-tracecontext-headers]
+
+```{applies_to}
+apm_agent_java: ga 1.37.0
+```
 
 Use this option to disable `tracecontext` headers injection to any outgoing communication.
 
@@ -722,7 +810,11 @@ Disabling `tracecontext` headers injection means that [distributed tracing](docs
 | `elastic.apm.disable_outgoing_tracecontext_headers` | `disable_outgoing_tracecontext_headers` | `ELASTIC_APM_DISABLE_OUTGOING_TRACECONTEXT_HEADERS` |
 
 
-## `span_min_duration` ([1.16.0]) [config-span-min-duration]
+## `span_min_duration` [config-span-min-duration]
+
+```{applies_to}
+apm_agent_java: ga 1.16.0
+```
 
 Sets the minimum duration of spans. Spans that execute faster than this threshold are attempted to be discarded.
 
@@ -743,7 +835,11 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `0ms`.
 | `elastic.apm.span_min_duration` | `span_min_duration` | `ELASTIC_APM_SPAN_MIN_DURATION` |
 
 
-## `cloud_provider` ([1.21.0]) [config-cloud-provider]
+## `cloud_provider` [config-cloud-provider]
+
+```{applies_to}
+apm_agent_java: ga 1.21.0
+```
 
 This config value allows you to specify which cloud provider should be assumed for metadata collection. By default, the agent will attempt to detect the cloud provider or, if that fails, will use trial and error to collect the metadata.
 
@@ -771,7 +867,11 @@ A boolean specifying if the agent should search the class hierarchy for public a
 | `elastic.apm.enable_public_api_annotation_inheritance` | `enable_public_api_annotation_inheritance` | `ELASTIC_APM_ENABLE_PUBLIC_API_ANNOTATION_INHERITANCE` |
 
 
-## `transaction_name_groups` ([1.33.0]) [config-transaction-name-groups]
+## `transaction_name_groups` [config-transaction-name-groups]
+
+```{applies_to}
+apm_agent_java: ga 1.33.0
+```
 
 With this option, you can group transaction names that contain dynamic parts with a wildcard expression. For example, the pattern `GET /user/*/cart` would consolidate transactions, such as `GET /users/42/cart` and `GET /users/73/cart` into a single transaction name `GET /users/*/cart`, hence reducing the transaction name cardinality.
 
@@ -788,7 +888,11 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 | `elastic.apm.transaction_name_groups` | `transaction_name_groups` | `ELASTIC_APM_TRANSACTION_NAME_GROUPS` |
 
 
-## `trace_continuation_strategy` ([1.34.0]) [config-trace-continuation-strategy]
+## `trace_continuation_strategy` [config-trace-continuation-strategy]
+
+```{applies_to}
+apm_agent_java: ga 1.34.0
+```
 
 This option allows some control over how the APM agent handles W3C trace-context headers on incoming requests. By default, the `traceparent` and `tracestate` headers are used per W3C spec for distributed tracing. However, in certain cases it can be helpful to not use the incoming `traceparent` header. Some example use cases:
 
@@ -818,7 +922,11 @@ Valid options: `continue`, `restart`, `restart_external`
 | `elastic.apm.trace_continuation_strategy` | `trace_continuation_strategy` | `ELASTIC_APM_TRACE_CONTINUATION_STRATEGY` |
 
 
-## `baggage_to_attach` ([1.43.0]) [config-baggage-to-attach]
+## `baggage_to_attach` [config-baggage-to-attach]
+
+```{applies_to}
+apm_agent_java: ga 1.43.0
+```
 
 If any baggage key matches any of the patterns provided via this config option, the corresponding baggage key and value will be automatically stored on the corresponding transactions, spans and errors. The baggage keys will be prefixed with "baggage." on storage.
 

--- a/docs/reference/config-datastore.md
+++ b/docs/reference/config-datastore.md
@@ -18,7 +18,11 @@ products:
 
 
 
-## `elasticsearch_capture_body_urls` ([1.37.0]) [config-elasticsearch-capture-body-urls]
+## `elasticsearch_capture_body_urls` [config-elasticsearch-capture-body-urls]
+
+```{applies_to}
+apm_agent_java: ga 1.37.0
+```
 
 The URL path patterns for which the APM agent will capture the request body of outgoing requests to Elasticsearch made with the `elasticsearch-restclient` instrumentation. The default setting captures the body for Elasticsearch REST APIs searches and counts.
 

--- a/docs/reference/config-datastore.md
+++ b/docs/reference/config-datastore.md
@@ -2,6 +2,16 @@
 navigation_title: "Datastore"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-datastore.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Datastore configuration options [config-datastore]

--- a/docs/reference/config-http.md
+++ b/docs/reference/config-http.md
@@ -18,7 +18,11 @@ products:
 
 
 
-## `capture_body_content_types` ([1.5.0] performance) [config-capture-body-content-types]
+## `capture_body_content_types` (performance) [config-capture-body-content-types]
+
+```{applies_to}
+apm_agent_java: ga 1.5.0
+```
 
 Configures which content types should be recorded.
 
@@ -56,7 +60,11 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 | `elastic.apm.transaction_ignore_urls` | `transaction_ignore_urls` | `ELASTIC_APM_TRANSACTION_IGNORE_URLS` |
 
 
-## `transaction_ignore_user_agents` ([1.22.0]) [config-transaction-ignore-user-agents]
+## `transaction_ignore_user_agents` [config-transaction-ignore-user-agents]
+
+```{applies_to}
+apm_agent_java: ga 1.22.0
+```
 
 Used to restrict requests from certain User-Agents from being instrumented.
 
@@ -75,7 +83,11 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 | `elastic.apm.transaction_ignore_user_agents` | `transaction_ignore_user_agents` | `ELASTIC_APM_TRANSACTION_IGNORE_USER_AGENTS` |
 
 
-## `use_path_as_transaction_name` ([1.0.0]) [config-use-path-as-transaction-name]
+## `use_path_as_transaction_name` [config-use-path-as-transaction-name]
+
+```{applies_to}
+apm_agent_java: ga 1.0.0
+```
 
 If set to `true`, transaction names of unsupported or partially-supported frameworks will be in the form of `$method $path` instead of just `$method unknown route`.
 
@@ -116,7 +128,11 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 | `elastic.apm.url_groups` | `url_groups` | `ELASTIC_APM_URL_GROUPS` |
 
 
-## `capture_http_client_request_body_size` ([1.52.0] experimental) [config-capture-http-client-request-body-size]
+## `capture_http_client_request_body_size` (experimental) [config-capture-http-client-request-body-size]
+
+```{applies_to}
+apm_agent_java: ga 1.52.0
+```
 
 ::::{note}
 This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
@@ -139,7 +155,11 @@ Currently only support for Apache Http Client v4 and v5, HttpUrlConnection, Spri
 | `elastic.apm.capture_http_client_request_body_size` | `capture_http_client_request_body_size` | `ELASTIC_APM_CAPTURE_HTTP_CLIENT_REQUEST_BODY_SIZE` |
 
 
-## `capture_http_client_request_body_as_label` ([1.54.0]) [config-capture-http-client-request-body-as-label]
+## `capture_http_client_request_body_as_label` [config-capture-http-client-request-body-as-label]
+
+```{applies_to}
+apm_agent_java: ga 1.54.0
+```
 
 ::::{note}
 This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.

--- a/docs/reference/config-http.md
+++ b/docs/reference/config-http.md
@@ -2,6 +2,16 @@
 navigation_title: "HTTP"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-http.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # HTTP configuration options [config-http]

--- a/docs/reference/config-huge-traces.md
+++ b/docs/reference/config-huge-traces.md
@@ -2,6 +2,16 @@
 navigation_title: "Huge Traces"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-huge-traces.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm  
 ---
 
 # Huge Traces configuration options [config-huge-traces]

--- a/docs/reference/config-huge-traces.md
+++ b/docs/reference/config-huge-traces.md
@@ -18,7 +18,11 @@ products:
 
 
 
-## `span_compression_enabled` ([1.30.0]) [config-span-compression-enabled]
+## `span_compression_enabled` [config-span-compression-enabled]
+
+```{applies_to}
+apm_agent_java: ga 1.30.0
+```
 
 Setting this option to true will enable span compression feature. Span compression reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that some information such as DB statements of all the compressed spans will not be collected.
 
@@ -33,7 +37,11 @@ Setting this option to true will enable span compression feature. Span compressi
 | `elastic.apm.span_compression_enabled` | `span_compression_enabled` | `ELASTIC_APM_SPAN_COMPRESSION_ENABLED` |
 
 
-## `span_compression_exact_match_max_duration` ([1.30.0]) [config-span-compression-exact-match-max-duration]
+## `span_compression_exact_match_max_duration` [config-span-compression-exact-match-max-duration]
+
+```{applies_to}
+apm_agent_java: ga 1.30.0
+```
 
 Consecutive spans that are exact match and that are under this threshold will be compressed into a single composite span. This option does not apply to composite spans. This reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that the DB statements of all the compressed spans will not be collected.
 
@@ -50,7 +58,11 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `50ms`.
 | `elastic.apm.span_compression_exact_match_max_duration` | `span_compression_exact_match_max_duration` | `ELASTIC_APM_SPAN_COMPRESSION_EXACT_MATCH_MAX_DURATION` |
 
 
-## `span_compression_same_kind_max_duration` ([1.30.0]) [config-span-compression-same-kind-max-duration]
+## `span_compression_same_kind_max_duration` [config-span-compression-same-kind-max-duration]
+
+```{applies_to}
+apm_agent_java: ga 1.30.0
+```
 
 Consecutive spans to the same destination that are under this threshold will be compressed into a single composite span. This option does not apply to composite spans. This reduces the collection, processing, and storage overhead, and removes clutter from the UI. The tradeoff is that the DB statements of all the compressed spans will not be collected.
 
@@ -67,7 +79,11 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `0ms`.
 | `elastic.apm.span_compression_same_kind_max_duration` | `span_compression_same_kind_max_duration` | `ELASTIC_APM_SPAN_COMPRESSION_SAME_KIND_MAX_DURATION` |
 
 
-## `exit_span_min_duration` ([1.30.0]) [config-exit-span-min-duration]
+## `exit_span_min_duration` [config-exit-span-min-duration]
+
+```{applies_to}
+apm_agent_java: ga 1.30.0
+```
 
 Exit spans are spans that represent a call to an external service, like a database. If such calls are very short, they are usually not relevant and can be ignored.
 

--- a/docs/reference/config-jax-rs.md
+++ b/docs/reference/config-jax-rs.md
@@ -31,7 +31,11 @@ By default, the agent will scan for @Path annotations on the whole class hierarc
 | `elastic.apm.enable_jaxrs_annotation_inheritance` | `enable_jaxrs_annotation_inheritance` | `ELASTIC_APM_ENABLE_JAXRS_ANNOTATION_INHERITANCE` |
 
 
-## `use_jaxrs_path_as_transaction_name` ([1.8.0]) [config-use-jaxrs-path-as-transaction-name]
+## `use_jaxrs_path_as_transaction_name` [config-use-jaxrs-path-as-transaction-name]
+
+```{applies_to}
+apm_agent_java: ga 1.8.0
+```
 
 By default, the agent will use `ClassName#methodName` for the transaction name of JAX-RS requests. If you want to use the URI template from the `@Path` annotation, set the value to `true`.
 

--- a/docs/reference/config-jax-rs.md
+++ b/docs/reference/config-jax-rs.md
@@ -2,6 +2,16 @@
 navigation_title: "JAX-RS"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-jax-rs.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # JAX-RS configuration options [config-jax-rs]

--- a/docs/reference/config-jmx.md
+++ b/docs/reference/config-jmx.md
@@ -18,7 +18,11 @@ products:
 
 
 
-## `capture_jmx_metrics` ([1.11.0]) [config-capture-jmx-metrics]
+## `capture_jmx_metrics` [config-capture-jmx-metrics]
+
+```{applies_to}
+apm_agent_java: ga 1.11.0
+```
 
 Report metrics from JMX to the APM Server
 

--- a/docs/reference/config-jmx.md
+++ b/docs/reference/config-jmx.md
@@ -2,6 +2,16 @@
 navigation_title: "JMX"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-jmx.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # JMX configuration options [config-jmx]

--- a/docs/reference/config-logging.md
+++ b/docs/reference/config-logging.md
@@ -2,6 +2,16 @@
 navigation_title: "Logging"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-logging.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Logging configuration options [config-logging]

--- a/docs/reference/config-logging.md
+++ b/docs/reference/config-logging.md
@@ -60,7 +60,11 @@ When logging to a file, the log will be formatted in new-line-delimited JSON. Wh
 | `elastic.apm.log_file` | `log_file` | `ELASTIC_APM_LOG_FILE` |
 
 
-## `log_ecs_reformatting` ([1.22.0] experimental) [config-log-ecs-reformatting]
+## `log_ecs_reformatting` (experimental) [config-log-ecs-reformatting]
+
+```{applies_to}
+apm_agent_java: ga 1.22.0
+```
 
 ::::{note}
 This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
@@ -96,7 +100,11 @@ Valid options: `OFF`, `SHADE`, `REPLACE`, `OVERRIDE`
 | `elastic.apm.log_ecs_reformatting` | `log_ecs_reformatting` | `ELASTIC_APM_LOG_ECS_REFORMATTING` |
 
 
-## `log_ecs_reformatting_additional_fields` ([1.26.0]) [config-log-ecs-reformatting-additional-fields]
+## `log_ecs_reformatting_additional_fields` [config-log-ecs-reformatting-additional-fields]
+
+```{applies_to}
+apm_agent_java: ga 1.26.0
+```
 
 A comma-separated list of key-value pairs that will be added as additional fields to all log events. Takes the format `key=value[,key=value[,...]]`, for example: `key1=value1,key2=value2`. Only relevant if [`log_ecs_reformatting`](#config-log-ecs-reformatting) is set to any option other than `OFF`. Additional fields are currently not supported for direct log sending through the agent.
 
@@ -137,7 +145,11 @@ If [`log_ecs_reformatting`](#config-log-ecs-reformatting) is set to `SHADE` or `
 | `elastic.apm.log_ecs_reformatting_dir` | `log_ecs_reformatting_dir` | `ELASTIC_APM_LOG_ECS_REFORMATTING_DIR` |
 
 
-## `log_file_size` ([1.17.0]) [config-log-file-size]
+## `log_file_size` [config-log-file-size]
+
+```{applies_to}
+apm_agent_java: ga 1.17.0
+```
 
 The size of the log file.
 
@@ -152,7 +164,11 @@ The agent always keeps one history file so that the max total log file size is t
 | `elastic.apm.log_file_size` | `log_file_size` | `ELASTIC_APM_LOG_FILE_SIZE` |
 
 
-## `log_format_sout` ([1.17.0]) [config-log-format-sout]
+## `log_format_sout` [config-log-format-sout]
+
+```{applies_to}
+apm_agent_java: ga 1.17.0
+```
 
 Defines the log format when logging to `System.out`.
 
@@ -169,7 +185,11 @@ Valid options: `PLAIN_TEXT`, `JSON`
 | `elastic.apm.log_format_sout` | `log_format_sout` | `ELASTIC_APM_LOG_FORMAT_SOUT` |
 
 
-## `log_format_file` ([1.17.0]) [config-log-format-file]
+## `log_format_file` [config-log-format-file]
+
+```{applies_to}
+apm_agent_java: ga 1.17.0
+```
 
 Defines the log format when logging to a file.
 
@@ -186,7 +206,11 @@ Valid options: `PLAIN_TEXT`, `JSON`
 | `elastic.apm.log_format_file` | `log_format_file` | `ELASTIC_APM_LOG_FORMAT_FILE` |
 
 
-## `log_sending` ([1.36.0] experimental) [config-log-sending]
+## `log_sending` (experimental) [config-log-sending]
+
+```{applies_to}
+apm_agent_java: ga 1.36.0
+```
 
 ::::{note}
 This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.

--- a/docs/reference/config-messaging.md
+++ b/docs/reference/config-messaging.md
@@ -2,6 +2,16 @@
 navigation_title: "Messaging"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-messaging.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Messaging configuration options [config-messaging]

--- a/docs/reference/config-messaging.md
+++ b/docs/reference/config-messaging.md
@@ -37,7 +37,11 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 | `elastic.apm.ignore_message_queues` | `ignore_message_queues` | `ELASTIC_APM_IGNORE_MESSAGE_QUEUES` |
 
 
-## `jms_listener_packages` (performance [1.36.0]) [config-jms-listener-packages]
+## `jms_listener_packages` (performance) [config-jms-listener-packages]
+
+```{applies_to}
+apm_agent_java: ga 1.36.0
+```
 
 Defines which packages contain JMS MessageListener implementations for instrumentation. When empty (default), all inner-classes or any classes that have *Listener* or *Message* in their names are considered.
 
@@ -54,7 +58,11 @@ Starting from version 1.43.0, the classes that are part of the *application_pack
 | `elastic.apm.jms_listener_packages` | `jms_listener_packages` | `ELASTIC_APM_JMS_LISTENER_PACKAGES` |
 
 
-## `rabbitmq_naming_mode` ([1.46.0]) [config-rabbitmq-naming-mode]
+## `rabbitmq_naming_mode` [config-rabbitmq-naming-mode]
+
+```{applies_to}
+apm_agent_java: ga 1.46.0
+```
 
 Defines whether the agent should use the exchanges, the routing key or the queue for the naming of RabbitMQ Transactions. Valid options are `QUEUE`, `ROUTING_KEY` and `EXCHANGE`. Note that `QUEUE` only works when using RabbitMQ via spring-amqp and `ROUTING_KEY` only works for the non spring-client.
 

--- a/docs/reference/config-metrics.md
+++ b/docs/reference/config-metrics.md
@@ -18,7 +18,11 @@ products:
 
 
 
-## `dedot_custom_metrics` ([1.22.0]) [config-dedot-custom-metrics]
+## `dedot_custom_metrics` [config-dedot-custom-metrics]
+
+```{applies_to}
+apm_agent_java: ga 1.22.0
+```
 
 Replaces dots with underscores in the metric names for Micrometer metrics.
 
@@ -38,7 +42,11 @@ Setting this to `false` can lead to mapping conflicts as dots indicate nesting i
 | `elastic.apm.dedot_custom_metrics` | `dedot_custom_metrics` | `ELASTIC_APM_DEDOT_CUSTOM_METRICS` |
 
 
-## `custom_metrics_histogram_boundaries` ([1.37.0] experimental) [config-custom-metrics-histogram-boundaries]
+## `custom_metrics_histogram_boundaries` (experimental) [config-custom-metrics-histogram-boundaries]
+
+```{applies_to}
+apm_agent_java: ga 1.37.0
+```
 
 ::::{note}
 This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
@@ -58,9 +66,13 @@ Note that for OpenTelemetry 1.32.0 or newer this setting will only work when usi
 | `elastic.apm.custom_metrics_histogram_boundaries` | `custom_metrics_histogram_boundaries` | `ELASTIC_APM_CUSTOM_METRICS_HISTOGRAM_BOUNDARIES` |
 
 
-## `metric_set_limit` ([1.33.0]) [config-metric-set-limit]
+## `metric_set_limit` [config-metric-set-limit]
 
-Limits the number of active metric sets. The metrics sets have associated labels, and the metrics sets are held internally in a map using the labels as keys. The map is limited in size by this option to prevent unbounded growth. If you hit the limit, you’ll receive a warning in the agent log. The recommended option to workaround the limit is to try to limit the cardinality of the labels, eg naming your transactions so that there are fewer distinct transaction names. But if you must, you can use this option to increase the limit.
+```{applies_to}
+apm_agent_java: ga 1.33.0
+```
+
+Limits the number of active metric sets. The metrics sets have associated labels, and the metrics sets are held internally in a map using the labels as keys. The map is limited in size by this option to prevent unbounded growth. If you select the limit, you'll receive a warning in the agent log. The recommended option to workaround the limit is to try to limit the cardinality of the labels, eg naming your transactions so that there are fewer distinct transaction names. But if you must, you can use this option to increase the limit.
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -71,9 +83,13 @@ Limits the number of active metric sets. The metrics sets have associated labels
 | `elastic.apm.metric_set_limit` | `metric_set_limit` | `ELASTIC_APM_METRIC_SET_LIMIT` |
 
 
-## `agent_reporter_health_metrics` ([1.35.0]) [config-agent-reporter-health-metrics]
+## `agent_reporter_health_metrics` [config-agent-reporter-health-metrics]
 
-Enables metrics which capture the health state of the agent’s event reporting mechanism.
+```{applies_to}
+apm_agent_java: ga 1.35.0
+```
+
+Enables metrics which capture the health state of the agent's event reporting mechanism.
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -84,7 +100,11 @@ Enables metrics which capture the health state of the agent’s event reporting 
 | `elastic.apm.agent_reporter_health_metrics` | `agent_reporter_health_metrics` | `ELASTIC_APM_AGENT_REPORTER_HEALTH_METRICS` |
 
 
-## `agent_background_overhead_metrics` ([1.35.0]) [config-agent-background-overhead-metrics]
+## `agent_background_overhead_metrics` [config-agent-background-overhead-metrics]
+
+```{applies_to}
+apm_agent_java: ga 1.35.0
+```
 
 Enables metrics which capture the resource consumption of agent background tasks.
 

--- a/docs/reference/config-metrics.md
+++ b/docs/reference/config-metrics.md
@@ -2,6 +2,16 @@
 navigation_title: "Metrics"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-metrics.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Metrics configuration options [config-metrics]

--- a/docs/reference/config-profiling.md
+++ b/docs/reference/config-profiling.md
@@ -2,6 +2,16 @@
 navigation_title: "Profiling"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-profiling.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Profiling configuration options [config-profiling]

--- a/docs/reference/config-profiling.md
+++ b/docs/reference/config-profiling.md
@@ -18,9 +18,13 @@ products:
 
 
 
-## `universal_profiling_integration_enabled` ([1.50.0]) [config-universal-profiling-integration-enabled]
+## `universal_profiling_integration_enabled` [config-universal-profiling-integration-enabled]
 
-If enabled, the apm agent will correlate it’s transaction with the profiling data from elastic universal profiling running on the same host.
+```{applies_to}
+apm_agent_java: ga 1.50.0
+```
+
+If enabled, the apm agent will correlate it's transaction with the profiling data from elastic universal profiling running on the same host.
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -31,9 +35,13 @@ If enabled, the apm agent will correlate it’s transaction with the profiling d
 | `elastic.apm.universal_profiling_integration_enabled` | `universal_profiling_integration_enabled` | `ELASTIC_APM_UNIVERSAL_PROFILING_INTEGRATION_ENABLED` |
 
 
-## `universal_profiling_integration_buffer_size` ([1.50.0]) [config-universal-profiling-integration-buffer-size]
+## `universal_profiling_integration_buffer_size` [config-universal-profiling-integration-buffer-size]
 
-The feature needs to buffer ended local-root spans for a short duration to ensure that all of its profiling data has been received.This configuration option configures the buffer size in number of spans. The higher the number of local root spans per second, the higher this buffer size should be set. The agent will log a warning if it is not capable of buffering a span due to insufficient buffer size. This will cause the span to be exported immediately instead with possibly incomplete profiling correlation data.
+```{applies_to}
+apm_agent_java: ga 1.50.0
+```
+
+The feature needs to buffer ended local-root spans for a short duration to ensure that all of its profiling data has been received. This configuration option configures the buffer size in number of spans. The higher the number of local root spans per second, the higher this buffer size should be set. The agent will log a warning if it is not capable of buffering a span due to insufficient buffer size. This will cause the span to be exported immediately instead with possibly incomplete profiling correlation data.
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -44,9 +52,13 @@ The feature needs to buffer ended local-root spans for a short duration to ensur
 | `elastic.apm.universal_profiling_integration_buffer_size` | `universal_profiling_integration_buffer_size` | `ELASTIC_APM_UNIVERSAL_PROFILING_INTEGRATION_BUFFER_SIZE` |
 
 
-## `universal_profiling_integration_socket_dir` ([1.50.0]) [config-universal-profiling-integration-socket-dir]
+## `universal_profiling_integration_socket_dir` [config-universal-profiling-integration-socket-dir]
 
-The extension needs to bind a socket to a file for communicating with the universal profiling host agent.This configuration option can be used to change the location. Note that the total path name (including the socket) must not exceed 100 characters due to OS restrictions. If unset, the value of the `java.io.tmpdir` system property will be used.
+```{applies_to}
+apm_agent_java: ga 1.50.0
+```
+
+The extension needs to bind a socket to a file for communicating with the universal profiling host agent. This configuration option can be used to change the location. Note that the total path name (including the socket) must not exceed 100 characters due to OS restrictions. If unset, the value of the `java.io.tmpdir` system property will be used.
 
 | Default | Type | Dynamic |
 | --- | --- | --- |
@@ -57,7 +69,11 @@ The extension needs to bind a socket to a file for communicating with the univer
 | `elastic.apm.universal_profiling_integration_socket_dir` | `universal_profiling_integration_socket_dir` | `ELASTIC_APM_UNIVERSAL_PROFILING_INTEGRATION_SOCKET_DIR` |
 
 
-## `profiling_inferred_spans_enabled` ([1.15.0] experimental) [config-profiling-inferred-spans-enabled]
+## `profiling_inferred_spans_enabled` (experimental) [config-profiling-inferred-spans-enabled]
+
+```{applies_to}
+apm_agent_java: ga 1.15.0
+```
 
 ::::{note}
 This feature is currently experimental, which means it is disabled by default and it is not guaranteed to be backwards compatible in future releases.
@@ -88,7 +104,11 @@ This feature is not available on Windows and on OpenJ9. In addition only Java 7 
 | `elastic.apm.profiling_inferred_spans_enabled` | `profiling_inferred_spans_enabled` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_ENABLED` |
 
 
-## `profiling_inferred_spans_logging_enabled` ([1.37.0]) [config-profiling-inferred-spans-logging-enabled]
+## `profiling_inferred_spans_logging_enabled` [config-profiling-inferred-spans-logging-enabled]
+
+```{applies_to}
+apm_agent_java: ga 1.37.0
+```
 
 By default, async profiler prints warning messages about missing JVM symbols to standard output. Set this option to `false` to suppress such messages
 
@@ -103,7 +123,11 @@ By default, async profiler prints warning messages about missing JVM symbols to 
 | `elastic.apm.profiling_inferred_spans_logging_enabled` | `profiling_inferred_spans_logging_enabled` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_LOGGING_ENABLED` |
 
 
-## `profiling_inferred_spans_sampling_interval` ([1.15.0]) [config-profiling-inferred-spans-sampling-interval]
+## `profiling_inferred_spans_sampling_interval` [config-profiling-inferred-spans-sampling-interval]
+
+```{applies_to}
+apm_agent_java: ga 1.15.0
+```
 
 The frequency at which stack traces are gathered within a profiling session. The lower you set it, the more accurate the durations will be. This comes at the expense of higher overhead and more spans for potentially irrelevant operations. The minimal duration of a profiling-inferred span is the same as the value of this setting.
 
@@ -120,7 +144,11 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `50ms`.
 | `elastic.apm.profiling_inferred_spans_sampling_interval` | `profiling_inferred_spans_sampling_interval` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_SAMPLING_INTERVAL` |
 
 
-## `profiling_inferred_spans_min_duration` ([1.15.0]) [config-profiling-inferred-spans-min-duration]
+## `profiling_inferred_spans_min_duration` [config-profiling-inferred-spans-min-duration]
+
+```{applies_to}
+apm_agent_java: ga 1.15.0
+```
 
 The minimum duration of an inferred span. Note that the min duration is also implicitly set by the sampling interval. However, increasing the sampling interval also decreases the accuracy of the duration of inferred spans.
 
@@ -137,7 +165,11 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `0ms`.
 | `elastic.apm.profiling_inferred_spans_min_duration` | `profiling_inferred_spans_min_duration` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_MIN_DURATION` |
 
 
-## `profiling_inferred_spans_included_classes` ([1.15.0]) [config-profiling-inferred-spans-included-classes]
+## `profiling_inferred_spans_included_classes` [config-profiling-inferred-spans-included-classes]
+
+```{applies_to}
+apm_agent_java: ga 1.15.0
+```
 
 If set, the agent will only create inferred spans for methods which match this list. Setting a value may slightly reduce overhead and can reduce clutter by only creating spans for the classes you are interested in. Example: `org.example.myapp.*`
 
@@ -154,7 +186,11 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 | `elastic.apm.profiling_inferred_spans_included_classes` | `profiling_inferred_spans_included_classes` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_INCLUDED_CLASSES` |
 
 
-## `profiling_inferred_spans_excluded_classes` ([1.15.0]) [config-profiling-inferred-spans-excluded-classes]
+## `profiling_inferred_spans_excluded_classes` [config-profiling-inferred-spans-excluded-classes]
+
+```{applies_to}
+apm_agent_java: ga 1.15.0
+```
 
 Excludes classes for which no profiler-inferred spans should be created.
 
@@ -171,7 +207,11 @@ This option supports the wildcard `*`, which matches zero or more characters. Ex
 | `elastic.apm.profiling_inferred_spans_excluded_classes` | `profiling_inferred_spans_excluded_classes` | `ELASTIC_APM_PROFILING_INFERRED_SPANS_EXCLUDED_CLASSES` |
 
 
-## `profiling_inferred_spans_lib_directory` ([1.18.0]) [config-profiling-inferred-spans-lib-directory]
+## `profiling_inferred_spans_lib_directory` [config-profiling-inferred-spans-lib-directory]
+
+```{applies_to}
+apm_agent_java: ga 1.18.0
+```
 
 Profiling requires that the [async-profiler](https://github.com/jvm-profiling-tools/async-profiler) shared library is exported to a temporary location and loaded by the JVM. The partition backing this location must be executable, however in some server-hardened environments, `noexec` may be set on the standard `/tmp` partition, leading to `java.lang.UnsatisfiedLinkError` errors. Set this property to an alternative directory (e.g. `/var/tmp`) to resolve this. If unset, the value of the `java.io.tmpdir` system property will be used.
 

--- a/docs/reference/config-reference-properties-file.md
+++ b/docs/reference/config-reference-properties-file.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-reference-properties-file.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Property file reference [config-reference-properties-file]

--- a/docs/reference/config-reporter.md
+++ b/docs/reference/config-reporter.md
@@ -223,7 +223,11 @@ Allowed byte units are `b`, `kb` and `mb`. `1kb` is equal to `1024b`.
 | `elastic.apm.api_request_size` | `api_request_size` | `ELASTIC_APM_API_REQUEST_SIZE` |
 
 
-## `metrics_interval` ([1.3.0]) [config-metrics-interval]
+## `metrics_interval` [config-metrics-interval]
+
+```{applies_to}
+apm_agent_java: ga 1.3.0
+```
 
 The interval at which the agent sends metrics to the APM Server, rounded down to the nearest second (ie 3783ms would be applied as 3000ms). If there is an interval (step) defined in the Meter, that interval (to the nearest second) will instead be used, for that Meter. If the Meter step interval is less than 1 second, the meter will not be reported. Must be at least `1s`. Set to `0s` to deactivate.
 
@@ -238,7 +242,11 @@ Supports the duration suffixes `ms`, `s` and `m`. Example: `30s`.
 | `elastic.apm.metrics_interval` | `metrics_interval` | `ELASTIC_APM_METRICS_INTERVAL` |
 
 
-## `disable_metrics` ([1.3.0]) [config-disable-metrics]
+## `disable_metrics` [config-disable-metrics]
+
+```{applies_to}
+apm_agent_java: ga 1.3.0
+```
 
 Disables the collection of certain metrics. If the name of a metric matches any of the wildcard expressions, it will not be collected. Example: `foo.*,bar.*`
 

--- a/docs/reference/config-reporter.md
+++ b/docs/reference/config-reporter.md
@@ -2,6 +2,16 @@
 navigation_title: "Reporter"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-reporter.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Reporter configuration options [config-reporter]

--- a/docs/reference/config-serverless.md
+++ b/docs/reference/config-serverless.md
@@ -2,6 +2,16 @@
 navigation_title: "Serverless"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-serverless.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Serverless configuration options [config-serverless]

--- a/docs/reference/config-serverless.md
+++ b/docs/reference/config-serverless.md
@@ -18,7 +18,11 @@ products:
 
 
 
-## `aws_lambda_handler` ([1.28.0]) [config-aws-lambda-handler]
+## `aws_lambda_handler` [config-aws-lambda-handler]
+
+```{applies_to}
+apm_agent_java: ga 1.28.0
+```
 
 This config option must be used when running the agent in an AWS Lambda context. This config value allows to specify the fully qualified name of the class handling the lambda function. An empty value (default value) indicates that the agent is not running within an AWS lambda function.
 
@@ -31,7 +35,11 @@ This config option must be used when running the agent in an AWS Lambda context.
 | `elastic.apm.aws_lambda_handler` | `aws_lambda_handler` | `ELASTIC_APM_AWS_LAMBDA_HANDLER` |
 
 
-## `data_flush_timeout` ([1.28.0]) [config-data-flush-timeout]
+## `data_flush_timeout` [config-data-flush-timeout]
+
+```{applies_to}
+apm_agent_java: ga 1.28.0
+```
 
 This config value allows to specify the timeout in milliseconds for flushing APM data at the end of a serverless function. For serverless functions, APM data is written in a synchronous way, thus, blocking the termination of the function util data is written or the specified timeout is reached.
 

--- a/docs/reference/config-stacktrace.md
+++ b/docs/reference/config-stacktrace.md
@@ -2,6 +2,16 @@
 navigation_title: "Stacktrace"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/config-stacktrace.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Stacktrace configuration options [config-stacktrace]

--- a/docs/reference/config-stacktrace.md
+++ b/docs/reference/config-stacktrace.md
@@ -48,6 +48,10 @@ the instrumentation aspect of this configuration option - specifying which class
 
 ## `stack_trace_limit` (performance) [config-stack-trace-limit]
 
+```{applies_to}
+apm_agent_java: ga 1.0.0
+```
+
 Setting it to 0 will disable stack trace collection. Any positive integer value will be used as the maximum number of frames to collect. Setting it -1 means that all frames will be collected.
 
 [![dynamic config](images/dynamic-config.svg "") ](/reference/configuration.md#configuration-dynamic)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/configuration.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Configuration [configuration]

--- a/docs/reference/frequently-asked-questions.md
+++ b/docs/reference/frequently-asked-questions.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/faq.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Frequently asked questions [faq]

--- a/docs/reference/how-to-find-slow-methods.md
+++ b/docs/reference/how-to-find-slow-methods.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/java-method-monitoring.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # How to find slow methods [java-method-monitoring]
@@ -8,7 +18,7 @@ mapped_pages:
 Identifying a problematic service is only half of the battle when diagnosing application slowdowns. Luckily, the Elastic APM Java Agent provides multiple ways to get method-level insights into your code. This can help you diagnose slow requests due to heavy computations, inefficient algorithms, or similar problems not related to interactions between services.
 
 
-## *If you don’t know which methods you want to monitor…​* [_if_you_dont_know_which_methods_you_want_to_monitor]
+## *If you don’t know which methods you want to monitor… * [_if_you_dont_know_which_methods_you_want_to_monitor]
 
 
 ### Sampling-based profiler [_sampling_based_profiler]
@@ -20,7 +30,7 @@ Find out which part of your code is making your application slow by periodically
 [Learn more](/reference/method-sampling-based.md)
 
 
-## *If you know which methods you want to monitor…​* [_if_you_know_which_methods_you_want_to_monitor]
+## *If you know which methods you want to monitor… * [_if_you_know_which_methods_you_want_to_monitor]
 
 
 ### API/Code [_apicode]

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -2,6 +2,16 @@
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/intro.html
   - https://www.elastic.co/guide/en/apm/agent/java/current/index.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # APM Java agent [intro]
@@ -18,7 +28,7 @@ The minimum required version of the APM Server is 6.5.0
 
 The Agent auto-instruments [Supported technologies](/reference/set-up-apm-java-agent.md#supported-technologies) and records interesting events, like spans for database queries and transactions for incoming HTTP requests. To do this, it leverages the capability of the JVM to instrument the bytecode of classes. This means that for the supported technologies, there are no code changes required.
 
-Spans are grouped in transactions — by default, one for each incoming HTTP request. But it’s possible to create custom transactions not associated with an HTTP request. Transactions and Spans are sent to the APM Server, where they’re converted to a format suitable for Elasticsearch. You can then use the APM app in Kibana to gain insight into latency issues and error culprits within your application.
+Spans are grouped in transactions — by default, one for each incoming HTTP request. But it’s possible to create custom transactions not associated with an HTTP request. Transactions and Spans are sent to the APM Server, where they’re converted to a format suitable for Elasticsearch. You can then use the APM app in Kibana to gain insight into latency issues and error culprits within your application.
 
 More detailed information on how the Agent works can be found in the [FAQ](/reference/frequently-asked-questions.md#faq-how-does-it-work).
 

--- a/docs/reference/logs.md
+++ b/docs/reference/logs.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/logs.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm  
 ---
 
 # Logs [logs]

--- a/docs/reference/method-annotations.md
+++ b/docs/reference/method-annotations.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/method-annotations.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Annotations [method-annotations]

--- a/docs/reference/method-api.md
+++ b/docs/reference/method-api.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/method-api.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # API/Code [method-api]

--- a/docs/reference/method-config-based.md
+++ b/docs/reference/method-config-based.md
@@ -1,13 +1,23 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/method-config-based.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Configuration-based [method-config-based]
 
 Use the [`trace_methods`](/reference/config-core.md#config-trace-methods) configuration option to specify additional methods to instrument. You can match methods via wildcards in the package, class or method name, by their modifier (like public), by a particular annotation, and more. Because you don’t need to modify your source code, this makes it possible to monitor code in 3rd party libraries.
 
-Be careful, it’s easy to overuse `trace_methods` by matching too many methods—​hurting both runtime and startup performance. Use in conjunction with [`span_min_duration`](/reference/config-core.md#config-span-min-duration) when setting for entire packages in order to avoid having too many spans in the APM app.
+Be careful, it’s easy to overuse `trace_methods` by matching too many methods— hurting both runtime and startup performance. Use in conjunction with [`span_min_duration`](/reference/config-core.md#config-span-min-duration) when setting for entire packages in order to avoid having too many spans in the APM app.
 
 For more information, and examples, see the [`trace_methods`](/reference/config-core.md#config-trace-methods) configuration reference.
 

--- a/docs/reference/method-sampling-based.md
+++ b/docs/reference/method-sampling-based.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/method-sampling-based.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Sampling-based profiler [method-sampling-based]

--- a/docs/reference/metrics.md
+++ b/docs/reference/metrics.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/metrics.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Metrics [metrics]
@@ -12,7 +22,7 @@ These metrics will be sent regularly to the APM Server and from there to Elastic
 The metrics will be stored in the `apm-*` index and have the `processor.event` property set to `metric`.
 
 ::::{note}
-Dedicated JVM metrics views are available since Elastic stack version 7.2. Starting in 7.5, metrics are aggregated separately for each JVM, relying on the ID of the underlying system — either container ID (where applicable) or hostname. Starting in Java agent version 1.11.0, it is possible to manually configure a unique name for each service node/JVM through [`service_node_name`](/reference/config-core.md#config-service-node-name). When multiple JVMs are running on the same host and report data for the same service, this configuration is required in order to be able to view metrics at the JVM level.
+Dedicated JVM metrics views are available since Elastic stack version 7.2. Starting in 7.5, metrics are aggregated separately for each JVM, relying on the ID of the underlying system — either container ID (where applicable) or hostname. Starting in Java agent version 1.11.0, it is possible to manually configure a unique name for each service node/JVM through [`service_node_name`](/reference/config-core.md#config-service-node-name). When multiple JVMs are running on the same host and report data for the same service, this configuration is required in order to be able to view metrics at the JVM level.
 ::::
 
 

--- a/docs/reference/opentelemetry-bridge.md
+++ b/docs/reference/opentelemetry-bridge.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/opentelemetry-bridge.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # OpenTelemetry bridge [opentelemetry-bridge]

--- a/docs/reference/opentracing-bridge.md
+++ b/docs/reference/opentracing-bridge.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/opentracing-bridge.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # OpenTracing bridge [opentracing-bridge]

--- a/docs/reference/overhead-performance-tuning.md
+++ b/docs/reference/overhead-performance-tuning.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/tuning-and-overhead.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Overhead and performance tuning [tuning-and-overhead]

--- a/docs/reference/plugin-api.md
+++ b/docs/reference/plugin-api.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/plugin-api.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Plugin API [plugin-api]

--- a/docs/reference/public-api.md
+++ b/docs/reference/public-api.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/public-api.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Public API [public-api]

--- a/docs/reference/set-up-apm-java-agent.md
+++ b/docs/reference/set-up-apm-java-agent.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/setup.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Set up the APM Java Agent [setup]

--- a/docs/reference/setup-attach-api.md
+++ b/docs/reference/setup-attach-api.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/setup-attach-api.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Programmatic API setup to self-attach [setup-attach-api]

--- a/docs/reference/setup-attach-cli.md
+++ b/docs/reference/setup-attach-cli.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/setup-attach-cli.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Automatic setup with apm-agent-attach-cli.jar [setup-attach-cli]
@@ -85,19 +95,19 @@ The JVM arguments may contain sensitive information, such as passwords provided 
 :   Includes all JVMs for attachment.
 
 
-**--include-pid <pid>…​**
+**--include-pid <pid>… **
 :   A PID to include.
 
 
-**--include-main/--exclude-main <pattern>…​**
+**--include-main/--exclude-main <pattern>… **
 :   A regular expression of fully qualified main class names or paths to JARs of applications the java agent should be attached to. Performs a partial match so that `foo` matches `/bin/foo.jar`.
 
 
-**--include-vmarg/--exclude-vmarg <pattern>…​**
+**--include-vmarg/--exclude-vmarg <pattern>… **
 :   A regular expression that is matched against the arguments passed to the JVM, such as system properties. Performs a partial match so that `attach=true` matches the system property `-Delastic.apm.attach=true`.
 
 
-**--include-user/--exclude-user <user>…​**
+**--include-user/--exclude-user <user>… **
 :   A username that is matched against the operating system user that run the JVM. For included users, make sure that the user this program is running under is either the same user or has permissions to switch to the user that runs the target JVM.
 
 
@@ -114,7 +124,7 @@ This option cannot be used in conjunction with `--args-provider`
 
 
 
-**-C --config <key=value>…​**
+**-C --config <key=value>… **
 :   This repeatable option sets one agent configuration option.
 
 Example: `--config server_url=http://127.0.0.1:8200`

--- a/docs/reference/setup-javaagent.md
+++ b/docs/reference/setup-javaagent.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/setup-javaagent.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Manual setup with -javaagent flag [setup-javaagent]

--- a/docs/reference/ssl-configuration.md
+++ b/docs/reference/ssl-configuration.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/ssl-configuration.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # SSL/TLS communication with APM Server [ssl-configuration]

--- a/docs/reference/supported-technologies.md
+++ b/docs/reference/supported-technologies.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/supported-technologies-details.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Supported technologies [supported-technologies-details]
@@ -156,7 +166,7 @@ This section lists all supported asynchronous frameworks.
 | `ExecutorService` |  | The agent propagates the context for `ExecutorService` s. | 1.4.0 |
 | `ScheduledExecutorService` |  | The agent propagates the context for `ScheduledExecutorService#schedule` (this does not include `scheduleAtFixedRate` or `scheduleWithFixedDelay`. | 1.17.0 |
 | `ForkJoinPool` |  | The agent propagates the context for `ForkJoinPool` s. | 1.17.0 |
-| Scala Future | 2.13.x | The agent propagates the context when using the `scala.concurrent.Future` or `scala.concurrent.Promise`.It will propagate the context when using chaining methods such as `map`, `flatMap`, `traverse`, …​NOTE: To enable Scala Future support, you need to enable experimental plugins. | 1.18.0 |
+| Scala Future | 2.13.x | The agent propagates the context when using the `scala.concurrent.Future` or `scala.concurrent.Promise`.It will propagate the context when using chaining methods such as `map`, `flatMap`, `traverse`, … NOTE: To enable Scala Future support, you need to enable experimental plugins. | 1.18.0 |
 | Reactor | 3.2.x+ | The agent propagates the context for `Flux` and `Mono`. | 1.24.0 (experimental), 1.34.0 (GA) |
 
 

--- a/docs/reference/tracing-apis.md
+++ b/docs/reference/tracing-apis.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/apis.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Tracing APIs [apis]

--- a/docs/reference/upgrading.md
+++ b/docs/reference/upgrading.md
@@ -1,6 +1,16 @@
 ---
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/upgrading.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Upgrading [upgrading]

--- a/docs/release-notes/breaking-changes.md
+++ b/docs/release-notes/breaking-changes.md
@@ -1,5 +1,15 @@
 ---
 navigation_title: "Breaking changes"
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM Java Agent breaking changes

--- a/docs/release-notes/deprecations.md
+++ b/docs/release-notes/deprecations.md
@@ -1,5 +1,15 @@
 ---
 navigation_title: "Deprecations"
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM Java Agent deprecations [elastic-apm-java-agent-deprecations]

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -3,6 +3,16 @@ navigation_title: "Elastic APM Java Agent"
 mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/java/current/release-notes-1.x.html
   - https://www.elastic.co/guide/en/apm/agent/java/current/release-notes.html
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM Java Agent release notes [elastic-apm-java-agent-release-notes]

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -1,6 +1,15 @@
 ---
 navigation_title: "Known issues"
-
+applies_to:
+  stack:
+  serverless:
+    observability:
+  product:
+    apm_agent_java: ga
+products:
+  - id: cloud-serverless
+  - id: observability
+  - id: apm
 ---
 
 # Elastic APM Java Agent known issues [elastic-apm-java-agent-known-issues]


### PR DESCRIPTION
Adds ` applies_to` metadata for cumulative docs. See https://docs-v3-preview.elastic.dev/elastic/docs-builder/tree/main/syntax/applies

Contributes to https://github.com/elastic/docs-content-internal/issues/253