### PR TITLE
temporary revert aws sdk version for tests

### DIFF
--- a/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/pom.xml
+++ b/apm-agent-plugins/apm-aws-sdk/apm-aws-sdk-2-plugin/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
-        <version.aws.sdk>2.34.6</version.aws.sdk>
+        <version.aws.sdk>2.32.13</version.aws.sdk>
         <version.aws.jms>2.0.0</version.aws.jms>
         <!-- AWS SDK v2 is compiled for Java 8 -->
         <maven.compiler.target>8</maven.compiler.target>


### PR DESCRIPTION
## What does this PR do?

Instrumentation tests fail with the latest version, hence breaking the build.
This PR just reverts to one of previous version while we investigate further the underlying issue.

The failing test with the latest version is `co.elastic.apm.agent.awssdk.v2.S3ClientIT`.
