### PR TITLE
[Docs] Convert asciidoc lifecycle markers into Docs V3 syntax

### DIFF
--- a/docs/reference/config-reference-properties-file.md
+++ b/docs/reference/config-reference-properties-file.md
@@ -512,7 +512,7 @@ applies_to:
 #
 # A few examples:
 #
-#  - `org.example.*` added:[1.4.0,Omitting the method is possible since 1.4.0]
+#  - `org.example.*` {applies_to}`apm_agent_java: ga 1.4.0` Omitting the method is possible since 1.4.0
 #  - `org.example.*#*` (before 1.4.0, you need to specify a method matcher)
 #  - `org.example.MyClass#myMethod`
 #  - `org.example.MyClass#myMethod()`


### PR DESCRIPTION
There are some leftover asciidoc markers for identifying preview, beta, and deprecated features. This PR converts those into the syntax now expected by the markdown documentation system.

Rel: https://github.com/elastic/docs-content/issues/2951

cc @elastic/ingest-docs lmk if that looks right to you, I don't have any rights on this repo