### PR TITLE
fix(webflux): fix NoSuchMethodError when using spring framework 7 wit…

### DIFF
--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/main/java/co/elastic/apm/agent/springwebflux/WebfluxHelper.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/main/java/co/elastic/apm/agent/springwebflux/WebfluxHelper.java
@@ -58,7 +58,9 @@ import java.lang.reflect.Type;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import static co.elastic.apm.agent.tracer.AbstractSpan.PRIORITY_HIGH_LEVEL_FRAMEWORK;
 import static co.elastic.apm.agent.tracer.AbstractSpan.PRIORITY_LOW_LEVEL_FRAMEWORK;
@@ -313,13 +315,16 @@ public class WebfluxHelper {
     }
 
     private static void copyHeaders(HttpHeaders source, PotentiallyMultiValuedMap destination) {
-        for (Map.Entry<String, List<String>> header : source.entrySet()) {
+        // This is the only way I could find to make a multiValueMap without having access
+        // to the api from spring framework 7 that will work across versions 5, 6 and 7
+        Map<String, List<String>> multiValueHeaderMap = source.toSingleValueMap().keySet()
+            .parallelStream().collect(Collectors.toMap(e -> e, key -> Objects.requireNonNull(source.get(key))));
+        for (Map.Entry<String, List<String>> header : multiValueHeaderMap.entrySet()) {
             for (String value : header.getValue()) {
                 destination.add(header.getKey(), value);
             }
         }
     }
-
     private static void copyCookies(MultiValueMap<String, HttpCookie> source, PotentiallyMultiValuedMap destination) {
         for (Map.Entry<String, List<HttpCookie>> cookie : source.entrySet()) {
             for (HttpCookie value : cookie.getValue()) {


### PR DESCRIPTION
…h webflux

## What does this PR do?
This PR fixes an issue with the experimental support for Spring framework 7 that was added [PR](https://github.com/elastic/apm-agent-java/pull/4489). When running the agent, it will throw a NoSuchMethodError exception due to the `HttpHeaders.entrySet` method. This is due to HttpHeaders [no longer implementing the MultiValueMap contract](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpHeaders.html).\
I have changed the copying of header to only use API's that are still available across version 5, 6 and 7.
The test `co.elastic.apm.agent.springwebflux.AbstractServerInstrumentationTest#dispatchHello` covers this fix.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.md](https://github.com/elastic/apm-agent-java/blob/main/docs/reference/supported-technologies.md)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
