### PR TITLE
fix reference config properties build

### DIFF
--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfigurationImpl.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/configuration/CoreConfigurationImpl.java
@@ -636,7 +636,7 @@ public class CoreConfigurationImpl extends ConfigurationOptionProvider implement
             "\n" +
             "A few examples:\n" +
             "\n" +
-            " - `org.example.*` added:[1.4.0,Omitting the method is possible since 1.4.0]\n" +
+            " - `org.example.*` Omitting the method is possible since 1.4.0\n" +
             " - `org.example.*#*` (before 1.4.0, you need to specify a method matcher)\n" +
             " - `org.example.MyClass#myMethod`\n" +
             " - `org.example.MyClass#myMethod()`\n" +

--- a/docs/reference/config-reference-properties-file.md
+++ b/docs/reference/config-reference-properties-file.md
@@ -512,7 +512,7 @@ applies_to:
 #
 # A few examples:
 #
-#  - `org.example.*` {applies_to}`apm_agent_java: ga 1.4.0` Omitting the method is possible since 1.4.0
+#  - `org.example.*` Omitting the method is possible since 1.4.0
 #  - `org.example.*#*` (before 1.4.0, you need to specify a method matcher)
 #  - `org.example.MyClass#myMethod`
 #  - `org.example.MyClass#myMethod()`


### PR DESCRIPTION
The generated reference config properties fails in CI, this is probably due to moving back the reference documentation in this repository, the `{applies_to}` marker is not very relevant so I've fixed it by removing it.