### PR TITLE
Fix broken "openjdk:*" docker images used for testing

### DIFF
--- a/integration-tests/external-plugin-otel-test/external-plugin-otel-test-app/src/test/java/ExternalPluginOTelIT.java
+++ b/integration-tests/external-plugin-otel-test/external-plugin-otel-test-app/src/test/java/ExternalPluginOTelIT.java
@@ -40,7 +40,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class ExternalPluginOTelIT {
 
-    private static final String DOCKER_IMAGE = "openjdk:11";
+    private static final String DOCKER_IMAGE = "azul/zulu-openjdk:11-latest";
 
     @ParameterizedTest
     @ValueSource(booleans = {true, false})

--- a/integration-tests/main-app-test/src/test/java/co/elastic/apm/test/AgentSetupIT.java
+++ b/integration-tests/main-app-test/src/test/java/co/elastic/apm/test/AgentSetupIT.java
@@ -39,15 +39,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AgentSetupIT {
 
+    private static final String OPENJDK_17 = "azul/zulu-openjdk:17-latest";
+
     @ParameterizedTest
     @CsvSource({
-        "openjdk:7,STANDARD",
-        "openjdk:8,STANDARD",
-        "openjdk:8,JAVA8_BUILD",
-        "openjdk:11,STANDARD",
-        "openjdk:11,JAVA8_BUILD",
-        "openjdk:17,STANDARD",
-        "openjdk:17,JAVA8_BUILD"
+        "azul/zulu-openjdk:7-latest,STANDARD",
+        "azul/zulu-openjdk:8-latest,STANDARD",
+        "azul/zulu-openjdk:8-latest,JAVA8_BUILD",
+        "azul/zulu-openjdk:11-latest,STANDARD",
+        "azul/zulu-openjdk:11-latest,JAVA8_BUILD",
+        "azul/zulu-openjdk:17-latest,STANDARD",
+        "azul/zulu-openjdk:17-latest,JAVA8_BUILD"
     })
     void testServiceNameAndVersionFromManifest(String image, AgentFileAccessor.Variant agentVariant) {
         try (AgentTestContainer.JarApp app = testAppWithJavaAgent(image, agentVariant)) {
@@ -63,7 +65,7 @@ class AgentSetupIT {
     void testSecurityManagerWarning() {
         String expectedMsg = "Security manager without agent grant-all permission";
 
-        try (AgentTestContainer.JarApp app = testAppWithJavaAgent("openjdk:17", AgentFileAccessor.Variant.STANDARD)) {
+        try (AgentTestContainer.JarApp app = testAppWithJavaAgent(OPENJDK_17, AgentFileAccessor.Variant.STANDARD)) {
 
             app.withSecurityManager(null)
                 // using a dummy command since testcontainers 1.21.0 as waiting on stderr msg is not working anymore
@@ -90,7 +92,7 @@ class AgentSetupIT {
             "};"), StandardOpenOption.CREATE
         );
 
-        try (AgentTestContainer.JarApp app = testAppWithJavaAgent("openjdk:17", AgentFileAccessor.Variant.STANDARD)) {
+        try (AgentTestContainer.JarApp app = testAppWithJavaAgent(OPENJDK_17, AgentFileAccessor.Variant.STANDARD)) {
             app.withSecurityManager(MountableFile.forHostPath(tempPolicy))
                 .withStartupTimeout(Duration.ofSeconds(10))
                 .waitingFor(Wait.forLogMessage(".*Hello World!.*", 1))

--- a/integration-tests/quarkus/pom.xml
+++ b/integration-tests/quarkus/pom.xml
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mockserver</artifactId>
-            <version>1.17.6</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integration-tests/quarkus/quarkus-jaxrs-base/src/test/java/co/elastic/apm/quarkus/jaxrs/AbstractQuarkusJaxRSTest.java
+++ b/integration-tests/quarkus/quarkus-jaxrs-base/src/test/java/co/elastic/apm/quarkus/jaxrs/AbstractQuarkusJaxRSTest.java
@@ -83,7 +83,7 @@ public abstract class AbstractQuarkusJaxRSTest {
             .append("-javaagent:/tmp/elastic-apm-agent.jar -jar /srv/quarkus-app/quarkus-run.jar")
             .toString();
 
-        app = new GenericContainer<>("openjdk:11")
+        app = new GenericContainer<>("azul/zulu-openjdk:11-latest")
             .withCommand(cmd)
             .withCopyFileToContainer(MountableFile.forHostPath(AgentFileAccessor.getPathToJavaagent()), "/tmp/elastic-apm-agent.jar")
             .withCopyFileToContainer(MountableFile.forHostPath("target/quarkus-app"), "/srv/quarkus-app")


### PR DESCRIPTION
- `openjdk:11` docker image and a few others are not available anymore, replace them with azul equivalents
  - issue only happens locally after removing the docker images, but this is more common in CI where images are pulled.
- align version of a testcontainers dependency
  - not related nor required to fix tests, but worth simplifying