### PR TITLE
fix lettuce integration test

### DIFF
--- a/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/lettuce/Lettuce5InstrumentationIT.java
+++ b/apm-agent-plugins/apm-redis-plugin/apm-lettuce-plugin/src/test/java/co/elastic/apm/agent/lettuce/Lettuce5InstrumentationIT.java
@@ -75,9 +75,9 @@ public class Lettuce5InstrumentationIT extends AbstractRedisInstrumentationTest 
     public void testBatchedLettuce() throws Exception {
         RedisAsyncCommands<String, String> async = connection.async();
         async.set("foo", "bar").get();
-        async.setAutoFlushCommands(false);
+        connection.setAutoFlushCommands(false);
         List<RedisFuture<String>> futures = List.of(async.get("foo"), async.get("foo"));
-        async.flushCommands();
+        connection.flushCommands();
         LettuceFutures.awaitAll(Duration.ofSeconds(5), futures.toArray(new RedisFuture[0]));
         assertTransactionWithRedisSpans("SET", "GET", "GET");
     }


### PR DESCRIPTION
## What does this PR do?

Fixes lettuce 5 (and later) instrumentation as the API has changed in a recent release, the related PR is https://github.com/redis/lettuce/pull/3343.

This code change seems to be strictly equivalent, also in the future for lettuce 7.x it won't be possible to access the underlying connection from `RedisAsyncCommands` through the now deprecated `getStatefulConnection` so directly accessing it from the connection seems to be the most future-proof option.