### PR TITLE
fix(webflux): fix NoSuchMethodError when using spring framework 7 with webflux

### DIFF
--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>co.elastic.apm</groupId>
+        <artifactId>apm-spring-webflux</artifactId>
+        <version>1.56.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>apm-spring-webflux-plugin-spring7</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <!-- for licence header plugin -->
+        <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
+
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${version.spring-boot-4}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-spring-webflux-spring5</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <!-- through the spring-boot dependency management, the test app will be "updated" to spring boot 4 -->
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-spring-webflux-testapp-spring7</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-spring-webflux-spring5</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <!-- required for context-propagation during tests, but only at runtime -->
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-reactor-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>co.elastic.apm</groupId>
+            <artifactId>apm-reactor-plugin</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.ivy</groupId>
+            <artifactId>ivy</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7HeaderGetterTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7HeaderGetterTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux;
+
+public class Spring7HeaderGetterTest extends Spring7Test {
+
+    public Spring7HeaderGetterTest() {
+        super(Impl.class);
+    }
+
+    public static class Impl extends HeaderGetterTest {
+
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7ServerAnnotatedInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7ServerAnnotatedInstrumentationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux;
+
+
+public class Spring7ServerAnnotatedInstrumentationTest extends Spring7Test {
+
+    public Spring7ServerAnnotatedInstrumentationTest() {
+        super(Impl.class);
+    }
+
+    public static class Impl extends ServerAnnotatedInstrumentationTest {
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7ServerFunctionalInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7ServerFunctionalInstrumentationTest.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux;
+
+public class Spring7ServerFunctionalInstrumentationTest extends Spring7Test {
+
+    public Spring7ServerFunctionalInstrumentationTest() {
+        super(Impl.class);
+    }
+
+    public static class Impl extends ServerFunctionalInstrumentationTest {
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7ServletContainerTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7ServletContainerTest.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux;
+
+public class Spring7ServletContainerTest extends ServletContainerTest {
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7Test.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7Test.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux;
+
+import org.junit.jupiter.api.Test;
+import org.junit.platform.launcher.Launcher;
+import org.junit.platform.launcher.LauncherDiscoveryRequest;
+import org.junit.platform.launcher.core.LauncherDiscoveryRequestBuilder;
+import org.junit.platform.launcher.core.LauncherFactory;
+import org.junit.platform.launcher.listeners.SummaryGeneratingListener;
+import org.junit.platform.launcher.listeners.TestExecutionSummary;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.platform.engine.discovery.DiscoverySelectors.selectClass;
+
+abstract class Spring7Test {
+    private Class<?> actualTestClass;
+
+    public Spring7Test(Class<?> testClazz) {
+        this.actualTestClass = testClazz;
+    }
+
+    @Test
+    public void runTests() {
+        LauncherDiscoveryRequest request = LauncherDiscoveryRequestBuilder.request()
+            .selectors(selectClass(actualTestClass))
+            .build();
+        Launcher launcher = LauncherFactory.create();
+        SummaryGeneratingListener listener = new SummaryGeneratingListener();
+        launcher.registerTestExecutionListeners(listener);
+        launcher.execute(request);
+
+        for (TestExecutionSummary.Failure failure : listener.getSummary().getFailures()) {
+            System.out.println(failure);
+            failure.getException().printStackTrace();
+        }
+        assertThat(listener.getSummary().getTestsFailedCount())
+            .describedAs("at least one test failure reported, see stack trace for investigation")
+            .isZero();
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7WebSocketServerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-plugin-spring7/src/test/java/co/elastic/apm/agent/springwebflux/Spring7WebSocketServerInstrumentationTest.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux;
+
+
+public class Spring7WebSocketServerInstrumentationTest extends WebSocketServerInstrumentationTest {
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/main/java/co/elastic/apm/agent/springwebflux/WebfluxHelper.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/main/java/co/elastic/apm/agent/springwebflux/WebfluxHelper.java
@@ -58,7 +58,9 @@ import java.lang.reflect.Type;
 import java.net.InetSocketAddress;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiFunction;
+import java.util.stream.Collectors;
 
 import static co.elastic.apm.agent.tracer.AbstractSpan.PRIORITY_HIGH_LEVEL_FRAMEWORK;
 import static co.elastic.apm.agent.tracer.AbstractSpan.PRIORITY_LOW_LEVEL_FRAMEWORK;
@@ -313,7 +315,11 @@ public class WebfluxHelper {
     }
 
     private static void copyHeaders(HttpHeaders source, PotentiallyMultiValuedMap destination) {
-        for (Map.Entry<String, List<String>> header : source.entrySet()) {
+        // This is the only way I could find to make a multiValueMap without having access
+        // to the api from spring framework 7 that will work across versions 5, 6 and 7
+        Map<String, List<String>> multiValueHeaderMap = source.toSingleValueMap().keySet()
+            .parallelStream().collect(Collectors.toMap(e -> e, key -> Objects.requireNonNull(source.get(key))));
+        for (Map.Entry<String, List<String>> header : multiValueHeaderMap.entrySet()) {
             for (String value : header.getValue()) {
                 destination.add(header.getKey(), value);
             }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/main/java/co/elastic/apm/agent/springwebflux/WebfluxHelper.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/main/java/co/elastic/apm/agent/springwebflux/WebfluxHelper.java
@@ -60,6 +60,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static co.elastic.apm.agent.tracer.AbstractSpan.PRIORITY_HIGH_LEVEL_FRAMEWORK;
@@ -318,7 +319,12 @@ public class WebfluxHelper {
         // This is the only way I could find to make a multiValueMap without having access
         // to the api from spring framework 7 that will work across versions 5, 6 and 7
         Map<String, List<String>> multiValueHeaderMap = source.toSingleValueMap().keySet()
-            .parallelStream().collect(Collectors.toMap(e -> e, key -> Objects.requireNonNull(source.get(key))));
+            .parallelStream().collect(Collectors.toMap(Function.identity(), new Function<>() {
+                @Override
+                public List<String> apply(String key) {
+                    return Objects.requireNonNull(source.get(key));
+                }
+            }));
         for (Map.Entry<String, List<String>> header : multiValueHeaderMap.entrySet()) {
             for (String value : header.getValue()) {
                 destination.add(header.getKey(), value);

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/main/java/co/elastic/apm/agent/springwebflux/WebfluxHelper.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/main/java/co/elastic/apm/agent/springwebflux/WebfluxHelper.java
@@ -316,15 +316,12 @@ public class WebfluxHelper {
     }
 
     private static void copyHeaders(HttpHeaders source, PotentiallyMultiValuedMap destination) {
-        // This is the only way I could find to make a multiValueMap without having access
+        // This ensures we can make a MultiValueMap without having access
         // to the api from spring framework 7 that will work across versions 5, 6 and 7
+        Java7IdentityFunction identityFunction = new Java7IdentityFunction();
+        MultiValueCollectorFunction multiValueCollectorFunction = new MultiValueCollectorFunction(source);
         Map<String, List<String>> multiValueHeaderMap = source.toSingleValueMap().keySet()
-            .parallelStream().collect(Collectors.toMap(Function.identity(), new Function<>() {
-                @Override
-                public List<String> apply(String key) {
-                    return Objects.requireNonNull(source.get(key));
-                }
-            }));
+            .stream().collect(Collectors.toMap(identityFunction, multiValueCollectorFunction));
         for (Map.Entry<String, List<String>> header : multiValueHeaderMap.entrySet()) {
             for (String value : header.getValue()) {
                 destination.add(header.getKey(), value);
@@ -340,4 +337,27 @@ public class WebfluxHelper {
         }
     }
 
+    // Due to -source 7, lambdas cannot be used for the collector
+    private static class MultiValueCollectorFunction implements Function<String, List<String>> {
+        private final HttpHeaders source;
+
+        public MultiValueCollectorFunction(HttpHeaders source) {
+            this.source = source;
+        }
+
+        @Override
+        public List<String> apply(String key) {
+            return Objects.requireNonNull(source.getValuesAsList(key));
+        }
+    }
+
+    // Due to -source 7, static method invocations cannot be used
+    private static class Java7IdentityFunction implements Function<String, String> {
+        public Java7IdentityFunction() {}
+
+        @Override
+        public String apply(String key) {
+            return key;
+        }
+    }
 }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-spring5/src/test/java/co/elastic/apm/agent/springwebflux/AbstractServerInstrumentationTest.java
@@ -39,11 +39,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.core.SpringVersion;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.codec.ServerSentEvent;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 import reactor.core.publisher.Hooks;
 import reactor.test.StepVerifier;
 
+import java.lang.reflect.Field;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
@@ -140,8 +142,8 @@ public abstract class AbstractServerInstrumentationTest extends AbstractInstrume
                 .describedAs("non-standard request headers should be captured")
                 .isEqualTo("12345");
 
-            assertThat(headers.getFirst("Accept"))
-                .isEqualTo("text/plain, application/json");
+            assertThat(headers.getAll("Accept"))
+                .containsAll(List.of("text/plain" , "application/json"));
 
             assertThat(request.getCookies()
                 .getFirst("cookie"))
@@ -206,6 +208,15 @@ public abstract class AbstractServerInstrumentationTest extends AbstractInstrume
         // deal with API changes and deprecation in an ugly way
         try {
             return exception.getStatusCode().value();
+        } catch (Exception | Error e) {
+            // silently ignored
+        }
+        try {
+            // Due to the many breaking changes in the spring framework API in version 7, we have to access the status code through reflection.
+            // This will check if it can retrieve the int code via the HttpStatus.value() method, as getRawStatusCode() has been removed in 7
+            Field statusCode = exception.getClass().getSuperclass().getDeclaredField("statusCode");
+            statusCode.setAccessible(true);
+            return ((HttpStatus)statusCode.get(exception)).value();
         } catch (Exception | Error e) {
             // silently ignored
         }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/pom.xml
@@ -15,7 +15,7 @@
         <!-- for licence header plugin -->
         <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
 
-        <!-- this module is a test dependency, thus use same java version as tests -->
+        <!-- Spring boot 4 requires java 17-->
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
 

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/pom.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>co.elastic.apm</groupId>
+        <artifactId>apm-spring-webflux</artifactId>
+        <version>1.56.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>apm-spring-webflux-testapp-spring7</artifactId>
+    <name>${project.groupId}:${project.artifactId}</name>
+
+    <properties>
+        <!-- for licence header plugin -->
+        <apm-agent-parent.base.dir>${project.basedir}/../../..</apm-agent-parent.base.dir>
+
+        <!-- this module is a test dependency, thus use same java version as tests -->
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+
+        <!-- disable signature check as it's a test application -->
+        <animal.sniffer.skip>true</animal.sniffer.skip>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- using spring bom dependency to resolve dependencies -->
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${version.spring-boot-4}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>apm-agent-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+            <exclusions>
+                <!-- exclude logback as it conflicts with slf4j-simple provided by agent core -->
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+                <!-- exclude slf4j implementation as it conflicts with the one provide by agent core -->
+                <exclusion>
+                    <groupId>org.apache.logging.log4j</groupId>
+                    <artifactId>log4j-to-slf4j</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- include tomcat server in classpath to allow testing with servlets -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <!-- required otherwise we only have it in test scope, and makes map<>json conversion fail -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <finalName>${project.artifactId}</finalName>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- explicit version required as bom will not cover plugins, only dependencies -->
+                <version>4.1.0</version>
+                <configuration>
+                    <mainClass>co.elastic.apm.agent.springwebflux.testapp.WebFluxApplication</mainClass>
+                    <!-- by default original jar is replaced, which makes impossible to reuse as dependency -->
+                    <classifier>standalone</classifier>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingAnnotated.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingAnnotated.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux.testapp;
+
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.impl.transaction.IdImpl;
+import co.elastic.apm.agent.tracer.AbstractSpan;
+import co.elastic.apm.agent.tracer.GlobalTracer;
+import co.elastic.apm.agent.impl.transaction.TransactionImpl;
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import javax.annotation.Nullable;
+import java.util.Objects;
+
+/**
+ * Provides Webflux annotated endpoint
+ */
+@RestController
+@RequestMapping(value = "/annotated", produces = MediaType.TEXT_PLAIN_VALUE)
+public class GreetingAnnotated {
+
+    private static final Logger log = LoggerFactory.getLogger(GreetingAnnotated.class);
+
+    final GreetingHandler greetingHandler;
+
+    @Autowired
+    public GreetingAnnotated(GreetingHandler greetingHandler) {
+        this.greetingHandler = greetingHandler;
+    }
+
+    @RequestMapping("/hello")
+    public Mono<String> getHello(@RequestParam(value = "name", required = false) @Nullable String name) {
+        return greetingHandler.helloMessage(name);
+    }
+
+    @PreAuthorize("hasAuthority('ROLE_USER')")
+    @RequestMapping("/preauthorized")
+    public Mono<String> getPreauthorized() {
+        return greetingHandler.helloMessage("elastic");
+    }
+
+    @PreAuthorize("hasAuthority('ROLE_USER')")
+    @RequestMapping("/username")
+    public Mono<String> getSecurityContextUsername() {
+        return greetingHandler.getUsernameFromContext();
+    }
+
+    // protected by SecurityWebFilterChain#pathMatchers
+    @RequestMapping("/path-username")
+    public Mono<String> getSecurityContextUsernameByPathSecured() {
+        return greetingHandler.getUsernameFromContext();
+    }
+
+    @RequestMapping("/error-handler")
+    public Mono<String> handlerError() {
+        // using delayed exception here allows to ensure that the exception handler is properly
+        // executed, as its execution is part of the "dispatch" phase and is outside of "handler"
+        //
+        // this does not apply for functional definitions as the exception handler is directly part of the "handler"
+        // which is wrapped into the "dispatcher" (which we instrument).
+        return greetingHandler.delayedException();
+    }
+
+    @RequestMapping("/error-mono")
+    public Mono<String> monoError() {
+        return greetingHandler.monoError();
+    }
+
+    @RequestMapping("/empty-mono")
+    public Mono<String> monoEmpty() {
+        return greetingHandler.monoEmpty();
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<String> handleException(RuntimeException e) {
+        return ResponseEntity.status(500)
+            .body(greetingHandler.exceptionMessage(e));
+    }
+
+    @GetMapping("/hello-mapping")
+    public Mono<String> getMapping() {
+        return greetingHandler.helloMessage("GET");
+    }
+
+    @PostMapping("/hello-mapping")
+    public Mono<String> postMapping() {
+        return greetingHandler.helloMessage("POST");
+    }
+
+    @PutMapping("/hello-mapping")
+    public Mono<String> putMapping() {
+        return greetingHandler.helloMessage("PUT");
+    }
+
+    @DeleteMapping("/hello-mapping")
+    public Mono<String> deleteMapping() {
+        return greetingHandler.helloMessage("DELETE");
+    }
+
+    @PatchMapping("/hello-mapping")
+    public Mono<String> patchMapping() {
+        return greetingHandler.helloMessage("PATCH");
+    }
+
+    @RequestMapping(path = "/hello-mapping", method = {RequestMethod.HEAD, RequestMethod.OPTIONS, RequestMethod.TRACE})
+    public Mono<String> otherMapping(ServerHttpRequest request) {
+        return greetingHandler.helloMessage(request.getMethod().name());
+    }
+
+    @GetMapping("/with-parameters/{id}")
+    public Mono<String> withParameters(@PathVariable("id") String id) {
+        return greetingHandler.helloMessage(id);
+    }
+
+    @GetMapping(path = "/child-flux")
+    public Flux<String> getChildSpans(@RequestParam(value = "count", required = false, defaultValue = "3") int count,
+                                      @RequestParam(value = "duration", required = false, defaultValue = "5") long durationMillis,
+                                      @RequestParam(value = "delay", required = false, defaultValue = "5") long delayMillis) {
+
+        return greetingHandler.childSpans(count, delayMillis, durationMillis);
+    }
+
+    @GetMapping(path = "/child-flux/sse")
+    public Flux<ServerSentEvent<String>> getChildSpansSSE(@RequestParam(value = "count", required = false, defaultValue = "3") int count,
+                                                          @RequestParam(value = "duration", required = false, defaultValue = "5") long durationMillis,
+                                                          @RequestParam(value = "delay", required = false, defaultValue = "5") long delayMillis) {
+
+        return greetingHandler.childSpans(count, durationMillis, delayMillis)
+            .map(greetingHandler::toSSE);
+    }
+
+    @GetMapping("/custom-transaction-name")
+    public Mono<String> customTransactionName() {
+        log.debug("enter customTransactionName");
+        try {
+
+            IdImpl transactionId = null;
+            if (!GlobalTracer.isNoop()) {
+                // Transaction should be active, even if we are outside of Mono/Flux execution
+                // In practice, it's called after onSubscribe and before onNext, thus the active context is not provided
+                // by reactor plugin, but only by the webflux plugin that keeps the transaction active.
+                ElasticApmTracer tracer = GlobalTracer.get().require(ElasticApmTracer.class);
+                TransactionImpl transaction = Objects.requireNonNull(tracer.currentTransaction(), "active transaction is required");
+                // This mimics setting the name through the public API. We cannot use the public API if we want to test span recycling
+                transaction.withName("user-provided-name", AbstractSpan.PRIORITY_USER_SUPPLIED);
+                transactionId = transaction.getTraceContext().getId();
+            }
+
+
+            return greetingHandler.helloMessage("transaction=" + transactionId);
+        } finally {
+            log.debug("exit customTransactionName");
+        }
+    }
+
+    @GetMapping("/duration")
+    public Mono<String> duration(@RequestParam("duration") int durationMillis) {
+        return greetingHandler.duration(durationMillis);
+    }
+
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingFunctional.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingFunctional.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux.testapp;
+
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.tracer.AbstractSpan;
+import co.elastic.apm.agent.tracer.GlobalTracer;
+import co.elastic.apm.agent.impl.transaction.IdImpl;
+import co.elastic.apm.agent.impl.transaction.TransactionImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.server.RouterFunction;
+import org.springframework.web.reactive.function.server.RouterFunctions;
+import org.springframework.web.reactive.function.server.ServerRequest;
+import org.springframework.web.reactive.function.server.ServerResponse;
+import reactor.core.publisher.Mono;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import static org.springframework.web.reactive.function.server.RequestPredicates.accept;
+import static org.springframework.web.reactive.function.server.RequestPredicates.method;
+import static org.springframework.web.reactive.function.server.RequestPredicates.path;
+
+/**
+ * Provides functional Webflux endpoint
+ */
+@Configuration
+public class GreetingFunctional {
+
+    @Bean
+    public RouterFunction<ServerResponse> route(GreetingHandler greetingHandler) {
+
+        return RouterFunctions.route()
+            // 'hello' and 'hello2' are identical, but entry point in builder is not
+            .route(path("/functional/hello"),
+                request -> helloGreeting(greetingHandler, request.queryParam("name")))
+            .route(path("/functional/preauthorized"),
+                request -> helloGreeting(greetingHandler, Optional.of("elastic")))
+            .route(path("/functional/username"),
+                request -> getUsernameFromContext(greetingHandler))
+            .route(path("/functional/path-username"),
+                request -> getUsernameFromContext(greetingHandler))
+            //
+            .GET("/functional/hello2", accept(MediaType.TEXT_PLAIN),
+                request -> helloGreeting(greetingHandler, request.queryParam("name")))
+            // nested routes
+            .nest(path("/functional/nested"), builder -> builder
+                .route(method(HttpMethod.GET), request -> nested(greetingHandler, request.method().name()))
+                .route(method(HttpMethod.POST), request -> nested(greetingHandler, request.method().name()))
+            )
+            // path with parameters
+            .route(path("/functional/with-parameters/{id}"),
+                request -> helloGreeting(greetingHandler, Optional.of(request.pathVariable("id"))))
+            // route that supports multiple methods mapping
+            .route(path("/functional/hello-mapping"),
+                request -> helloGreeting(greetingHandler, Optional.of(request.method().name())))
+            // errors and mono corner cases
+            .GET("/functional/error-handler", accept(MediaType.TEXT_PLAIN), request -> greetingHandler.throwException())
+            .GET("/functional/error-mono", accept(MediaType.TEXT_PLAIN), request -> greetingHandler.monoError())
+            .GET("/functional/empty-mono", accept(MediaType.TEXT_PLAIN), request -> greetingHandler.monoEmpty())
+            // with known transaction duration
+            .GET("/functional/duration", accept(MediaType.TEXT_PLAIN), request -> response(greetingHandler.duration(getDuration(request))))
+            // custom transaction name set through API
+            .GET("/functional/custom-transaction-name", accept(MediaType.TEXT_PLAIN), request -> {
+                IdImpl transactionId = null;
+                if (!GlobalTracer.isNoop()) {
+                    ElasticApmTracer tracer = GlobalTracer.get().require(ElasticApmTracer.class);
+                    TransactionImpl transaction = Objects.requireNonNull(tracer.currentTransaction(), "active transaction is required");
+                    // This mimics setting the name through the public API. We cannot use the public API if we want to test span recycling
+                    transaction.withName("user-provided-name", AbstractSpan.PRIORITY_USER_SUPPLIED);
+                    transactionId = transaction.getTraceContext().getId();
+                }
+                return response(greetingHandler.helloMessage("transaction=" + transactionId));
+            })
+            .GET("/functional/child-flux", accept(MediaType.TEXT_PLAIN), request -> ServerResponse.ok()
+                .body(greetingHandler.childSpans(getCount(request), getDelay(request), getDuration(request)), String.class
+                ))
+            .route(path("/functional/child-flux/sse"),
+                request -> ServerResponse.ok()
+                    .body(greetingHandler.childSpans(getCount(request), getDelay(request), getDuration(request))
+                        .map(greetingHandler::toSSE), ServerSentEvent.class
+                    ))
+            // error handler
+            .onError(
+                e -> true, (e, request) -> ServerResponse
+                    .status(request.queryParam("status")
+                        .map(Integer::parseInt)
+                        .orElse(500))
+                    .bodyValue(greetingHandler.exceptionMessage(e))
+            )
+            .build();
+    }
+
+    private Long getDuration(ServerRequest request) {
+        return request.queryParam("duration").map(Long::parseLong).orElse(0L);
+    }
+
+    private int getCount(ServerRequest request) {
+        return request.queryParam("count").map(Integer::parseInt).orElse(1);
+    }
+
+    private Long getDelay(ServerRequest request) {
+        return request.queryParam("delay").map(Long::parseLong).orElse(0L);
+    }
+
+    private Mono<ServerResponse> nested(GreetingHandler greetingHandler, String methodName) {
+        return helloGreeting(greetingHandler, Optional.of("nested " + methodName));
+    }
+
+    private Mono<ServerResponse> helloGreeting(GreetingHandler greetingHandler, Optional<String> name) {
+        return response(greetingHandler.helloMessage(name.orElse(null)));
+    }
+
+    private Mono<ServerResponse> getUsernameFromContext(GreetingHandler greetingHandler) {
+        return response(greetingHandler.getUsernameFromContext());
+    }
+
+    private Mono<ServerResponse> response(Mono<String> value) {
+        return value.flatMap(s -> ServerResponse.ok()
+            .contentType(MediaType.TEXT_PLAIN)
+            .bodyValue(s));
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingHandler.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingHandler.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux.testapp;
+
+import co.elastic.apm.agent.impl.ElasticApmTracer;
+import co.elastic.apm.agent.tracer.GlobalTracer;
+import co.elastic.apm.agent.tracer.Span;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+
+import javax.annotation.Nullable;
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+@Component
+public class GreetingHandler {
+
+    public static final Scheduler CHILDREN_SCHEDULER = Schedulers.newBoundedElastic(16, 128, "children");
+
+    public Mono<String> helloMessage(@Nullable String name) {
+        return Mono.just(String.format("Hello, %s!", Optional.ofNullable(name).orElse("Spring")));
+    }
+
+    public <T> Mono<T> throwException() {
+        throw new RuntimeException("intentional exception");
+    }
+
+    public Mono<String> delayedException() {
+        return helloMessage(null)
+            .delayElement(Duration.ofMillis(50))
+            .flatMap(s -> {
+                throw new RuntimeException("intentional exception");
+            });
+    }
+
+    public <T> Mono<T> monoError() {
+        return Mono.error(new RuntimeException("intentional error"));
+    }
+
+    public <T> Mono<T> monoEmpty() {
+        return Mono.empty();
+    }
+
+    public String exceptionMessage(Throwable t) {
+        return "error handler: " + t.getMessage();
+    }
+
+    public Flux<String> childSpans(int count, long delayMillis, long durationMillis) {
+        return Flux.range(1, count)
+            .subscribeOn(CHILDREN_SCHEDULER)
+            // initial delay
+            .delayElements(Duration.ofMillis(delayMillis))
+            .map(i -> String.format("child %d", i))
+            .doOnNext(name -> {
+                if (!GlobalTracer.isNoop()) {
+                    Span<?> span = Objects.requireNonNull(GlobalTracer.get().require(ElasticApmTracer.class).currentTransaction()).createSpan();
+                    span.withName(String.format("%s id=%s", name, span.getTraceContext().getId()));
+                    try {
+                        fakeWork(durationMillis);
+                    } finally {
+                        span.end();
+                    }
+                }
+            });
+    }
+
+    public ServerSentEvent<String> toSSE(String s) {
+        // we might be able to inject a comment into SSE event for context propagation
+        return ServerSentEvent.<String>builder().data(s).build();
+    }
+
+    // Emulates a transaction that takes a known amount of time
+    // the whole transaction duration should include the delay
+    public Mono<String> duration(long durationMillis) {
+        return helloMessage(String.format("duration=%d", durationMillis))
+            .doOnNext(m -> fakeWork(durationMillis));
+    }
+
+    public Mono<String> getUsernameFromContext() {
+        return ReactiveSecurityContextHolder.getContext()
+            .flatMap(ctx -> Mono.just(ctx.getAuthentication().getName()));
+    }
+
+    private static void fakeWork(long durationMs) {
+        try {
+            Thread.sleep(durationMs);
+        } catch (InterruptedException e) {
+            // silently ignored
+        }
+    }
+
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingWebClient.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/GreetingWebClient.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux.testapp;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.client.ReactorNettyWebSocketClient;
+import org.springframework.web.reactive.socket.client.WebSocketClient;
+import org.springframework.web.util.UriBuilder;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Scheduler;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.Logger;
+import reactor.util.Loggers;
+
+import java.net.URI;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+public class GreetingWebClient {
+
+    private static final Logger logger = Loggers.getLogger(GreetingWebClient.class);
+
+    private final WebClient client;
+    private final String pathPrefix;
+    private final boolean useFunctionalEndpoint;
+    private final int port;
+    private final HttpHeaders headers;
+    private final MultiValueMap<String,String> cookies;
+    private final Scheduler clientScheduler;
+    private final WebSocketClient wsClient;
+    private final String wsBaseUri;
+    private final boolean logEnabled;
+
+
+    // this client also applies a few basic checks to ensure that application behaves
+    // as expected within unit tests and in packaged application without duplicating
+    // all the testing logic.
+
+    public GreetingWebClient(String host, int port, boolean useFunctionalEndpoint, boolean logEnabled) {
+        this.pathPrefix = useFunctionalEndpoint ? "/functional" : "/annotated";
+        String baseUri = String.format("http://%s:%d%s", host, port, pathPrefix);
+        this.wsBaseUri = String.format("ws://%s:%d", host, port);
+        this.port = port;
+        this.client = WebClient.builder()
+            .baseUrl(baseUri)
+            .clientConnector(new ReactorClientHttpConnector()) // allows to use either netty/reactor or jetty client
+            .build();
+        this.useFunctionalEndpoint = useFunctionalEndpoint;
+        this.headers = new HttpHeaders();
+        this.cookies = new LinkedMultiValueMap<>();
+        this.clientScheduler = Schedulers.newBoundedElastic(16, 128, "webflux-client");
+        this.wsClient = new ReactorNettyWebSocketClient();
+        this.logEnabled = logEnabled;
+    }
+
+    public Mono<String> getHelloMono() {
+        return requestMono("GET", "/hello", 200);
+    }
+
+    public Mono<String> getPreAuthorized(int expectedStatus) { return requestMono("GET", "/preauthorized", expectedStatus); }
+
+    public Mono<String> getSecurityContextUsername(int expectedStatus) { return requestMono("GET", "/username", expectedStatus); }
+
+    public Mono<String> getSecurityContextUsernameByPathSecured(int expectedStatus) { return requestMono("GET", "/path-username", expectedStatus); }
+
+    public Mono<String> getMappingError404() {
+        return requestMono("GET", "/error-404", 404);
+    }
+
+    public Mono<String> getHandlerError() {
+        return requestMono("GET", "/error-handler", 500);
+    }
+
+    public Mono<String> getMonoError() {
+        return requestMono("GET", "/error-mono", 500);
+    }
+
+    public Mono<String> getMonoEmpty() {
+        return requestMono("GET", "/empty-mono", 200);
+    }
+
+    public Mono<String> methodMapping(String method) {
+        return requestMono(method, "/hello-mapping", 200);
+    }
+
+    public Mono<String> withPathParameter(String param) {
+        return requestMono("GET", uriBuilder -> uriBuilder.path("/with-parameters/{id}").build(param), 200);
+    }
+
+    // nested routes, only relevant for functional routing
+    public Mono<String> nested(String method) {
+        return requestMono(method, "/nested", 200);
+    }
+
+    public Mono<String> duration(long durationMillis) {
+        return requestMono("GET", uriBuilder -> uriBuilder.path("/duration").queryParam("duration", durationMillis).build(), 200);
+    }
+
+    // returned as flux, but will only produce one element
+    public Flux<String> childSpans(int count, long durationMillis, long delay) {
+        return requestFlux(uriBuilder -> uriBuilder.path("/child-flux").queryParam("duration", durationMillis).queryParam("count", count).queryParam("delay", delay).build());
+    }
+
+    public List<String> webSocketPingPong(int count) {
+
+        // taken from https://github.com/spring-projects/spring-framework/blob/main/spring-webflux/src/test/java/org/springframework/web/reactive/socket/WebSocketIntegrationTests.java
+        Flux<String> input = Flux.range(1, count).map(i -> "ping-" + i);
+
+        AtomicReference<List<String>> actualRef = new AtomicReference<>();
+        this.wsClient.execute(URI.create(wsBaseUri + "/ping"), session ->
+            session.send(input.map(session::textMessage))
+                .thenMany(session.receive()
+                    .take(count)
+                    .map(WebSocketMessage::getPayloadAsText))
+                .collectList()
+                .doOnNext(actualRef::set)
+                .then())
+            .block(Duration.ofMillis(1000));
+
+        Objects.requireNonNull(actualRef.get());
+        return actualRef.get();
+    }
+
+    // returned as a stream of elements
+    public Flux<ServerSentEvent<String>> childSpansSSE(int count, long durationMillis, long delay) {
+        return requestFluxSSE(uriBuilder -> uriBuilder.path("/child-flux/sse").queryParam("duration", durationMillis).queryParam("count",count).queryParam("delay", delay).build());
+    }
+
+    // only relevant for annotated controller
+    public Mono<String> customTransactionName() {
+        return requestMono("GET", "/custom-transaction-name", 200);
+    }
+
+    @Deprecated
+    public Mono<String> requestMono(String method, String path, int expectedStatus) {
+        return requestMono(method, uriBuilder -> uriBuilder.path(path).build(), expectedStatus);
+    }
+
+    public Mono<String> requestMono(String method, Function<UriBuilder, URI> uriFunction, int expectedStatus) {
+        Mono<String> request = request(method, uriFunction, expectedStatus)
+            .bodyToMono(String.class)
+            .doOnError((throwable) -> logger.error("Exception occurred during requesting with exception class [{}]", throwable.getClass().getCanonicalName()))
+            .publishOn(clientScheduler);
+        return logEnabled ? request.log(logger) : request;
+    }
+
+    public void sampleRequests() {
+
+        Duration timeout = Duration.ofMillis(1000);
+
+        getHelloMono().block(timeout);
+        getMappingError404().onErrorResume(e -> Mono.empty()).block(timeout);
+        getHandlerError().onErrorResume(e -> Mono.empty()).block(timeout);
+        getMonoError().onErrorResume(e -> Mono.empty()).block(timeout);
+
+        Stream.of("GET", "POST", "PUT", "DELETE").forEach(method -> methodMapping(method).block(timeout));
+
+        withPathParameter("12345").block(timeout);
+
+        childSpans(5, 3, 1)
+            .blockLast(timeout);
+
+        childSpansSSE(5, 3, 1)
+            .blockLast(timeout);
+
+        webSocketPingPong(5);
+    }
+
+    private Flux<String> requestFlux(Function<UriBuilder, URI> uriFunction) {
+        Flux<String> request = request("GET", uriFunction, 200)
+            .bodyToFlux(String.class)
+            .publishOn(clientScheduler);
+        return logEnabled ? request.log(logger) : request;
+    }
+
+    private Flux<ServerSentEvent<String>> requestFluxSSE(Function<UriBuilder, URI> uriFunction) {
+
+        // required to get proper return generic type
+        ParameterizedTypeReference<ServerSentEvent<String>> type = new ParameterizedTypeReference<>() {
+        };
+
+        Flux<ServerSentEvent<String>> request = request("GET", uriFunction, 200)
+            .bodyToFlux(type)
+            .publishOn(clientScheduler);
+
+        return logEnabled ? request.log(logger) : request;
+    }
+
+    private WebClient.ResponseSpec request(String method, Function<UriBuilder, URI> uriFunction, int expectedStatus) {
+        return client.method(HttpMethod.valueOf(method))
+            .uri(uriFunction)
+            .accept(MediaType.TEXT_PLAIN, MediaType.APPLICATION_JSON)
+            .headers(httpHeaders -> httpHeaders.addAll(headers))
+            .cookies(httpCookies -> httpCookies.addAll(cookies))
+            .retrieve()
+            .onRawStatus(status -> status != expectedStatus, r -> Mono.error(new IllegalStateException("unexpected response status")));
+    }
+
+    @Override
+    public String toString() {
+        return String.format("GreetingWebClient [%s]", pathPrefix);
+    }
+
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public boolean useFunctionalEndpoint() {
+        return useFunctionalEndpoint;
+    }
+
+    public void setHeader(String name, String value) {
+        headers.add(name, value);
+    }
+
+    public void setCookie(String name, String value) {
+        cookies.add(name, value);
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/WebFluxApplication.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/WebFluxApplication.java
@@ -1,0 +1,220 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux.testapp;
+
+import co.elastic.apm.agent.sdk.logging.Logger;
+import co.elastic.apm.agent.sdk.logging.LoggerFactory;
+import org.springframework.boot.Banner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import javax.net.ServerSocketFactory;
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+@SpringBootApplication
+public class WebFluxApplication {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebFluxApplication.class);
+
+    private static final int DEFAULT_PORT = 8080;
+
+    public static void main(String[] args) {
+        List<String> arguments = Arrays.asList(args);
+        int port = Integer.parseInt(parseOption(arguments, "--port", Integer.toString(DEFAULT_PORT)));
+        String server = parseOption(arguments, "--server", "netty");
+        int count = Integer.parseInt(parseOption(arguments, "--count", "0"));
+
+        boolean isClient = arguments.contains("--client");
+        boolean logEnabled = arguments.contains("--log");
+
+        boolean isBench = arguments.contains("--benchmark");
+        boolean waitForKey = arguments.contains("--wait");
+
+        if (isBench) {
+            // start the whole server & client
+            App app = run(port, server, logEnabled);
+
+            count = Math.max(count, 100); // any smaller benchmark is not meaningful
+            try {
+                if (waitForKey) {
+                    waitForKey();
+                }
+
+                // warmup has same duration as benchmark to help having consistent results
+                logger.info("warmup requests ({})", count);
+                doSampleRequests(app::getClient, count);
+                logger.info("warmup complete");
+
+                if (waitForKey) {
+                    waitForKey();
+                }
+
+                logger.info("start benchmark ({})", count);
+                doSampleRequests(app::getClient, count);
+                logger.info("benchmark complete");
+
+                if (waitForKey) {
+                    waitForKey();
+                }
+
+
+            } finally {
+                app.close();
+            }
+        } else if (isClient) {
+            count = Math.max(count, 1);
+            doSampleRequests(useFunc -> new GreetingWebClient("localhost", port, useFunc, logEnabled), count);
+        } else {
+
+            try (App app = run(port, server, logEnabled)) {
+                if (count > 0) {
+                    doSampleRequests(useFunc -> new GreetingWebClient("localhost", port, useFunc, logEnabled), count);
+                }
+
+                // leave server running
+                waitForKey();
+            }
+        }
+
+    }
+
+    private static void doSampleRequests(Function<Boolean, GreetingWebClient> clientProvider, int count) {
+        List<GreetingWebClient> clients = Stream.of(true, false)
+            .map(clientProvider)
+            .collect(Collectors.toList());
+
+        long start = System.currentTimeMillis();
+        int statusFrequency = count <= 10 ? 1 : count / 10;
+
+        long timeLastUpdate = start;
+        int countLastUpdate = 0;
+
+        for (int i = 1; i <= count; i++) {
+            clients.forEach(GreetingWebClient::sampleRequests);
+
+            if (i % statusFrequency == 0 || i == count) {
+                long now = System.currentTimeMillis();
+                long timeSpent = now - timeLastUpdate;
+                int countSinceLastUpdate = i - countLastUpdate;
+                System.out.printf("progress = %1$6.02f %% (%2$d), count = %3$d in %4$d ms, average = %5$.02f ms%n",
+                    i * 100d / count,
+                    i,
+                    countSinceLastUpdate,
+                    timeSpent,
+                    timeSpent * 1d / countSinceLastUpdate
+                );
+                timeLastUpdate = now;
+                countLastUpdate = i;
+
+                if (i == count) {
+                    long totalTime = System.currentTimeMillis() - start;
+                    System.out.printf("total count = %d in %d ms, average = %.02f%n", count, totalTime, 1.0D * totalTime / count);
+                }
+            }
+        }
+
+    }
+
+    /**
+     * Stores application state, using inner-class to avoid interfering with Spring boot application
+     */
+    public static class App implements Closeable {
+        private final int port;
+        private final ConfigurableApplicationContext context;
+        private final boolean logEnabled;
+
+        private App(int port, ConfigurableApplicationContext context, boolean logEnabled) {
+            this.port = port;
+            this.context = context;
+            this.logEnabled = logEnabled;
+        }
+
+        public GreetingWebClient getClient(boolean useFunctional) {
+            return new GreetingWebClient("localhost", port, useFunctional, logEnabled);
+        }
+
+        @Override
+        public void close() {
+            context.close();
+        }
+    }
+
+    /**
+     * Starts application on provided port
+     *
+     * @param port       port to use
+     * @param server     server implementation to use
+     * @param logEnabled true to enable client and server logging (very verbose, better for debugging)
+     * @return application context
+     */
+    public static App run(int port, String server, boolean logEnabled) {
+        if (port < 0) {
+            port = getAvailableRandomPort();
+        }
+
+        SpringApplication app = new SpringApplication(WebFluxApplication.class);
+        Map<String, Object> appProperties = new HashMap<>();
+        app.setBannerMode(Banner.Mode.OFF);
+        appProperties.put("server.port", port);
+        appProperties.put("server", server);
+        appProperties.put("logging.level.org.springframework", logEnabled ? "ERROR" : "OFF");
+        app.setDefaultProperties(appProperties);
+
+        return new App(port, app.run(), logEnabled);
+    }
+
+    private static String parseOption(List<String> arguments, String option, String defaultValue) {
+        int index = arguments.indexOf(option);
+        if (index < 0 || arguments.size() <= index) {
+            return defaultValue;
+        }
+        return arguments.get(index + 1);
+    }
+
+    private static int getAvailableRandomPort() {
+        int port;
+        try (ServerSocket socket = ServerSocketFactory.getDefault().createServerSocket(0, 1, InetAddress.getByName("localhost"))) {
+            port = socket.getLocalPort();
+        } catch (IOException e) {
+            port = DEFAULT_PORT;
+        }
+        return port;
+    }
+
+    private static void waitForKey() {
+        System.out.println("hit any key to continue");
+        try {
+            System.in.read();
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/WebFluxConfig.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/WebFluxConfig.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux.testapp;
+
+
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.reactor.netty.NettyReactiveWebServerFactory;
+import org.springframework.boot.reactor.netty.NettyRouteProvider;
+import org.springframework.boot.reactor.netty.NettyServerCustomizer;
+import org.springframework.boot.tomcat.TomcatConnectorCustomizer;
+import org.springframework.boot.tomcat.TomcatContextCustomizer;
+import org.springframework.boot.tomcat.TomcatProtocolHandlerCustomizer;
+import org.springframework.boot.tomcat.reactive.TomcatReactiveWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ReactorResourceFactory;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.userdetails.MapReactiveUserDetailsService;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.web.reactive.HandlerMapping;
+import org.springframework.web.reactive.config.EnableWebFlux;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+import org.springframework.web.reactive.handler.SimpleUrlHandlerMapping;
+import org.springframework.web.reactive.socket.WebSocketHandler;
+import org.springframework.web.reactive.socket.WebSocketMessage;
+import org.springframework.web.reactive.socket.server.RequestUpgradeStrategy;
+import org.springframework.web.reactive.socket.server.WebSocketService;
+import org.springframework.web.reactive.socket.server.support.HandshakeWebSocketService;
+import org.springframework.web.reactive.socket.server.support.WebSocketHandlerAdapter;
+import org.springframework.web.reactive.socket.server.upgrade.ReactorNettyRequestUpgradeStrategy;
+import org.springframework.web.reactive.socket.server.upgrade.StandardWebSocketUpgradeStrategy;
+import reactor.core.publisher.Flux;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+@EnableWebFlux
+@EnableWebFluxSecurity
+@EnableReactiveMethodSecurity
+public class WebFluxConfig implements WebFluxConfigurer {
+
+    // those server methods are just plain copies of ReactiveWebServerFactoryConfiguration inner classes
+    // with different annotations to allow selecting server implementation through properties and not only
+    // classpath availability
+
+    // Tomcat
+
+    @Bean
+    @ConditionalOnProperty(name = "server", havingValue = "tomcat")
+    TomcatReactiveWebServerFactory tomcatReactiveWebServerFactory(
+        ObjectProvider<TomcatConnectorCustomizer> connectorCustomizers,
+        ObjectProvider<TomcatContextCustomizer> contextCustomizers,
+        ObjectProvider<TomcatProtocolHandlerCustomizer<?>> protocolHandlerCustomizers) {
+        TomcatReactiveWebServerFactory factory = new TomcatReactiveWebServerFactory();
+        factory.getConnectorCustomizers()
+            .addAll(connectorCustomizers.orderedStream().collect(Collectors.toList()));
+        factory.getContextCustomizers()
+            .addAll(contextCustomizers.orderedStream().collect(Collectors.toList()));
+        factory.getProtocolHandlerCustomizers()
+            .addAll(protocolHandlerCustomizers.orderedStream().collect(Collectors.toList()));
+        return factory;
+    }
+
+    // Tomcat Websocket support
+
+    @Bean
+    @Qualifier("requestUpdateStrategy")
+    @ConditionalOnProperty(name = "server", havingValue = "tomcat")
+    RequestUpgradeStrategy tomcatRequestUpgradeStrategy() {
+        return new StandardWebSocketUpgradeStrategy();
+    }
+
+    // Netty
+
+    @Bean
+    @ConditionalOnMissingBean
+    ReactorResourceFactory reactorServerResourceFactory() {
+        return new ReactorResourceFactory();
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "server", havingValue = "netty", matchIfMissing = true)
+    NettyReactiveWebServerFactory nettyReactiveWebServerFactory(@Qualifier("reactorServerResourceFactory") ReactorResourceFactory resourceFactory,
+                                                                ObjectProvider<NettyRouteProvider> routes, ObjectProvider<NettyServerCustomizer> serverCustomizers) {
+        NettyReactiveWebServerFactory serverFactory = new NettyReactiveWebServerFactory();
+        serverFactory.setResourceFactory(resourceFactory);
+        routes.orderedStream().forEach(serverFactory::addRouteProviders);
+        serverFactory.getServerCustomizers().addAll(serverCustomizers.orderedStream().collect(Collectors.toList()));
+        return serverFactory;
+    }
+
+    // Netty Websocket support
+
+    @Bean
+    @Qualifier("requestUpdateStrategy")
+    @ConditionalOnProperty(name = "server", havingValue = "netty")
+    RequestUpgradeStrategy nettyRequestUpgradeStrategy() {
+        return new ReactorNettyRequestUpgradeStrategy();
+    }
+
+
+    // Generic Websocket support
+
+    @Bean
+    public HandlerMapping webSocketHandlerMapping() {
+        SimpleUrlHandlerMapping handlerMapping = new SimpleUrlHandlerMapping();
+        handlerMapping.setOrder(1);
+        handlerMapping.setUrlMap(Map.of("/ping", pingPongHandler()));
+        return handlerMapping;
+    }
+
+    private static WebSocketHandler pingPongHandler() {
+        return session -> {
+            Flux<WebSocketMessage> output = session.receive()
+                .map(msg -> session.textMessage(msg.getPayloadAsText().replaceFirst("ping", "pong")));
+            return session.send(output);
+        };
+    }
+
+    @Bean
+    public WebSocketHandlerAdapter handlerAdapter(WebSocketService webSocketService) {
+        return new WebSocketHandlerAdapter(webSocketService);
+    }
+
+    @Bean
+    public WebSocketService webSocketService(@Qualifier("requestUpdateStrategy") RequestUpgradeStrategy upgradeStrategy) {
+        return new HandshakeWebSocketService(upgradeStrategy);
+    }
+
+    @Bean
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        return http
+            .csrf(ServerHttpSecurity.CsrfSpec::disable)
+            .authorizeExchange(e ->
+                e.pathMatchers("/annotated/path-username").hasAnyAuthority("ROLE_USER")
+                .pathMatchers("/functional/path-username", "/functional/username", "/functional/preauthorized").hasAnyAuthority("ROLE_USER")
+                .pathMatchers("/**").permitAll())
+            .httpBasic(Customizer.withDefaults())
+            .build();
+    }
+
+    @Bean
+    public MapReactiveUserDetailsService userDetailsService() {
+        return new MapReactiveUserDetailsService(
+            User.withDefaultPasswordEncoder()
+                .username("elastic")
+                .password("changeme")
+                .roles("USER")
+                .build());
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/WebFluxConfig.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/WebFluxConfig.java
@@ -19,7 +19,6 @@
 package co.elastic.apm.agent.springwebflux.testapp;
 
 
-
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -33,6 +32,7 @@ import org.springframework.boot.tomcat.TomcatProtocolHandlerCustomizer;
 import org.springframework.boot.tomcat.reactive.TomcatReactiveWebServerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.ReactorResourceFactory;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity;
@@ -41,6 +41,7 @@ import org.springframework.security.config.web.server.ServerHttpSecurity;
 import org.springframework.security.core.userdetails.MapReactiveUserDetailsService;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import org.springframework.security.web.server.firewall.StrictServerWebExchangeFirewall;
 import org.springframework.web.reactive.HandlerMapping;
 import org.springframework.web.reactive.config.EnableWebFlux;
 import org.springframework.web.reactive.config.WebFluxConfigurer;
@@ -56,7 +57,6 @@ import org.springframework.web.reactive.socket.server.upgrade.StandardWebSocketU
 import reactor.core.publisher.Flux;
 
 import java.util.Map;
-import java.util.stream.Collectors;
 
 @Configuration
 @EnableWebFlux
@@ -78,11 +78,11 @@ public class WebFluxConfig implements WebFluxConfigurer {
         ObjectProvider<TomcatProtocolHandlerCustomizer<?>> protocolHandlerCustomizers) {
         TomcatReactiveWebServerFactory factory = new TomcatReactiveWebServerFactory();
         factory.getConnectorCustomizers()
-            .addAll(connectorCustomizers.orderedStream().collect(Collectors.toList()));
+            .addAll(connectorCustomizers.orderedStream().toList());
         factory.getContextCustomizers()
-            .addAll(contextCustomizers.orderedStream().collect(Collectors.toList()));
+            .addAll(contextCustomizers.orderedStream().toList());
         factory.getProtocolHandlerCustomizers()
-            .addAll(protocolHandlerCustomizers.orderedStream().collect(Collectors.toList()));
+            .addAll(protocolHandlerCustomizers.orderedStream().toList());
         return factory;
     }
 
@@ -110,7 +110,7 @@ public class WebFluxConfig implements WebFluxConfigurer {
         NettyReactiveWebServerFactory serverFactory = new NettyReactiveWebServerFactory();
         serverFactory.setResourceFactory(resourceFactory);
         routes.orderedStream().forEach(serverFactory::addRouteProviders);
-        serverFactory.getServerCustomizers().addAll(serverCustomizers.orderedStream().collect(Collectors.toList()));
+        serverFactory.getServerCustomizers().addAll(serverCustomizers.orderedStream().toList());
         return serverFactory;
     }
 
@@ -158,8 +158,8 @@ public class WebFluxConfig implements WebFluxConfigurer {
             .csrf(ServerHttpSecurity.CsrfSpec::disable)
             .authorizeExchange(e ->
                 e.pathMatchers("/annotated/path-username").hasAnyAuthority("ROLE_USER")
-                .pathMatchers("/functional/path-username", "/functional/username", "/functional/preauthorized").hasAnyAuthority("ROLE_USER")
-                .pathMatchers("/**").permitAll())
+                    .pathMatchers("/functional/path-username", "/functional/username", "/functional/preauthorized").hasAnyAuthority("ROLE_USER")
+                    .pathMatchers("/**").permitAll())
             .httpBasic(Customizer.withDefaults())
             .build();
     }
@@ -173,4 +173,13 @@ public class WebFluxConfig implements WebFluxConfigurer {
                 .roles("USER")
                 .build());
     }
+
+    @Bean
+    @Primary
+    public StrictServerWebExchangeFirewall httpFirewall() {
+        StrictServerWebExchangeFirewall firewall = new StrictServerWebExchangeFirewall();
+        firewall.setUnsafeAllowAnyHttpMethod(true);
+        return firewall;
+    }
+
 }

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/package-info.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/main/java/co/elastic/apm/agent/springwebflux/testapp/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+@NonnullApi
+package co.elastic.apm.agent.springwebflux.testapp;
+
+import co.elastic.apm.agent.sdk.NonnullApi;

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/test/java/co/elastic/apm/agent/springwebflux/testapp/AnnotatedEndpointTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/test/java/co/elastic/apm/agent/springwebflux/testapp/AnnotatedEndpointTest.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux.testapp;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AnnotatedEndpointTest extends ApplicationTest {
+
+    @LocalServerPort
+    private int serverPort;
+
+    @Override
+    protected GreetingWebClient createClient() {
+
+        return new GreetingWebClient("localhost", serverPort, false, true);
+    }
+
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/test/java/co/elastic/apm/agent/springwebflux/testapp/ApplicationTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/test/java/co/elastic/apm/agent/springwebflux/testapp/ApplicationTest.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux.testapp;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.http.codec.ServerSentEvent;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import reactor.test.StepVerifier;
+
+import java.util.function.Predicate;
+
+public abstract class ApplicationTest {
+
+    protected GreetingWebClient client;
+
+    protected abstract GreetingWebClient createClient();
+
+    @BeforeEach
+    void beforeEach() {
+        // test with functional endpoints only, testing both functional and annotated controller should be properly
+        // covered by instrumentation tests.
+        client = createClient();
+    }
+
+    @Test
+    void helloMono() {
+        StepVerifier.create(client.getHelloMono())
+            .expectNext("Hello, Spring!")
+            .verifyComplete();
+    }
+
+    @Test
+    void mappingError() {
+        StepVerifier.create(client.getMappingError404())
+            .expectErrorMatches(expectClientError(404))
+            .verify();
+    }
+
+    @Test
+    void handlerException() {
+        StepVerifier.create(client.getHandlerError())
+            .expectErrorMatches(expectClientError(500))
+            .verify();
+    }
+
+    @Test
+    void handlerMonoError() {
+        StepVerifier.create(client.getMonoError())
+            .expectErrorMatches(expectClientError(500))
+            .verify();
+    }
+
+    @Test
+    void handlerMonoEmpty() {
+        StepVerifier.create(client.getMonoEmpty())
+            .verifyComplete();
+    }
+
+    @ParameterizedTest
+    @CsvSource({"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS", "TRACE"})
+    void methodMapping(String method) {
+        var verifier = StepVerifier.create(client.methodMapping(method));
+        if ("HEAD".equals(method)) {
+            verifier.verifyComplete();
+        } else {
+            verifier.expectNext(String.format("Hello, %s!", method))
+                .verifyComplete();
+        }
+    }
+
+    @Test
+    void withPathParameter() {
+        StepVerifier.create(client.withPathParameter("42"))
+            .expectNext("Hello, 42!")
+            .verifyComplete();
+    }
+
+    @Test
+    void withChildrenSpans() {
+        StepVerifier.create(client.childSpans(3, 50, 10))
+            .expectNext("child 1child 2child 3")
+            .verifyComplete();
+    }
+
+    @Test
+    void withChildrenSpansSSE() {
+        StepVerifier.create(client.childSpansSSE(3, 50, 10))
+            .expectNextMatches(checkSSE(1))
+            .expectNextMatches(checkSSE(2))
+            .expectNextMatches(checkSSE(3))
+            .verifyComplete();
+    }
+
+    @Test
+    void customTransactionName() {
+        StepVerifier.create(client.customTransactionName())
+            .expectNext("Hello, transaction=null!")
+            .verifyComplete();
+    }
+
+    @Test
+    void duration() {
+        StepVerifier.create(client.duration(42))
+            .expectNext("Hello, duration=42!")
+            .verifyComplete();
+    }
+
+    private static Predicate<ServerSentEvent<String>> checkSSE(final int index) {
+        return sse -> {
+            String data = sse.data();
+            if (data == null) {
+                return false;
+            }
+            return data.equals(String.format("child %d", index));
+        };
+    }
+
+    private Predicate<Throwable> expectClientError(int expectedStatus) {
+        return error -> (error instanceof WebClientResponseException)
+            && ((WebClientResponseException) error).getStatusCode().value() == expectedStatus;
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/test/java/co/elastic/apm/agent/springwebflux/testapp/FunctionalEndpointTest.java
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/test/java/co/elastic/apm/agent/springwebflux/testapp/FunctionalEndpointTest.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.agent.springwebflux.testapp;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import reactor.test.StepVerifier;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class FunctionalEndpointTest extends ApplicationTest {
+
+    @LocalServerPort
+    private int serverPort;
+
+    @Override
+    protected GreetingWebClient createClient() {
+        return new GreetingWebClient("localhost", serverPort, true, true);
+    }
+
+    // nested routes are only available on functional endpoint
+
+    @ParameterizedTest
+    @CsvSource({"GET", "POST"})
+    void nestedRoutes(String method) {
+        StepVerifier.create(client.nested(method))
+            .expectNext(String.format("Hello, nested %s!", method))
+            .verifyComplete();
+
+    }
+}

--- a/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/test/resources/application.properties
+++ b/apm-agent-plugins/apm-spring-webflux/apm-spring-webflux-testapp-spring7/src/test/resources/application.properties
@@ -1,0 +1,6 @@
+# set to DEBUG for easier test application debugging
+logging.level.root=DEBUG
+#
+
+# allows to set current server implementation: 'tomcat' or 'netty'
+server=netty

--- a/apm-agent-plugins/apm-spring-webflux/pom.xml
+++ b/apm-agent-plugins/apm-spring-webflux/pom.xml
@@ -19,15 +19,18 @@
         <!-- spring boot version to use for dependency management & testing -->
         <version.spring-boot-2>2.7.16</version.spring-boot-2>
         <version.spring-boot-3>3.5.7</version.spring-boot-3>
+        <version.spring-boot-4>4.1.0</version.spring-boot-4>
     </properties>
 
     <modules>
         <module>apm-spring-webflux-plugin</module>
         <module>apm-spring-webclient-plugin</module>
         <module>apm-spring-webflux-testapp</module>
+        <module>apm-spring-webflux-testapp-spring7</module>
         <module>apm-spring-webflux-spring5</module>
         <module>apm-spring-webflux-common</module>
         <module>apm-spring-webflux-common-spring5</module>
+        <module>apm-spring-webflux-plugin-spring7</module>
     </modules>
 
     <dependencies>


### PR DESCRIPTION
## What does this PR do?
This PR fixes an issue with the experimental support for Spring framework 7 that was added [PR](https://github.com/elastic/apm-agent-java/pull/4489). When running the agent, it will throw a NoSuchMethodError exception due to the `HttpHeaders.entrySet` method. This is due to HttpHeaders [no longer implementing the MultiValueMap contract](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/http/HttpHeaders.html).\
I have changed the copying of header to only use API's that are still available across version 5, 6 and 7.
The test `co.elastic.apm.agent.springwebflux.AbstractServerInstrumentationTest#dispatchHello` covers this fix.

## Checklist
<!--
You only have to fill one category of checkboxes, depending on the type of the PR.
Please DO NOT remove any item, ~~striking through~~ those that do not apply.
Just ignore the checkboxes of categories that don't apply.
-->

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.md](https://github.com/elastic/apm-agent-java/blob/main/docs/reference/supported-technologies.md)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
