### PR TITLE
Dependabot ignoring integration-tests path

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    exclude-paths:
+      - "integration-tests/**"
     allow:
       - dependency-name: "com.lmax:disruptor"
       - dependency-name: "org.jctools:jctools-core"
@@ -44,9 +46,6 @@ updates:
       - dependency-name: "io.opentelemetry:*"
       - dependency-name: "io.opentelemetry.semconv:*"
     ignore:
-      - dependency-name: "net.bytebuddy:byte-buddy-agent"
-        # We deliberately want to keep this older version of Byte Buddy for our runtime attach test
-        versions: [ "<=1.9.16" ]
       - dependency-name: "org.slf4j:slf4j-api"
         # A static arbitrary version used within our external plugin test + latest for java 7
         versions: [ "<=1.7.25", "1.7.36" ]


### PR DESCRIPTION
Based on this comment: https://github.com/elastic/apm-agent-java/pull/4257#issuecomment-3426233981

Attempt to _hopefully_ make dependabot ignore dependencies under the `integration-tests` dir by using a recently introduced feature, [exclude-paths](https://github.blog/changelog/2025-08-26-dependabot-can-now-exclude-automatic-pull-requests-for-manifests-in-selected-subdirectories/).