### PR TITLE
Handle multiple invalid server URLs

### DIFF
--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -13,6 +13,7 @@ This file contains all changes which are not released yet.
 * Fix unsupported-aggregation warning in OpenTelemetry metric SDK exporter to use SLF4J-style `{}` placeholders instead of `%s`, so the metric name and aggregation type are rendered in the log message - [#4466](https://github.com/elastic/apm-agent-java/pull/4466)
 * Stop OTel metrics exporter from throwing `IndexOutOfBoundsException` when a histogram has no explicit bucket boundaries - [#4465](https://github.com/elastic/apm-agent-java/pull/4465)
 * Cast to parent buffer for Java 8 buffer method compatibility - [#4498](https://github.com/elastic/apm-agent-java/pull/4498)
+* Minor fix to remove NPE noise if multiple APM URLs are invalid - [#4501](https://github.com/elastic/apm-agent-java/pull/4501)
 <!--FIXES-END-->
 # Features and enhancements
 <!--ENHANCEMENTS-START-->

--- a/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
+++ b/apm-agent-core/src/main/java/co/elastic/apm/agent/report/ApmServerHealthChecker.java
@@ -100,7 +100,13 @@ public class ApmServerHealthChecker implements Callable<Version> {
                 return null;
             }
         });
-        versions.remove(null);
+        return getMinVersionOrUnknown(versions);
+    }
+
+    static Version getMinVersionOrUnknown(List<Version> versions) {
+        while (versions.remove(null)) {
+            // remove all unavailable server results before comparing versions
+        }
         if (!versions.isEmpty()) {
             return Collections.min(versions);
         }

--- a/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerHealthCheckerTest.java
+++ b/apm-agent-core/src/test/java/co/elastic/apm/agent/report/ApmServerHealthCheckerTest.java
@@ -22,6 +22,9 @@ import co.elastic.apm.agent.common.util.Version;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,5 +41,26 @@ class ApmServerHealthCheckerTest {
         // 6.x
         body = "{\"ok\":{\"build_date\":\"2021-10-13T17:29:41Z\",\"build_sha\":\"04a84d8d3d0358af5e73b3581c4ba37fbdbc979e\",\"version\":\"6.8.20\"}}";
         assertThat(ApmServerHealthChecker.parseVersion(body).compareTo(Version.of("6.8.20"))).isEqualTo(0);
+    }
+
+    @Test
+    void testMinVersionIgnoresUnavailableServers() {
+        List<Version> versions = new ArrayList<>(Arrays.asList(
+            Version.of("8.0.0"),
+            null,
+            Version.of("7.17.0"),
+            null
+        ));
+
+        assertThat(ApmServerHealthChecker.getMinVersionOrUnknown(versions))
+            .isEqualTo(Version.of("7.17.0"));
+    }
+
+    @Test
+    void testMinVersionReturnsUnknownWhenAllServersUnavailable() {
+        List<Version> versions = new ArrayList<>(Arrays.asList(null, null));
+
+        assertThat(ApmServerHealthChecker.getMinVersionOrUnknown(versions))
+            .isEqualTo(ApmServerHealthChecker.UNKNOWN_VERSION);
     }
 }


### PR DESCRIPTION
## What does this PR do?

If multiple URLs in server_urls are invalid, an NPE is thrown (and each is removed eventually but an NPE thrown until only one is left)

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.md](https://github.com/elastic/apm-agent-java/blob/main/docs/reference/supported-technologies.md)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
