### PR TITLE
remove deprecated maven await config

### DIFF
--- a/.github/workflows/release-step-3.yml
+++ b/.github/workflows/release-step-3.yml
@@ -118,8 +118,6 @@ jobs:
     steps:
       - uses: elastic/oblt-actions/maven/await-artifact@v1
         with:
-          maven-central: true
-          sonatype-central: false
           group-id: 'co.elastic.apm'
           artifact-id: 'elastic-apm-agent'
           version: ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
Same as https://github.com/elastic/elastic-otel-java/pull/1230

The `maven-central` and `sonatype-central` options are not relevant anymore in the await-artifact (it's now maven-central only).

Related changes
- https://github.com/elastic/oblt-actions/pull/480
- https://github.com/elastic/oblt-actions/pull/1085