### PR TITLE
fix tests for webflux making build longer

### DIFF
--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
@@ -199,7 +199,22 @@ public abstract class AbstractServerInstrumentationTest extends AbstractInstrume
 
     private Predicate<Throwable> expectClientError(int expectedStatus) {
         return error -> (error instanceof WebClientResponseException)
-            && ((WebClientResponseException) error).getStatusCode().value() == expectedStatus;
+            && getStatusCode((WebClientResponseException) error) == expectedStatus;
+    }
+
+    private static int getStatusCode(WebClientResponseException exception) {
+        // deal with API changes and deprecation in an ugly way
+        try {
+            return exception.getStatusCode().value();
+        } catch (Exception | Error e) {
+            // silently ignored
+        }
+        try {
+            return exception.getRawStatusCode();
+        } catch (Exception | Error e) {
+            return -1;
+        }
+
     }
 
     @ParameterizedTest


### PR DESCRIPTION
## What does this PR do?

Changes introduced in #4237 made the unit tests fail, but the most noticeable effect is that it makes them way slower, hence further compounding the build issues we have (#2955).

When testing locally, the tests appeared stalled on the exception thrown here.
With the workaround the tests execute locally in about ~15min, so there is no more any reason they take an hour and timeout in CI.
