### PR TITLE
Do not close cached JarFile obtained from JarURLConnection

### DIFF
--- a/CHANGELOG.next-release.md
+++ b/CHANGELOG.next-release.md
@@ -10,6 +10,8 @@ This file contains all changes which are not released yet.
 # Fixes
 <!--FIXES-START-->
 
+* Fix `JarFile` obtained from a caching `JarURLConnection` being closed while still shared/in-use, which could crash Spring Boot executable jar startups - [#4541](https://github.com/elastic/apm-agent-java/issues/4541)
+
 <!--FIXES-END-->
 # Features and enhancements
 <!--ENHANCEMENTS-START-->

--- a/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchers.java
+++ b/apm-agent-plugin-sdk/src/main/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchers.java
@@ -233,6 +233,7 @@ public class CustomElementMatchers {
     private static Version readImplementationVersion(@Nullable ProtectionDomain protectionDomain, @Nullable String mavenGroupId, @Nullable String mavenArtifactId) throws IOException, URISyntaxException {
         Version version = null;
         JarFile jarFile = null;
+        boolean closeJarFile = true;
 
         if (protectionDomain == null) {
             logger.info("Cannot read implementation version - got null ProtectionDomain");
@@ -247,7 +248,10 @@ public class CustomElementMatchers {
                     // does not yet establish an actual connection
                     URLConnection urlConnection = jarUrl.openConnection();
                     if (urlConnection instanceof JarURLConnection) {
-                        jarFile = ((JarURLConnection) urlConnection).getJarFile();
+                        JarURLConnection jarURLConnection = (JarURLConnection) urlConnection;
+                        // JarURLConnection may return a shared cached JarFile that must not be closed by the caller
+                        jarFile = jarURLConnection.getJarFile();
+                        closeJarFile = !jarURLConnection.getUseCaches();
                     } else {
                         jarFile = new JarFile(new File(jarUrl.toURI()));
                     }
@@ -291,7 +295,7 @@ public class CustomElementMatchers {
                 }
             }
         } finally {
-            if (jarFile != null) {
+            if (jarFile != null && closeJarFile) {
                 try {
                     jarFile.close();
                 } catch (IOException e) {

--- a/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
+++ b/apm-agent-plugin-sdk/src/test/java/co/elastic/apm/agent/sdk/bytebuddy/CustomElementMatchersTest.java
@@ -25,6 +25,8 @@ import org.junit.jupiter.api.io.TempDir;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.JarURLConnection;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -41,6 +43,8 @@ import java.security.ProtectionDomain;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
 
 import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.classLoaderCanLoadClass;
 import static co.elastic.apm.agent.sdk.bytebuddy.CustomElementMatchers.implementationVersionGte;
@@ -64,6 +68,28 @@ class CustomElementMatchersTest {
         URL originalUrl = HttpClient.class.getProtectionDomain().getCodeSource().getLocation();
         URL jarFileUrl = new URL("jar:" + originalUrl.toString() + "!/");
         testSemVerLteMatcher(new ProtectionDomain(new CodeSource(jarFileUrl, new CodeSigner[0]), null));
+    }
+
+    @Test
+    void testSemVerLteWithJarFileUrlDoesNotCloseSharedCachedJarFile() throws IOException {
+        // JarURLConnection#getJarFile() returns a shared cached JarFile instance by default (getUseCaches() == true).
+        // Reading the implementation version must not close that shared instance, as other code may still be using it.
+        URL originalUrl = HttpClient.class.getProtectionDomain().getCodeSource().getLocation();
+        URL jarFileUrl = new URL("jar:" + originalUrl.toString() + "!/");
+
+        JarURLConnection jarURLConnection = (JarURLConnection) jarFileUrl.openConnection();
+        assertThat(jarURLConnection.getUseCaches()).isTrue();
+        JarFile cachedJarFile = jarURLConnection.getJarFile();
+
+        ProtectionDomain protectionDomain = new ProtectionDomain(new CodeSource(jarFileUrl, new CodeSigner[0]), null);
+        assertThat(implementationVersionLte("5").matches(protectionDomain)).isTrue();
+
+        // the shared cached JarFile must still be usable after the matcher ran
+        JarEntry manifestEntry = cachedJarFile.getJarEntry("META-INF/MANIFEST.MF");
+        assertThat(manifestEntry).isNotNull();
+        try (InputStream input = cachedJarFile.getInputStream(manifestEntry)) {
+            assertThat(input.read()).isNotEqualTo(-1);
+        }
     }
 
     @Test


### PR DESCRIPTION
## What does this PR do?

`CustomElementMatchers#readImplementationVersion` closes the `JarFile` it uses to read a library's version unconditionally in its `finally` block. When the class's `ProtectionDomain` resolves to a `JarURLConnection` (the common case), `JarURLConnection#getJarFile()` returns a **shared, cached** `JarFile` instance by default (caching is on unless `setUseCaches(false)` was called), and per its contract that instance must not be closed by the caller.

Closing it breaks every other concurrent reader/classloader backed by the same cached `JarFile`. On Spring Boot executable jars this is severe: Boot's `nested:` protocol returns its shared cached `NestedJarFile` for a dependency jar, and that same instance also backs classloading for that jar. Closing it during a version-gated instrumentation check (e.g. the Mongo driver check) can fail concurrent classloads with `NoClassDefFoundError` and reads with `ZipException: ZipFile closed`, causing an intermittent startup crash.

Fixes #4541

This PR tracks whether the connection actually owns a private (non-cached) `JarFile` via `JarURLConnection#getUseCaches()`, and only closes it in that case. The `new JarFile(file)` branch (non-`JarURLConnection` case) is unaffected and is still always closed.

## Checklist

- [ ] This is an enhancement of existing features, or a new feature in existing plugins
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] I have made corresponding changes to the documentation
- [x] This is a bugfix
  - [x] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [x] I have added tests that would fail without this fix
- [ ] This is a new plugin
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)
  - [ ] My code follows the [style guidelines of this project](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#java-language-formatting-guidelines)
  - [ ] I have made corresponding changes to the documentation
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] New and existing [**unit** tests](https://github.com/elastic/apm-agent-java/blob/main/CONTRIBUTING.md#testing) pass locally with my changes
  - [ ] I have updated [supported-technologies.md](https://github.com/elastic/apm-agent-java/blob/main/docs/reference/supported-technologies.md)
  - [ ] Added an API method or config option? Document in which version this will be introduced
  - [ ] Added an instrumentation plugin? Describe how you made sure that old, non-supported versions are not instrumented by accident.
- [ ] This is something else
  - [ ] I have updated [CHANGELOG.next-release.md](https://github.com/elastic/apm-agent-java/blob/main/CHANGELOG.next-release.md)

Note: only compiled `apm-agent-plugin-sdk` locally (`./mvnw -pl apm-agent-plugin-sdk -am compile`/`test-compile`, both clean); did not run the full test/verify suite locally, so CI should be the source of truth there.
