### PR TITLE
dependabot ignore okhttp major update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,9 @@ updates:
       - dependency-name: "com.amazonaws:aws-java-sdk-dynamodb"
       - dependency-name: "com.amazonaws:aws-java-sdk"
       - dependency-name: "software.amazon.awssdk:*"
+      # we do not have support for 5.x yet
+      - dependency-name: "com.squareup.okhttp3:okhttp"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: "maven"
     directory: "/apm-agent-plugins"
     schedule:


### PR DESCRIPTION
documentation of this limitation will be covered in #4242 

Should trigger https://github.com/elastic/apm-agent-java/pull/4163 to be closed when merged.