### PR TITLE
skip unit tests for docs PR

### DIFF
--- a/.github/workflows/main-docs.yml
+++ b/.github/workflows/main-docs.yml
@@ -27,3 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: 'echo "Not required for docs"'
+
+  # dummy steps that allow to bypass those mandatory checks for tests
+  app-server-integration-tests:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "Not required for docs"'


### PR DESCRIPTION
Because we now require the `Unit Tests` step to be a mandatory check, we need to fake it in the docs build otherwise we have a mandatory check that can't be completed.

Unblocks merging #4242 