### PR TITLE
Pinning Spring Boot major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -64,7 +64,9 @@ updates:
       - dependency-name: "io.vertx:*"
         update-types: [ "version-update:semver-major" ]
       - dependency-name: "org.springframework.boot:*"
-        update-types: [ "version-update:semver-patch" ] # ignore spring patch updates to prevent PR spam
+        # Ignore patch updates to prevent PR spam, and major updates because Spring Boot versions are
+        # intentionally pinned per instrumentation generation.
+        update-types: [ "version-update:semver-patch", "version-update:semver-major" ]
       # Since these AWS dependencies are heavy and are being released very frequently, we ignore in the weekly update and update monthly
       - dependency-name: "com.amazonaws:aws-java-sdk-s3"
       - dependency-name: "com.amazonaws:aws-java-sdk-dynamodb"


### PR DESCRIPTION
Prevents automatic major version bumps, as the ones shown [here](https://github.com/elastic/apm-agent-java/pull/4474).