### PR TITLE
chore: prevent dependabot from bumping jedis across major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,9 @@ updates:
       - dependency-name: "com.amazonaws:aws-java-sdk-dynamodb"
       - dependency-name: "com.amazonaws:aws-java-sdk"
       - dependency-name: "software.amazon.awssdk:*"
+      # Each jedis module is intentionally pinned to a specific major version.
+      - dependency-name: "redis.clients:jedis"
+        update-types: [ "version-update:semver-major" ]
       # we do not have support for 5.x yet
       - dependency-name: "com.squareup.okhttp3:okhttp"
         update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
Avoids these kinds of automated PRs in the future: https://github.com/elastic/apm-agent-java/pull/4540