### PR TITLE
Skip OTel histogram exports with no explicit bucket boundaries

### DIFF
--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -10,6 +10,7 @@ This file contains all changes which are not released yet.
 # Fixes
 <!--FIXES-START-->
 * Exclude `XmlLayout` class from log4j dependency - [#4459](https://github.com/elastic/apm-agent-java/pull/4459)
+* Stop OTel metrics exporter from throwing `IndexOutOfBoundsException` when a histogram has no explicit bucket boundaries
 <!--FIXES-END-->
 # Features and enhancements
 <!--ENHANCEMENTS-START-->

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/main/java/co/elastic/apm/agent/otelmetricsdk/OtelMetricSerializer.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/main/java/co/elastic/apm/agent/otelmetricsdk/OtelMetricSerializer.java
@@ -104,6 +104,14 @@ public class OtelMetricSerializer {
 
     private void addHistogramValues(CharSequence name, CharSequence instrScopeName, HistogramData histogramData) {
         for (HistogramPointData histo : histogramData.getPoints()) {
+            if (histo.getBoundaries().isEmpty()) {
+                // A histogram with no explicit boundaries has a single (-Inf, +Inf) bucket from
+                // which we cannot derive a representative value to send to the APM server.
+                if (metricsWithBadAggregations.add(name.toString())) {
+                    logger.warn("Ignoring histogram '{}' because it has no explicit bucket boundaries", name);
+                }
+                continue;
+            }
             long timestampMicros = histo.getEpochNanos() / 1000L;
             MetricSetSerializer metricSet = getOrCreateMetricSet(instrScopeName, timestampMicros, histo.getAttributes());
             metricSet.addExplicitBucketHistogram(name, histo.getBoundaries(), histo.getCounts());

--- a/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/test/java/co/elastic/apm/agent/otelmetricsdk/PrivateUserSdkOtelMetricsTest.java
+++ b/apm-agent-plugins/apm-opentelemetry/apm-opentelemetry-metricsdk-plugin/src/test/java/co/elastic/apm/agent/otelmetricsdk/PrivateUserSdkOtelMetricsTest.java
@@ -21,6 +21,7 @@ package co.elastic.apm.agent.otelmetricsdk;
 import co.elastic.apm.agent.configuration.MetricsConfigurationImpl;
 import io.opentelemetry.api.metrics.DoubleHistogram;
 import io.opentelemetry.api.metrics.DoubleHistogramBuilder;
+import io.opentelemetry.api.metrics.LongCounter;
 import io.opentelemetry.api.metrics.Meter;
 import io.opentelemetry.api.metrics.MeterProvider;
 import io.opentelemetry.sdk.metrics.Aggregation;
@@ -111,6 +112,33 @@ public class PrivateUserSdkOtelMetricsTest extends AbstractOtelMetricsTest {
         } catch (NoSuchMethodException e) {
             super.testDefaultHistogramBuckets();
         }
+    }
+
+    @Test
+    public void testHistogramWithEmptyBoundariesIsDropped() {
+        // A View configured with no explicit bucket boundaries produces a single (-Inf, +Inf)
+        // bucket. Our exporter cannot represent that, so it must skip the histogram point
+        // without throwing.
+        sdkCustomizer = builder -> builder.registerView(
+            InstrumentSelector.builder().setName("no_bounds_histo").build(),
+            View.builder().setAggregation(Aggregation.explicitBucketHistogram(List.of())).build()
+        );
+
+        Meter testMeter = createMeter("test");
+        DoubleHistogram badHisto = testMeter.histogramBuilder("no_bounds_histo").build();
+        LongCounter counter = testMeter.counterBuilder("ok_counter").build();
+
+        badHisto.record(1.0);
+        badHisto.record(2.0);
+        counter.add(7);
+
+        resetReporterAndFlushMetrics();
+        // The bad histogram is dropped, but unrelated metrics in the same metricset still export.
+        assertThatMetricSets(reporter.getBytes())
+            .hasMetricsetCount(1)
+            .first()
+            .containsValueMetric("ok_counter", 7)
+            .hasMetricsCount(1);
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes #4464.

When a user configures an OpenTelemetry histogram via a `View` with `Aggregation.explicitBucketHistogram(List.of())`, the resulting `HistogramPointData` has an empty boundaries list and a single `(-Inf, +Inf)` bucket. The exporter unconditionally read `boundaries.get(0)`, throwing `IndexOutOfBoundsException` on every export interval — which `PeriodicMetricReader` catches and logs, dropping the entire metrics batch:

```
[2026-05-07T23:51:14,066][WARN ][i.o.s.m.e.PeriodicMetricReader] [runTask-0] Exporter threw an Exception java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
        at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:100)
        at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:106)
        at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:302)
        at java.base/java.util.Objects.checkIndex(Objects.java:365)
        at java.base/java.util.ArrayList.get(ArrayList.java:428)
        at java.base/java.util.Collections$UnmodifiableList.get(Collections.java:1507)
        at co.elastic.apm.agent.otelmetricsdk.MetricSetSerializer.convertAndSerializeHistogramBucketBoundaries(MetricSetSerializer.java:157)
        at co.elastic.apm.agent.otelmetricsdk.MetricSetSerializer.addExplicitBucketHistogram(MetricSetSerializer.java:110)
        at co.elastic.apm.agent.otelmetricsdk.OtelMetricSerializer.addHistogramValues(OtelMetricSerializer.java:109)
        at co.elastic.apm.agent.otelmetricsdk.OtelMetricSerializer.addValues(OtelMetricSerializer.java:84)
        at co.elastic.apm.agent.otelmetricsdk.ElasticOtelMetricsExporter.export(ElasticOtelMetricsExporter.java:83)
        at io.opentelemetry.sdk.metrics@1.60.1/io.opentelemetry.sdk.metrics.export.PeriodicMetricReader$Scheduled.doRun(PeriodicMetricReader.java:215)
        at io.opentelemetry.sdk.metrics@1.60.1/io.opentelemetry.sdk.metrics.export.PeriodicMetricReader$Scheduled.run(PeriodicMetricReader.java:193)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:545)
        at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:371)
        at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:310)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
        at co.elastic.apm.agent.util.ExecutorUtils$2.run(ExecutorUtils.java:99)
        at java.base/java.lang.Thread.run(Thread.java:1516)
```

## Fix

Skip empty-boundaries histogram points in `OtelMetricSerializer.addHistogramValues` instead of forwarding them to `MetricSetSerializer`. The Elastic histogram metric format derives a representative value per bucket from the boundaries, so a single unbounded bucket is unrepresentable on the wire regardless. Other metrics in the same export batch are unaffected.

A one-time `WARN` is logged per metric name, following the existing convention since the `metricsWithBadAggregations` set is already used for de-duplication.