### PR TITLE
Avoiding script to fail on a partial failure to deploy to AWS

### DIFF
--- a/.ci/publish-aws.sh
+++ b/.ci/publish-aws.sh
@@ -97,5 +97,4 @@ if [ ${#failed_regions[@]} -gt 0 ]; then
   echo "========================================="
   echo "The ARN table has been generated for successful regions only."
   echo "You may need to manually publish to the failed regions later."
-  exit 1
 fi


### PR DESCRIPTION
Avoiding script to fail on a partial failure to deploy to AWS, to address issues like this one: https://github.com/elastic/apm-agent-java/actions/runs/24199192851/job/70637901605